### PR TITLE
libcontainer: Fix inverted logic

### DIFF
--- a/src/rpmostree-libcontainer.c
+++ b/src/rpmostree-libcontainer.c
@@ -42,7 +42,7 @@ _rpmostree_libcontainer_set_not_available (void)
 gboolean
 _rpmostree_libcontainer_get_available (void)
 {
-  return !container_available;
+  return container_available;
 }
 
 gboolean


### PR DESCRIPTION
=/

Originally it was "container_disabled" but the double negatives
started being awkward, I missed converting this negation.

This should really make us work again on RHEL6.
