### PR TITLE
tests/vmcheck: Fix test-misc-1.sh syntax

### DIFF
--- a/tests/vmcheck/test-misc-1.sh
+++ b/tests/vmcheck/test-misc-1.sh
@@ -103,12 +103,12 @@ assert_file_has_content err.txt 'ReloadConfig not allowed for user'
 echo "ok auth"
 
 # Test coreos-rootfs
-vm_shell_inline << EOF
+vm_shell_inline > coreos-rootfs.txt << EOF
     mkdir /var/tmp/coreos-rootfs
     rpm-ostree coreos-rootfs seal /var/tmp/coreos-rootfs
     lsattr -d /var/tmp/coreos-rootfs
     rpm-ostree coreos-rootfs seal /var/tmp/coreos-rootfs
-EOF > coreos-rootfs.txt
+EOF
 assert_file_has_content_literal coreos-rootfs.txt '----i-------------- /var/tmp/coreos-rootfs'
 
 # Assert that we can do status as non-root


### PR DESCRIPTION
The `EOF` needs to be alone on a line to be valid. The way to redirect
the output is unintuitively to do it at the beginning of the line
instead.