### PR TITLE
RFC: app/compose: Add --legacy to start deprecation process

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -58,6 +58,7 @@ static gboolean opt_download_only;
 static gboolean opt_force_nocache;
 static gboolean opt_cache_only;
 static gboolean opt_unified_core;
+static gboolean opt_legacy;
 static char *opt_proxy;
 static char *opt_output_repodata_dir;
 static char **opt_metadata_strings;
@@ -82,6 +83,7 @@ static GOptionEntry install_option_entries[] = {
   { "download-only", 0, 0, G_OPTION_ARG_NONE, &opt_download_only, "Like --dry-run, but download RPMs as well; requires --cachedir", NULL },
   { "ex-unified-core", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_unified_core, "Compat alias for --unified-core", NULL }, // Compat
   { "unified-core", 0, 0, G_OPTION_ARG_NONE, &opt_unified_core, "Use new \"unified core\" codepath", NULL },
+  { "legacy", 0, 0, G_OPTION_ARG_NONE, &opt_legacy, "Use the legacy codepath", NULL },
   { "proxy", 0, 0, G_OPTION_ARG_STRING, &opt_proxy, "HTTP proxy", "PROXY" },
   { "dry-run", 0, 0, G_OPTION_ARG_NONE, &opt_dry_run, "Just print the transaction and exit", NULL },
   { "output-repodata-dir", 0, 0, G_OPTION_ARG_STRING, &opt_output_repodata_dir, "Save downloaded repodata in DIR", "DIR" },
@@ -544,6 +546,13 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
                                 GError       **error)
 {
   g_autoptr(RpmOstreeTreeComposeContext) self = g_new0 (RpmOstreeTreeComposeContext, 1);
+
+  if (!opt_print_only)
+    g_print ("Currently running in %s mode\n",
+             opt_unified_core ? "unified core" : "legacy");
+
+  if (!opt_print_only && !opt_unified_core && !opt_legacy)
+    g_printerr ("%swarning: In the future, the default compose mode will be --unified-mode. The legacy mode will be deprecated but available behind --legacy for some time. Use one of the two switches above to squash this warning.%s\n", get_bold_start (), get_bold_end ());
 
   /* Init fds to -1 */
   self->workdir_dfd = self->rootfs_dfd = self->cachedir_dfd = -1;

--- a/tests/common/libtest-core.sh
+++ b/tests/common/libtest-core.sh
@@ -113,6 +113,15 @@ assert_file_has_content_literal () {
     done
 }
 
+assert_not_file_has_content_literal () {
+    fpath=$1; shift
+    for s in "$@"; do
+        if grep -q -F -e "$s" "$fpath"; then
+            _fatal_print_file "$fpath" "File '$fpath' matches fixed string list '$s'"
+        fi
+    done
+}
+
 assert_symlink_has_content () {
     if ! test -L "$1"; then
         fatal "File '$1' is not a symbolic link"

--- a/tests/compose-tests/libcomposetest.sh
+++ b/tests/compose-tests/libcomposetest.sh
@@ -70,7 +70,7 @@ runcompose() {
     # The workdir will be cleaned up (or not) with the overall test dir
     rm ${compose_workdir} -rf
     mkdir ${test_tmpdir}/workdir
-    env RPMOSTREE_PRESERVE_TMPDIR=1 rpm-ostree compose tree ${compose_base_argv} ${treefile} "$@"
+    env RPMOSTREE_PRESERVE_TMPDIR=1 rpm-ostree compose tree ${compose_base_argv} ${treefile} "$@" |& tee compose-output.txt
     commit=$(jq -r '.["ostree-commit"]' < "${composejson}")
     ostree --repo=${repo} pull-local ${repobuild} "${treeref:-${commit}}"
     echo "$(date): finished compose"

--- a/tests/compose-tests/test-basic-unified.sh
+++ b/tests/compose-tests/test-basic-unified.sh
@@ -34,6 +34,12 @@ echo "ok no cachedir"
 . ${dn}/libbasic-test.sh
 basic_test
 
+assert_file_has_content_literal compose-output.txt "Currently running in unified"
+# And check that we *didn't* print a warning
+assert_not_file_has_content_literal compose-output.txt \
+  "warning: In the future, the default compose mode will be --unified-mode"
+echo "ok current mode and legacy warning"
+
 # This one is done by postprocessing /var
 ostree --repo=${repobuild} cat ${treeref} /usr/lib/tmpfiles.d/pkg-filesystem.conf > autovar.txt
 # Picked this one at random as an example of something that won't likely be

--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -21,6 +21,21 @@ runcompose --add-metadata-from-json metadata.json
 . ${dn}/libbasic-test.sh
 basic_test
 
+assert_file_has_content_literal compose-output.txt "Currently running in legacy"
+# And check that we printed a warning
+assert_file_has_content_literal compose-output.txt \
+  "warning: In the future, the default compose mode will be --unified-mode"
+echo "ok current mode and legacy warning"
+
+# Now run it again directly but with --dry-run so it's a no-op, but use --legacy
+# to check we squash the warning
+rpm-ostree compose tree ${compose_base_argv} ${treefile} --dry-run --legacy |& tee out.txt
+assert_file_has_content_literal out.txt "Currently running in legacy"
+# And check that we *didn't* print a warning
+assert_not_file_has_content_literal out.txt \
+  "warning: In the future, the default compose mode will be --unified-mode"
+echo "ok squash legacy warning"
+
 # This one is done by postprocessing /var
 ostree --repo=${repobuild} cat ${treeref} /usr/lib/tmpfiles.d/rpm-ostree-1-autovar.conf > autovar.txt
 # Picked this one at random as an example of something that won't likely be


### PR DESCRIPTION
First, start printing the current mode we're operating in. This will
make it clear from the output if the default changes. Second, add a new
`--legacy` switch that users can use today to explicit opt into the
current default. And third, start emitting a warning if neither
`--legacy` nor `--unified-core` is given.

The way I'm thinking we can do this is (timespans flexible of course):
- next 6 months: print warning unless mode is explicitly chosen
- following 6 months: change default, print deprecation warning if
  `--legacy` is given
- afterwards: remove `--legacy`, gradually clean up code, and profit