### PR TITLE
libpriv/scripts: Replace crypto-policies lua script

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -14,7 +14,7 @@ parallel rpms: {
         # restore those through a build opt later on. Being able to stash RPMs directly is
         # super nice (and archiving later on will make it easy for anyone to download
         # binaries from PRs in the future) and meshes well with the following stages.
-        export PATH="/root/.cargo/bin:\$PATH"
+        export PATH="\$HOME/.cargo/bin:\$PATH"
         cargo install cbindgen
         cbindgen -c rust/cbindgen.toml -o rpmostree-rust.h rust
 

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -170,6 +170,20 @@ static const RpmOstreeLuaReplacement lua_replacements[] = {
     "libdir=" LIBDIR "\n"
     "exec iconvconfig -o ${libdir}/gconv/gconv-modules.cache --nostdlib ${libdir}/gconv"
   },
+  /* See https://bugzilla.redhat.com/show_bug.cgi?id=1847454.
+   * Code originally introduced in:
+   * https://src.fedoraproject.org/rpms/crypto-policies/c/9b9c9f7378c3fd375b9a08d5283c530a51a5de34?branch=master
+   * Keying off the installed machines FIPS mode for the installroot doesn't make sense, so
+   * just revert back to baking in the DEFAULT config.
+   */
+  { "crypto-policies.post",
+    "/usr/bin/bash",
+    "cp " DATADIR "/crypto-policies/default-config " SYSCONFDIR "/crypto-policies/config\n"
+    "echo DEFAULT > " SYSCONFDIR "/crypto-policies/state/current\n"
+    "for f in " DATADIR "/crypto-policies/DEFAULT/*; do\n"
+    "  ln -sf $f " SYSCONFDIR "/crypto-policies/back-ends/$(basename $f .txt).config\n"
+    "done"
+  },
   /* Just for the tests */
   { "rpmostree-lua-override-test.post",
     "/usr/bin/sh",

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -81,3 +81,7 @@ echo "ok coreos-rootfs seal"
 # Reload as root https://github.com/projectatomic/rpm-ostree/issues/976
 rpm-ostree reload
 echo "ok reload"
+
+# See rpmostree-scripts.c
+grep ^DEFAULT /etc/crypto-policies/config
+echo "ok crypto-policies DEFAULT backend"


### PR DESCRIPTION
The latest crypto-policies package changed recently to dynamically set
the policy at install time so that if FIPS is enabled, the selected
backend is `FIPS`:

https://src.fedoraproject.org/rpms/crypto-policies/c/9b9c9f7378c3fd375b9a08d5283c530a51a5de34?branch=master

This doesn't really make sense for us though since the compose server
configuration should be decoupled from the installroot. (More generally,
this also affects e.g. `yum install --installroot`).

Override the script for now so that we always select the `DEFAULT`
policy. We'll discuss with upstream to see what the right solution is
there.

This also works around the fact that rpm-ostree doesn't yet implement
Lua (#749).

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1847454
Resolves: https://github.com/coreos/fedora-coreos-tracker/issues/540