### PR TITLE
Move D-Bus conf file to $(datadir)/dbus-1/system.d

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -71,7 +71,7 @@ librpmostreed_la_LIBADD = \
 	$(NULL)
 
 dbusconf_DATA = $(srcdir)/src/daemon/org.projectatomic.rpmostree1.conf
-dbusconfdir = ${sysconfdir}/dbus-1/system.d
+dbusconfdir = $(datadir)/dbus-1/system.d
 
 systemdunit_service_in_files = \
 	$(srcdir)/src/daemon/rpm-ostreed.service.in \

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -151,7 +151,7 @@ $PYTHON autofiles.py > files \
   '%{_bindir}/*' \
   '%{_libdir}/%{name}' \
   '%{_mandir}/man*/*' \
-  '%{_sysconfdir}/dbus-1/system.d/*' \
+  '%{_datadir}/dbus-1/system.d/*' \
   '%{_sysconfdir}/rpm-ostreed.conf' \
   '%{_prefix}/lib/systemd/system/*' \
   '%{_libexecdir}/rpm-ostree*' \


### PR DESCRIPTION

Since D-Bus 1.9.18 configuration files installed by third-party should
go in share/dbus-1/system.d. The old location is for sysadmin overrides.