### PR TITLE
unpacker: Build with older libarchive without zstd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,6 +122,10 @@ dnl bundled libdnf
 PKGDEP_RPMOSTREE_CFLAGS="-I $(pwd)/libdnf -I $(pwd)/libdnf-build $PKGDEP_RPMOSTREE_CFLAGS"
 PKGDEP_RPMOSTREE_LIBS="-L$(pwd)/libdnf-build/libdnf -ldnf $PKGDEP_RPMOSTREE_LIBS"
 
+dnl RHEL8.1 has old libarchive
+AS_IF([pkg-config --atleast-version=3.3.3 libarchive],
+  [AC_DEFINE([HAVE_LIBARCHIVE_ZSTD], 1, [Define if we have libarchive with zstd])])
+
 dnl This is the current version in Fedora 25.
 AS_IF([pkg-config --atleast-version=4.14.2 rpm], [], [AC_MSG_ERROR([librpm 4.14.2 required])])
 

--- a/src/libpriv/rpmostree-unpacker-core.c
+++ b/src/libpriv/rpmostree-unpacker-core.c
@@ -74,7 +74,9 @@ rpmostree_unpack_rpm2cpio (int fd, GError **error)
         archive_read_support_filter_gzip,
         archive_read_support_filter_xz,
         archive_read_support_filter_bzip2,
+#ifdef HAVE_LIBARCHIVE_ZSTD
         archive_read_support_filter_zstd,
+#endif
         archive_read_support_format_cpio };
 
     for (i = 0; i < G_N_ELEMENTS (archive_setup_funcs); i++)


### PR DESCRIPTION
It's not in RHEL8.1, and I'm trying to rebase rpm-ostree.
