### PR TITLE
daemon: Add an error prefix in local repo pulls

### DIFF
--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -974,7 +974,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
         g_strdup_printf ("file:///proc/self/fd/%d", self->local_repo_remote_dfd);
       if (!ostree_repo_pull (repo, local_repo_uri, (char**)refs_to_fetch,
                              OSTREE_REPO_PULL_FLAGS_NONE, progress, cancellable, error))
-        return FALSE;
+        return glnx_prefix_error (error, "Pulling commit %s from local repo", rev);
       rpmostree_transaction_emit_progress_end (RPMOSTREE_TRANSACTION (transaction));
 
       /* as far as the rest of the code is concerned, we're rebasing to :SHA256 now */


### PR DESCRIPTION
One OpenShift user saw this from rpm-ostree:

```
client(id:cli dbus:1.583 unit:machine-config-daemon-host.service uid:0) added; new total=1
Initiated txn UpdateDeployment for client(id:cli dbus:1.583 unit:machine-config-daemon-host.service uid:0): /org/projectatomic/rpmostree1/rhcos
Txn UpdateDeployment on /org/projectatomic/rpmostree1/rhcos failed: File header size 4294967295 exceeds size 0
```

which isn't very helpful. Let's add some error
prefixing here just to clarify this is pulling from
the repo.

xref https://github.com/ostreedev/ostree/pull/2118
