### PR TITLE
ci: Download the latest ostree even if from stable repos

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -61,9 +61,11 @@ parallel insttests: {
           coreos-assembler init --force https://github.com/coreos/fedora-coreos-config
           # include our built rpm-ostree in the image
           mkdir -p overrides/rpm
-          # And further for now, temporarily override ostree, see
-          # https://github.com/coreos/rpm-ostree/pull/2015
-          dnf --disablerepo=* --enablerepo=f31-coreos-continuous download ostree ostree-libs
+          # Let's make sure we're always composing with the latest ostree. This could be
+          # from the continuous repo (which for now we manually use to fast-track ostree
+          # builds which are needed to get rpm-ostree patches in, but eventually will be
+          # automated) or from the regular repos.
+          dnf download ostree ostree-libs --arch x86_64
           mv *.rpm overrides/rpm
           coreos-assembler fetch
           coreos-assembler build


### PR DESCRIPTION
Right now, rebuilding ostree into the continuous tag is manual, so we've
only been doing it when necessary to fast-track something e.g. for
rpm-ostree or cosa (see [1] for the long-term goal).

Which means when finding an ostree to use to override in our CI-built
FCOS, we should just let dnf find whatever the latest version is, even
if it's just from the regular Fedora repos.

[1] https://github.com/packit-service/packit/issues/264