### PR TITLE
upgrade: Download only /usr/share/rpm in check-diff

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -30,6 +30,9 @@ librpmostree_la_SOURCES = \
 	src/rpmostree-util.h \
 	src/hif-utils.c \
 	src/hif-utils.h \
+	src/rpmostree-treepkgdiff.c \
+	src/rpmostree-treepkgdiff.h \
+	src/rpmostree-builtin-rpm.h  \
 	$(NULL)
 if BUILDOPT_PATCHED_HAWKEY_AND_LIBSOLV
 librpmostree_la_SOURCES += \

--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -107,9 +107,9 @@ Boston, MA 02111-1307, USA.
           <command>--reboot</command> or <command>-r </command> to initiate a reboot after upgrade is prepared.
         </para>
 
-          <para><command>--allow-downgrade</command> to permit deployment of chronologically older trees.
+          <para><command>--allow-downgrade</command> to permit deployment of chronologically older trees.</para>
 
-        </para>
+          <para><option>--check-diff</option> to download only /usr/share/rpm in order to do a package-level diff between the two versions.</para>
       </listitem>
       </varlistentry>
 

--- a/src/rpmostree-builtin-rpm.c
+++ b/src/rpmostree-builtin-rpm.c
@@ -28,6 +28,7 @@
 #include "rpmostree-builtins.h"
 #include "rpmostree-treepkgdiff.h"
 #include "rpmostree-util.h"
+#include "rpmostree-builtin-rpm.h"
 
 /* FIXME: */
 #define OSTREE_GIO_FAST_QUERYINFO ("standard::name,standard::type,standard::size,standard::is-symlink,standard::symlink-target," \
@@ -517,7 +518,7 @@ _RPMOSTREE_DEFINE_TRIVIAL_CLEANUP_FUNC(struct RpmHeadersDiff *,
 
 #define _cleanup_rpmhdrs_diff_ __attribute__((cleanup(rpmhdrs_diff_freep)))
 
-static struct RpmHeadersDiff *
+struct RpmHeadersDiff *
 rpmhdrs_diff (struct RpmHeaders *l1,
 	      struct RpmHeaders *l2)
 {
@@ -592,7 +593,7 @@ _rpmhdrs_diff_cmp_end (const GPtrArray *hs1, const GPtrArray *hs2)
 static void
 _gptr_array_reverse (GPtrArray *data);
 
-static void
+void
 rpmhdrs_diff_prnt_diff (GFile *root1, GFile *root2, struct RpmHeadersDiff *diff,
                         GCancellable   *cancellable,
                         GError        **error)
@@ -820,15 +821,7 @@ rpmhdrs_diff_prnt_block (GFile *root1, GFile *root2,
   rpmhdrs_diff_free (diff);
 }
 
-/* data needed to extract rpm/yum data from a commit revision */
-struct RpmRevisionData
-{
-  struct RpmHeaders *rpmdb;
-  GFile *root;
-  char *commit;
-};
-
-static void
+void
 rpmrev_free (struct RpmRevisionData *ptr)
 {
   gs_unref_object GFile *root = NULL;
@@ -849,11 +842,7 @@ rpmrev_free (struct RpmRevisionData *ptr)
   g_free (ptr);
 }
 
-_RPMOSTREE_DEFINE_TRIVIAL_CLEANUP_FUNC(struct RpmRevisionData *, rpmrev_free);
-
-#define _cleanup_rpmrev_ __attribute__((cleanup(rpmrev_freep)))
-
-static struct RpmRevisionData *
+struct RpmRevisionData *
 rpmrev_new (OstreeRepo *repo, GFile *rpmdbdir, const char *rev,
 	    const GPtrArray *patterns,
 	    GCancellable   *cancellable,

--- a/src/rpmostree-builtin-rpm.h
+++ b/src/rpmostree-builtin-rpm.h
@@ -1,0 +1,52 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2014 Anne LoVerso <anne.loverso@students.olin.edu>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include <rpm/rpmlib.h>
+#include <rpm/rpmlog.h>
+#include "rpmostree-util.h"
+
+struct RpmRevisionData
+{
+  struct RpmHeaders *rpmdb;
+  GFile *root;
+  char *commit;
+};
+
+struct RpmHeadersDiff *
+rpmhdrs_diff (struct RpmHeaders *l1,
+              struct RpmHeaders *l2);
+
+void
+rpmhdrs_diff_prnt_diff (GFile *root1, GFile *root2, struct RpmHeadersDiff *diff,
+                        GCancellable   *cancellable,
+                        GError        **error);
+
+void
+rpmrev_free (struct RpmRevisionData *ptr);
+
+_RPMOSTREE_DEFINE_TRIVIAL_CLEANUP_FUNC(struct RpmRevisionData *, rpmrev_free);
+
+#define _cleanup_rpmrev_ __attribute__((cleanup(rpmrev_freep)))
+
+struct RpmRevisionData *
+rpmrev_new (OstreeRepo *repo, GFile *rpmdbdir, const char *rev,
+      const GPtrArray *patterns,
+      GCancellable   *cancellable,
+      GError        **error);


### PR DESCRIPTION
```
    This improves on the check-diff option by only downloading the
    /usr/share/rpm directory to do a package diff.  This prevents downloading
    the whole deployment and the necessity to do a cleanup later.
```

upgrade: Add check-only option to test if a new version is ready

```
    This option queries the ostree repo to compare the checksums of
    versions to determine if a new update is available.  This allows
    a sysadmin to check for updates without commiting to deploying
    the new version.  Future iterations could include a package diff
    instead of a simple true/false.
```
