### PR TITLE
build-sys: Disable zchunk for libdnf if we don't have it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -131,8 +131,9 @@ AS_IF([pkg-config --atleast-version=4.14.2 rpm], [], [AC_MSG_ERROR([librpm 4.14.
 
 dnl We don't *actually* use this ourself, but librepo does, and libdnf gets confused
 dnl if librepo doesn't support it.
+have_zchunk=no
 AS_IF([pkg-config --exists zck],
-  [AC_DEFINE([HAVE_ZCHUNK], 1, [Define if we have zchunk])])
+  [have_zchunk=yes; AC_DEFINE([HAVE_ZCHUNK], 1, [Define if we have zchunk])])
 
 AC_PATH_PROG([XSLTPROC], [xsltproc])
 
@@ -264,6 +265,9 @@ dnl And propagate the release/debug type to cmake
 cmake_args=-DCMAKE_BUILD_TYPE=RelWithDebugInfo
 if test ${debug_release} = debug; then
   cmake_args="-DCMAKE_BUILD_TYPE=Debug"
+fi
+if test x${have_zchunk} = xno; then
+  cmake_args="${cmake_args} -DWITH_ZCHUNK:BOOL=0"
 fi
 export cmake_args
 


### PR DESCRIPTION
Going to update rpm-ostree for RHEL 8.3, we did a huge bump
in libdnf which now defaults to enabling zchunk in its build
system.  We added the infrastructure before to detect things,
so propagate that to libdnf.
