### PR TITLE
ffiutil: Format full errors from anyhow

### DIFF
--- a/rust/src/ffiutil.rs
+++ b/rust/src/ffiutil.rs
@@ -153,7 +153,7 @@ pub(crate) fn error_to_glib<E: Display>(e: &E, gerror: *mut *mut glib_sys::GErro
     }
     unsafe {
         assert!((*gerror).is_null());
-        let c_msg = CString::new(e.to_string()).unwrap();
+        let c_msg = CString::new(format!("{:#}", e)).unwrap();
         *gerror = glib_sys::g_error_new_literal(
             gio_sys::g_io_error_quark(),
             gio_sys::G_IO_ERROR_FAILED,


### PR DESCRIPTION
We need to use this alternative formatter to get full errors
including the full context chain.  IMO the anyhow default is broken.
