### PR TITLE
compose: Add an `automatic-version-suffix` key

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -182,6 +182,10 @@ It supports the following parameters:
 
    Example: `automatic-version-prefix: "22.0"`
 
+ * `automatic-version-suffix`: String, optional: This must be a single ASCII
+   character.  The default value is `.`.  Used by `automatic-version-prefix`.
+   For example, if you set this to `-` then `22` will become `22-1`, `22-2` etc.
+
  * `add-commit-metadata`: Map<String, Object>, optional: Metadata to inject as
    part of composed commits. Keys inserted here can still be overridden at the
    command line with `--add-metadata-string` or `--add-metadata-from-json`.

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -299,6 +299,7 @@ fn treefile_merge(dest: &mut TreeComposeConfig, src: &mut TreeComposeConfig) {
         machineid_compat,
         releasever,
         automatic_version_prefix,
+        automatic_version_suffix,
         mutate_os_release,
         preserve_passwd,
         check_passwd,
@@ -452,6 +453,15 @@ impl Treefile {
                     )
                     .into());
                 }
+            }
+        }
+        if let Some(version_suffix) = config.automatic_version_suffix.as_ref() {
+            if !(version_suffix.len() == 1 && version_suffix.is_ascii()) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("Invalid automatic-version-suffix, must be exactly one ASCII character: {}", version_suffix)
+                )
+                .into());
             }
         }
         Ok(())
@@ -687,6 +697,9 @@ struct TreeComposeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "automatic-version-prefix")]
     automatic_version_prefix: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "automatic-version-suffix")]
+    automatic_version_suffix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "mutate-os-release")]
     mutate_os_release: Option<String>,

--- a/src/app/rpmostree-compose-builtin-rojig.c
+++ b/src/app/rpmostree-compose-builtin-rojig.c
@@ -402,8 +402,11 @@ impl_rojig_build (RpmOstreeRojigCompose *self,
         _rpmostree_jsonutil_object_require_string_member (self->treefile, "automatic-version-prefix", error);
       if (!ver_prefix)
         return FALSE;
+      const char *ver_suffix = NULL;
+      if (!_rpmostree_jsonutil_object_get_optional_string_member (self->treefile, "automatic-version-suffix", &ver_suffix, error))
+        return FALSE;
 
-      next_version = _rpmostree_util_next_version (ver_prefix, self->previous_version, error);
+      next_version = _rpmostree_util_next_version (ver_prefix, ver_suffix, self->previous_version, error);
       if (!next_version)
         return FALSE;
       g_hash_table_insert (self->metadata, g_strdup (OSTREE_COMMIT_META_KEY_VERSION),

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -854,6 +854,9 @@ impl_install_tree (RpmOstreeTreeComposeContext *self,
         _rpmostree_jsonutil_object_require_string_member (self->treefile, "automatic-version-prefix", error);
       if (!ver_prefix)
         return FALSE;
+      const char *ver_suffix = NULL;
+      if (!_rpmostree_jsonutil_object_get_optional_string_member (self->treefile, "automatic-version-suffix", &ver_suffix, error))
+        return FALSE;
 
       g_autofree char *last_version = NULL;
       if (self->previous_checksum)
@@ -867,7 +870,7 @@ impl_install_tree (RpmOstreeTreeComposeContext *self,
           (void)g_variant_lookup (previous_metadata, OSTREE_COMMIT_META_KEY_VERSION, "s", &last_version);
         }
 
-      next_version = _rpmostree_util_next_version (ver_prefix, last_version, error);
+      next_version = _rpmostree_util_next_version (ver_prefix, ver_suffix, last_version, error);
       if (!next_version)
         return FALSE;
       g_hash_table_insert (self->metadata, g_strdup (OSTREE_COMMIT_META_KEY_VERSION),

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -79,6 +79,7 @@ rpmostree_translate_path_for_ostree (const char *path);
 
 char *
 _rpmostree_util_next_version (const char   *auto_version_prefix,
+                              const char   *version_suffix,
                               const char   *last_version,
                               GError      **error);
 


### PR DESCRIPTION
This allows replacing the `.` in automatic version increments
with whatever one wants (as long as it's a single ASCII character)
right now.

The specific motivation here is for at least RHEL CoreOS to use
`version-suffix: "-"` so that its versions can become valid
semantic versions.

Related: https://github.com/coreos/rpm-ostree/issues/1954
