### PR TITLE
WIP: Support running in default kube privileges

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -112,6 +112,15 @@ tests:
     -v $(pwd):/srv/code -w /srv/code
     registry.fedoraproject.org/fedora:27 /bin/sh -c
     "./ci/build.sh && make install && ./tests/compose"
+  # And now one that isn't --privileged https://github.com/projectatomic/rpm-ostree/issues/1329
+  - docker run --rm --security-opt seccomp=unconfined
+    --security-opt label=type:spc_t \
+    -e RPMOSTREE_COMPOSE_TEST_USE_REPOS=/etc/yum.repos.d.host
+    -v /etc/yum.repos.d:/etc/yum.repos.d.host:ro
+    -v $(pwd):/srv/code -w /srv/code
+    registry.fedoraproject.org/fedora:27 /bin/sh -c
+    "./ci/build.sh && make install && env TESTS=basic ./tests/compose"
+
 
 artifacts:
   - test-compose-logs

--- a/src/libpriv/rpmostree-bwrap.h
+++ b/src/libpriv/rpmostree-bwrap.h
@@ -25,7 +25,6 @@
 #include "libglnx.h"
 
 typedef enum {
-  RPMOSTREE_BWRAP_IMMUTABLE = 0,
   RPMOSTREE_BWRAP_MUTATE_ROFILES,
   RPMOSTREE_BWRAP_MUTATE_FREELY
 } RpmOstreeBwrapMutability;

--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -41,6 +41,7 @@ struct _RpmOstreeContext {
   DnfContext *dnfctx;
   OstreeRepo *ostreerepo;
   OstreeRepo *pkgcache_repo;
+  gboolean enable_fuse;
   OstreeRepoDevInoCache *devino_cache;
   gboolean unprivileged;
   OstreeSePolicy *sepolicy;

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -68,14 +68,11 @@ run_bwrap_mutably (int           rootfs_fd,
     bwrap = rpmostree_bwrap_new (rootfs_fd,
                                  RPMOSTREE_BWRAP_MUTATE_ROFILES,
                                  error,
-                                 "--ro-bind", "./var", "/var",
                                  NULL);
   else
     bwrap = rpmostree_bwrap_new (rootfs_fd,
                                  RPMOSTREE_BWRAP_MUTATE_FREELY,
                                  error,
-                                 "--bind", "var", "/var",
-                                 "--bind", "usr/etc", "/etc",
                                  NULL);
 
   if (!bwrap)

--- a/src/libpriv/rpmostree-scripts.h
+++ b/src/libpriv/rpmostree-scripts.h
@@ -63,6 +63,7 @@ rpmostree_script_run_sync (DnfPackage    *pkg,
                            RpmOstreeScriptKind kind,
                            int            rootfs_fd,
                            GLnxTmpDir    *var_lib_rpm_statedir,
+                           gboolean       enable_fuse,
                            guint         *out_n_run,
                            GCancellable  *cancellable,
                            GError       **error);
@@ -70,6 +71,7 @@ rpmostree_script_run_sync (DnfPackage    *pkg,
 gboolean
 rpmostree_transfiletriggers_run_sync (Header         hdr,
                                       int            rootfs_fd,
+                                      gboolean       enable_fuse,
                                       guint         *out_n_run,
                                       GCancellable  *cancellable,
                                       GError       **error);


### PR DESCRIPTION
prep: https://github.com/projectatomic/rpm-ostree/pull/1333

---

For https://github.com/projectatomic/rpm-ostree/issues/1329

Note that we need to disable seccomp and *also* unfortunately use `spc_t`.  TODO: Get a looser `container-selinux` policy for this.
