### PR TITLE
compose: Support 'boot_location' to facilitate GRUB2

### DIFF
--- a/doc/treefile.md
+++ b/doc/treefile.md
@@ -14,6 +14,14 @@ Treefile
  * `selinux`: boolean, optional: Defaults to `true`.  If `false`, then
    no SELinux labeling will be performed on the server side.
 
+ * `boot_location`: string, optional: Historically, ostree put bootloader data
+    in /boot.  However, this has a few flaws; it gets shadowed at boot time,
+    and also makes dealing with Anaconda installation harder.  There are 3
+    possible values:
+    * "legacy": the default, data goes in /boot
+    * "both": Kernel data in /boot and /usr/lib/ostree-boot
+    * "new": Kernel data in /usr/lib/ostree-boot
+
  * `bootstrap_packages`: Array of strings, mandatory: The `glibc` and
    `nss-altfiles` packages (and ideally nothing else) must be in this
    set; rpm-ostree will modify the `/etc/nsswitch.conf` in the target

--- a/src/rpmostree-postprocess.h
+++ b/src/rpmostree-postprocess.h
@@ -22,8 +22,15 @@
 
 #include <ostree.h>
 
+typedef enum {
+  RPMOSTREE_POSTPROCESS_BOOT_LOCATION_LEGACY,
+  RPMOSTREE_POSTPROCESS_BOOT_LOCATION_BOTH,
+  RPMOSTREE_POSTPROCESS_BOOT_LOCATION_NEW
+} RpmOstreePostprocessBootLocation;
+
 gboolean
 rpmostree_postprocess (GFile         *rootfs,
+                       RpmOstreePostprocessBootLocation boot_style,
                        GCancellable  *cancellable,
                        GError       **error);
 


### PR DESCRIPTION
Having content in /boot in OSTree was always ugly, because we ended up
mounting over it in the deployment location at boot.

This was even worse in the anaconda rpmostreepayload code, because of
the juggling of the mount point that needed to take place.

Trying to add a GRUB2 backend to OSTree is what finally forced this
change.  Now, we put kernels (in the tree) by default in _both_ /boot
and /usr/lib/ostree-boot.

OSTree itself knows to look in both locations.  Anaconda is going to
just hard require trees with the new location though.
