### PR TITLE
Remove unnecessary new line of version output

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -115,7 +115,7 @@ main (int    argc,
             }
           else if (cmd == NULL && g_str_equal (argv[in], "--version"))
             {
-              g_print ("%s\n  %s\n", PACKAGE_STRING, "");
+              g_print ("%s\n", PACKAGE_STRING);
               return 0;
             }
           else if (cmd == NULL)


### PR DESCRIPTION
Current output is ...

```
[root@localhost rpm-ostree]# rpm-ostree --version
rpm-ostree 2014.111

[root@localhost rpm-ostree]# 
```

Sorry If you intend to insert new line, but I think it is not necessary.
