### PR TITLE
rust: Add license to our internal crates, check licenses in CI

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -48,6 +48,12 @@ unit: {
       """)
   }
 },
+license: {
+  cosaPod(buildroot: true, runAsUser: 0, memory: "1Gi", cpu: "2") {
+      checkout scm
+      shwrap("./ci/license-check.sh")
+  }
+},
 clang: {
   // Build with clang/clang++
   def n = 5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "rpmostree-rust"
 version = "0.1.0"
 authors = ["Colin Walters <walters@verbum.org>", "Jonathan Lebon <jonathan@jlebon.com>"]
 edition = "2018"
+# Most of our Rust code is actually MIT, but our C/C++ is LGPL and
+# we also directly depend on the LGPLv2 systemd crate.
+# This is "license of the whole" as opposed "license of the individual code files".
+license = "LGPL-2.1-or-later"
 # See https://rust-lang.github.io/rfcs/2495-min-rust-version.html
 # Usually, we try to keep this to no newer than current RHEL8 rust-toolset version.
 # You can find the current versions from here:

--- a/ci/license-check.sh
+++ b/ci/license-check.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xeuo pipefail
+cargo install cargo-lichking
+cargo lichking list
+cargo lichking check
+echo "License check OK"

--- a/rust/libdnf-sys/Cargo.toml
+++ b/rust/libdnf-sys/Cargo.toml
@@ -2,6 +2,8 @@
 name = "libdnf-sys"
 version = "0.1.0"
 authors = ["Colin Walters <walters@verbum.org>", "Jonathan Lebon <jonathan@jlebon.com>"]
+# The C code it links to is this
+license = "LGPL-2.1-or-later"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
I was playing with
https://github.com/Nemo157/cargo-lichking
in preparation for adding it to our CI.

I thought of this when I came across https://gitlab.com/woshilapin/with_tempdir/
and then noticed it was lgplv3, and wondered whether
we e.g. had any incompatible licenses in our dependency graph.
According to this (and looking at the output of `cargo lichking list`)
we're good.  But we need to keep this in mind.
