### PR TITLE
Remove `make vmcheck` wrapper

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -99,7 +99,7 @@ stage("Run vmcheck") {
             set -xeuo pipefail
             fcos=\$(ls builds/latest/*/*.qcow2) # */
             ln -sf "\$(realpath \${fcos})" tests/vmcheck/image.qcow2
-            NHOSTS=${nhosts} tests/vmcheck.sh
+            NHOSTS=${nhosts} SKIP_VMOVERLAY=1 tests/vmcheck.sh
           """
         }
       } finally {

--- a/HACKING.md
+++ b/HACKING.md
@@ -40,7 +40,7 @@ Testing
 You can use `make check` in a container to run the unit tests.  However,
 if you want to test the daemon in a useful way, you'll need virtualization.
 
-There's a `make vmcheck` test suite that requires a `ssh-config` in the
+There's a `./tests/vmcheck.sh` test suite that requires a `ssh-config` in the
 source directory toplevel.  You can provision a VM however you want; libvirt
 directly, vagrant, a remote OpenStack/EC2 instance, etc.  If you choose
 vagrant for example, do something like this:
@@ -51,12 +51,12 @@ vagrant ssh-config > /path/to/src/rpm-ostree/ssh-config
 
 The host is expected to be called `vmcheck` in the
 `ssh-config`. You can specify multiple hosts and parallelize
-the `make vmcheck` testsuite run through the `HOSTS`
+the `./tests/vmcheck.sh` testsuite run through the `HOSTS`
 variable. For example, if you have three nodes named
 `vmcheck[123]`, you can use:
 
 ```sh
-make vmcheck HOSTS='vmcheck1 vmcheck2 vmcheck3'
+./tests/vmcheck.sh HOSTS='vmcheck1 vmcheck2 vmcheck3'
 ```
 
 Once you have a `ssh-config` set up:

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -68,29 +68,17 @@ check-local:
 	@echo "  *** NOTE ***"
 	@echo "  *** NOTE ***"
 	@echo " \"make check\" only runs a subset of rpm-ostree's tests."
-	@echo " Use \"make vmcheck\" to run remaining tests in a VM."
+	@echo " Use \"./tests/vmcheck.sh\" to run remaining tests in a VM."
 	@echo "  *** NOTE ***"
 	@echo "  *** NOTE ***"
 
-.PHONY: vmsync vmoverlay vmcheck testenv
+.PHONY: vmsync testenv
 
 vmsync:
 	@set -e; if [ -z "$(SKIP_INSTALL)" ]; then \
 		env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/install.sh; \
 	fi; \
 	env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/sync.sh
-
-vmoverlay:
-	@set -e; \
-	if [ -z "$(SKIP_INSTALL)" ] && [ -z "$(SKIP_VMOVERLAY)" ]; then \
-	  env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/install.sh; \
-	fi; \
-	env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/overlay.sh;
-
-# One can run the vmcheck.sh script directly. The make target is useful for local
-# development so that e.g. we automatically overlay.
-vmcheck: vmoverlay
-	@tests/vmcheck.sh
 
 testenv:
 	@echo "===== ENTERING TESTENV ====="

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please look at `git log` and match the commit log style.
 Running the test suite
 ----------------------
 
-There is `make check` as well as `make vmcheck`. See also what
+There is `make check` as well as `./tests/vmcheck.sh`. See also what
 the [PAPR](.papr.yml) file does.
 
 Coding style

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,8 +19,7 @@ Tests are divided into three groups:
   it doesn't require building and doesn't use uninstalled binaries.
 
 - Tests in the `vmcheck` directory are oriented around using
-  Vagrant.  Use `make vmcheck` to run them.
-  See also `HACKING.md` in the top directory.
+  coreos-assembler.  See also `HACKING.md` in the top directory.
 
 The `common` directory contains files used by multiple
 tests. The `utils` directory contains helper utilities

--- a/tests/vmcheck.sh
+++ b/tests/vmcheck.sh
@@ -6,6 +6,8 @@ topsrcdir=$(cd "$dn/.." && pwd)
 commondir=$(cd "$dn/common" && pwd)
 export topsrcdir commondir
 
+${dn}/vmcheck/overlay.sh
+
 # https://github.com/coreos/coreos-assembler/pull/632
 ncpus() {
   if ! grep -q kubepods /proc/1/cgroup; then

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
+dn=$(cd $(dirname $0) && pwd)
 . ${commondir}/libvm.sh
+
+if [ -z "${SKIP_INSTALL:-}" ] && [ -z "${SKIP_VMOVERLAY:-}" ]; then
+  ${dn}/install.sh
+fi
 
 # Thin wrapper around `cosa dev-overlay`.
 

--- a/tests/vmcheck/sync.sh
+++ b/tests/vmcheck/sync.sh
@@ -8,7 +8,7 @@ if test -z "${INSIDE_VM:-}"; then
     vm_setup
 
     if ! vm_ssh_wait 30; then
-      echo "ERROR: A running VM is required for 'make vmcheck'."
+      echo "ERROR: A running VM is required"
       exit 1
     fi
 

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -50,10 +50,4 @@ To sync over and install the built binaries to the Vagrant VM:
 make vmsync
 ```
 
-You may also want to use `vmcheck`, like this:
-
-```
-make vmoverlay && make vmcheck
-```
-
-Also see [HACKING.md](../HACKING.md).
+See [HACKING.md](../HACKING.md).


### PR DESCRIPTION
Using `make` as an entrypoint works best when the extended target
needs to interact somehow with building the software.
We need `make check` to be a target becuase it actually does
build code.

But for `vmcheck` that's not true.  And in particular using
`make` targets is awkward when one wants
to configure/shortcut what the target is doing, as we have with
the environment variables `SKIP_VMOVERLAY` etc.

I think it's just cleaner and more obvious to have a script to
execute - and this script can have command line arguments.

All this does is remove the `make vmcheck` wrapper, but I
want to rewrite the entrypoint script to have e.g.
`./tests/vmcheck -O` where `-O` means "skip overlay".
