### PR TITLE
app/dbus: Suggest `journalctl -xe` if bus owner changes

### DIFF
--- a/src/app/rpmostree-dbus-helpers.c
+++ b/src/app/rpmostree-dbus-helpers.c
@@ -583,12 +583,14 @@ on_owner_changed (GObject    *object,
                   GParamSpec *pspec,
                   gpointer    user_data)
 {
-  /* Owner shouldn't change durning a transaction
+  /* Owner shouldn't change during a transaction
    * that messes with notifications, abort, abort.
    */
   TransactionProgress *tp = user_data;
   tp->error = g_dbus_error_new_for_dbus_error ("org.projectatomic.rpmostreed.Error.Failed",
-                                               "Bus owner changed, aborting.");
+                                               "Bus owner changed, aborting. This likely "
+                                               "means the daemon crashed; check logs with "
+                                               "`journalctl -xe`.");
   transaction_progress_end (tp);
 }
 


### PR DESCRIPTION
In the large majority of cases, the `"Bus owner changed"` error is due
to something going wrong with the daemon rather than D-Bus itself. Let's
give a hint to check the journal so that users can investigate and e.g.
just paste the journal output as part of the initial issue report.