### PR TITLE
compose: Add support for "default_target"

### DIFF
--- a/doc/treefile.md
+++ b/doc/treefile.md
@@ -25,6 +25,8 @@ Treefile
 
  * `units`: Array of strings, optional: Systemd units to enable by default
 
+ * `default_target`: String, optional: Set the default systemd target
+
  * `include`: string, optional: Path to another treefile which will be
    used as an inheritance base.  The semantics for inheritance are:
    Non-array values in child values override parent values.  Array

--- a/src/rpmostree-compose-builtin-tree.c
+++ b/src/rpmostree-compose-builtin-tree.c
@@ -1082,6 +1082,25 @@ rpmostree_compose_builtin_tree (int             argc,
                       cancellable, NULL, NULL, error))
       goto out;
   }
+
+  {
+    const char *default_target = NULL;
+    gs_unref_object GFile *default_target_path =
+      g_file_resolve_relative_path (yumroot, "usr/etc/systemd/system/default.target");
+      
+    if (!object_get_optional_string_member (treefile, "default_target",
+                                            &default_target, error))
+      goto out;
+
+    if (default_target != NULL)
+      {
+        (void) gs_file_unlink (default_target_path, NULL, NULL);
+        
+        if (!g_file_make_symbolic_link (default_target_path, default_target,
+                                        cancellable, error))
+          goto out;
+      }
+  }
     
   {
     const char *gpgkey;


### PR DESCRIPTION
Currently the systemd RPM ships with default.target ->
graphical.target, which is either itself changed by Anaconda (via
parsing /etc/sysconfig/desktop, which...anyways let's stop here).

Or anaconda might set it directly to multi-user.target.

For rpm-ostree, we perform some minimal level of "preconfiguration"
per tree, so they are directly usable without an intervening
installer.

As an example for fedora-atomic/base/core, we just want
multi-user.target.  Thus, this patch provides the treefile author a
declarative mechanism to set it.
