### PR TITLE
upgrader: Pull using new `timestamp-check-from-rev`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,7 @@ LIBS="$save_LIBS"
 # Remember to update AM_CPPFLAGS in Makefile.am when bumping GIO req.
 PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [gio-unix-2.0 >= 2.50.0 json-glib-1.0
-				     ostree-1 >= 2020.1
+				     ostree-1 >= 2020.4
 				     libsystemd
 				     polkit-gobject-1
 				     rpm librepo libsolv

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -43,7 +43,7 @@ BuildRequires: gnome-common
 BuildRequires: /usr/bin/g-ir-scanner
 # Core requirements
 # One way to check this: `objdump -p /path/to/rpm-ostree | grep LIBOSTREE` and pick the highest (though that might miss e.g. new struct members)
-BuildRequires: pkgconfig(ostree-1) >= 2019.2
+BuildRequires: pkgconfig(ostree-1) >= 2019.4
 BuildRequires: pkgconfig(polkit-gobject-1)
 BuildRequires: pkgconfig(json-glib-1.0)
 BuildRequires: pkgconfig(rpm)

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -432,7 +432,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
             g_autoptr(GVariant) opts = g_variant_ref_sink (g_variant_builder_end (optbuilder));
             if (!ostree_repo_pull_with_options (self->repo, origin_remote, opts, progress,
                                                 cancellable, error))
-              return FALSE;
+              return glnx_prefix_error (error, "While pulling %s", override_commit ?: origin_ref);
 
             if (progress)
               ostree_async_progress_finish (progress);
@@ -503,7 +503,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
         {
           if (!ostree_sysroot_upgrader_check_timestamps (self->repo, self->base_revision,
                                                          new_base_rev, error))
-            return FALSE;
+            return glnx_prefix_error (error, "While checking against deployment timestamp");
         }
 
       g_free (self->base_revision);

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -416,11 +416,11 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
                                      g_variant_new_variant (g_variant_new_string (dir_to_pull)));
             g_variant_builder_add (optbuilder, "{s@v}", "flags",
                                    g_variant_new_variant (g_variant_new_int32 (flags)));
-            /* Add the timestamp check, unless disabled. The option was added in
-             * libostree v2017.11 */
+            /* Add the timestamp check, unless disabled. We used to use `timestamp-check`
+             * here but now use `timestamp-check-from-rev`, added in libostree v2020.4. */
             if (!allow_older)
-              g_variant_builder_add (optbuilder, "{s@v}", "timestamp-check",
-                                     g_variant_new_variant (g_variant_new_boolean (TRUE)));
+              g_variant_builder_add (optbuilder, "{s@v}", "timestamp-check-from-rev",
+                                     g_variant_new_variant (g_variant_new_string (self->base_revision)));
             g_variant_builder_add (optbuilder, "{s@v}", "refs",
                                    g_variant_new_variant (g_variant_new_strv (
                                                                               (const char *const *)&origin_ref, 1)));


### PR DESCRIPTION
Both libostree and rpm-ostree support downgrade protection. But what
that means is different between the two. For libostree, downgrade
protection means not fetching any commit which is older than what the
current ref is pointing at. For rpm-ostree, it means not *deploying*
any commit which is older than what the current *deployment* is on.

These two are mostly the same most of the time, but can differ. For
example, on a remote ref which has commits A -> B -> C, where the client
is sitting on a deployment from A, downgrade protection should not
prevent the client from upgrading to B even if there is a newer commit
C.

Since there is no hard relation enforced between what the state of the
OSTree ref is locally and deployments (e.g. we fully support users
manually doing `ostree pull`), it doesn't make sense to compare against
the tip of the ref. Instead, use the new `timestamp-check-from-rev`
to tell libostree to compare against our base revision, which is what we
care about.

Closes: coreos/fedora-coreos-tracker#481