### PR TITLE
daemon/transaction-types: Fix dnf cache override

### DIFF
--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -749,8 +749,9 @@ get_sack_for_booted (OstreeSysroot    *sysroot,
     return FALSE;
 
   DnfContext *dnfctx = rpmostree_context_get_dnf (ctx);
+
   /* we always want to force a refetch of the metadata */
-  dnf_context_set_cache_age (dnfctx, 0);
+  rpmostree_context_set_dnf_caching (ctx, RPMOSTREE_CONTEXT_DNF_CACHE_NEVER);
 
   /* point libdnf to our repos dir */
   rpmostree_context_configure_from_deployment (ctx, sysroot, booted_deployment);
@@ -1928,10 +1929,7 @@ refresh_md_transaction_execute (RpmostreedTransaction *transaction,
     return FALSE;
 
   if (force)
-    {
-      DnfContext *dnfctx = rpmostree_context_get_dnf (ctx);
-      dnf_context_set_cache_age (dnfctx, 0);
-    }
+    rpmostree_context_set_dnf_caching (ctx, RPMOSTREE_CONTEXT_DNF_CACHE_NEVER);
 
   /* point libdnf to our repos dir */
   rpmostree_context_configure_from_deployment (ctx, sysroot, cfg_merge_deployment);

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -204,13 +204,16 @@ EOF
 vm_rpmostree cleanup -rpmb
 vm_cmd rm -f /etc/yum.repos.d/vmcheck.repo
 vm_build_rpm_repo_mode skip refresh-md-old-pkg
-vm_rpmostree refresh-md
+vm_rpmostree refresh-md | tee out.txt
+assert_file_has_content_literal out.txt "Updating metadata for 'vmcheck-http'"
 vm_build_rpm_repo_mode skip refresh-md-new-pkg
-vm_rpmostree refresh-md # shouldn't do anything since it hasn't expired yet
+vm_rpmostree refresh-md | tee out.txt # shouldn't do anything since it hasn't expired yet
+assert_file_has_content_literal out.txt "rpm-md repo 'vmcheck-http' (cached)"
 if vm_rpmostree install refresh-md-new-pkg --dry-run; then
   assert_not_reached "successfully dry-run installed new pkg from cached rpmmd?"
 fi
-vm_rpmostree refresh-md -f
+vm_rpmostree refresh-md -f | tee out.txt
+assert_file_has_content_literal out.txt "Updating metadata for 'vmcheck-http'"
 if ! vm_rpmostree install refresh-md-new-pkg --dry-run; then
   assert_not_reached "failed to dry-run install new pkg from cached rpmmd?"
 fi


### PR DESCRIPTION
Minor regression from #1587. There were places that were still doing
`dnf_context_set_cache_age()` manually, but those calls didn't exactly
have the intended effect since the core now handled caching itself.

The actual result was that the metadata was still being updated, but not
during the `dnf_repo_check` pass that the core does, but rather the
`Importing rpm-md` pass it does right after. So then, we were
incorrectly printing `(cached)` even though we'd update it afterwards.

Switch to the new way of doing things.