### PR TITLE
libpriv/kernel: Hack around vmlinuz path in HMAC file

### DIFF
--- a/src/libpriv/rpmostree-kernel.c
+++ b/src/libpriv/rpmostree-kernel.c
@@ -393,6 +393,38 @@ rpmostree_finalize_kernel (int rootfs_dfd,
         return glnx_throw_errno_prefix (error, "linkat(%s)", kernel_modules_path);
     }
 
+  /* If there's an HMAC file, fix the path to the kernel in it to be relative. Right now,
+   * the kernel spec encodes `/boot/vmlinux-$kver`, which of course not going to work for
+   * us. We should work towards making this change directly into the kernel spec. */
+  g_autofree char *hmac_path = g_build_filename (modules_bootdir, ".vmlinuz.hmac", NULL);
+  if (!glnx_fstatat_allow_noent (rootfs_dfd, hmac_path, NULL, 0, error))
+    return FALSE;
+  if (errno == 0)
+    {
+      g_autofree char *contents = glnx_file_get_contents_utf8_at (rootfs_dfd, hmac_path,
+                                                                  NULL, cancellable, error);
+      if (contents == NULL)
+        return FALSE;
+
+      /* rather than trying to parse and understand the *sum format, just hackily replace */
+      g_autofree char *old_path = g_strconcat ("  /boot/vmlinuz-", kver, NULL);
+      g_autofree char *new_path = g_strconcat ("  vmlinuz-", kver, NULL);
+      g_autofree char *new_contents =
+        rpmostree_str_replace (contents, old_path, new_path, error);
+      if (!new_contents)
+        return FALSE;
+
+      /* sanity check there are no '/' in there; that way too we just error out if the path
+       * or format changes (but really, this should be a temporary hack...) */
+      if (strchr (new_contents, '/') != 0)
+        return glnx_throw (error, "Unexpected / in .vmlinuz.hmac: %s", new_contents);
+
+      if (!glnx_file_replace_contents_at (rootfs_dfd, hmac_path,
+                                          (guint8*)new_contents, -1, 0,
+                                          cancellable, error))
+        return FALSE;
+    }
+
   /* Replace the initramfs */
   g_autofree char *initramfs_modules_path = g_build_filename (modules_bootdir, "initramfs.img", NULL);
   if (unlinkat (rootfs_dfd, initramfs_modules_path, 0) < 0)

--- a/src/libpriv/rpmostree-kernel.c
+++ b/src/libpriv/rpmostree-kernel.c
@@ -353,7 +353,7 @@ rpmostree_finalize_kernel (int rootfs_dfd,
                            GError **error)
 {
   const char slash_bootdir[] = "boot";
-  g_autofree char *modules_bootdir = g_strconcat ("usr/lib/modules/", kver, NULL);
+  g_autofree char *modules_bootdir = g_build_filename ("usr/lib/modules", kver, NULL);
 
   /* Calculate the sha256sum of the kernel+initramfs (called the "boot
    * checksum"). We checksum the initramfs from the tmpfile fd (via mmap()) to
@@ -371,7 +371,7 @@ rpmostree_finalize_kernel (int rootfs_dfd,
   }
   const char *boot_checksum_str = g_checksum_get_string (boot_checksum);
 
-  g_autofree char *kernel_modules_path = g_strconcat (modules_bootdir, "/vmlinuz", NULL);;
+  g_autofree char *kernel_modules_path = g_build_filename (modules_bootdir, "vmlinuz", NULL);
   /* It's possible the bootdir is already the modules directory; in that case,
    * we don't need to rename.
    */
@@ -394,7 +394,7 @@ rpmostree_finalize_kernel (int rootfs_dfd,
     }
 
   /* Replace the initramfs */
-  g_autofree char *initramfs_modules_path = g_strconcat (modules_bootdir, "/initramfs.img", NULL);
+  g_autofree char *initramfs_modules_path = g_build_filename (modules_bootdir, "initramfs.img", NULL);
   if (unlinkat (rootfs_dfd, initramfs_modules_path, 0) < 0)
     {
       if (errno != ENOENT)


### PR DESCRIPTION
As mentioned in the comment block:

```
If there's an HMAC file, fix the path to the kernel in it to be
relative. Right now, the kernel spec encodes `/boot/vmlinux-$kver`,
which of course not going to work for us. We should work towards making
this change directly into the kernel spec.
```

For background, see this comment and following:
https://github.com/ostreedev/ostree/pull/1962#issuecomment-547488164

---

This is dependent on some dracut fixes too, so let's not merge this yet!