### PR TITLE
core: Add error prefixing in import path

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -2453,7 +2453,7 @@ start_async_import_one_package (RpmOstreeContext *self, DnfPackage *pkg,
     rpmostree_importer_new_take_fd (&fd, ostreerepo, pkg, flags,
                                     self->sepolicy, error);
   if (!unpacker)
-    return FALSE;
+    return glnx_prefix_error (error, "creating importer");
 
   if (rojig_xattrs)
     {
@@ -2547,7 +2547,7 @@ rpmostree_context_import_rojig (RpmOstreeContext *self,
   if (self->async_error)
     {
       g_propagate_error (error, g_steal_pointer (&self->async_error));
-      return FALSE;
+      return glnx_prefix_error (error, "importing RPMs");
     }
 
   rpmostree_output_progress_end (&progress);
@@ -3287,7 +3287,7 @@ relabel_if_necessary (RpmOstreeContext *self,
   if (self->async_error)
     {
       g_propagate_error (error, g_steal_pointer (&self->async_error));
-      return FALSE;
+      return glnx_prefix_error (error, "relabeling");
     }
 
   rpmostree_output_progress_end (&progress);

--- a/src/libpriv/rpmostree-unpacker-core.c
+++ b/src/libpriv/rpmostree-unpacker-core.c
@@ -92,6 +92,7 @@ rpmostree_unpack_rpm2cpio (int fd, GError **error)
   if (archive_read_open_fd (ret, fd, 10240) != ARCHIVE_OK)
     {
       propagate_libarchive_error (error, ret);
+      glnx_prefix_error (error, "rpmostree_unpack_rpm2cpio");
       goto out;
     }
 


### PR DESCRIPTION
Seeing this in the FCOS pipeline:
```
Downloading from 'fedora-coreos-pool'... done
error: cannot open Packages database in /proc/self/fd/21/usr/share/rpm
Importing packages... done
error: Can't stat fd 38
```

The first error is librpm...which, is somehow not fatal?  It
also appears to be swallowing the underlying real error.

For the second had to Google search it but the main hit for `Can't stat fd` is
in libarchive which led me to this code, which is probably right.
But let's be sure by adding some error prefixing.
