### PR TITLE
core: Use `SOLVER_FAVOR` in relaxed mode

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -2113,6 +2113,11 @@ rpmostree_context_prepare (RpmOstreeContext *self,
           /* remove our locked packages from the exclusion set */
           map_subtract (named_pkgs_map, dnf_packageset_get_map (locked_pset));
           dnf_sack_add_excludes (sack, named_pkgs);
+
+          /* Additionally, we want libsolv to favor locked packages when choosing between
+           * alternatives. */
+          for (guint i = 0; i < locked_pkgs->len; i++)
+            hy_goal_favor (goal, locked_pkgs->pdata[i]);
         }
     }
 


### PR DESCRIPTION
This closes the loop on the "developer experience" when composing with
lockfiles. We want to remain flexible and allow adding/removing packages
from the manifest without editing lockfiles. But we still want libsolv
to give preference to lockfile packages when evaluating alternatives.

For example, if the manifest has a request for a `foobar` Provides which
both `foo` and `bar` provide and `foo` is in the lockfile, but not
`bar`, we want libsolv to give priority to `foo`. IOW, the presence of a
package in a lockfile is a signal that we expect the Provides to be met
by that package.

Use libsolv's `SOLVER_FAVOR` for this.