### PR TITLE
app/reset: Fix argc range check

### DIFF
--- a/src/app/rpmostree-builtin-reset.c
+++ b/src/app/rpmostree-builtin-reset.c
@@ -72,7 +72,7 @@ rpmostree_builtin_reset (int             argc,
                                        error))
     return FALSE;
 
-  if (argc < 1 || argc > 2)
+  if (argc != 1)
     {
       rpmostree_usage_error (context, "Too few or too many arguments", error);
       return FALSE;


### PR DESCRIPTION
Otherwise, e.g. `rpm-ostree reset foobar` doesn't actually error out.
Some users have hit this as a typo for
`rpm-ostree override reset foobar`.