### PR TITLE
rebase: Make use of new upgrader API to ignore unconfigured state

### DIFF
--- a/src/rpmostree-builtin-rebase.c
+++ b/src/rpmostree-builtin-rebase.c
@@ -88,8 +88,9 @@ rpmostree_builtin_rebase (int             argc,
   if (!ostree_sysroot_load (sysroot, cancellable, error))
     goto out;
 
-  upgrader = ostree_sysroot_upgrader_new_for_os (sysroot, opt_osname,
-                                                 cancellable, error);
+  upgrader = ostree_sysroot_upgrader_new_for_os_with_flags (sysroot, opt_osname,
+                                                            OSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED,
+                                                            cancellable, error);
   if (!upgrader)
     goto out;
 


### PR DESCRIPTION
"atomic rebase" is mostly a copy of "ostree admin switch", so let's
also pick up the changes in ostree admin switch for the new
unconfigured state flag.

This allows a user to "atomic rebase" on an unconfigured system.

Related: #31
