### PR TITLE
daemon: Use IOSchedulingClass=idle

### DIFF
--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -6,6 +6,14 @@ ConditionPathExists=/ostree
 [Service]
 Type=dbus
 BusName=org.projectatomic.rpmostree1
+# Be nice to concurrent processes; operating system updates
+# are usually a background thing.  See e.g.
+# https://github.com/openshift/machine-config-operator/issues/1897
+# https://github.com/ostreedev/ostree/pull/2152
+# This option is most effective in combination with
+# a block scheduler such as `bfq`, which is the systemd
+# default since https://github.com/systemd/systemd/pull/13321
+IOSchedulingClass=idle
 # To use the read-only sysroot bits
 MountFlags=slave
 NotifyAccess=main

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -56,6 +56,10 @@ fi
 assert_file_has_content err.txt 'Unknown.*command'
 echo "ok error on unknown command"
 
+systemctl show -p IOSchedulingClass rpm-ostreed >out.txt
+assert_file_has_content out.txt 'IOSchedulingClass=3'
+echo "ok IO scheduling"
+
 stateroot=$(dirname $(ls /ostree/deploy/*/var))
 ospath=/org/projectatomic/rpmostree1/${stateroot//-/_}
 # related: https://github.com/coreos/fedora-coreos-config/issues/194


### PR DESCRIPTION
Pairs with: https://github.com/ostreedev/ostree/pull/2152

Be nice to concurrent processes; operating system updates
are usually a background thing.  See e.g.
https://github.com/openshift/machine-config-operator/issues/1897
https://github.com/ostreedev/ostree/pull/2152
This option is most effective in combination with
a block scheduler such as `bfq`, which is the systemd
default since https://github.com/systemd/systemd/pull/13321
