### PR TITLE
compose: Add a "warn and sleep" if --unified-core is not provided

### DIFF
--- a/docs/manual/compose-server.md
+++ b/docs/manual/compose-server.md
@@ -1,3 +1,14 @@
+## Using higher level build tooling
+
+Originally `rpm-ostree compose tree` was intended to be a "high level" tool,
+but that didn't work out very well in practice.  Today, you should consider
+it as a low level tool.  For example, most people that want to generate
+OSTree commits *also* want to generate bootable disk images, and rpm-ostree
+has nothing to do with that.
+
+One example higher level tool that takes care of both OSTree commit generation
+and bootable disk images is [coreos-assembler](https://github.com/coreos/coreos-assembler).
+
 ## Background on managing an OSTree repository
 
 Before you get started, it's recommended to read (at least) these two sections
@@ -59,7 +70,7 @@ If you're doing this multiple times, it's strongly recommended to create a cache
 directory:
 
 ```
-# rpm-ostree compose tree --cachedir=cache --repo=/srv/centos-atomic/build-repo sig-atomic-buildscripts/centos-atomic-host.json
+# rpm-ostree compose tree --unified-core --cachedir=cache --repo=/srv/centos-atomic/build-repo sig-atomic-buildscripts/centos-atomic-host.json
 ```
 
 This will download RPMs from the referenced repos, and commit the result to the

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -343,6 +343,17 @@ install_packages (RpmOstreeTreeComposeContext  *self,
 
       rpmostree_context_set_repos (self->corectx, self->build_repo, self->pkgcache_repo);
     }
+  else
+    {
+      /* Secret environment variable for those desperate */
+      if (!g_getenv ("RPM_OSTREE_I_KNOW_NON_UNIFIED_CORE_IS_DEPRECATED"))
+        {
+          g_printerr ("\nNOTICE: Running rpm-ostree compose tree without --unified-core is deprecated.\n"
+                      " Please add --unified-core to the command line and ensure your content\n"
+                      " works with it.  For more information, see https://github.com/coreos/rpm-ostree/issues/729\n\n");
+          g_usleep (G_USEC_PER_SEC * 5);
+        }
+    }
 
   if (!rpmostree_context_prepare (self->corectx, cancellable, error))
     return FALSE;


### PR DESCRIPTION
Tracker: https://github.com/coreos/rpm-ostree/issues/729

---

Start adding some pain if `--unified-core` isn't provided
to help flush out anyone relying on it.  (And I think today
pungi is not passing it, so e.g. Fedora IoT/Silverblue are impacted)

Prep for merging https://github.com/coreos/rpm-ostree/pull/1793
