### PR TITLE
"rpm-ostree db version" is busted

### DIFF
--- a/src/rpmostree-db-builtin-version.c
+++ b/src/rpmostree-db-builtin-version.c
@@ -71,6 +71,8 @@ _builtin_db_version (OstreeRepo *repo, GFile *rpmdbdir, GPtrArray *revs,
 
         rpmdbv = rpmhdrs_rpmdbv (rpmrev->root, rpmrev->rpmdb,
                                  cancellable, error);
+        if (rpmdbv == NULL)
+          goto out;
 
         // FIXME: g_console?
         if (!g_str_equal (rev, rpmrev->commit))


### PR DESCRIPTION
```
# rpm-ostree rpm version 1d4c0bf
(rpm-ostree 2014.109 rpm:15612): GLib-WARNING **: GError set over the top of a previous GError or uninitialized memory.
This indicates a bug in someone's code. You must ensure an error is NULL before it's set.
The overwriting error message was: No such file or directory: /var/lib

(... snipped: this warning repeated many many times ...)

ostree commit: 1d4c0bf (1d4c0bf26f1d4dbc179e0baeced16c3a141a5938fe0dada414af3039e16e56fc)
  rpmdbv is:                         354:dfc6707e046a6797da96be6c565f50264f17b1cf
error: No such file or directory: /var/lib
```
