### PR TITLE
history: Avoid erroring if no history database to clean

### DIFF
--- a/rust/src/history.rs
+++ b/rust/src/history.rs
@@ -203,6 +203,9 @@ fn history_get_oldest_deployment_msg_timestamp() -> Fallible<Option<u64>> {
 /// that correspond to deployments older than that one. Essentially, this binds pruning to
 /// journal pruning. Called from C through `ror_history_prune()`.
 fn history_prune() -> Fallible<()> {
+    if !Path::new(RPMOSTREE_HISTORY_DIR).exists() {
+        return Ok(())
+    }
     let oldest_timestamp = history_get_oldest_deployment_msg_timestamp()?;
 
     // Cleanup any entry older than the oldest entry in the journal. Also nuke anything else that


### PR DESCRIPTION
The ostree test suite was creating deployments manually
(skipping the rpm-ostree upgrader layer which would write history)
and then calling `rpm-ostree cleanup` which tried to open the
history dir and failed.

Just return early if there's no history directory when we're
asked to clean up.
