### PR TITLE
build-sys: Hard require libostree 2020.1

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -61,6 +61,9 @@ parallel vmcheck: {
           coreos-assembler init --force https://github.com/coreos/fedora-coreos-config
           # include our built rpm-ostree in the image
           mkdir -p overrides/rpm
+          # And further for now, temporarily override ostree, see
+          # https://github.com/coreos/rpm-ostree/pull/2015
+          dnf --disablerepo=* --enablerepo=f31-coreos-continuous download ostree ostree-libs
           mv *.rpm overrides/rpm
           coreos-assembler build
         """)

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -10,19 +10,9 @@ if [ -n "${SKIP_INSTALLDEPS:-}" ]; then
     exit 0
 fi
 
-# Use the latest ostree by default (XXX: currently pulling in f29 ostree, need
-# to bump rdgo to f30 or wait for packit)
-id=$(. /etc/os-release && echo $ID)
+# Add the continuous tag for latest build tools and mark as required.
 version_id=$(. /etc/os-release && echo $VERSION_ID)
-if [ "$id" == fedora ] && [ "$version_id" -ge 29 ]; then
-    echo -e '[fahc]\nmetadata_expire=1m\nbaseurl=https://ci.centos.org/artifacts/sig-atomic/fahc/rdgo/build/\ngpgcheck=0\n' > /etc/yum.repos.d/fahc.repo
-    # Until we fix https://github.com/rpm-software-management/libdnf/pull/149
-    excludes='exclude=ostree ostree-libs ostree-grub2 rpm-ostree'
-    for repo in /etc/yum.repos.d/fedora*.repo; do
-        cat ${repo} | (while IFS= read -r line; do if echo "$line" | grep -qE -e '^enabled=1'; then echo "${excludes}"; fi; echo "$line"; done) > ${repo}.new
-        mv ${repo}.new ${repo}
-    done
-fi
+echo -e "[f${version_id}-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f${version_id}-coreos-continuous/latest/\$basearch/\ngpgcheck=0\nskip_if_unavailable=False\n" > /etc/yum.repos.d/coreos.repo
 
 pkg_upgrade
 # install base builddeps like @buildsys-build

--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,7 @@ LIBS="$save_LIBS"
 # Remember to update AM_CPPFLAGS in Makefile.am when bumping GIO req.
 PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [gio-unix-2.0 >= 2.50.0 json-glib-1.0
-				     ostree-1 >= 2018.9
+				     ostree-1 >= 2020.1
 				     libsystemd
 				     polkit-gobject-1
 				     rpm librepo libsolv
@@ -121,12 +121,6 @@ PKG_CHECK_MODULES(PKGDEP_RPMOSTREE_RS, [libcurl openssl])
 dnl bundled libdnf
 PKGDEP_RPMOSTREE_CFLAGS="-I $(pwd)/libdnf -I $(pwd)/libdnf-build $PKGDEP_RPMOSTREE_CFLAGS"
 PKGDEP_RPMOSTREE_LIBS="-L$(pwd)/libdnf-build/libdnf -ldnf $PKGDEP_RPMOSTREE_LIBS"
-
-dnl Version check this until it's stable
-save_LIBS=$LIBS
-LIBS=$PKGDEP_RPMOSTREE_LIBS
-AC_CHECK_FUNCS(ostree_sysroot_set_mount_namespace_in_use)
-LIBS=$save_LIBS
 
 dnl RHEL8.1 has old libarchive
 AS_IF([pkg-config --atleast-version=3.3.3 libarchive],

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -762,11 +762,9 @@ rpmostreed_sysroot_populate (RpmostreedSysroot *self,
   const char *sysroot_path = rpmostree_sysroot_get_path (RPMOSTREE_SYSROOT (self));
   g_autoptr(GFile) sysroot_file = g_file_new_for_path (sysroot_path);
   self->ot_sysroot = ostree_sysroot_new (sysroot_file);
-#ifdef HAVE_OSTREE_SYSROOT_SET_MOUNT_NAMESPACE_IN_USE
   if (!ostree_sysroot_initialize (self->ot_sysroot, error))
     return FALSE;
   ostree_sysroot_set_mount_namespace_in_use (self->ot_sysroot);
-#endif
 
   /* This creates and caches an OstreeRepo instance inside
    * OstreeSysroot to ensure subsequent ostree_sysroot_get_repo()

--- a/src/daemon/rpmostreed-transaction.c
+++ b/src/daemon/rpmostreed-transaction.c
@@ -574,7 +574,6 @@ transaction_initable_init (GInitable *initable,
        */
       priv->sysroot = ostree_sysroot_new (tmp_path);
       /* See also related code in rpmostreed-sysroot.c */
-#ifdef HAVE_OSTREE_SYSROOT_SET_MOUNT_NAMESPACE_IN_USE
       if (!ostree_sysroot_initialize (priv->sysroot, error))
         return FALSE;
       /* We use MountFlags=slave in the unit file, which combined
@@ -582,7 +581,6 @@ transaction_initable_init (GInitable *initable,
       * https://github.com/ostreedev/ostree/issues/1265
       **/
       ostree_sysroot_set_mount_namespace_in_use (priv->sysroot);
-#endif
       g_signal_connect (priv->sysroot, "journal-msg",
                         G_CALLBACK (on_sysroot_journal_msg), self);
 


### PR DESCRIPTION
The current `rpm-ostree-2020.1-1.fc31.x86_64` in Fedora
was [built with a truly ancient libostree](https://kojipkgs.fedoraproject.org//packages/rpm-ostree/2020.1/1.fc31/data/logs/x86_64/root.log)
because Fedora's build system is weird and only adds packages
released after "gold" into the buildroot via an override
that times out.

This actively breaks things because rpm-ostree isn't
detecting the read-only sysroot.

Let's bump our hard requirement.
