### PR TITLE
vmcheck: Work around read-only /sysroot

### DIFF
--- a/tests/vmcheck/runtest.sh
+++ b/tests/vmcheck/runtest.sh
@@ -37,8 +37,8 @@ export VMTESTS=1
 # shellcheck source=../common/libvm.sh
 . "${commondir}/libvm.sh"
 
-if vm_kola_spawn "${outputdir}/kola" && \
-    "${topsrcdir}/tests/vmcheck/test-${testname}.sh"; then
+vm_kola_spawn "${outputdir}/kola"
+if "${topsrcdir}/tests/vmcheck/test-${testname}.sh"; then
   echo "PASS: ${testname}" >&3
 else
   echo "FAIL: ${testname}" >&3

--- a/tests/vmcheck/test-db.sh
+++ b/tests/vmcheck/test-db.sh
@@ -169,10 +169,10 @@ echo "ok db diff"
 # metadata to check that `db diff` is indeed using the rpmdb.pkglist metadata
 commit_path=$(get_obj_path /ostree/repo $pending_layered_csum commit)
 vm_cmd test -f $commit_path
-vm_cmd cp $commit_path $commit_path.bak
+vm_cmd_sysroot_rw cp $commit_path $commit_path.bak
 vm_rpmostree cleanup -p
 vm_cmd test ! -f $commit_path
-vm_cmd mv $commit_path.bak $commit_path
+vm_cmd_sysroot_rw mv $commit_path.bak $commit_path
 if vm_cmd ostree checkout --subpath /usr/share/rpm $pending_layered_csum; then
   assert_not_reached "Was able to checkout /usr/share/rpm?"
 fi

--- a/tests/vmcheck/test-download-only.sh
+++ b/tests/vmcheck/test-download-only.sh
@@ -46,22 +46,22 @@ osname=$(vm_get_booted_deployment_info osname)
 # use the var through /sysroot/ to make sure we always get hardlinks
 remote_repo=/ostree/deploy/$osname/var/tmp/vmcheck/repo
 REMOTE_OSTREE="vm_cmd ostree --repo=$remote_repo"
-vm_cmd rm -rf $remote_repo
-vm_cmd mkdir -p $remote_repo
+vm_cmd_sysroot_rw rm -rf $remote_repo
+vm_cmd_sysroot_rw mkdir -p $remote_repo
 $REMOTE_OSTREE init --mode=bare
 $REMOTE_OSTREE pull-local /ostree/repo vmcheck
 vm_cmd ostree remote delete --if-exists vmcheck_remote
 vm_cmd ostree remote add --no-gpg-verify vmcheck_remote file://$remote_repo
 
 go_offline() {
-  vm_cmd mv ${remote_repo}{,.bak}
-  vm_cmd mv /var/tmp/vmcheck/yumrepo{,.bak}
+  vm_cmd_sysroot_rw mv ${remote_repo}{,.bak}
+  vm_cmd_sysroot_rw mv /var/tmp/vmcheck/yumrepo{,.bak}
   YUMREPO=/var/tmp/vmcheck/yumrepo.bak/packages/x86_64
 }
 
 go_online() {
-  vm_cmd mv /var/tmp/vmcheck/yumrepo{.bak,}
-  vm_cmd mv ${remote_repo}{.bak,}
+  vm_cmd_sysroot_rw mv /var/tmp/vmcheck/yumrepo{.bak,}
+  vm_cmd_sysroot_rw mv ${remote_repo}{.bak,}
   YUMREPO=/var/tmp/vmcheck/yumrepo/packages/x86_64
 }
 

--- a/tests/vmcheck/test-layering-basic-2.sh
+++ b/tests/vmcheck/test-layering-basic-2.sh
@@ -69,9 +69,11 @@ vm_rpmostree install test-pkgcache-migrate-pkg{1,2}
 
 # jury-rig a pkgcache of the olden days
 OLD_PKGCACHE_DIR=/ostree/repo/extensions/rpmostree/pkgcache
-vm_cmd test -L ${OLD_PKGCACHE_DIR}
-vm_cmd rm ${OLD_PKGCACHE_DIR}
-vm_cmd mkdir ${OLD_PKGCACHE_DIR}
+vm_shell_inline_sysroot_rw <<EOF
+test -L ${OLD_PKGCACHE_DIR}
+rm ${OLD_PKGCACHE_DIR}
+mkdir ${OLD_PKGCACHE_DIR}
+EOF
 vm_cmd ostree init --repo ${OLD_PKGCACHE_DIR} --mode=bare
 vm_cmd ostree pull-local --repo ${OLD_PKGCACHE_DIR} /ostree/repo \
   rpmostree/pkg/test-pkgcache-migrate-pkg{1,2}/1.0-1.x86__64

--- a/tests/vmcheck/test-livefs.sh
+++ b/tests/vmcheck/test-livefs.sh
@@ -150,7 +150,7 @@ fi
 vm_cmd test -f /${dummy_file_to_modify}
 generate_upgrade() {
     # Create a modified vmcheck commit
-    vm_shell_inline <<EOF
+    vm_shell_inline_sysroot_rw <<EOF
       cd /ostree/repo/tmp
       rm vmcheck -rf
       ostree checkout vmcheck vmcheck --fsync=0

--- a/tests/vmcheck/test-misc-1.sh
+++ b/tests/vmcheck/test-misc-1.sh
@@ -133,7 +133,7 @@ vm_rpmostree usroverlay
 vm_cmd test -w /usr/bin
 echo "ok usroverlay"
 
-vm_shell_inline <<EOF
+vm_shell_inline_sysroot_rw <<EOF
     rpm-ostree cleanup -p
     originpath=\$(ostree admin --print-current-dir).origin
     cp -a \${originpath}{,.orig}

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -266,7 +266,7 @@ vm_pending_is_staged
 # deployment root it expects to exist. I played with overriding the service file
 # so we just do e.g. /usr/bin/false, but the issue is we still want the "start"
 # journal msg to be emitted.
-vm_cmd rm -rf $(vm_get_deployment_root 0)
+vm_cmd_sysroot_rw rm -rf $(vm_get_deployment_root 0)
 
 # and now check that we notice there was a failure in `status`
 vm_reboot


### PR DESCRIPTION
We need to adapt some of our tests here which assume that `/sysroot` is
writable. However, in FCOS this is no longer the case now that we enable
`sysroot.readonly`.

We only remount rw for the couple of operations that need it so that we
still retain coverage for the ro path everywhere else.