### PR TITLE
doc/treefile.md: The `repos` are not pulled from the system `/etc/yum.repos.d`

### DIFF
--- a/doc/treefile.md
+++ b/doc/treefile.md
@@ -9,7 +9,7 @@ Treefile
    none.
 
  * `repos` array of strings, mandatory: Names of yum repositories to
-   use, from the system `/etc/yum.repos.d`.
+   use, from `.repo` files in the same directory as the treefile.
 
  * `selinux`: boolean, optional: Defaults to `true`.  If `false`, then
    no SELinux labeling will be performed on the server side.


### PR DESCRIPTION
They come from `.repo` files in the same directory as the treefile.
