### PR TITLE
WIP: Print package diff against previously default pending deployment rather than booted

### DIFF
--- a/Makefile-lib.am
+++ b/Makefile-lib.am
@@ -28,6 +28,7 @@ librpmostree_1_la_SOURCES = \
 	src/lib/rpmostree.c \
 	src/lib/rpmostree-db.c \
 	src/lib/rpmostree-package.c \
+	src/lib/rpmostree-private.h \
 	$(NULL)
 
 librpmostree_1_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/libglnx -I$(srcdir)/src/libpriv -I$(srcdir)/src/lib \

--- a/src/app/rpmostree-builtin-deploy.c
+++ b/src/app/rpmostree-builtin-deploy.c
@@ -97,7 +97,10 @@ rpmostree_builtin_deploy (int            argc,
                                 cancellable, &os_proxy, error))
     return FALSE;
 
-  g_autoptr(GVariant) previous_deployment = rpmostree_os_dup_default_deployment (os_proxy);
+  g_autoptr(RpmOstreeDeployment) starting_default_deployment =
+    rpmostree_get_default_deployment (sysroot_proxy, cancellable, error);
+  if (!starting_default_deployment)
+    return FALSE;
 
   if (opt_preview)
     {
@@ -181,19 +184,15 @@ rpmostree_builtin_deploy (int            argc,
     }
   else if (!opt_reboot)
     {
-      if (!rpmostree_has_new_default_deployment (os_proxy, previous_deployment))
-        {
-          invocation->exit_code = RPM_OSTREE_EXIT_UNCHANGED;
-          return TRUE;
-        }
-
-      /* do diff without dbus: https://github.com/projectatomic/rpm-ostree/pull/116 */
-      const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
-      if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
-            RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0, cancellable, error))
+      gboolean changed;
+      if (!rpmostree_print_diff_from_deployment (starting_default_deployment, &changed,
+                                                 cancellable, error))
         return FALSE;
 
-      g_print ("Run \"systemctl reboot\" to start a reboot\n");
+      if (!changed)
+        invocation->exit_code = RPM_OSTREE_EXIT_UNCHANGED;
+      else
+        g_print ("Run \"systemctl reboot\" to start a reboot\n");
     }
 
   return TRUE;

--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -158,7 +158,10 @@ rpmostree_builtin_rebase (int             argc,
         }
     }
 
-  g_autoptr(GVariant) previous_deployment = rpmostree_os_dup_default_deployment (os_proxy);
+  g_autoptr(RpmOstreeDeployment) starting_default_deployment =
+    rpmostree_get_default_deployment (sysroot_proxy, cancellable, error);
+  if (!starting_default_deployment)
+    return FALSE;
 
   GVariantDict dict;
   g_variant_dict_init (&dict, NULL);
@@ -222,6 +225,6 @@ rpmostree_builtin_rebase (int             argc,
   return rpmostree_transaction_client_run (invocation, sysroot_proxy, os_proxy,
                                            options, FALSE,
                                            transaction_address,
-                                           previous_deployment,
+                                           starting_default_deployment,
                                            cancellable, error);
 }

--- a/src/app/rpmostree-builtin-reset.c
+++ b/src/app/rpmostree-builtin-reset.c
@@ -90,7 +90,10 @@ rpmostree_builtin_reset (int             argc,
                                 cancellable, &os_proxy, error))
     return FALSE;
 
-  g_autoptr(GVariant) previous_deployment = rpmostree_os_dup_default_deployment (os_proxy);
+  g_autoptr(RpmOstreeDeployment) starting_default_deployment =
+    rpmostree_get_default_deployment (sysroot_proxy, cancellable, error);
+  if (!starting_default_deployment)
+    return FALSE;
 
   GVariantDict dict;
   g_variant_dict_init (&dict, NULL);
@@ -110,6 +113,6 @@ rpmostree_builtin_reset (int             argc,
   return rpmostree_transaction_client_run (invocation, sysroot_proxy, os_proxy,
                                            options, FALSE,
                                            transaction_address,
-                                           previous_deployment,
+                                           starting_default_deployment,
                                            cancellable, error);
 }

--- a/src/app/rpmostree-builtin-rollback.c
+++ b/src/app/rpmostree-builtin-rollback.c
@@ -76,7 +76,11 @@ rpmostree_builtin_rollback (int             argc,
                                 cancellable, &os_proxy, error))
     return FALSE;
 
-  g_autoptr(GVariant) previous_deployment = rpmostree_os_dup_default_deployment (os_proxy);
+  g_autoptr(RpmOstreeDeployment) starting_default_deployment =
+    rpmostree_get_default_deployment (sysroot_proxy, cancellable, error);
+  if (!starting_default_deployment)
+    return FALSE;
+
   /* really, rollback only supports the "reboot" option; all others are ignored */
   GVariantDict dict;
   g_variant_dict_init (&dict, NULL);
