### PR TITLE
Add --disable-compose-tooling build option

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -45,15 +45,21 @@ librpmostree_la_LIBADD = $(AM_LDFLAGS) $(PKGDEP_RPMOSTREE_LIBS)
 
 rpm_ostree_SOURCES = src/main.c \
 	src/rpmostree-builtins.h \
-	src/rpmostree-builtin-compose.c \
 	src/rpmostree-builtin-upgrade.c \
 	src/rpmostree-builtin-rollback.c \
 	src/rpmostree-builtin-rebase.c \
 	src/rpmostree-builtin-status.c \
 	src/rpmostree-builtin-rpm.c \
+	$(NULL)
+
+if BUILDOPT_COMPOSE_TOOLING
+rpm_ostree_SOURCES += \
 	src/rpmostree-compose-builtin-tree.c \
 	src/rpmostree-compose-builtin-sign.c \
+	src/rpmostree-builtin-compose.c \
 	$(NULL)
+endif
+
 rpm_ostree_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/src -DPKGLIBDIR=\"$(pkglibdir)\" $(PKGDEP_RPMOSTREE_CFLAGS)
 rpm_ostree_LDADD = $(AM_LDFLAGS) $(PKGDEP_RPMOSTREE_LIBS) librpmostree.la
 

--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,17 @@ AC_ARG_ENABLE(usrbinatomic,
               [enable_usrbinatomic=no])
 AM_CONDITIONAL(BUILDOPT_USRBINATOMIC, [test x$enable_usrbinatomic = xyes])
 
+dnl Some distributions may want to support the client tooling, but not
+dnl the server side.
+AC_ARG_ENABLE(compose-tooling,
+              AS_HELP_STRING([--enable-compose-tooling],
+                             [Build compose tooling]),,
+              [enable_compose_tooling=yes])
+AM_CONDITIONAL(BUILDOPT_COMPOSE_TOOLING, [test x$enable_compose_tooling = xyes])
+AS_IF([test x$enable_compose_tooling = xyes], [
+    AC_DEFINE(HAVE_COMPOSE_TOOLING, 1, [Define if we are building compose tooling])
+])
+
 AC_CONFIG_FILES([
 Makefile
 ])
@@ -62,4 +73,5 @@ echo "
 
     patched hawkey:	$enable_patched_hawkey_and_libsolv
     usrbinatomic:	$enable_usrbinatomic
+    compose tooling:	$enable_compose_tooling
 "

--- a/packaging/Makefile.dist-packaging
+++ b/packaging/Makefile.dist-packaging
@@ -7,23 +7,22 @@ srcdir=$(shell pwd)
 PACKAGE=rpm-ostree
 
 PKG_VER = $(PACKAGE)-$(GITREV_FOR_PKG)
+PKG_CLIENT_VER = $(PACKAGE)-client-$(GITREV_FOR_PKG)
 
 dist-snapshot:
-	set -x; \
-	echo "PACKAGE=$(PACKAGE)"; \
-	TARFILE_TMP=$(PKG_VER).tar.tmp; \
-	echo "Archiving $(PACKAGE) at $(GITREV)"; \
-	(cd ..; git archive --format=tar --prefix=$(PKG_VER)/ $(GITREV)) > $${TARFILE_TMP}; \
-	(cd $$(git rev-parse --show-toplevel); git submodule status) | while read line; do \
-	  rev=$$(echo $$line | cut -f 1 -d ' '); path=$$(echo $$line | cut -f 2 -d ' '); \
-	  echo "Archiving $${path} at $${rev}"; \
-	  (cd $(srcdir)/$$path; git archive --format=tar --prefix=$(PKG_VER)/$$path/ $${rev}) > submodule.tar; \
-	  tar -A -f $${TARFILE_TMP} submodule.tar; \
-	  rm submodule.tar; \
-	done; \
-	mv $(PKG_VER).tar{.tmp,}; \
-	rm -f $(PKG_VER).tar.xz; \
+	./make-git-snapshot.sh "$(srcdir)" "$(PKG_VER)" "$(GITREV)"
+	rm -f $(PKG_VER).tar.xz
 	xz $(PKG_VER).tar 
+
+dist-snapshot-without-compose-tooling:
+	./make-git-snapshot.sh "$(srcdir)" "$(PKG_CLIENT_VER)" "$(GITREV)"; \
+	rm tmp -rf; \
+	mkdir tmp; \
+	tar -C tmp -x "--exclude=$(PKG_CLIENT_VER)/src/*compose*" -f $(PKG_CLIENT_VER).tar; \
+	(cd tmp && tar -cf ../$(PKG_CLIENT_VER).tar.filtered *); \
+	mv $(PKG_CLIENT_VER).tar{.filtered,}; \
+	rm -f $(PKG_CLIENT_VER).tar.xz; \
+	xz $(PKG_CLIENT_VER).tar 
 
 srpm: dist-snapshot
 	 sed -e "s,^Version:.*,Version: $(GITREV_FOR_PKG)," $(PACKAGE).spec.in > $(PACKAGE).spec; \

--- a/src/main.c
+++ b/src/main.c
@@ -32,7 +32,9 @@
 #include "libgsystem.h"
 
 static RpmOstreeCommand commands[] = {
+#ifdef HAVE_COMPOSE_TOOLING
   { "compose", rpmostree_builtin_compose, 0 },
+#endif
   { "upgrade", rpmostree_builtin_upgrade, 0 },
   { "rebase", rpmostree_builtin_rebase, 0 },
   { "rollback", rpmostree_builtin_rollback, 0 },


### PR DESCRIPTION
Some downstreams want the ability to separate the compose tooling from
the client, for e.g. support reasons.

This approach supports generating a tarball without the source for the
compose command, and requires specifying a config option to disable
it.
