### PR TITLE
daemon: Use MountFlags=slave and opt-in to OSTree read-only /sysroot

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,6 +122,12 @@ dnl bundled libdnf
 PKGDEP_RPMOSTREE_CFLAGS="-I $(pwd)/libdnf -I $(pwd)/libdnf-build $PKGDEP_RPMOSTREE_CFLAGS"
 PKGDEP_RPMOSTREE_LIBS="-L$(pwd)/libdnf-build/libdnf -ldnf $PKGDEP_RPMOSTREE_LIBS"
 
+dnl Version check this until it's stable
+save_LIBS=$LIBS
+LIBS=$PKGDEP_RPMOSTREE_LIBS
+AC_CHECK_FUNCS(ostree_sysroot_set_mount_namespace_in_use)
+LIBS=$save_LIBS
+
 dnl RHEL8.1 has old libarchive
 AS_IF([pkg-config --atleast-version=3.3.3 libarchive],
   [AC_DEFINE([HAVE_LIBARCHIVE_ZSTD], 1, [Define if we have libarchive with zstd])])

--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -6,6 +6,8 @@ ConditionPathExists=/ostree
 [Service]
 Type=dbus
 BusName=org.projectatomic.rpmostree1
+# To use the read-only sysroot bits
+MountFlags=slave
 NotifyAccess=main
 @SYSTEMD_ENVIRON@
 ExecStart=@bindir@/rpm-ostree start-daemon

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -758,9 +758,15 @@ rpmostreed_sysroot_populate (RpmostreedSysroot *self,
 {
   g_return_val_if_fail (self != NULL, FALSE);
 
+  /* See also related code in rpmostred-transaction.c */
   const char *sysroot_path = rpmostree_sysroot_get_path (RPMOSTREE_SYSROOT (self));
   g_autoptr(GFile) sysroot_file = g_file_new_for_path (sysroot_path);
   self->ot_sysroot = ostree_sysroot_new (sysroot_file);
+#ifdef HAVE_OSTREE_SYSROOT_SET_MOUNT_NAMESPACE_IN_USE
+  if (!ostree_sysroot_initialize (self->ot_sysroot, error))
+    return FALSE;
+  ostree_sysroot_set_mount_namespace_in_use (self->ot_sysroot);
+#endif
 
   /* This creates and caches an OstreeRepo instance inside
    * OstreeSysroot to ensure subsequent ostree_sysroot_get_repo()

--- a/src/daemon/rpmostreed-transaction.c
+++ b/src/daemon/rpmostreed-transaction.c
@@ -573,6 +573,16 @@ transaction_initable_init (GInitable *initable,
        * everything from disk.
        */
       priv->sysroot = ostree_sysroot_new (tmp_path);
+      /* See also related code in rpmostreed-sysroot.c */
+#ifdef HAVE_OSTREE_SYSROOT_SET_MOUNT_NAMESPACE_IN_USE
+      if (!ostree_sysroot_initialize (priv->sysroot, error))
+        return FALSE;
+      /* We use MountFlags=slave in the unit file, which combined
+      * with this ensures we support read-only /sysroot mounts.
+      * https://github.com/ostreedev/ostree/issues/1265
+      **/
+      ostree_sysroot_set_mount_namespace_in_use (priv->sysroot);
+#endif
       g_signal_connect (priv->sysroot, "journal-msg",
                         G_CALLBACK (on_sysroot_journal_msg), self);
 

--- a/tests/vmcheck/test-kernel-args.sh
+++ b/tests/vmcheck/test-kernel-args.sh
@@ -24,6 +24,12 @@ set -euo pipefail
 
 set -x
 
+# XXX: uncomment this when we migrate CI to FCOS
+# # Note this test is run with forced read-only sysroot on
+# # https://github.com/coreos/rpm-ostree/pull/1896
+# vm_cmd ostree config --repo /sysroot/ostree/repo set sysroot.readonly true
+# vm_cmd systemctl restart rpm-ostreed
+
 osname=$(vm_get_booted_deployment_info osname)
 
 vm_kargs_now() {
@@ -144,3 +150,8 @@ vm_rpmostree kargs > kargs.txt
 assert_file_has_content_literal kargs.txt 'PACKAGE=TEST'
 assert_file_has_content_literal kargs.txt 'PACKAGE2=TEST2'
 echo "ok kargs display with multiple operations"
+
+# XXX: uncomment this when we migrate CI to FCOS
+# # And reset this bit
+# vm_cmd ostree config --repo /sysroot/ostree/repo set sysroot.readonly false
+# vm_reboot


### PR DESCRIPTION
This is all we need to tell libostree that we support a read-only
`/sysroot` and `/boot`.

See https://github.com/ostreedev/ostree/issues/1265
PR in https://github.com/ostreedev/ostree/pull/1767
