### PR TITLE
compose: Protect the system during treecompose using container APIs

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -42,7 +42,7 @@ librpmostree_la_SOURCES += \
 	$(NULL)
 endif
 librpmostree_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/src -DPKGLIBDIR=\"$(pkglibdir)\" $(PKGDEP_RPMOSTREE_CFLAGS)
-librpmostree_la_LIBADD = $(AM_LDFLAGS) $(PKGDEP_RPMOSTREE_LIBS)
+librpmostree_la_LIBADD = $(AM_LDFLAGS) $(PKGDEP_RPMOSTREE_LIBS) $(CAP_LIBS)
 
 rpm_ostree_SOURCES = src/main.c \
 	src/rpmostree-builtins.h \

--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,12 @@ LT_INIT([disable-static])
 
 PKG_PROG_PKG_CONFIG
 
+save_LIBS="$LIBS"
+LIBS=
+AC_SEARCH_LIBS([cap_init], [cap], [], [AC_MSG_ERROR([*** POSIX caps library not found])])
+CAP_LIBS="$LIBS"
+AC_SUBST(CAP_LIBS)
+
 PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [gio-unix-2.0 json-glib-1.0 ostree-1 >= 2014.7 libgsystem rpm hawkey])
 AC_PATH_PROG([XSLTPROC], [xsltproc])


### PR DESCRIPTION
I was looking again at using hawkey/librepo, and realized just how
much I'd have to fight all of these libraries to avoid affecting
the running system.

What we really want to do with librepo/hawkey is run them effectively
unprivileged, and to hide the system's RPM database from them.  This
is a baby step towards that, by confining our existing yum.
- /usr, /etc, and /var/lib/rpm are mounted read-only
- yum is now run under CLONE_NEWPID, to avoid stray %post scripts
  affecting system processes
