### PR TITLE
kargs: Support --append and --delete simultaneously

### DIFF
--- a/src/app/rpmostree-builtin-kargs.c
+++ b/src/app/rpmostree-builtin-kargs.c
@@ -196,12 +196,6 @@ rpmostree_builtin_kargs (int            argc,
                    "Cannot specify both --delete and --replace");
       return FALSE;
     }
-  if (opt_kernel_delete_strings && opt_kernel_append_strings)
-    {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
-                   "Cannot specify both --delete and --append");
-      return FALSE;
-    }
   if (opt_import_proc_cmdline && opt_deploy_index)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -2449,20 +2449,20 @@ kernel_arg_transaction_execute (RpmostreedTransaction *transaction,
             return FALSE;
         }
     }
-  else
-    {
-      if (self->kernel_args_replaced)
-        {
-          for (char **iter = self->kernel_args_replaced; iter && *iter; iter++)
-            {
-              const char *arg = *iter;
-              if (!ostree_kernel_args_new_replace (kargs, arg, error))
-                return FALSE;
-            }
-        }
 
-      if (self->kernel_args_added)
-        ostree_kernel_args_append_argv (kargs, self->kernel_args_added);
+  if (self->kernel_args_replaced)
+    {
+      for (char **iter = self->kernel_args_replaced; iter && *iter; iter++)
+        {
+          const char *arg = *iter;
+          if (!ostree_kernel_args_new_replace (kargs, arg, error))
+            return FALSE;
+        }
+    }
+
+  if (self->kernel_args_added)
+    {
+      ostree_kernel_args_append_argv (kargs, self->kernel_args_added);
     }
 
   /* After all the arguments are processed earlier, we convert it to a string list*/

--- a/tests/vmcheck/test-kernel-args.sh
+++ b/tests/vmcheck/test-kernel-args.sh
@@ -48,6 +48,15 @@ assert_file_has_content_literal kargs.txt 'FOO=BAR'
 assert_file_has_content_literal kargs.txt 'APPENDARG=VALAPPEND APPENDARG=2NDAPPEND'
 echo "ok kargs append"
 
+# Ensure the result flows through with rpm-ostree kargs
+vm_rpmostree kargs --append=APPENDARG=3RDAPPEND --delete=APPENDARG=VALAPPEND
+vm_rpmostree kargs > kargs.txt
+assert_not_file_has_content kargs.txt 'APPENDARG=VALAPPEND'
+assert_file_has_content_literal kargs.txt 'APPENDARG=3RDAPPEND'
+# And reset to previous state
+vm_rpmostree cleanup -p
+echo "ok kargs append and delete"
+
 # Test for rpm-ostree kargs delete
 vm_kargs_now kargs --delete FOO
 vm_cmd grep ^options /boot/loader/entries/ostree-2-$osname.conf > tmp_conf.txt


### PR DESCRIPTION
Code I wrote for the machine-config-operator expected it to
work, and I don't see a reason not to support it.

See https://github.com/openshift/machine-config-operator/issues/1265
