### PR TITLE
Add a `flavor=docker` to treefiles

### DIFF
--- a/src/app/rpmostree-builtin-container.c
+++ b/src/app/rpmostree-builtin-container.c
@@ -30,7 +30,8 @@ typedef struct {
 
 static RpmOstreeContainerCommand container_subcommands[] = {
   { "init", rpmostree_container_builtin_init },
-  { "assemble", rpmostree_container_builtin_assemble },
+  { "assemble-checkout", rpmostree_container_builtin_assemble_checkout },
+  { "assemble-export", rpmostree_container_builtin_assemble_export },
   /* { "start", rpmostree_container_builtin_start }, */
   { "upgrade", rpmostree_container_builtin_upgrade },
   { NULL, NULL }

--- a/src/app/rpmostree-container-builtins.h
+++ b/src/app/rpmostree-container-builtins.h
@@ -27,7 +27,8 @@
 G_BEGIN_DECLS
 
 gboolean rpmostree_container_builtin_init (int argc, char **argv, GCancellable *cancellable, GError **error);
-gboolean rpmostree_container_builtin_assemble (int argc, char **argv, GCancellable *cancellable, GError **error);
+gboolean rpmostree_container_builtin_assemble_checkout (int argc, char **argv, GCancellable *cancellable, GError **error);
+gboolean rpmostree_container_builtin_assemble_export (int argc, char **argv, GCancellable *cancellable, GError **error);
 /* gboolean rpmostree_container_builtin_start (int argc, char **argv, GCancellable *cancellable, GError **error); */
 gboolean rpmostree_container_builtin_upgrade (int argc, char **argv, GCancellable *cancellable, GError **error);
 

--- a/src/libpriv/rpmostree-bwrap.h
+++ b/src/libpriv/rpmostree-bwrap.h
@@ -43,6 +43,14 @@ RpmOstreeBwrap *rpmostree_bwrap_new (int rootfs,
                                      GError **error,
                                      ...) G_GNUC_NULL_TERMINATED;
 
+RpmOstreeBwrap *rpmostree_bwrap_new_host (GError **error, ...) G_GNUC_NULL_TERMINATED;
+
+gboolean rpmostree_bwrap_bind_rofiles (RpmOstreeBwrap *bwrap,
+                                       int         src_dfd,
+                                       const char *src,
+                                       const char *dest,
+                                       GError **error);
+
 void rpmostree_bwrap_append_bwrap_argv (RpmOstreeBwrap *bwrap, ...) G_GNUC_NULL_TERMINATED;
 void rpmostree_bwrap_append_child_argv (RpmOstreeBwrap *bwrap, ...) G_GNUC_NULL_TERMINATED;
 

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1185,6 +1185,24 @@ rpmostree_rootfs_postprocess_common (int           rootfs_fd,
   return ret;
 }
 
+gboolean
+rpmostree_rootfs_postprocess_docker (int           rootfs_fd,
+                                     GCancellable *cancellable,
+                                     GError       **error)
+{
+  if (renameat (rootfs_fd, "usr/etc", rootfs_fd, "etc") < 0)
+    {
+      glnx_set_prefix_error_from_errno (error, "%s", "Renaming /usr/etc to /etc");
+      return FALSE;
+    }
+  if (renameat (rootfs_fd, "usr/share/rpm", rootfs_fd, "var/lib/rpm") < 0)
+    {
+      glnx_set_prefix_error_from_errno (error, "%s", "Renaming /usr/share/rpm to /var/lib/rpm");
+      return FALSE;
+    }
+  return TRUE;
+}
+
 /**
  * rpmostree_copy_additional_files:
  *

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -48,6 +48,11 @@ rpmostree_rootfs_postprocess_common (int           rootfs_fd,
                                      GError       **error);
 
 gboolean
+rpmostree_rootfs_postprocess_docker (int           rootfs_fd,
+                                     GCancellable *cancellable,
+                                     GError       **error);
+
+gboolean
 rpmostree_prepare_rootfs_get_sepolicy (int            dfd,
                                        const char    *path,
                                        OstreeSePolicy **out_sepolicy,

--- a/tests/check/postprocess.sh
+++ b/tests/check/postprocess.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo foo > /tmp/target-rootfs/foo

--- a/tests/check/test-ucontainer.sh
+++ b/tests/check/test-ucontainer.sh
@@ -36,7 +36,21 @@ EOF
 
 rpm-ostree container assemble empty.conf
 assert_has_dir roots/empty.0
+test -f roots/empty/usr/etc/group
 ostree --repo=repo rev-parse empty
+
+cat >empty-docker.conf <<EOF
+[tree]
+ref=empty-docker
+packages=empty
+repos=test-repo
+flavor=docker
+EOF
+
+rpm-ostree container assemble empty-docker.conf
+assert_has_dir roots/empty-docker.0
+ostree --repo=repo rev-parse empty-docker
+test -f roots/empty-docker/etc/group
 echo "ok assemble"
 
 cat >nobranch.conf <<EOF


### PR DESCRIPTION
I'm playing with `rpm-ostree container` to make Docker images
(specifically a base image), and right now the main thing is that we
need to rename `/usr/etc` back to `/etc`.
