### PR TITLE
Release 2020.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ dnl Then git push origin v201X.XX.
 dnl Then create the xz tarball from `make -f Makefile.dist-packaging dist-snapshot`.
 dnl Then create a GitHub release for the new release tag and attach the tarball.
 m4_define([year_version], [2020])
-m4_define([release_version], [2])
+m4_define([release_version], [3])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [atomic-devel@projectatomic.io])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2020.2
+Version: 2020.3
 Release: 1%{?dist}
 #VCS: https://github.com/cgwalters/rpm-ostree
 # This tarball is generated via "cd packaging && make -f Makefile.dist-packaging dist-snapshot"


### PR DESCRIPTION
Seems about time, but also to get the crypto-policies workaround out:
https://github.com/coreos/fedora-coreos-tracker/issues/540