### PR TITLE
 postprocess: Move /etc/ld.so.cache → /usr

### DIFF
--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -38,3 +38,9 @@ echo "ok boot files"
 ostree --repo=${repobuild} ls -R ${treeref} /usr/share/man > manpages.txt
 assert_file_has_content manpages.txt man5/ostree.repo.5
 echo "ok manpages"
+
+ostree --repo=${repobuild} ls -R ${treeref} /usr/etc/ld.so.cache > ls.txt
+assert_file_has_content ls.txt '^l0777.*/usr/etc/ld.so.cache -> \.\./usr/ld.so.cache'
+assert_file_has_content bootls.txt initramfs
+echo "ok ld.so.cache"
+


### PR DESCRIPTION
(Peeling this off as a WIP - not really tested locally yet)

This is an "index file" similar to many others; see for example
[the fontconfig case](https://bugzilla.redhat.com/show_bug.cgi?id=1377367).
That one was in `/var`, and while `/etc` isn't quite as bad,
it's still not a human-editable file, and should be lifecycle bound
with `/usr`.

This will be a bit more important with livefs, since with that we'd need to
change the running `/etc`.