### PR TITLE
rust: rustfmt(*) and (re)add a CI check for it

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -28,7 +28,7 @@ parallel rpms: {
   }
 },
 codestyle: {
-  cosaPod {
+  cosaPod(buildroot: true) {
       checkout scm
       shwrap("""
         # Jenkins by default only fetches the branch it's testing. Explicitly fetch master

--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -6,24 +6,6 @@ set -xeuo pipefail
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
 
-# Add checks here which depend on the build container
-# but don't require a full build (code static analysis).
-if test -x /usr/bin/rustfmt; then
-    echo "Verifying rustfmt"
-    if !git diff --quiet --exit-code; then
-        echo "outstanding diff before rustfmt" 1>&2
-        exit 1
-    fi
-    make -f Makefile-extra.inc rustfmt
-    if git diff --quiet --exit-code; then
-        git diff
-        echo "Please run rustfmt"
-        exit 1
-    fi
-else
-    echo "No /usr/bin/rustfmt, skipping"
-fi
-
 ${dn}/build.sh
 # NB: avoid make function because our RPM building doesn't
 # support parallel runs right now

--- a/ci/codestyle.sh
+++ b/ci/codestyle.sh
@@ -1,12 +1,22 @@
 #!/bin/sh
-set -xeuo pipefail
+set -euo pipefail
 
-echo "Checking for tabs:"
+echo -n "Checking for tabs..."
 (git grep -E '^	+' -- '*.[ch]' || true) > tabdamage.txt
 if test -s tabdamage.txt; then
     echo "Error: tabs in .[ch] files:"
     cat tabdamage.txt
     exit 1
 fi
+echo "ok"
 
+echo -n "checking rustfmt..."
+cd rust
+for crate in $(find -iname Cargo.toml); do
+    if ! cargo fmt --manifest-path ${crate} -- --check; then
+        echo "cargo fmt failed; run: cd $(dirname ${crate}) && cargo fmt" 1>&2
+        exit 1
+    fi
+done
+cd ..
 echo "ok"

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -6,11 +6,11 @@
 
 use anyhow::Result;
 use openat;
+use openat_ext::OpenatDirExt;
 use rayon::prelude::*;
 use std::io;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use openat_ext::OpenatDirExt;
 
 use crate::utils;
 
@@ -72,7 +72,9 @@ fn postprocess_subs_dist(rootfs_dfd: &openat::Dir) -> Result<()> {
     let path = Path::new("usr/etc/selinux/targeted/contexts/files/file_contexts.subs_dist");
     if let Some(f) = rootfs_dfd.open_file_optional(path)? {
         let f = io::BufReader::new(f);
-        let tmp_path = utils::parent_dir(path).unwrap().join("file_contexts.subs_dist.tmp");
+        let tmp_path = utils::parent_dir(path)
+            .unwrap()
+            .join("file_contexts.subs_dist.tmp");
         let o = rootfs_dfd.write_file(&tmp_path, 0o644)?;
         let mut bufw = io::BufWriter::new(&o);
         for line in f.lines() {

--- a/rust/src/history.rs
+++ b/rust/src/history.rs
@@ -52,7 +52,7 @@
 //! than scanning the whole journal upfront. This can then be e.g. piped through
 //! a pager, stopped after N entries, etc...
 
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use openat::{self, Dir, SimpleType};
 use std::collections::VecDeque;
 use std::ffi::CString;
@@ -204,7 +204,7 @@ fn history_get_oldest_deployment_msg_timestamp() -> Result<Option<u64>> {
 /// journal pruning. Called from C through `ror_history_prune()`.
 fn history_prune() -> Result<()> {
     if !Path::new(RPMOSTREE_HISTORY_DIR).exists() {
-        return Ok(())
+        return Ok(());
     }
     let oldest_timestamp = history_get_oldest_deployment_msg_timestamp()?;
 

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use anyhow::{Result, bail, Context};
+use anyhow::{bail, Context, Result};
 use std::collections::HashMap;
 use std::io::prelude::*;
 use std::path::Path;
@@ -41,7 +41,7 @@ impl InputFormat {
 /// Given a lockfile/treefile config definition, parse it
 pub fn parse_stream<T, R: io::Read>(fmt: &InputFormat, input: &mut R) -> Result<T>
 where
-    T: serde::de::DeserializeOwned
+    T: serde::de::DeserializeOwned,
 {
     let parsed: T = match fmt {
         InputFormat::JSON => {
@@ -86,22 +86,27 @@ fn download_url_to_tmpfile(url: &str) -> Result<fs::File> {
 
 /// Open file for reading and provide context containing filename on failures.
 pub fn open_file<P: AsRef<Path>>(filename: P) -> Result<fs::File> {
-    return Ok(fs::File::open(filename.as_ref())
-        .with_context(|| format!("Can't open file {:?} for reading", filename.as_ref().display()))?);
+    return Ok(fs::File::open(filename.as_ref()).with_context(|| {
+        format!(
+            "Can't open file {:?} for reading",
+            filename.as_ref().display()
+        )
+    })?);
 }
 
 /// Open file for writing and provide context containing filename on failures.
 pub fn create_file<P: AsRef<Path>>(filename: P) -> Result<fs::File> {
-    return Ok(fs::File::create(filename.as_ref())
-        .with_context(|| format!("Can't open file {:?} for writing", filename.as_ref().display()))?);
+    return Ok(fs::File::create(filename.as_ref()).with_context(|| {
+        format!(
+            "Can't open file {:?} for writing",
+            filename.as_ref().display()
+        )
+    })?);
 }
 
 /// Open file for writing, passes a Writer to a closure, and closes the file, with O_TMPFILE
 /// semantics.
-pub fn write_file<P, F>(
-    filename: P,
-    f: F
-) -> Result<()>
+pub fn write_file<P, F>(filename: P, f: F) -> Result<()>
 where
     P: AsRef<Path>,
     F: Fn(&mut io::BufWriter<&mut fs::File>) -> Result<()>,
@@ -119,11 +124,9 @@ where
 // Surprising we need a wrapper for this... parent() returns a slice of its buffer, so doesn't
 // handle going up relative paths well: https://github.com/rust-lang/rust/issues/36861
 pub fn parent_dir(filename: &Path) -> Option<&Path> {
-    filename.parent().map(|p| if p.as_os_str() == "" {
-        ".".as_ref()
-    } else {
-        p
-    })
+    filename
+        .parent()
+        .map(|p| if p.as_os_str() == "" { ".".as_ref() } else { p })
 }
 
 /// Given an input string `s`, replace variables of the form `${foo}` with


### PR DESCRIPTION
We haven't been consistent about doing this; I personally
think rustfmt is a big aggressive with the line wrapping
but eh, consistency is more important.

And heh so I tried to `git push --set-upstream cgwalters` and
that failed because there was an already extant `rustfmt`
branch from a while ago...looking at that code it got lost
in the CI refactoring - we're not running `build-check.sh`
at the moment.

Move the rustfmt bits into `codestyle.sh` which is closer
to where it should be anyways.
