### PR TITLE
rust: Fully remove failure crate

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,8 +5,6 @@ authors = ["Colin Walters <walters@verbum.org>", "Jonathan Lebon <jonathan@jlebo
 edition = "2018"
 
 [dependencies]
-# TODO remove this
-failure = "0.1.7"
 anyhow = "1.0"
 serde = "1.0.105"
 serde_derive = "1.0.105"

--- a/rust/src/coreos_rootfs.rs
+++ b/rust/src/coreos_rootfs.rs
@@ -11,7 +11,7 @@
 //! is here in rpm-ostree as a convenience.
 
 use std::os::unix::prelude::*;
-use failure::{Fallible, ResultExt};
+use anyhow::{Result, Context};
 use structopt::StructOpt;
 use openat;
 use nix;
@@ -74,7 +74,7 @@ fn to_cstr<P: openat::AsPath>(path: P) -> std::io::Result<P::Buffer> {
 }
 
 /// Set the immutable bit
-fn seal(opts: &SealOpts) -> Fallible<()> {
+fn seal(opts: &SealOpts) -> Result<()> {
     let fd = unsafe {
         let fd = libc::open(to_cstr(opts.sysroot.as_str())?.as_ref().as_ptr(), libc::O_CLOEXEC | libc::O_DIRECTORY);
         if fd < 0 {
@@ -94,10 +94,10 @@ fn seal(opts: &SealOpts) -> Fallible<()> {
 }
 
 /// Main entrypoint
-fn coreos_rootfs_main(args: &Vec<String>) -> Fallible<()> {
+fn coreos_rootfs_main(args: &Vec<String>) -> Result<()> {
     let opt = Opt::from_iter(args.iter());
     match opt {
-        Opt::Seal(ref opts) => seal(opts).with_context(|e| format!("Sealing: {}", e.to_string()))?,
+        Opt::Seal(ref opts) => seal(opts).context("Sealing rootfs failed")?,
     };
     Ok(())
 }

--- a/rust/src/journal.rs
+++ b/rust/src/journal.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use failure::Fallible;
+use anyhow::Result;
 use systemd::id128::Id128;
 use systemd::journal;
 
@@ -12,7 +12,7 @@ static OSTREE_FINALIZE_STAGED_SERVICE: &'static str = "ostree-finalize-staged.se
 static OSTREE_DEPLOYMENT_FINALIZING_MSG_ID: &'static str = "e8646cd63dff4625b77909a8e7a40994";
 static OSTREE_DEPLOYMENT_COMPLETE_MSG_ID: &'static str = "dd440e3e549083b63d0efc7dc15255f1";
 
-fn print_staging_failure_msg(msg: Option<&str>) -> Fallible<()> {
+fn print_staging_failure_msg(msg: Option<&str>) -> Result<()> {
     println!("Warning: failed to finalize previous deployment");
     if let Some(msg) = msg {
         println!("         {}", msg);
@@ -25,7 +25,7 @@ fn print_staging_failure_msg(msg: Option<&str>) -> Fallible<()> {
 }
 
 /// Look for a failure from ostree-finalized-stage.service in the journal of the previous boot.
-fn journal_print_staging_failure() -> Fallible<()> {
+fn journal_print_staging_failure() -> Result<()> {
     let mut j = journal::Journal::open(journal::JournalFiles::System, false, true)?;
 
     // first, go to the first entry of the current boot


### PR DESCRIPTION
I previously ran out of steam in the switch and wanted to
get the PR out for feedback before continuing, but it turns
out I basically stopped 2 meters from the finish line.  Completing
the switch from `failure` → `anyhow` was quite easy.

