### PR TITLE
rust/libdnf_sys: Use uninstantiable type rather than wrapper struct

### DIFF
--- a/rust/src/libdnf_sys.rs
+++ b/rust/src/libdnf_sys.rs
@@ -12,10 +12,8 @@ use glib_sys;
  * https://github.com/swig/swig/issues/1468) or at least `bindgen` for the strict C parts of the
  * API. For now, I just took the shortcut of manually defining a tiny subset we care about. */
 
-#[repr(C)]
-pub(crate) struct DnfPackage(libc::c_void);
-#[repr(C)]
-pub(crate) struct DnfRepo(libc::c_void);
+pub(crate) enum DnfPackage {}
+pub(crate) enum DnfRepo {}
 
 #[allow(dead_code)]
 extern {


### PR DESCRIPTION
When we ran rustfmt, it converted our bare `extern` blocks to
`extern "C"` which has a different meaning apparently.

This caused cbindgen to try to interpret the structs, and it barfed
on the newtype void wrappers.

Looking at libgit2-rs, it seems to use these "uninstantiable types"
instead.

Prep for using `rustfmt`.
