### PR TITLE
build-sys: Remove --enable-new-name

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -102,13 +102,6 @@ libexec_SCRIPTS = rpm-ostreed
 rpm-ostreed: $(srcdir)/src/daemon/rpm-ostreed-stub.sh.in Makefile
 	$(SED_SUBST) $< > $@.tmp && mv $@.tmp $@
 
-install-daemon-altname-hook:
-	mv $(DESTDIR)$(systemdunitdir)/rpm-ostreed.service $(DESTDIR)$(systemdunitdir)/$(primaryname)d.service
-	ln -sf $(primaryname)d.service $(DESTDIR)$(systemdunitdir)/rpm-ostreed.service
-if BUILDOPT_NEW_NAME
-INSTALL_DATA_HOOKS += install-daemon-altname-hook
-endif
-
 # We don't yet rename the DBus related items
 service_in_files = $(srcdir)/src/daemon/org.projectatomic.rpmostree1.service.in
 service_DATA     = $(service_in_files:.service.in=.service)

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -77,13 +77,6 @@ rpm_ostree_LDADD = $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la librpmostree-1.l
 privdatadir=$(pkglibdir)
 privdata_DATA = src/app/rpm-ostree-0-integration.conf
 
-install-bin-hook:
-	mv $(DESTDIR)$(bindir)/rpm-ostree $(DESTDIR)$(bindir)/$(primaryname)
-	ln -sf $(primaryname) $(DESTDIR)$(bindir)/rpm-ostree
-if BUILDOPT_NEW_NAME
-INSTALL_DATA_HOOKS += install-bin-hook
-endif
-
 # Propagate automake verbose mode
 cargo_build = $(cargo) build $(if $(subst 0,,$(V)),--verbose,)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -18,12 +18,7 @@
 include Makefile-decls.am
 include Makefile-extra.inc
 
-newname = nts
-if BUILDOPT_NEW_NAME
-primaryname = $(newname)
-else
 primaryname = rpm-ostree
-endif
 
 SUBDIRS += .
 

--- a/configure.ac
+++ b/configure.ac
@@ -181,12 +181,6 @@ AC_ARG_ENABLE(installed_tests,
               [enable_installed_tests=no])
 AM_CONDITIONAL(BUILDOPT_INSTALL_TESTS, test x$enable_installed_tests = xyes)
 
-AC_ARG_ENABLE(new-name,
-              AS_HELP_STRING([--enable-new-name],
-                             [Install additionally as nts (default: no)]),,
-              [enable_new_name=no])
-AM_CONDITIONAL(BUILDOPT_NEW_NAME, test x$enable_new_name = xyes)
-
 AC_ARG_WITH(bubblewrap,
               AS_HELP_STRING([--with-bubblewrap],
                              [Path to bubblewrap binary (default: /usr/bin/bwrap)]),,
@@ -298,7 +292,6 @@ AC_OUTPUT
 echo "
     $PACKAGE $VERSION
 
-    nts name:                                $enable_new_name
     introspection:                           $found_introspection
     bubblewrap:                              $with_bubblewrap
     gtk-doc:                                 $enable_gtk_doc


### PR DESCRIPTION
We didn't ship this for a long time and...well, naming is hard, I guess
it's not going to happen soon.
