### PR TITLE
status: Don't output AutomaticUpdates: disabled by default

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -295,12 +295,17 @@ print_daemon_state (RPMOSTreeSysroot *sysroot_proxy,
     g_print ("Warning: failed to query journal: %s\n", local_error->message);
   g_print ("%s%s", get_bold_end (), get_red_end ());
 
-  g_print ("AutomaticUpdates: ");
   if (g_str_equal (policy, "none"))
-    g_print ("disabled\n");
+    {
+      /* https://github.com/coreos/fedora-coreos-tracker/issues/271
+       * https://github.com/coreos/rpm-ostree/issues/1747
+       */
+      if (opt_verbose)
+        g_print ("AutomaticUpdates: disabled");
+    }
   else
     {
-      g_print ("%s", policy);
+      g_print ("AutomaticUpdates: %s", policy);
 
       /* don't try to get info from systemd if we're not on the system bus */
       if (bus_type != G_BUS_TYPE_SYSTEM)

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -645,7 +645,7 @@ vm_ostreeupdate_prepare_reboot() {
     vm_assert_status_jq ".deployments[0][\"origin\"] == \"vmcheckmote:vmcheck\"" \
                         ".deployments[0][\"booted\"]" \
                         ".deployments[0][\"version\"] == \"v1\""
-    vm_rpmostree status > status.txt
+    vm_rpmostree status --verbose > status.txt
     assert_file_has_content_literal status.txt 'AutomaticUpdates: disabled'
     # start it up again since we rebooted
     vm_start_httpd ostree_server $REMOTE_OSTREE 8888

--- a/tests/vmcheck/test-autoupdate-check.sh
+++ b/tests/vmcheck/test-autoupdate-check.sh
@@ -59,7 +59,9 @@ vm_rpmostree cleanup -m
 
 # make sure that off means off
 vm_change_update_policy off
-vm_rpmostree status | grep 'AutomaticUpdates: disabled'
+vm_rpmostree status --verbose | grep 'AutomaticUpdates: disabled'
+vm_rpmostree status > status.txt
+assert_not_file_has_content status.txt 'AutomaticUpdates:'
 vm_rpmostree upgrade --trigger-automatic-update-policy > out.txt
 assert_file_has_content out.txt "Automatic updates are not enabled; exiting"
 # check we didn't download any metadata (skip starting dir)
@@ -180,7 +182,7 @@ echo "ok --check/--preview layered pkgs check policy"
 vm_change_update_policy off
 vm_rpmostree cleanup -m
 vm_cmd systemctl stop rpm-ostreed
-vm_rpmostree status | grep 'AutomaticUpdates: disabled'
+vm_rpmostree status --verbose | grep 'AutomaticUpdates: disabled'
 assert_check_preview_rc 0
 assert_output
 echo "ok --check/--preview layered pkgs off policy"

--- a/tests/vmcheck/test-autoupdate-stage.sh
+++ b/tests/vmcheck/test-autoupdate-stage.sh
@@ -32,7 +32,7 @@ vm_ostreeupdate_create v2
 
 vm_rpmostree cleanup -m
 
-vm_rpmostree status > status.txt
+vm_rpmostree status --verbose > status.txt
 assert_file_has_content status.txt 'AutomaticUpdates: disabled'
 vm_change_update_policy stage
 vm_rpmostree status > status.txt


### PR DESCRIPTION
Pre-FCOS we made an effort for automatic updates but nowadays
with Fedora CoreOS we generally expect people to be using zincati.

Until we fix the "agent registration" problem:
https://github.com/coreos/rpm-ostree/issues/1747
Let's not confuse people by printing `AutomaticUpdates: disabled`.

Only print if it's set to a value in non-verbose mode.
