### PR TITLE
ci/installdeps: add distribution-gpg-keys

### DIFF
--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -24,4 +24,4 @@ dnf builddep --spec -y packaging/rpm-ostree.spec.in --allowerasing
 pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq python3-pyyaml \
     libubsan libasan libtsan elfutils fuse sudo python3-gobject-base \
     selinux-policy-devel selinux-policy-targeted python3-createrepo_c \
-    rsync python3-rpm parallel clang rustfmt-preview
+    rsync python3-rpm parallel clang rustfmt-preview distribution-gpg-keys


### PR DESCRIPTION
This is needed by the compose tests. This is part of cosa already, which
is why CI isn't hitting this, but we want to support users not
developing on top of the cosa buildroot container that can just run
`ci/installdeps.sh`.