### PR TITLE
manifest: Add `lockfile-repos` field

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -17,7 +17,7 @@ It supports the following parameters:
    secret key must be in the home directory of the building user.  Defaults to
    none.
 
- * `repos` array of strings, mandatory: Names of yum repositories to
+ * `repos`: array of strings, mandatory: Names of yum repositories to
    use, from any files that end in `.repo`, in the same directory as
    the treefile.  `rpm-ostree compose tree` does not use the system
    `/etc/yum.repos.d`, because it's common to want to compose a target
@@ -304,3 +304,9 @@ version of `rpm-ostree`.
 
  * `rojig`: Object, optional.  Sub-keys are `name`, `summary`, `license`,
    and `description`.  Of those, `name` and `license` are mandatory.
+
+ * `lockfile-repos`: array of strings, optional: Semantically similar to
+   `repo`, but these repos will only be used to fetch packages locked
+   via lockfiles. This is useful when locked packages are kept
+   separately from the primary repos and one wants to ensure that
+   rpm-ostree will otherwise not select unlocked packages from them.

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -313,6 +313,7 @@ fn treefile_merge(dest: &mut TreeComposeConfig, src: &mut TreeComposeConfig) {
     );
     merge_vecs!(
         repos,
+        lockfile_repos,
         packages,
         bootstrap_packages,
         exclude_packages,
@@ -645,6 +646,9 @@ struct TreeComposeConfig {
     rojig: Option<Rojig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     repos: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "lockfile-repos")]
+    lockfile_repos: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     selinux: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/app/rpmostree-composeutil.c
+++ b/src/app/rpmostree-composeutil.c
@@ -251,6 +251,8 @@ rpmostree_composeutil_get_treespec (RpmOstreeContext  *ctx,
     return FALSE;
   if (!treespec_bind_array (treedata, treespec, "repos", NULL, TRUE, error))
     return FALSE;
+  if (!treespec_bind_array (treedata, treespec, "lockfile-repos", NULL, FALSE, error))
+    return FALSE;
   if (!treespec_bind_bool (treedata, treespec, "documentation", TRUE, error))
     return FALSE;
   if (!treespec_bind_bool (treedata, treespec, "recommends", TRUE, error))

--- a/tests/compose.sh
+++ b/tests/compose.sh
@@ -126,6 +126,7 @@ EOF
 import sys, json
 y = json.load(sys.stdin)
 y["repos"] = ["cache"]
+y.pop("lockfile-repos", None)
 json.dump(y, sys.stdout)' < manifest.json > manifest.json.new
   mv manifest.json{.new,}
   git add .


### PR DESCRIPTION
In Fedora CoreOS, we have a "coreos-pool" repo from which all packages
in lockfiles are tagged for reproducible builds. This repo is shared
across all streams, including those on f31 and f32.

Thus, it makes no sense for composes to ever pick packages unconstrained
from the pool without being guided by a lockfile. Otherwise, one can
easily end up with e.g. f32 packages in an f31 compose.

Add a new `lockfile-repos` for this which is only used for fetching
lockfile packages and nothing else. This for example will also allow
e.g. `cosa fetch --update-lockfile` to Just Work as expected by only
fetching new packages from regular yum repos.