### PR TITLE
compose: Support "preserve-passwd" option (enabled by default)

### DIFF
--- a/doc/treefile.md
+++ b/doc/treefile.md
@@ -61,6 +61,13 @@ Treefile
 
    Note this does not alter the RPM database, so `rpm -V` will complain.
 
+ * `preserve-passwd`: boolean, optional: Defaults to `true`.  If enabled,
+   copy the `/etc/passwd` (and `/usr/lib/passwd`) files from the previous commit
+   if they exist.  This helps ensure consistent uid/gid allocations across
+   builds.  However, it does mean that removed users will exist in the `passwd`
+   database forever.  It also does not help clients switch between unrelated
+   trees.
+
  * `check-passwd`: Object, optional: Checks to run against the new passwd file
    before accepting the tree. All the entries specified should exist (unless
    ignored) and have the same values or the compose will fail. There are four

--- a/src/rpmostree-compose-builtin-tree.c
+++ b/src/rpmostree-compose-builtin-tree.c
@@ -940,6 +940,23 @@ rpmostree_compose_builtin_tree (int             argc,
     self->serialized_treefile = g_bytes_new_take (treefile_buf, len);
   }
 
+  {
+    gboolean generate_from_previous = TRUE;
+
+    if (!_rpmostree_jsonutil_object_get_optional_boolean_member (treefile,
+                                                                 "preserve-passwd",
+                                                                 &generate_from_previous,
+                                                                 error))
+      goto out;
+
+    if (generate_from_previous)
+      {
+        if (!rpmostree_generate_passwd_from_previous (repo, yumroot, ref,
+                                                      cancellable, error))
+          goto out;
+      }
+  }
+
   if (!yuminstall (self, treefile, yumroot,
                    (char**)packages->pdata,
                    cancellable, error))

--- a/src/rpmostree-json-parsing.c
+++ b/src/rpmostree-json-parsing.c
@@ -133,6 +133,31 @@ _rpmostree_jsonutil_object_require_int_member (JsonObject     *object,
   return TRUE;
 }
 
+gboolean
+_rpmostree_jsonutil_object_get_optional_boolean_member (JsonObject     *object,
+                                                       const char     *member_name,
+                                                       gboolean       *out_value,
+                                                       GError        **error)
+{
+  gboolean ret = FALSE;
+  JsonNode *node = json_object_get_member (object, member_name);
+
+  if (node != NULL)
+    {
+      if (json_node_get_value_type (node) != G_TYPE_BOOLEAN)
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Member '%s' is not a boolean", member_name);
+          goto out;
+        }
+      *out_value = json_node_get_boolean (node);
+    }
+
+  ret = TRUE;
+ out:
+  return ret;
+}
+
 const char *
 _rpmostree_jsonutil_array_require_string_element (JsonArray      *array,
 						  guint           i,

--- a/src/rpmostree-json-parsing.h
+++ b/src/rpmostree-json-parsing.h
@@ -47,6 +47,12 @@ _rpmostree_jsonutil_object_require_int_member (JsonObject     *object,
                                                gint64         *out_val,
                                                GError        **error);
 
+gboolean
+_rpmostree_jsonutil_object_get_optional_boolean_member (JsonObject     *object,
+                                                       const char     *member_name,
+                                                       gboolean       *out_value,
+                                                       GError        **error);
+
 const char *
 _rpmostree_jsonutil_array_require_string_element (JsonArray      *array,
                                                   guint           i,

--- a/src/rpmostree-passwd-util.h
+++ b/src/rpmostree-passwd-util.h
@@ -39,3 +39,10 @@ rpmostree_check_groups (OstreeRepo      *repo,
                         JsonObject      *treedata,
                         GCancellable    *cancellable,
                         GError         **error);
+
+gboolean
+rpmostree_generate_passwd_from_previous (OstreeRepo      *repo,
+                                         GFile           *yumroot,
+                                         const char      *ref,
+                                         GCancellable    *cancellable,
+                                         GError         **error);


### PR DESCRIPTION
The checking code from #56 landed, and started triggering for me on
the `dockerroot` user. It's nice to know it works. Then the issue
is... "what now"?

It turns out in the case of `dockerroot` it's actually unused, so we
could fix this by deleting it. But in general we need to support
dynamic uids/gids/. And we can't yet take a hard dep on #49.

So this patch changes things so we take a copy of the passwd/group
data from the previous commit.  Any users subsequently added in the
_new_ commit will be additive.

Closes: https://github.com/projectatomic/rpm-ostree/issues/78
