### PR TITLE
s/RPM-OSTree/rpm-ostree/

### DIFF
--- a/docs/manual/background.md
+++ b/docs/manual/background.md
@@ -24,7 +24,7 @@ to fall cleanly into one of two camps: package-based or image-based.
  * - Often paired with a separate application mechanism, but misses out on things that aren't apps
  * - Administrators still need to know content inside
 
-## How RPM-OSTree provides a middle ground
+## How rpm-ostree provides a middle ground
 
 rpm-ostree in its default mode feels more like image replication, but
 the underlying architecture allows a lot of package-like flexibility.

--- a/man/rpm-ostreed.conf.xml
+++ b/man/rpm-ostreed.conf.xml
@@ -44,7 +44,7 @@ Boston, MA 02111-1307, USA.
 
   <refnamediv>
     <refname>rpm-ostreed.conf</refname>
-    <refpurpose>RPM-OSTree daemon configuration file</refpurpose>
+    <refpurpose>rpm-ostree daemon configuration file</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
@@ -55,7 +55,7 @@ Boston, MA 02111-1307, USA.
     <title>Description</title>
 
     <para>
-      This file configures the RPM-OSTree daemon.
+      This file configures the rpm-ostree daemon.
     </para>
   </refsect1>
 

--- a/rust/src/history.rs
+++ b/rust/src/history.rs
@@ -16,7 +16,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-//! High-level interface to retrieve host RPM-OSTree history. The two main C
+//! High-level interface to retrieve host rpm-ostree history. The two main C
 //! APIs are `ror_history_ctx_new()` which creates a context object
 //! (`HistoryCtx`), and `ror_history_ctx_next()`, which iterates through history
 //! entries (`HistoryEntry`).
@@ -38,7 +38,7 @@
 //!   - starting from the most recent journal entry, go backwards searching for
 //!     OSTree boot messages
 //!   - when a boot message is found, keep going backwards to find its matching
-//!     RPM-OSTree deploy message by comparing the two messages' deployment path
+//!     rpm-ostree deploy message by comparing the two messages' deployment path
 //!     fields
 //!   - when a match is found, return a `HistoryEntry`
 //!   - start up the search again for the next boot message
@@ -94,7 +94,7 @@ struct BootMarker {
     node: DevIno,
 }
 
-/// Marker for RPM-OSTree deployment messages.
+/// Marker for rpm-ostree deployment messages.
 #[derive(Clone)]
 struct DeploymentMarker {
     timestamp: u64,
@@ -281,7 +281,7 @@ impl HistoryCtx {
         Ok(None)
     }
 
-    /// Creates a marker from an RPM-OSTree deploy message. Uses the `DEPLOYMENT_TIMESTAMP`
+    /// Creates a marker from an rpm-ostree deploy message. Uses the `DEPLOYMENT_TIMESTAMP`
     /// in the message as the deploy time. This matches the history gv filename for that
     /// deployment. Returns None if record is incomplete.
     fn deployment_record_to_marker(&self, record: &JournalRecord) -> Result<Option<Marker>> {
@@ -323,7 +323,7 @@ impl HistoryCtx {
         })
     }
 
-    /// Goes to the next OSTree boot or RPM-OSTree deploy msg in the journal, creates a
+    /// Goes to the next OSTree boot or rpm-ostree deploy msg in the journal, creates a
     /// marker for it, and returns it.
     fn find_next_marker(&mut self) -> Result<Option<Marker>> {
         self.set_search_mode(JournalSearchMode::BootAndDeploymentMsgs)?;

--- a/src/app/rpmostree-builtin-ex.c
+++ b/src/app/rpmostree-builtin-ex.c
@@ -33,7 +33,7 @@ static RpmOstreeCommand ex_subcommands[] = {
   { "rojig2commit", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
     "Convert an rpm-ostree rojig into an OSTree commit", rpmostree_ex_builtin_rojig2commit },
   { "history", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    "Inspect RPM-OSTree history of the system", rpmostree_ex_builtin_history },
+    "Inspect rpm-ostree history of the system", rpmostree_ex_builtin_history },
   /* temporary aliases; nuke in next version */
   { "reset", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS | RPM_OSTREE_BUILTIN_FLAG_HIDDEN,
     NULL, rpmostree_builtin_reset },

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -793,7 +793,7 @@ impl_install_tree (RpmOstreeTreeComposeContext *self,
   *out_changed = FALSE;
 
   /* Print version number */
-  g_printerr ("RPM-OSTree Version: %s\n", PACKAGE_VERSION);
+  g_printerr ("rpm-ostree version: %s\n", PACKAGE_VERSION);
 
   /* Without specifying --cachedir we'd just toss the data we download, so let's
    * catch that.

--- a/src/daemon/rpm-ostree-bootstatus.service.in
+++ b/src/daemon/rpm-ostree-bootstatus.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=Log RPM-OSTree Booted Deployment Status To Journal
+Description=Log rpm-ostree Booted Deployment Status To Journal
 Documentation=man:rpm-ostree(1)
 ConditionPathExists=/run/ostree-booted
 

--- a/src/daemon/rpm-ostreed-automatic.service.in
+++ b/src/daemon/rpm-ostreed-automatic.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=RPM-OSTree Automatic Update
+Description=rpm-ostree Automatic Update
 Documentation=man:rpm-ostree(1) man:rpm-ostreed.conf(5)
 ConditionPathExists=/run/ostree-booted
 

--- a/src/daemon/rpm-ostreed-automatic.timer
+++ b/src/daemon/rpm-ostreed-automatic.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=RPM-OSTree Automatic Update Trigger
+Description=rpm-ostree Automatic Update Trigger
 Documentation=man:rpm-ostree(1) man:rpm-ostreed.conf(5)
 ConditionPathExists=/run/ostree-booted
 

--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=RPM-OSTree System Management Daemon
+Description=rpm-ostree System Management Daemon
 Documentation=man:rpm-ostree(1)
 ConditionPathExists=/ostree
 


### PR DESCRIPTION
We are have been pretty inconsistent about this; I think while it's
true the project is called "OSTree", "RPM-OSTree" is just annoying
to type and looks weird.  `rpm-ostree` requires much less
"shift key gymnastics".

Also, the "proper name" style like RPM/OSTree is best when
something can be viewed more "abstractly" - there are multiple
RPM implementations (historically) and OSTree also is a *concept*
in addition to an implementation.

rpm-ostree though is much more of a "concrete" thing so it
makes more sense to use it as a "project name".
