### PR TITLE
treefile: Add exclude-packages

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -61,6 +61,15 @@ It supports the following parameters:
  * `packages-$basearch`: Array of strings, optional: Set of installed packages, used
     only if $basearch matches the target architecture name.
 
+ * `exclude-packages`: Array of strings, optional: Each entry in this list is a package name
+   which will be filtered out.  If a package listed in the manifest ("manifest package") indirectly hard depends
+   on one of these packages, it will be a fatal error.  If a manifest package recommends one
+   of these packages, the recommended package will simply be omitted.  It is also a fatal
+   error to include a package both as a manifest package and in the blacklist.
+
+   An example use case for this is for Fedora CoreOS, which will blacklist the `python` and `python3`
+   packages to ensure that nothing included in the OS starts depending on it in the future.
+
  * `ostree-layers`: Array of strings, optional: After all packages are unpacked,
     check out these OSTree refs, which must already be in the destination repository.
     Any conflicts with packages will be an error.

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -310,6 +310,7 @@ fn treefile_merge(dest: &mut TreeComposeConfig, src: &mut TreeComposeConfig) {
         repos,
         packages,
         bootstrap_packages,
+        exclude_packages,
         ostree_layers,
         ostree_override_layers,
         install_langs,
@@ -656,6 +657,9 @@ struct TreeComposeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "ostree-override-layers")]
     ostree_override_layers: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "exclude-packages")]
+    exclude_packages: Option<Vec<String>>,
 
     // Content installation opts
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/app/rpmostree-composeutil.c
+++ b/src/app/rpmostree-composeutil.c
@@ -247,6 +247,8 @@ rpmostree_composeutil_get_treespec (RpmOstreeContext  *ctx,
 
   if (!treespec_bind_array (treedata, treespec, "packages", NULL, TRUE, error))
     return FALSE;
+  if (!treespec_bind_array (treedata, treespec, "exclude-packages", NULL, FALSE, error))
+    return FALSE;
   if (!treespec_bind_array (treedata, treespec, "repos", NULL, TRUE, error))
     return FALSE;
   if (!treespec_bind_bool (treedata, treespec, "documentation", TRUE, error))

--- a/tests/common/libtest-core.sh
+++ b/tests/common/libtest-core.sh
@@ -113,6 +113,15 @@ assert_file_has_content_literal () {
     done
 }
 
+assert_not_file_has_content_literal () {
+    fpath=$1; shift
+    for s in "$@"; do
+        if grep -q -F -e "$s" "$fpath"; then
+            _fatal_print_file "$fpath" "File '$fpath' matches fixed string list '$s'"
+        fi
+    done
+}
+
 assert_symlink_has_content () {
     if ! test -L "$1"; then
         fatal "File '$1' is not a symbolic link"

--- a/tests/compose/test-excludes.sh
+++ b/tests/compose/test-excludes.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -xeuo pipefail
+
+dn=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=libcomposetest.sh
+. "${dn}/libcomposetest.sh"
+
+# Add a local rpm-md repo for recommends testing
+treefile_append "repos" '["test-repo"]'
+build_rpm foodep
+build_rpm foobar recommends foobar-rec requires foodep
+build_rpm foobar-rec
+
+echo gpgcheck=0 >> yumrepo.repo
+ln "$PWD/yumrepo.repo" config/yumrepo.repo
+# the top-level manifest doesn't have any packages, so just set it
+treefile_append "packages" '["foobar"]'
+treefile_set 'recommends' "True"
+
+runcompose --dry-run >log.txt
+assert_file_has_content_literal log.txt 'foobar-1.0'
+assert_file_has_content_literal log.txt 'foobar-rec-1.0'
+rm -f log.txt
+echo "ok no exclude"
+
+# Test exclude
+treefile_append "exclude-packages" '["foobar-rec"]'
+
+runcompose --dry-run >log.txt
+assert_file_has_content_literal log.txt 'foobar-1.0'
+assert_not_file_has_content_literal log.txt 'foobar-rec-1.0'
+rm -f log.txt
+echo "ok exclude recommend"
+
+treefile_append "exclude-packages" '["foodep"]'
+
+if runcompose --dry-run &>err.txt; then
+  fatal "compose unexpectedly succeeded"
+fi
+assert_file_has_content err.txt 'package foodep.*is filtered out by exclude filtering'
+echo "ok exclude included"

--- a/tests/compose/test-misc-tweaks.sh
+++ b/tests/compose/test-misc-tweaks.sh
@@ -27,6 +27,9 @@ treefile_append "include" '["documentation.yaml", "recommends.yaml"]'
 treefile_del 'recommends'
 treefile_del 'documentation'
 
+# Test blacklists
+treefile_append "exclude-packages" '["somenonexistent-package", "gnome-shell"]'
+
 # Note this overrides:
 # $ rpm -q systemd
 # systemd-243.4-1.fc31.x86_64


### PR DESCRIPTION
In FCOS we have a kola test that basically does `rpm -q python`.
It's...a bit silly to spawn a whole VM for this.  Ensuring that
some specific packages don't get included has come up in a few
cases.

I think FCOS/RHCOS at least will want to blacklist `dnf` for example.
And as noted above, FCOS could blacklist `python`.

One major benefit of doing this inside rpm-ostree is that one
gets the full "libsolv error message experience" when dependency
resolution fails, e.g. blacklisting `glibc` I get:

```
 Problem 79: conflicting requests
  - package coreos-installer-systemd-0.1.2-1.fc31.x86_64 requires coreos-installer = 0.1.2-1.fc31, but none of the providers can be installed
  - package coreos-installer-0.1.2-1.fc31.x86_64 requires rtld(GNU_HASH), but none of the providers can be installed
  - package glibc-2.30-10.fc31.x86_64 is filtered out by exclude filtering
  - package glibc-2.30-7.fc31.x86_64 is filtered out by exclude filtering
  - package glibc-2.30-8.fc31.x86_64 is filtered out by exclude filtering
  - package glibc-2.30-5.fc31.i686 is filtered out by exclude filtering
  - package glibc-2.30-5.fc31.x86_64 is filtered out by exclude filtering
  - package glibc-2.30-10.fc31.i686 is filtered out by exclude filtering
```
