### PR TITLE
Remove call of dnf_context_set_yumdb_enabled

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -419,7 +419,6 @@ rpmostree_context_new_system (OstreeRepo   *repo,
 
   dnf_context_set_check_disk_space (self->dnfctx, FALSE);
   dnf_context_set_check_transaction (self->dnfctx, FALSE);
-  dnf_context_set_yumdb_enabled (self->dnfctx, FALSE);
 
   return self;
 }


### PR DESCRIPTION
The function was removed from libdnf-0.14.0 without replacement. There is no
yumdb support anymore. All information is stored in sqlight database.