### PR TITLE
Scan build fixes

### DIFF
--- a/src/app/rpmostree-compose-builtin-rojig.c
+++ b/src/app/rpmostree-compose-builtin-rojig.c
@@ -603,6 +603,7 @@ rpmostree_compose_builtin_rojig (int             argc,
   g_autoptr(RpmOstreeRojigCompose) self = NULL;
   if (!rpm_ostree_rojig_compose_new (treefile_path, &self, cancellable, error))
     return FALSE;
+  g_assert (self); /* Pacify static analysis */
   gboolean changed;
   if (!impl_rojig_build (self, outdir, &changed, cancellable, error))
     return FALSE;

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1187,6 +1187,7 @@ rpmostree_compose_builtin_install (int             argc,
   g_autoptr(RpmOstreeTreeComposeContext) self = NULL;
   if (!rpm_ostree_compose_context_new (treefile_path, &self, cancellable, error))
     return FALSE;
+  g_assert (self); /* Pacify static analysis */
   gboolean changed;
   if (!impl_install_tree (self, &changed, cancellable, error))
     {
@@ -1347,6 +1348,7 @@ rpmostree_compose_builtin_tree (int             argc,
   g_autoptr(RpmOstreeTreeComposeContext) self = NULL;
   if (!rpm_ostree_compose_context_new (treefile_path, &self, cancellable, error))
     return FALSE;
+  g_assert (self); /* Pacify static analysis */
   gboolean changed;
   if (!impl_install_tree (self, &changed, cancellable, error))
     {

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -3148,7 +3148,7 @@ relabel_in_thread (GTask            *task,
   RpmOstreeContext *self = source;
   RelabelTaskData *tdata = task_data;
 
-  gboolean changed;
+  gboolean changed = FALSE;
   if (!relabel_in_thread_impl (self, tdata->name, tdata->evr, tdata->arch,
                                tdata->tmpdir_dfd, &changed,
                                cancellable, &local_error))
@@ -3662,7 +3662,7 @@ add_install (RpmOstreeContext *self,
   if (!ostree_repo_load_commit (pkgcache_repo, cached_rev, &commit, NULL, error))
     return FALSE;
 
-  gboolean sepolicy_matches;
+  gboolean sepolicy_matches = FALSE;
   if (self->sepolicy)
     {
       if (!commit_has_matching_sepolicy (commit, self->sepolicy, &sepolicy_matches,

--- a/src/libpriv/rpmostree-rojig-assembler.c
+++ b/src/libpriv/rpmostree-rojig-assembler.c
@@ -232,8 +232,8 @@ rojig_require_next_entry (RpmOstreeRojigAssembler    *self,
                           GCancellable      *cancellable,
                           GError           **error)
 {
-  gboolean eof;
-  struct archive_entry *entry;
+  gboolean eof = FALSE;
+  struct archive_entry *entry = NULL;
   if (!rojig_next_entry (self, &eof, &entry, cancellable, error))
     return FALSE;
   if (eof)
@@ -458,12 +458,13 @@ rpmostree_rojig_assembler_write_new_objects (RpmOstreeRojigAssembler    *self,
    */
   while (TRUE)
     {
-      gboolean eof;
-      struct archive_entry *entry;
+      gboolean eof = FALSE;
+      struct archive_entry *entry = NULL;
       if (!rojig_next_entry (self, &eof, &entry, cancellable, error))
         return FALSE;
       if (eof)
         break;
+      g_assert (entry); /* Pacify static analysis */
       const char *pathname = peel_entry_pathname (entry, error);
       if (!pathname)
         return FALSE;
@@ -576,12 +577,13 @@ rpmostree_rojig_assembler_next_xattrs (RpmOstreeRojigAssembler    *self,
   *out_objid_to_xattrs = NULL;
 
   /* Look for an xattr entry */
-  gboolean eof;
-  struct archive_entry *entry;
+  gboolean eof = FALSE;
+  struct archive_entry *entry = NULL;
   if (!rojig_next_entry (self, &eof, &entry, cancellable, error))
     return FALSE;
   if (eof)
     return TRUE; /* 🔚 Early return */
+  g_assert (entry); /* Pacify static analysis */
 
   const char *pathname = peel_entry_pathname (entry, error);
   if (!pathname)

--- a/src/libpriv/rpmostree-rojig-build.c
+++ b/src/libpriv/rpmostree-rojig-build.c
@@ -503,7 +503,7 @@ build_objid_map_for_package (RpmOstreeCommit2RojigContext *self,
        * size → checksum, so we can heuristically later try to find
        * "content-identical objects" i.e. they differ only in metadata.
        */
-      guint32 objsize;
+      guint32 objsize = 0;
       if (!query_objsize_assert_32bit (self->pkgcache_repo, checksum, &objsize, error))
         return FALSE;
       if (objsize >= BIG_OBJ_SIZE)
@@ -1148,7 +1148,7 @@ impl_commit2rojig (RpmOstreeCommit2RojigContext *self,
    */
   GLNX_HASH_TABLE_FOREACH (self->commit_content_objects, const char *, checksum)
     {
-      guint32 objsize;
+      guint32 objsize = 0;
       if (!query_objsize_assert_32bit (self->repo, checksum, &objsize, error))
         return FALSE;
       const gboolean is_big = objsize >= BIG_OBJ_SIZE;
@@ -1218,7 +1218,7 @@ impl_commit2rojig (RpmOstreeCommit2RojigContext *self,
   GLNX_HASH_TABLE_FOREACH_IT (new_reachable_big, it, const char *, checksum,
                               void *, unused)
     {
-      guint32 objsize;
+      guint32 objsize = 0;
       if (!query_objsize_assert_32bit (self->repo, checksum, &objsize, error))
         return FALSE;
       g_assert_cmpint (objsize, >=, BIG_OBJ_SIZE);

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -1300,7 +1300,7 @@ rpmostree_nevra_to_cache_branch (const char *nevra,
    * branch. Something something Rust slices... */
 
   g_autofree char *name = NULL;
-  guint64 epoch;
+  guint64 epoch = 0;
   g_autofree char *version = NULL;
   g_autofree char *release = NULL;
   g_autofree char *arch = NULL;


### PR DESCRIPTION
In which it is discovered that [scan-build exists](https://clang-analyzer.llvm.org/scan-build.html).
No real bugs in this batch, just quieting the scanner.