### PR TITLE
rust: Start porting from failure to anyhow

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9,6 +9,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +693,7 @@ dependencies = [
 name = "rpmostree-rust"
 version = "0.1.0"
 dependencies = [
+ "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "c_utf8 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1003,6 +1009,7 @@ dependencies = [
 
 [metadata]
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,7 +5,9 @@ authors = ["Colin Walters <walters@verbum.org>", "Jonathan Lebon <jonathan@jlebo
 edition = "2018"
 
 [dependencies]
+# TODO remove this
 failure = "0.1.7"
+anyhow = "1.0"
 serde = "1.0.105"
 serde_derive = "1.0.105"
 serde_json = "1.0"
@@ -28,6 +30,7 @@ indicatif = "0.14.0"
 lazy_static = "1.1.0"
 envsubst = "0.1.0"
 chrono = { version = "0.4.11", features = ["serde"] }
+
 
 [lib]
 name = "rpmostree_rust"

--- a/rust/src/lockfile.rs
+++ b/rust/src/lockfile.rs
@@ -7,7 +7,7 @@
 /* Copied and adapted from: treefile.rs
  */
 
-use failure::Fallible;
+use anyhow::Result;
 use serde_derive::{Deserialize, Serialize};
 use serde_json;
 use std::collections::{HashMap, BTreeMap};
@@ -20,7 +20,7 @@ use std::convert::TryInto;
 use crate::utils;
 
 /// Given a lockfile filename, parse it
-fn lockfile_parse<P: AsRef<Path>>(filename: P,) -> Fallible<LockfileConfig> {
+fn lockfile_parse<P: AsRef<Path>>(filename: P,) -> Result<LockfileConfig> {
     let filename = filename.as_ref();
     let fmt = utils::InputFormat::detect_from_filename(filename)?;
     let mut f = io::BufReader::new(utils::open_file(filename)?);
@@ -34,7 +34,7 @@ fn lockfile_parse<P: AsRef<Path>>(filename: P,) -> Fallible<LockfileConfig> {
 }
 
 /// Given lockfile filenames, parse them. Later lockfiles may override packages from earlier ones.
-fn lockfile_parse_multiple<P: AsRef<Path>>(filenames: &[P]) -> Fallible<LockfileConfig> {
+fn lockfile_parse_multiple<P: AsRef<Path>>(filenames: &[P]) -> Result<LockfileConfig> {
     let mut final_lockfile: Option<LockfileConfig> = None;
     for filename in filenames {
         let lf = lockfile_parse(filename)?;
@@ -277,7 +277,7 @@ mod ffi {
         }
 
         int_glib_error(utils::write_file(filename, |w| {
-            serde_json::to_writer_pretty(w, &lockfile).map_err(failure::Error::from)
+            Ok(serde_json::to_writer_pretty(w, &lockfile)?)
         }), gerror)
     }
 }


### PR DESCRIPTION
The failure crate isn't actively developed anymore.  The
main benefit of `anyhow` is it uses the standard error type.
More info:
https://docs.rs/crate/anyhow/1.0.28

Start the porting process.

Note that the `envsubst` crate has a public dependency on
`failure`, so we need to start mapping its errors.
