### PR TITLE
spec: Fix up conditionals for ELN

### DIFF
--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -14,18 +14,17 @@ URL: https://github.com/projectatomic/rpm-ostree
 
 ExclusiveArch: %{rust_arches}
 
-%if 0%{?fedora}
+%if 0%{?rhel} && !0%{?eln}
+BuildRequires: rust-toolset
+%else
 BuildRequires: cargo
 BuildRequires: rust
-%else
-# assume el8
-BuildRequires: rust-toolset
 %endif
 
 # RHEL8 doesn't ship zchunk today.  See also the comments
 # in configure.ac around this as libdnf/librepo need to be in
 # sync, and today we bundle libdnf but not librepo.
-%if 0%{?rhel}
+%if 0%{?rhel} && 0%{?rhel} <= 8
 %bcond_with zchunk
 %else
 %bcond_without zchunk

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2020.1
+Version: 2020.2
 Release: 1%{?dist}
 #VCS: https://github.com/cgwalters/rpm-ostree
 # This tarball is generated via "cd packaging && make -f Makefile.dist-packaging dist-snapshot"


### PR DESCRIPTION
The `rust-toolset` package does not exist in Fedora, so we cannot
use it for BuildRequires. Change the conditional to exclude ELN
from the %rhel conditional.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>