### PR TITLE
importer: Use /run instead of /var/run

### DIFF
--- a/src/libpriv/rpmostree-importer.c
+++ b/src/libpriv/rpmostree-importer.c
@@ -548,6 +548,18 @@ path_for_tmpfiles_should_be_ignored (const char *path)
   return g_str_has_prefix (path, "/var/lib/rpm");
 }
 
+/* systemd-tmpfiles complains loudly about writing to /var/run; ideally,
+ * all of the packages get fixed for this but...eh.
+ */
+static void
+append_translated_tmpfiles_path (GString *buf, const char *path)
+{
+  static const char varrun[] = "/var/run/";
+  if (g_str_has_prefix (path, varrun))
+    path += strlen ("/var");
+  g_string_append (buf, path);
+}
+
 static void
 append_tmpfiles_d (RpmOstreeImporter *self,
                    const char *path,
@@ -576,7 +588,7 @@ append_tmpfiles_d (RpmOstreeImporter *self,
 
   g_string_append_c (tmpfiles_d, filetype_c);
   g_string_append_c (tmpfiles_d, ' ');
-  g_string_append (tmpfiles_d, path);
+  append_translated_tmpfiles_path (tmpfiles_d, path);
 
   switch (g_file_info_get_file_type (finfo))
     {

--- a/tests/compose/test-basic-unified.sh
+++ b/tests/compose/test-basic-unified.sh
@@ -66,6 +66,9 @@ assert_file_has_content_literal autovar.txt 'd /var/log/chrony 0755 chrony chron
 if ostree --repo="${repo}" cat "${treeref}" /usr/lib/tmpfiles.d/pkg-rpm.conf > rpm.txt 2>/dev/null; then
     assert_not_file_has_content rpm.txt 'd /var/lib/rpm'
 fi
+ostree --repo="${repo}" cat "${treeref}" /usr/lib/tmpfiles.d/pkg-pam.conf > autovar.txt
+# Verify translating /var/run -> /run
+assert_file_has_content_literal autovar.txt 'd /run/console'
 echo "ok autovar"
 
 # And redo it to trigger relabeling. Also test --no-parent at the same time.


### PR DESCRIPTION
Translate RPM paths under `/var/run` to `/run` automatically; this
quiets down systemd.  Since we end up running `systemd-tmpfiles`
a few times in FCOS reducing spew here is particularly valuable.

The bug is really in the packages here but...we don't have an
agile process for fixing them.

Note that for this fix to take effect, if you have a `cache/pkgcache-repo`
you'll need to remove it.