@@ -93,6 +97,6 @@ rpmostree_builtin_rollback (int             argc,
   return rpmostree_transaction_client_run (invocation, sysroot_proxy, os_proxy,
                                            options, FALSE,
                                            transaction_address,
-                                           previous_deployment,
+                                           starting_default_deployment,
                                            cancellable, error);
 }

--- a/src/app/rpmostree-dbus-helpers.h
+++ b/src/app/rpmostree-dbus-helpers.h
@@ -24,6 +24,7 @@
 
 #include "rpm-ostreed-generated.h"
 #include "rpmostree-builtin-types.h"
+#include "rpmostree-libbuiltin.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -80,7 +81,7 @@ rpmostree_transaction_client_run             (RpmOstreeCommandInvocation *invoca
                                               GVariant         *options,
                                               gboolean          exit_unchanged_77,
                                               const char *transaction_address,
-                                              GVariant         *previous_deployment,
+                                              RpmOstreeDeployment *previous_deployment,
                                               GCancellable *cancellable,
                                               GError **error);
 

--- a/src/app/rpmostree-libbuiltin.h
+++ b/src/app/rpmostree-libbuiltin.h
@@ -59,9 +59,23 @@ rpmostree_usage_error (GOptionContext  *context,
                        const char      *message,
                        GError         **error);
 
+typedef struct RpmOstreeDeployment RpmOstreeDeployment;
+
+RpmOstreeDeployment*
+rpmostree_get_default_deployment (RPMOSTreeSysroot *sysroot_proxy,
+                                  GCancellable  *cancellable,
+                                  GError       **error);
+
+void
+rpmostree_deployment_free (RpmOstreeDeployment *deployment);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (RpmOstreeDeployment, rpmostree_deployment_free);
+
 gboolean
-rpmostree_has_new_default_deployment (RPMOSTreeOS *os_proxy,
-                                      GVariant    *previous_deployment);
+rpmostree_print_diff_from_deployment (RpmOstreeDeployment *deployment,
+                                      gboolean      *out_changed,
+                                      GCancellable  *cancellable,
+                                      GError       **error);
 
 gboolean
 rpmostree_print_treepkg_diff_from_sysroot_path (const gchar   *sysroot_path,

--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -84,7 +84,10 @@ pkg_change (RpmOstreeCommandInvocation *invocation,
                                 cancellable, &os_proxy, error))
     return FALSE;
 
-  g_autoptr(GVariant) previous_deployment = rpmostree_os_dup_default_deployment (os_proxy);
+  g_autoptr(RpmOstreeDeployment) starting_default_deployment =
+    rpmostree_get_default_deployment (sysroot_proxy, cancellable, error);
+  if (!starting_default_deployment)
+    return FALSE;
 
   GVariantDict dict;
   g_variant_dict_init (&dict, NULL);
@@ -138,7 +141,7 @@ pkg_change (RpmOstreeCommandInvocation *invocation,
   return rpmostree_transaction_client_run (invocation, sysroot_proxy, os_proxy,
                                            options, opt_unchanged_exit_77,
                                            transaction_address,
-                                           previous_deployment,
+                                           starting_default_deployment,
                                            cancellable, error);
 }
 

--- a/src/lib/rpmostree-db.c
+++ b/src/lib/rpmostree-db.c
@@ -24,6 +24,7 @@
 
 #include "rpmostree-db.h"
 #include "rpmostree-rpm-util.h"
+#include "rpmostree-private.h"
 #include "rpmostree-package-priv.h"
 #include "rpmostree-refsack.h"
 
@@ -165,6 +166,6 @@ rpm_ostree_db_diff_ext (OstreeRepo               *repo,
       return TRUE;
     }
 
-  return _rpm_ostree_diff_package_lists (orig_pkglist, new_pkglist, out_removed, out_added,
+  return _rpm_ostree_package_diff_lists (orig_pkglist, new_pkglist, out_removed, out_added,
                                          out_modified_old, out_modified_new, NULL);
 }

--- a/src/lib/rpmostree-package.c
+++ b/src/lib/rpmostree-package.c
@@ -30,6 +30,7 @@
 
 #include "config.h"
 
+#include "rpmostree-private.h"
 #include "rpmostree-package-priv.h"
 #include "rpmostree-rpm-util.h"
 
@@ -313,7 +314,7 @@ next_pkg_has_different_name (const char *name, GPtrArray *pkgs, guint cur_i)
  * multilib) are counted as different packages.
  * */
 gboolean
