### PR TITLE
compose: Make 'bootstrap_packages' actually optional now

### DIFF
--- a/src/rpmostree-compose-builtin-tree.c
+++ b/src/rpmostree-compose-builtin-tree.c
@@ -989,9 +989,12 @@ rpmostree_compose_builtin_tree (int             argc,
   bootstrap_packages = g_ptr_array_new ();
   packages = g_ptr_array_new ();
 
-  if (!_rpmostree_jsonutil_append_string_array_to (treefile, "bootstrap_packages", packages,
-                                                   cancellable, error))
-    goto out;
+  if (json_object_has_member (treefile, "bootstrap_packages"))
+    {
+      if (!_rpmostree_jsonutil_append_string_array_to (treefile, "bootstrap_packages", packages,
+                                                       cancellable, error))
+        goto out;
+    }
   if (!_rpmostree_jsonutil_append_string_array_to (treefile, "packages", packages,
                                                    cancellable, error))
     goto out;


### PR DESCRIPTION
It has in practice been optional since:
827e711eb74135f075f02f5c44685e4e35c1a8b1

Now let's let people write treefiles without it.
