### PR TITLE
postprocess: Add a symlink /usr/lib/sysimage/rpm to the rpmdb

### DIFF
--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -35,6 +35,7 @@
 /* See http://lists.rpm.org/pipermail/rpm-maint/2017-October/006681.html */
 #define RPMOSTREE_RPMDB_LOCATION "usr/share/rpm"
 #define RPMOSTREE_SYSIMAGE_DIR "usr/lib/sysimage"
+#define RPMOSTREE_SYSIMAGE_RPMDB RPMOSTREE_SYSIMAGE_DIR "/rpm"
 #define RPMOSTREE_BASE_RPMDB RPMOSTREE_SYSIMAGE_DIR "/rpm-ostree-base-db"
 
 /* put it in cache dir so it gets destroyed naturally with a `cleanup -m` */

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1087,6 +1087,11 @@ rpmostree_postprocess_final (int            rootfs_dfd,
                              rootfs_dfd, RPMOSTREE_BASE_RPMDB,
                              cancellable, error))
         return glnx_prefix_error (error, "Hardlinking %s", RPMOSTREE_BASE_RPMDB);
+      /* And write a symlink from the proposed standard /usr/lib/sysimage/rpm
+       * to our /usr/share/rpm - eventually we will invert this.
+       */
+     if (symlinkat ("../../share/rpm", rootfs_dfd, RPMOSTREE_SYSIMAGE_RPMDB) < 0)
+        return glnx_throw_errno_prefix (error, "symlinking %s", RPMOSTREE_SYSIMAGE_RPMDB);
     }
 
   return TRUE;

--- a/tests/compose/libbasic-test.sh
+++ b/tests/compose/libbasic-test.sh
@@ -36,6 +36,7 @@ for path in /usr/share/rpm /usr/lib/sysimage/rpm-ostree-base-db; do
     ostree --repo=${repo} ls -R ${treeref} ${path} > db.txt
     assert_file_has_content_literal db.txt /Packages
 done
+ostree --repo=${repo} ls ${treeref} /usr/lib/sysimage/rpm >/dev/null
 echo "ok db"
 
 ostree --repo=${repo} show --print-metadata-key exampleos.gitrepo ${treeref} > meta.txt


### PR DESCRIPTION
Following on to:

- http://lists.rpm.org/pipermail/rpm-maint/2017-October/006681.html
- https://github.com/coreos/rpm-ostree/pull/1142/
- https://github.com/openSUSE/libsolv/pull/386

Write a symlink in `/usr/lib/sysimage/rpm` pointing to our current
`/usr/share/rpm` - this way clients can start looking for it there,
and then at some point we'll flip the symlink around and
have `/usr/share/rpm` pointing to the new location.

(Doing a hard swap now has upgrade implications)
