### PR TITLE
tests: Misc tweaks

### DIFF
--- a/tests/common/libtest-core.sh
+++ b/tests/common/libtest-core.sh
@@ -22,7 +22,7 @@
 # Boston, MA 02111-1307, USA.
 
 fatal() {
-    echo $@ 1>&2; exit 1
+    echo error: $@ 1>&2; exit 1
 }
 # fatal() is shorter to type, but retain this alias
 assert_not_reached () {

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -17,6 +17,10 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
+if test -z "${LIBTEST_SH:-}"; then
+  . ${commondir}/libtest.sh
+fi
+
 # prepares the VM and library for action
 vm_setup() {
   export VM=${VM:-vmcheck}

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -14,7 +14,7 @@ else
   cosa_buildid=${COSA_BUILDID:-latest}
   cosa_builddir=${cosa_builds}/${cosa_buildid}/${basearch}
   if [ ! -e "${cosa_builddir}/meta.json" ]; then
-    fatal "No image provide (use VMIMAGE, or cosa-builds/ or COSA_BUILDS)"
+    fatal "No image provided (use VMIMAGE, or cosa-builds/ or COSA_BUILDS)"
   fi
 
   cosa_qemu_path=$(jq -er '.images.qemu.path' "${cosa_builddir}/meta.json")


### PR DESCRIPTION
- Have libvm.sh inherit libtest, otherwise we don't have `fatal`
- Add `error: ` prefix to `fatal` messages for clarity
- Add missing plural