-_rpm_ostree_diff_package_lists (GPtrArray  *a,
+_rpm_ostree_package_diff_lists (GPtrArray  *a,
                                 GPtrArray  *b,
                                 GPtrArray **out_unique_a,
                                 GPtrArray **out_unique_b,

--- a/src/lib/rpmostree-private.h
+++ b/src/lib/rpmostree-private.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
  *
- * Copyright (C) 2015 Red Hat, In.c
+ * Copyright (C) 2019 Red Hat, Inc.
  *
  * Licensed under the GNU Lesser General Public License Version 2.1
  *
@@ -19,20 +19,17 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  */
 
+/* Private API between lib and app. */
+
 #pragma once
 
-#include <ostree.h>
-#include "rpmostree-package.h"
-#include "rpmostree-refsack.h"
+#include <glib.h>
 
-RpmOstreePackage * _rpm_ostree_package_new (RpmOstreeRefSack *rsack, DnfPackage *hypkg);
-
-RpmOstreePackage * _rpm_ostree_package_new_from_variant (GVariant *gv_nevra);
-
-gboolean
-_rpm_ostree_package_list_for_commit (OstreeRepo   *repo,
-                                     const char   *rev,
-                                     gboolean      allow_noent,
-                                     GPtrArray   **out_pkglist,
-                                     GCancellable *cancellable,
-                                     GError      **error);
+_RPMOSTREE_EXTERN gboolean
+_rpm_ostree_package_diff_lists (GPtrArray  *a,
+                                GPtrArray  *b,
+                                GPtrArray **out_unique_a,
+                                GPtrArray **out_unique_b,
+                                GPtrArray **out_modified_a,
+                                GPtrArray **out_modified_b,
+                                GPtrArray **out_common);


### PR DESCRIPTION
Still needs some tweaks and tests, though it works at least!

```
[root@f29-ros ~]# rpm-ostree install vagrant
Checking out tree 03e9fb4... done
...
Added:
  bsdtar-3.3.3-2.fc29.x86_64
  ruby-2.5.3-100.fc29.x86_64
  ruby-irb-2.5.3-100.fc29.noarch
  ruby-libs-2.5.3-100.fc29.x86_64
  rubygem-bigdecimal-1.3.4-100.fc29.x86_64
  rubygem-childprocess-0.5.9-5.fc29.noarch
  rubygem-concurrent-ruby-1.0.5-4.fc29.noarch
  rubygem-did_you_mean-1.2.0-100.fc29.noarch
  rubygem-domain_name-0.5.20180417-2.fc29.noarch
  rubygem-erubis-2.7.0-17.fc29.noarch
  rubygem-ffi-1.9.23-2.fc29.x86_64
  rubygem-hashicorp-checkpoint-0.1.5-2.fc29.noarch
  rubygem-http-cookie-1.0.3-5.fc29.noarch
  rubygem-i18n-1.0.0-2.fc29.noarch
  rubygem-io-console-0.4.6-100.fc29.x86_64
  rubygem-json-2.1.0-106.fc29.x86_64
  rubygem-listen-3.1.5-5.fc29.noarch
  rubygem-log4r-1.1.10-9.fc29.noarch
  rubygem-mime-types-3.1-5.fc29.noarch
  rubygem-mime-types-data-3.2016.0521-5.fc29.noarch
  rubygem-net-scp-1.2.1-9.fc29.noarch
  rubygem-net-sftp-2.1.2-8.fc29.noarch
  rubygem-net-ssh-4.2.0-3.fc29.noarch
  rubygem-netrc-0.11.0-4.fc29.noarch
  rubygem-openssl-2.1.2-100.fc29.x86_64
  rubygem-psych-3.0.2-100.fc29.x86_64
  rubygem-rb-inotify-0.9.7-6.fc29.noarch
  rubygem-rdoc-6.0.3-3.fc29.noarch
  rubygem-rest-client-2.0.0-5.fc29.noarch
  rubygem-unf-0.1.4-12.fc29.noarch
  rubygem-unf_ext-0.0.7.5-2.fc29.x86_64
  rubygems-2.7.6-100.fc29.noarch
  rubypick-1.1.1-9.fc29.noarch
  vagrant-2.1.2-3.fc29.noarch
Run "systemctl reboot" to start a reboot
[root@f29-ros ~]# rpm-ostree install ltrace
Checking out tree 03e9fb4... done
...
Added:
  ltrace-0.7.91-28.fc29.x86_64
Run "systemctl reboot" to start a reboot
[root@f29-ros ~]# rpm-ostree status
State: idle
AutomaticUpdates: disabled
Deployments:
  ostree://vmcheck
  └─ Dev overlay on fedora-atomic:fedora/29/x86_64/atomic-host (29.20190306.2; Mar 06 2019)
                 Timestamp: 2019-03-19T02:40:17Z
                BaseCommit: 03e9fb43647a93b010fb500962c16a3ade998e1540a2d8d127100516055d610b
                      Diff: 35 added
           LayeredPackages: ltrace vagrant

● ostree://vmcheck
  └─ Dev overlay on fedora-atomic:fedora/29/x86_64/atomic-host (29.20190306.2; Mar 06 2019)
                 Timestamp: 2019-03-19T02:40:17Z
                    Commit: 03e9fb43647a93b010fb500962c16a3ade998e1540a2d8d127100516055d610b
                  Unlocked: development
```

One thing this doesn't cover though is `--dry-run`. I.e. in dry run mode, we still print the full diff. I tried some hacks, though nothing that works super well. Will probably punt on that for now.

Closes: #945