### PR TITLE
compose: Add --ex-lockfile-strict

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -79,6 +79,7 @@ static char *opt_write_composejson_to;
 static gboolean opt_no_parent;
 static char *opt_write_lockfile_to;
 static char **opt_lockfiles;
+static gboolean opt_lockfile_strict;
 static char *opt_parent;
 
 /* shared by both install & commit */
@@ -104,6 +105,7 @@ static GOptionEntry install_option_entries[] = {
   { "workdir-tmpfs", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_workdir_tmpfs, "Use tmpfs for working state", NULL },
   { "ex-write-lockfile-to", 0, 0, G_OPTION_ARG_STRING, &opt_write_lockfile_to, "Write lockfile to FILE", "FILE" },
   { "ex-lockfile", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_lockfiles, "Read lockfile from FILE", "FILE" },
+  { "ex-lockfile-strict", 0, 0, G_OPTION_ARG_NONE, &opt_lockfile_strict, "With --ex-lockfile, require full match", NULL },
   { NULL }
 };
 
@@ -702,7 +704,7 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
       g_autoptr(GHashTable) map = ror_lockfile_read (opt_lockfiles, error);
       if (!map)
         return FALSE;
-      rpmostree_context_set_vlockmap (self->corectx, map);
+      rpmostree_context_set_vlockmap (self->corectx, map, opt_lockfile_strict);
       g_print ("Loaded lockfiles:\n  %s\n", g_strjoinv ("\n  ", opt_lockfiles));
     }
 

--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -73,6 +73,7 @@ struct _RpmOstreeContext {
   GHashTable *pkgs_to_replace; /* new gv_nevra --> old gv_nevra */
 
   GHashTable *vlockmap; /* nevra --> repochecksum */
+  gboolean vlockmap_strict;
 
   GLnxTmpDir tmpdir;
 

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -173,7 +173,10 @@ gboolean rpmostree_context_set_packages (RpmOstreeContext *self,
 
 GPtrArray *rpmostree_context_get_packages_to_import (RpmOstreeContext *self);
 
-void rpmostree_context_set_vlockmap (RpmOstreeContext *self, GHashTable *map);
+void
+rpmostree_context_set_vlockmap (RpmOstreeContext *self,
+                                GHashTable       *map,
+                                gboolean          strict);
 
 gboolean rpmostree_context_download (RpmOstreeContext *self,
                                      GCancellable     *cancellable,

--- a/tests/compose/libcomposetest.sh
+++ b/tests/compose/libcomposetest.sh
@@ -56,6 +56,10 @@ else:
   tf['$1'] += $2"
 }
 
+treefile_remove() {
+    treefile_pyedit "tf['$1'].remove($2)"
+}
+
 # for tests that need direct control on rpm-ostree
 export compose_base_argv="\
     --unified-core \


### PR DESCRIPTION
Today, lockfiles only restrict the NEVRA of specifc package names from
which libsolv can pick. But nothing stops libsolv from picking entirely
different packages which still satisfy the manifest requests.

This was mostly a theoretical issue in Fedora CoreOS, but became reality
with the addition of Fedora 32 packages in the pool. libsolv would
happily try to pick e.g. `libcurl-minimal` from f32 instead of sticking
with the f31 `libcurl` from the lockfiles:

https://github.com/coreos/fedora-coreos-streams/issues/75#issuecomment-610734584

(But more generally, see
https://github.com/coreos/fedora-coreos-tracker/issues/454).

Let's add a `--ex-lockfile-strict` mode, which in CI and production
pipeline build contexts will require that (1) *only* locked packages are
considered by libsolv, and (2) *all* locked packages were marked for
install.

One important thing to note here is that we don't short-circuit libsolv
and manually `hy_goal_install` lockfile packages. We want to make sure
the treefile is still canonical. Strict mode simply ensures that the
result agrees with the lockfile.

That said, even in developer contexts, we don't want the
`libcurl-minimal` issue that happened to be triggered. But we still want
to allow flexibility in adding and removing packages to make hacking
easier. I have some follow-up patches which will enable this.
