### PR TITLE
Move release instructions to RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+# Releasing rpm-ostree
+
+1. Increment the `year_version` and `release_version` macros in `configure.ac`.
+2. Increment the `Version` field in `rpm-ostree.spec.in`.
+3. Submit as a PR and wait until reviewed *and* CI is green.
+5. Once merged, do `git pull $upstream && git reset --hard $upstream/master` on
+   your local `master` branch to make sure you're on the right commit.
+6. Draft release notes by seeding a HackMD.io with `git shortlog $last_tag..`
+   and ideally collaborating with others. Filter out the commits from
+   `dependabot`. See previous releases for format.
+7. Use [`git-evtag`](https://github.com/cgwalters/git-evtag) to create a signed
+   tag with the release notes as its content. Make the first line be the name of
+   the tag itself.
+8. Push the tag using `git push $upstream v202X.XX`.
+9. Create the xz tarball using `make -C packaging -f Makefile.dist-packaging dist-snapshot`.
+10. Create a GitHub release for the new release tag using its contents and
+    attach the tarball.

--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,7 @@
 AC_PREREQ([2.63])
-dnl To do a release, increment this number and the spec file, commit, then submit it as a PR
-dnl to merge via prow.  After that, do `git pull origin && git reset --hard origin/master`.
-dnl Then draft release notes highlighting changes and generate the shortlog using
-dnl <https://github.com/cgwalters/homegit/blob/master/bin/git-shortlog-with-prs>.
-dnl Then use <https://github.com/cgwalters/git-evtag> to create a signed tag with the
-dnl release notes as its content.
-dnl Then git push origin v201X.XX.
-dnl Then create the xz tarball from `make -f Makefile.dist-packaging dist-snapshot`.
-dnl Then create a GitHub release for the new release tag and attach the tarball.
+dnl
+dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
+dnl
 m4_define([year_version], [2020])
 m4_define([release_version], [3])
 m4_define([package_version], [year_version.release_version])


### PR DESCRIPTION
The instructions for doing a release were outdated. Take the opportunity
to just move it to a dedicated markdown file and breaking it out to make
it easier to follow.

This is one step short of using a release checklist like some of the
other CoreOS projects do. This is a good base to eventually do that if
we want.