### PR TITLE
core: Mark all repos as "modular hotfixes"

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1158,6 +1158,12 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
    * So for now, let's tell libdnf that we do want to be able to see them. See:
    * https://github.com/projectatomic/rpm-ostree/issues/1435 */
   dnf_sack_set_module_excludes (dnf_context_get_sack (self->dnfctx), NULL);
+  /* And also mark all repos as hotfix repos so that we can indiscriminately cherry-pick
+   * from modular repos and non-modular repos alike. */
+  g_autoptr(GPtrArray) repos =
+    rpmostree_get_enabled_rpmmd_repos (self->dnfctx, DNF_REPO_ENABLED_PACKAGES);
+  for (guint i = 0; i < repos->len; i++)
+    dnf_repo_set_module_hotfixes (repos->pdata[i], TRUE);
 
   return TRUE;
 }

--- a/tests/compose/test-basic.sh
+++ b/tests/compose/test-basic.sh
@@ -17,21 +17,6 @@ echo gpgcheck=0 >> yumrepo.repo
 ln "$PWD/yumrepo.repo" config/yumrepo.repo
 treefile_append "packages" '["foobar"]'
 
-###
-# MAJOR HACK ALERT; drop modular pkgs because libdnf in the non-unified path
-# wants the modulemd available in the rpmmd, which neither our cache repo nor
-# pool have
-treefile_pyedit "
-tf['packages'].remove('afterburn')
-tf['packages'].remove('afterburn-dracut')
-tf['packages'].remove('fedora-coreos-pinger')
-tf['packages'].remove('sssd')
-"
-# have mercy
-echo 'exclude=libnghttp2' >> config/cache.repo
-build_rpm fake-libnghttp2 version 1.40.0 provides "libnghttp2.so.14()(64bit)"
-###
-
 treefile_pyedit "tf['add-commit-metadata']['foobar'] = 'bazboo'"
 treefile_pyedit "tf['add-commit-metadata']['overrideme'] = 'old var'"
 


### PR DESCRIPTION
This is a follow-up hack to #1797 to force libdnf to let us use modular
packages as if they were regular packages until we actually support
modules correctly (#1435).

A repo marked as a modular hotfix means that libdnf doesn't try to
filter out modular RPMs from the repo as it usually does.

Resolves: https://pagure.io/releng/failed-composes/issue/717