### PR TITLE
ci: Add prow Dockerfile

### DIFF
--- a/ci/prow/Dockerfile
+++ b/ci/prow/Dockerfile
@@ -1,0 +1,4 @@
+FROM registry.fedoraproject.org/fedora:30
+WORKDIR /src
+COPY . .
+RUN ./ci/build.sh


### PR DESCRIPTION
This is an exact copy of https://github.com/ostreedev/ostree/pull/1906
for now.  From that commit message:

I'd like to add OpenShift's prow to this repository. Let's start
by adding a Dockerfile - it doesn't really do anything besides build.

However...I've lately been thinking about e.g. shipping the ostree tests
as an image, and then e.g. we could test FCOS by running that container
(which would orchestrate the host's ostree).

Anyways, not doing that right now but this is a start.
