### PR TITLE
rust/lockfile: Add more metadata to generated lockfiles 

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -91,6 +91,18 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "chrono"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "clap"
 version = "2.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +436,15 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "num-integer"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +661,7 @@ name = "rpmostree-rust"
 version = "0.1.0"
 dependencies = [
  "c_utf8 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "envsubst 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -866,6 +888,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,6 +987,7 @@ dependencies = [
 "checksum c_utf8 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f747ed2575d426b7cbf0fcba5872db319a600d597391c339779a3d9835d1ea4d"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+"checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum clicolors-control 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
@@ -992,6 +1025,7 @@ dependencies = [
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
 "checksum nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dbf9993e59c894e3c08aa1c2712914e9e6bf1fcbfc6bef283e2183df345a4fee"
@@ -1041,6 +1075,7 @@ dependencies = [
 "checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,6 +27,7 @@ systemd = "0.4.0"
 indicatif = "0.11.0"
 lazy_static = "1.1.0"
 envsubst = "0.1.0"
+chrono = { version = "0.4.9", features = ["serde"] }
 
 [lib]
 name = "rpmostree_rust"

--- a/rust/src/libdnf_sys.rs
+++ b/rust/src/libdnf_sys.rs
@@ -14,6 +14,8 @@ use glib_sys;
 
 #[repr(C)]
 pub(crate) struct DnfPackage(libc::c_void);
+#[repr(C)]
+pub(crate) struct DnfRepo(libc::c_void);
 
 #[allow(dead_code)]
 extern {
@@ -21,6 +23,9 @@ extern {
     pub(crate) fn dnf_package_get_name(package: *mut DnfPackage) -> *const libc::c_char;
     pub(crate) fn dnf_package_get_evr(package: *mut DnfPackage) -> *const libc::c_char;
     pub(crate) fn dnf_package_get_arch(package: *mut DnfPackage) -> *const libc::c_char;
+
+    pub(crate) fn dnf_repo_get_id(repo: *mut DnfRepo) -> *const libc::c_char;
+    pub(crate) fn dnf_repo_get_timestamp_generated(repo: *mut DnfRepo) -> u64;
 }
 
 /* And some helper rpm-ostree C functions to deal with libdnf stuff. These are prime candidates for

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -352,7 +352,10 @@ install_packages (RpmOstreeTreeComposeContext  *self,
       g_autoptr(GPtrArray) pkgs = rpmostree_context_get_packages (self->corectx);
       g_assert (pkgs);
 
-      if (!ror_lockfile_write (opt_write_lockfile, pkgs, error))
+      g_autoptr(GPtrArray) rpmmd_repos =
+        rpmostree_get_enabled_rpmmd_repos (rpmostree_context_get_dnf (self->corectx),
+                                           DNF_REPO_ENABLED_PACKAGES);
+      if (!ror_lockfile_write (opt_write_lockfile, pkgs, rpmmd_repos, error))
         return FALSE;
     }
 

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -1455,3 +1455,19 @@ rpmostree_get_rojig_branch_pkg (DnfPackage *pkg)
                                  dnf_package_get_evr (pkg),
                                  dnf_package_get_arch (pkg));
 }
+
+GPtrArray*
+rpmostree_get_enabled_rpmmd_repos (DnfContext *dnfctx,
+                                   DnfRepoEnabled enablement)
+{
+  g_autoptr(GPtrArray) ret = g_ptr_array_new ();
+  GPtrArray *repos = dnf_context_get_repos (dnfctx);
+
+  for (guint i = 0; i < repos->len; i++)
+    {
+      DnfRepo *repo = repos->pdata[i];
+      if (dnf_repo_get_enabled (repo) & enablement)
+        g_ptr_array_add (ret, repo);
+    }
+  return g_steal_pointer (&ret);
+}

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -232,3 +232,6 @@ rpmostree_nevra_to_cache_branch (const char *nevra,
                                  GError    **error);
 char *
 rpmostree_cache_branch_to_nevra (const char *cachebranch);
+
+GPtrArray *
+rpmostree_get_enabled_rpmmd_repos (DnfContext *dnfctx, DnfRepoEnabled enablement);

--- a/tests/compose-tests/test-lockfile.sh
+++ b/tests/compose-tests/test-lockfile.sh
@@ -28,7 +28,9 @@ assert_has_file "versions.lock"
 assert_jq versions.lock \
   '.packages["test-pkg"].evra = "1.0-1.x86_64"' \
   '.packages["test-pkg-common"].evra = "1.0-1.x86_64"' \
-  '.packages["another-test-pkg"].evra = "1.0-1.x86_64"'
+  '.packages["another-test-pkg"].evra = "1.0-1.x86_64"' \
+  '.metadata.rpmmd_repos|length > 0' \
+  '.metadata.generated'
 echo "ok lockfile created"
 # Read lockfile back
 build_rpm test-pkg-common version 2.0


### PR DESCRIPTION
E.g. the generation timestamp, repos that were enabled, and their
generation timestamps.

This is just generally useful, though I'd like to make use specifically
of the new `metadata.generated` key in FCOS to drive versioning:

https://github.com/coreos/fedora-coreos-releng-automation/pull/50
