### PR TITLE
upgrader: Reset ref before fetching commit by override

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -432,7 +432,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
             g_autoptr(GVariant) opts = g_variant_ref_sink (g_variant_builder_end (optbuilder));
             if (!ostree_repo_pull_with_options (self->repo, origin_remote, opts, progress,
                                                 cancellable, error))
-              return FALSE;
+              return glnx_prefix_error (error, "While pulling %s", override_commit ?: origin_ref);
 
             if (progress)
               ostree_async_progress_finish (progress);
@@ -503,7 +503,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
         {
           if (!ostree_sysroot_upgrader_check_timestamps (self->repo, self->base_revision,
                                                          new_base_rev, error))
-            return FALSE;
+            return glnx_prefix_error (error, "While checking against deployment timestamp");
         }
 
       g_free (self->base_revision);


### PR DESCRIPTION
This is a short-term hack until we can depend on the new
`timestamp-check-from-rev` from ostree:

ostreedev/ostree#2099

That way, we still get downgrade protection, but wrt the checked out
deployment, not the local ref.

For more information, see
#2094
coreos/fedora-coreos-tracker#481