### PR TITLE
Fixed RemovedBasePackages list's lack of wrapped output values

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -752,7 +752,7 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
         }
 
       if (str->len)
-	rpmostree_print_kv_newline ("RemovedBasePackages", max_key_len, str->str, get_textarea_width (max_key_len));
+        rpmostree_print_kv_newline ("RemovedBasePackages", max_key_len, str->str, get_textarea_width (max_key_len));
     }
 
   /* only print inactive base removal requests in verbose mode */

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -752,7 +752,7 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
         }
 
       if (str->len)
-        rpmostree_print_kv ("RemovedBasePackages", max_key_len, str->str);
+	rpmostree_print_kv_newline ("RemovedBasePackages", max_key_len, str->str, get_textarea_width (max_key_len));
     }
 
   /* only print inactive base removal requests in verbose mode */

--- a/src/app/rpmostree-libbuiltin.c
+++ b/src/app/rpmostree-libbuiltin.c
@@ -46,6 +46,50 @@ rpmostree_print_kv (const char *key,
 }
 
 void
+rpmostree_print_kv_newline (const char *key,
+			    guint	maxkeylen,
+			    const char *value)
+{
+  const char delim[2] = ", ";
+  char *token;
+  int len = strlen (value);
+  token = strtok (value, delim);
+  
+  guint current_width = 0;
+  const guint area_width = get_textarea_width (maxkeylen);
+  
+  printf ("  %*s%s ", maxkeylen, key, strlen (key) ? ":" : " ");
+
+  while ( token != NULL ) 
+   {
+      const guint entry_width = strlen (token);
+
+      /* first print */
+      if (current_width == 0)
+        {
+          g_print ("%s", token);
+          current_width += entry_width;
+        }
+      else if ((current_width + entry_width + 1) <= area_width) /* +1 for space separator */
+        {
+          g_print (" %s", token);
+          current_width += (entry_width + 1);
+        }
+      else
+        {
+          /* always print at least one per line, even if we overflow */
+          putc ('\n', stdout);
+          rpmostree_print_kv_no_newline ("", maxkeylen, token);
+          current_width = entry_width;
+        }
+ 
+      token = strtok (NULL, delim);
+   }
+
+  putc ('\n', stdout);
+}
+
+void
 rpmostree_usage_error (GOptionContext  *context,
                        const char      *message,
                        GError         **error)

--- a/src/app/rpmostree-libbuiltin.c
+++ b/src/app/rpmostree-libbuiltin.c
@@ -48,7 +48,8 @@ rpmostree_print_kv (const char *key,
 void
 rpmostree_print_kv_newline (const char *key,
 			    guint	maxkeylen,
-			    const char *value)
+			    const char *value,
+			    guint	width)
 {
   const char delim[2] = ", ";
   char *token;
@@ -56,7 +57,7 @@ rpmostree_print_kv_newline (const char *key,
   token = strtok (value, delim);
   
   guint current_width = 0;
-  const guint area_width = get_textarea_width (maxkeylen);
+  const guint area_width = width;
   
   printf ("  %*s%s ", maxkeylen, key, strlen (key) ? ":" : " ");
 

--- a/src/app/rpmostree-libbuiltin.c
+++ b/src/app/rpmostree-libbuiltin.c
@@ -47,9 +47,9 @@ rpmostree_print_kv (const char *key,
 
 void
 rpmostree_print_kv_newline (const char *key,
-			    guint	maxkeylen,
-			    const char *value,
-			    guint	width)
+                            guint       maxkeylen,
+                            const char *value,
+                            guint       width)
 {
   const char delim[2] = ", ";
   char *token;

--- a/src/app/rpmostree-libbuiltin.h
+++ b/src/app/rpmostree-libbuiltin.h
@@ -48,7 +48,11 @@ void
 rpmostree_print_kv_no_newline (const char *key,
                                guint       maxkeylen,
                                const char *value);
-
+void
+rpmostree_print_kv_newline (const char *key,
+                            guint       maxkeylen,
+                            const char *value,
+			    guint	width);
 void
 rpmostree_print_kv (const char *key,
                     guint       maxkeylen,


### PR DESCRIPTION
Hello everybody,

My last experience submitting a PR and addressing your feedback with it really satisfied me, so I'm opening another one here!

A regression was reported with the changes made to the status output of RemovedBasePackages to group EVRs, which caused the output to no longer wrap "nicely."

This PR fixes that by adding a new built-in method to print key-value pairs in a way that retrieves the respective comma-separated values directly from a string. It does this in a way that accounts for the potential width of the text area.

This might be overkill, but we'll see. I'm very excited to hear your feedback.

Fixes #1613 

As you can see, the screenshot below depicts the output after & before my changes: 
![Screenshot from 2020-05-17 01-18-40](https://user-images.githubusercontent.com/20365014/82136735-9bc2f300-97de-11ea-9c93-789a2f571452.png)
