### PR TITLE
upgrade: s/update/upgrade/ in text

### DIFF
--- a/src/rpmostree-builtin-upgrade.c
+++ b/src/rpmostree-builtin-upgrade.c
@@ -121,7 +121,7 @@ rpmostree_builtin_upgrade (int             argc,
 
   if (!changed)
     {
-      g_print ("No updates available.\n");
+      g_print ("No upgrade available.\n");
     }
   else
     {
@@ -141,7 +141,7 @@ rpmostree_builtin_upgrade (int             argc,
                 goto out;
 #endif
 
-              g_print ("Updates prepared for next boot; run \"systemctl reboot\" to start a reboot\n");
+              g_print ("Upgrade prepared for next boot; run \"systemctl reboot\" to start a reboot\n");
             }
         }
 


### PR DESCRIPTION
The command name is upgrade, so use that term consistently.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1163989
