### PR TITLE
libpriv/kernel: add cap_mknod to dracut run

### DIFF
--- a/src/libpriv/rpmostree-kernel.c
+++ b/src/libpriv/rpmostree-kernel.c
@@ -564,6 +564,12 @@ rpmostree_run_dracut (int     rootfs_dfd,
       rpmostree_bwrap_bind_read (bwrap, "usr", "/usr");
     }
 
+  /* Need to let dracut create devices like /dev/urandom:
+   * https://bugzilla.redhat.com/show_bug.cgi?id=1778940
+   * https://bugzilla.redhat.com/show_bug.cgi?id=1401444
+   * https://bugzilla.redhat.com/show_bug.cgi?id=1380866 */
+  rpmostree_bwrap_append_bwrap_argv (bwrap, "--cap-add", "cap_mknod", NULL);
+
   if (dracut_host_tmpdir)
     rpmostree_bwrap_bind_readwrite (bwrap, dracut_host_tmpdir->path, "/tmp/dracut");
 


### PR DESCRIPTION
A lot of history with this. But essentially, dracut tries to `mknod` a
few character devices like `/dev/random` and `/dev/urandom` and fails.

We originally blocked `cap_mknod` because, well, `%post` scripts don't
really need to do that, and it would get wiped anyway. But there is a
use case for dracut's CPIO: we want `/dev/*random` to be available in
early boot *before* systemd even mounts `devtmpfs` because libgcrypt as
part of its constructor-time selftests in FIPS mode wants to read from
there.

For more fun, see:
https://bugzilla.redhat.com/show_bug.cgi?id=1778940
https://bugzilla.redhat.com/show_bug.cgi?id=1401444
https://bugzilla.redhat.com/show_bug.cgi?id=1380866