### PR TITLE
Detect whether zchunk (zck) is available at build time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,11 @@ AS_IF([pkg-config --atleast-version=3.3.3 libarchive],
 dnl This is the current version in Fedora 25.
 AS_IF([pkg-config --atleast-version=4.14.2 rpm], [], [AC_MSG_ERROR([librpm 4.14.2 required])])
 
+dnl We don't *actually* use this ourself, but librepo does, and libdnf gets confused
+dnl if librepo doesn't support it.
+AS_IF([pkg-config --exists zck],
+  [AC_DEFINE([HAVE_ZCHUNK], 1, [Define if we have zchunk])])
+
 AC_PATH_PROG([XSLTPROC], [xsltproc])
 
 GLIB_TESTS

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -22,6 +22,15 @@ BuildRequires: rust
 BuildRequires: rust-toolset
 %endif
 
+# RHEL8 doesn't ship zchunk today.  See also the comments
+# in configure.ac around this as libdnf/librepo need to be in
+# sync, and today we bundle libdnf but not librepo.
+%if 0%{?rhel}
+%bcond_with zchunk
+%else
+%bcond_without zchunk
+%endif
+
 # For the autofiles bits below
 BuildRequires: /usr/bin/python3
 # We always run autogen.sh
@@ -74,6 +83,9 @@ BuildRequires:  pkgconfig(json-c)
 BuildRequires:  pkgconfig(cppunit)
 BuildRequires:  pkgconfig(sqlite3)
 BuildRequires:  pkgconfig(smartcols)
+%if %{with zchunk}
+BuildRequires:  pkgconfig(zck) >= 0.9.11
+%endif
 BuildRequires:  gpgme-devel
 
 Requires:       libmodulemd1%{?_isa} >= %{libmodulemd_version}

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -431,6 +431,13 @@ rpmostree_context_new_system (OstreeRepo   *repo,
   dnf_context_set_check_disk_space (self->dnfctx, FALSE);
   dnf_context_set_check_transaction (self->dnfctx, FALSE);
 
+  /* Hack until libdnf+librepo know how to better negotaiate zchunk.
+   * see also the bits in configure.ac that define HAVE_ZCHUNK
+   **/
+#ifndef HAVE_ZCHUNK
+  dnf_context_set_zchunk (self->dnfctx, FALSE);
+#endif
+
   return self;
 }
 


### PR DESCRIPTION
We don't *actually* use this ourself, but librepo does, and libdnf gets confused
if librepo doesn't support it.  This is the case in RHEL8 currently.

Basically what breaks is trying to use the Fedora EPEL repo (has zchunk metadata)
on RHEL CoreOS.  And we have a test in kola that does this today.
