### PR TITLE
tests: Make more resistant to releasever changes

### DIFF
--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -528,10 +528,8 @@ vm_run_container() {
   # just automatically always share dnf cache so we don't redownload each time
   # (use -n so this ssh invocation doesn't consume stdin)
   vm_cmd -n mkdir -p /var/cache/dnf
-  # This uses a mirror since the Fedora registry is very flaky
-  # https://pagure.io/releng/issue/9282
   vm_cmd podman run --rm -v /var/cache/dnf:/var/cache/dnf:z $podman_args \
-    registry.svc.ci.openshift.org/coreos/fedora:31 "$@"
+    registry.fedoraproject.org/fedora:32 "$@"
 }
 
 # $1 - service name

--- a/tests/compose/test-misc-tweaks.sh
+++ b/tests/compose/test-misc-tweaks.sh
@@ -34,9 +34,9 @@ treefile_append "exclude-packages" '["somenonexistent-package", "gnome-shell"]'
 
 # Note this overrides:
 # $ rpm -q systemd
-# systemd-243.4-1.fc31.x86_64
-# $ rpm -qlv systemd|grep -F 'system/default.target '
-# lrwxrwxrwx    1 root    root                       16 May 11 06:59 /usr/lib/systemd/system/default.target -> graphical.target
+# systemd-245.4-1.fc32.x86_64
+# $ rpm -qlv systemd | grep -F 'system/default.target'
+# lrwxrwxrwx    1 root     root                       16 Apr  1 17:46 /usr/lib/systemd/system/default.target -> graphical.target
 treefile_set "default-target" '"multi-user.target"'
 treefile_append "units" '["zincati.service"]'
 # Need this in order to test unit enablement

--- a/tests/compose/test-mutate-os-release.sh
+++ b/tests/compose/test-mutate-os-release.sh
@@ -5,10 +5,10 @@ dn=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=libcomposetest.sh
 . "${dn}/libcomposetest.sh"
 
-releasever=31
-
 # make sure we clear out postprocess scripts, which might be using os-release
 treefile_set "postprocess" '[]'
+
+releasever=$(jq -r .releasever "${treefile}")
 
 # specifying the key but neither automatic_version_prefix nor
 # --add-metadata-string should cause no mutation

--- a/tests/compose/test-rojig-e2e.sh
+++ b/tests/compose/test-rojig-e2e.sh
@@ -34,7 +34,7 @@ do_commit2rojig() {
     echo "$(date): finished commit2rojig"
 }
 do_commit2rojig ${rev}
-test -f rojig-output/x86_64/fedora-coreos-42.0-1.fc31.x86_64.rpm
+test -f rojig-output/x86_64/fedora-coreos-42.0-1.fc*.x86_64.rpm
 
 ostree --repo=rojig-unpack-repo init --mode=bare-user
 echo 'fsync=false' >> rojig-unpack-repo/config
@@ -81,7 +81,7 @@ assert_file_has_content test-newpkg-list.txt 'test-newpkg-1.0-1.x86_64'
 
 # Rojig version 42.1
 do_commit2rojig ${newrev}
-path=rojig-output/x86_64/fedora-coreos-42.1-1.fc31.x86_64.rpm
+path=rojig-output/x86_64/fedora-coreos-42.1-1.fc*.x86_64.rpm
 rpm -qp --requires ${path} > requires.txt
 assert_file_has_content requires.txt 'glibc(.*) = '
 assert_file_has_content requires.txt 'systemd(.*) = '

--- a/tests/compose/test-rojig-pure.sh
+++ b/tests/compose/test-rojig-pure.sh
@@ -17,7 +17,7 @@ runcompose() {
 
 runcompose
 test -f treecompose.json
-test -f rojig-repo/x86_64/fedora-coreos-42-1.fc31.x86_64.rpm
+test -f rojig-repo/x86_64/fedora-coreos-42-1.fc*.x86_64.rpm
 echo "ok rojig ♲📦 initial"
 
 runcompose
@@ -27,5 +27,5 @@ echo "ok rojig no changes"
 treefile_set "documentation" 'False'
 runcompose
 test -f treecompose.json
-test -f rojig-repo/x86_64/fedora-coreos-42.1-1.fc31.x86_64.rpm
+test -f rojig-repo/x86_64/fedora-coreos-42.1-1.fc*.x86_64.rpm
 echo "ok rojig dropped docs"


### PR DESCRIPTION
Now that cosa and FCOS have moved to f32, a bunch of tests are breaking.
Let's make them more resistant to releasever changes.

While we're here though, bump the container image we use on the target
host to f32, and update the systemd example output.