### PR TITLE
 compose: Include base dracut args in commitmeta

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1034,6 +1034,17 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
   if (!_rpmostree_jsonutil_object_get_optional_boolean_member (self->treefile, "selinux", &selinux, error))
     return FALSE;
 
+  /* pick up any initramfs regeneration args to shove into the metadata */
+  JsonNode *initramfs_args = json_object_get_member (self->treefile, "initramfs-args");
+  if (initramfs_args)
+    {
+      GVariant *v = json_gvariant_deserialize (initramfs_args, "as", error);
+      if (!v)
+       return FALSE;
+      g_hash_table_insert (self->metadata, g_strdup ("rpmostree.initramfs-args"),
+                           g_variant_ref_sink (v));
+    }
+
   /* Convert metadata hash to GVariant */
   g_autoptr(GVariant) metadata = rpmostree_composeutil_finalize_metadata (self->metadata, self->rootfs_dfd, error);
   if (!metadata)

--- a/src/libpriv/rpmostree-kernel.c
+++ b/src/libpriv/rpmostree-kernel.c
@@ -514,11 +514,8 @@ rpmostree_run_dracut (int     rootfs_dfd,
                                               error))
     return FALSE;
 
-  /* Previously we used to error out if argv or rebuild_from_initramfs were both
-   * not set; now we simply use the defaults (which in Fedora today also means
-   * implicitly hostonly). That case is for `rpm-ostree override replace
-   * kernel.*.x86_64.rpm`.
-   */
+  /* Note rebuild_from_initramfs now is only used as a fallback in the client-side regen
+   * path when we can't fetch the canonical initramfs args to use. */
 
   if (rebuild_from_initramfs)
     {

--- a/tests/vmcheck/test-override-kernel.sh
+++ b/tests/vmcheck/test-override-kernel.sh
@@ -69,3 +69,7 @@ vm_cmd lsinitrd ${newroot}/usr/lib/modules/${kernel_release}/initramfs.img > lsi
 assert_file_has_content_literal lsinitrd.txt etc/foobar.conf
 
 echo "ok override kernel with custom initramfs args"
+
+# FCOS omits lvm; check that we still omit lvm here too
+assert_file_has_content_literal lsinitrd.txt "--omit 'lvm'"
+echo "ok override kernel uses base initramfs args"


### PR DESCRIPTION
Keep the base initramfs arguments used in the commit metadata. The
reasoning for this is that when regenerating the initramfs locally with
`rpm-ostree initramfs --enable`, we want to match how it was built in
the treecompose. This is important because the rest of the treecompose
assumes that e.g. certain dracut modules are included or omitted.

Right now, the way we achieve this is with using `dracut --rebuild`.
However, we no longer have access to the base initramfs when replacing
the kernel. Another issue with `--rebuild` is that when we *do* use it,
dracut just dumbly appends the arguments to the base args. So we then
end up with e.g. two `--kver` args, two `--add ostree`, two `--tmpdir`,
etc...

Another way to look at at this patch is that it unifies client-side and
server-side paths when generating the initramfs. The only difference
then is that we use the local `/etc` in the case of
`rpm-ostree initramfs --enable`.