### PR TITLE
rebase: Remove requirement for --experimental with local rebases

### DIFF
--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -147,8 +147,6 @@ rpmostree_builtin_rebase (int             argc,
     {
       if (*remainder == '/')
         {
-          if (!opt_experimental)
-            return glnx_throw (error, "Local repo rebase requires --experimental");
           const char *ref = strrchr (remainder, ':');
           if (!ref)
             return glnx_throw (error, "Missing ':' in LOCALPATH:REF rebase");

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -72,7 +72,7 @@ vm_rpmostree cleanup -p
 echo "ok rebase with custom origin"
 
 # Try again but making it think it's pulling from another local repo
-vm_rpmostree rebase --skip-purge /sysroot/ostree/repo:${booted_csum} --experimental
+vm_rpmostree rebase --skip-purge /sysroot/ostree/repo:${booted_csum}
 vm_rpmostree upgrade >out.txt
 assert_file_has_content_literal out.txt 'Pinned to commit; no upgrade available'
 vm_rpmostree cleanup -p


### PR DESCRIPTION
We've been shipping the MCO code using this for a long time,
it needs to stay in its current form and is not experimental.
