### PR TITLE
(merge after RHSCL has 2018) rust: Run `cargo fix --edition` for Rust 2018

### DIFF
--- a/rust/src/journal.rs
+++ b/rust/src/journal.rs
@@ -147,7 +147,7 @@ fn journal_print_staging_failure() -> Fallible<()> {
 
 mod ffi {
     use super::*;
-    use ffiutil::*;
+    use crate::ffiutil::*;
     use glib_sys;
     use libc;
     #[no_mangle]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -39,10 +39,10 @@ extern crate serde_yaml;
 mod ffiutil;
 
 mod treefile;
-pub use treefile::*;
+pub use crate::treefile::*;
 mod progress;
-pub use progress::*;
+pub use crate::progress::*;
 mod journal;
-pub use journal::*;
+pub use crate::journal::*;
 mod utils;
-pub use utils::*;
+pub use crate::utils::*;

--- a/rust/src/progress.rs
+++ b/rust/src/progress.rs
@@ -168,7 +168,7 @@ mod tests {
 
 mod ffi {
     use super::*;
-    use ffiutil::*;
+    use crate::ffiutil::*;
     use libc;
     use std::sync::MutexGuard;
 

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -28,7 +28,7 @@ use std::collections::HashMap;
 use std::io::prelude::*;
 use std::path::Path;
 use std::{collections, fs, io};
-use utils;
+use crate::utils;
 
 const ARCH_X86_64: &'static str = "x86_64";
 const INCLUDE_MAXDEPTH: u32 = 50;
@@ -812,7 +812,7 @@ packages:
 
 mod ffi {
     use super::*;
-    use ffiutil::*;
+    use crate::ffiutil::*;
     use glib_sys;
     use libc;
 

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -115,7 +115,7 @@ mod tests {
 
 mod ffi {
     use super::*;
-    use ffiutil::*;
+    use crate::ffiutil::*;
     use glib;
     use glib_sys;
     use libc;


### PR DESCRIPTION
Let's prepare our codebase to build with both Rust 2015 and 2018.
Next step is to add this to our CI.

https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html
