### PR TITLE
RFC: Add a CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+## [Unreleased]
+
+### Client
+
+### Server
+
+### Development
+
+- We now keep a changelog to make releases easier in the
+  future.
+
+[unreleased]: https://github.com/coreos/rpm-ostree/compare/v2020.1...HEAD

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,8 @@
 AC_PREREQ([2.63])
-dnl To do a release, increment this number and the spec file, commit, then submit it as a PR
+dnl To do a release, increment this number and the spec file, rename the CHANGELOG header,
+dnl and create a new `[Unreleased]` one. Then commit the changes and submit it as a PR
 dnl to merge via prow.  After that, do `git pull origin && git reset --hard origin/master`.
-dnl Then draft release notes highlighting changes and generate the shortlog using
+dnl Then draft release notes from the CHANGELOG.md and generate the shortlog using
 dnl <https://github.com/cgwalters/homegit/blob/master/bin/git-shortlog-with-prs>.
 dnl Then use <https://github.com/cgwalters/git-evtag> to create a signed tag with the
 dnl release notes as its content.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,15 +1,21 @@
 Submitting patches
 ------------------
 
-Submit a pull request against <https://github.com/projectatomic/rpm-ostree>.
+Submit a pull request against <https://github.com/coreos/rpm-ostree>.
 
 Please look at `git log` and match the commit log style.
+
+All contributions with user-visible changes should include a
+patch to the [CHANGELOG.md](CHANGELOG.md) under the
+"Unreleased" header. Non-trivial development-related changes
+are also welcome there.
 
 Running the test suite
 ----------------------
 
 There is `make check` as well as `make vmcheck`. See also what
-the [PAPR](.papr.yml) file does.
+the [Jenkinsfile](.cci.jenkinsfile) file does as well as the
+[HACKING.md](HACKING.md) document.
 
 Coding style
 ------------


### PR DESCRIPTION
Different reasons for this, this website elaborates a bit on them:

https://keepachangelog.com/

But there's more to it from my POV. This will make releases easier, and
I think one step closer towards automating it without losing the "human
touch" of release notes.

Now, we could make this part of commit messages and e.g. extract them.
This is the approach taken by
[conventional-changelog](https://github.com/conventional-changelog/standard-version).

Though I'm not entirely convinced with that approach. For one, commit
messages are for a different audience. Second, changelog entries are
meant to be much less detailed than commits and may be represented by
multiple commits/PRs.

Anyway, if we do this, I think we should start with the easy step first
of doing essentially what we already do during releases at PR time.
Then we can look at streamlining it if needed.