### PR TITLE
treecompose: Add initramfs-args to treefile

### DIFF
--- a/doc/treefile.md
+++ b/doc/treefile.md
@@ -42,6 +42,11 @@ Treefile
 
  * `default_target`: String, optional: Set the default systemd target
 
+ * `initramfs-args`: Array of strings, optional.  Passed to the
+    initramfs generation program (presently `dracut`).  An example use
+    case for this with Dracut is `--filesystems xfs,ext4` to ensure
+    specific filesystem drivers are included.
+
  * `remove-files`: Delete these files from the generated tree
 
  * `remove-from-packages`: Array, optional: Delete from specified packages


### PR DESCRIPTION
We're building generic initramfs images on the server side, but dracut
has logic to pick up some things from the host, like filesystems.

In the absence of host-specific initramfs images, it needs to be up to
the generating system what kernel modules end up in the initramfs.
Provide a generic option to passthrough dracut arguments.
