### PR TITLE
compose: Remove --output-repodata-dir

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -67,7 +67,6 @@ static gboolean opt_force_nocache;
 static gboolean opt_cache_only;
 static gboolean opt_unified_core;
 static char *opt_proxy;
-static char *opt_output_repodata_dir;
 static char **opt_metadata_strings;
 static char **opt_metadata_json;
 static char *opt_repo;
@@ -98,7 +97,6 @@ static GOptionEntry install_option_entries[] = {
   { "unified-core", 0, 0, G_OPTION_ARG_NONE, &opt_unified_core, "Use new \"unified core\" codepath", NULL },
   { "proxy", 0, 0, G_OPTION_ARG_STRING, &opt_proxy, "HTTP proxy", "PROXY" },
   { "dry-run", 0, 0, G_OPTION_ARG_NONE, &opt_dry_run, "Just print the transaction and exit", NULL },
-  { "output-repodata-dir", 0, 0, G_OPTION_ARG_STRING, &opt_output_repodata_dir, "Save downloaded repodata in DIR", "DIR" },
   { "print-only", 0, 0, G_OPTION_ARG_NONE, &opt_print_only, "Just expand any includes and print treefile", NULL },
   { "touch-if-changed", 0, 0, G_OPTION_ARG_STRING, &opt_touch_if_changed, "Update the modification time on FILE if a new commit was created", "FILE" },
   { "workdir", 0, 0, G_OPTION_ARG_STRING, &opt_workdir, "Working directory", "WORKDIR" },


### PR DESCRIPTION
This was apparently removed in: 2263bb35f6f785b00ad3db4772498fa1877b29fe
It's done nothing for the last 5 years, I think it's safe to remove.

I was just looking at this code when thinking about extensions.
