### PR TITLE
postprocess: Write preserved groups to *both* /etc/group and /usr/lib/gr...

### DIFF
--- a/src/rpmostree-postprocess.c
+++ b/src/rpmostree-postprocess.c
@@ -704,13 +704,27 @@ migrate_passwd_file_except_root (GFile         *rootfs,
           name = gr->gr_name;
         }
 
-      if (id == 0 || (preserve && g_hash_table_contains (preserve, name)))
+      if (id == 0)
         deststream = etcdest_stream;
 
       if (pw)
         r = putpwent (pw, deststream);
       else
         r = putgrent (gr, deststream);
+
+      /* If it's marked in the preserve group, we need to write to
+       * *both* /etc and /usr/lib in order to preserve semantics for
+       * upgraded systems from before we supported the preserve
+       * concept.
+       */
+      if (preserve && g_hash_table_contains (preserve, name))
+        {
+          g_assert (deststream == usrdest_stream);
+          if (pw)
+            r = putpwent (pw, etcdest_stream);
+          else
+            r = putgrent (gr, etcdest_stream);
+        }
 
       if (r == -1)
         {


### PR DESCRIPTION
...oup

Otherwise, upgraded systems which have modified /etc/group (by e.g.
adding a human user), will actually see the group drop out with bad
consequences.

It's harmless to have it in both, /etc will override /usr.

Fixes #67
