### PR TITLE
Add new `ex initramfs-etc` command

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -32,6 +32,7 @@ rpm_ostree_SOURCES = src/app/main.c \
 	src/app/rpmostree-builtin-cliwrap.c \
 	src/app/rpmostree-builtin-cleanup.c \
 	src/app/rpmostree-builtin-initramfs.c \
+	src/app/rpmostree-builtin-initramfs-etc.c \
 	src/app/rpmostree-builtin-livefs.c \
 	src/app/rpmostree-builtin-usroverlay.c \
 	src/app/rpmostree-builtin-override.c \

--- a/configure.ac
+++ b/configure.ac
@@ -94,7 +94,7 @@ LIBS="$save_LIBS"
 # Remember to update AM_CPPFLAGS in Makefile.am when bumping GIO req.
 PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [gio-unix-2.0 >= 2.50.0 json-glib-1.0
-				     ostree-1 >= 2020.1
+				     ostree-1 >= 2020.7
 				     libsystemd
 				     polkit-gobject-1
 				     rpm librepo libsolv

--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -662,6 +662,36 @@ Boston, MA 02111-1307, USA.
         </listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><command>ex initramfs-etc</command></term>
+
+        <listitem>
+          <para>
+            Experimental feature; subject to change.
+          </para>
+
+          <para>
+            Add configuration (<literal>/etc</literal>) files into the initramfs without
+            regenerating the entire initramfs. This is useful to be able to configure
+            services backing the root block device as well as early-boot services like
+            systemd and journald.
+          </para>
+
+          <para>
+            Use <command>--track</command> to start tracking a specific file. Can be
+            specified multiple times. A new deployment will be generated. Use
+            <command>--untrack</command> or <command>--untrack-all</command> to stop
+            tracking files.
+          </para>
+
+          <para>
+            When there are tracked files, any future created deployment (e.g. when doing an
+            upgrade) will ensure that they are synced. You can additionally use
+            <command>--force-sync</command> to simply generate a new deployment with the
+            latest versions of tracked files without upgrading.
+          </para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -42,7 +42,7 @@ BuildRequires: gnome-common
 BuildRequires: /usr/bin/g-ir-scanner
 # Core requirements
 # One way to check this: `objdump -p /path/to/rpm-ostree | grep LIBOSTREE` and pick the highest (though that might miss e.g. new struct members)
-BuildRequires: pkgconfig(ostree-1) >= 2019.2
+BuildRequires: pkgconfig(ostree-1) >= 2020.7
 BuildRequires: pkgconfig(polkit-gobject-1)
 BuildRequires: pkgconfig(json-glib-1.0)
 BuildRequires: pkgconfig(rpm)

--- a/src/app/rpmostree-builtin-ex.c
+++ b/src/app/rpmostree-builtin-ex.c
@@ -36,6 +36,8 @@ static RpmOstreeCommand ex_subcommands[] = {
 #endif
   { "history", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
     "Inspect rpm-ostree history of the system", rpmostree_ex_builtin_history },
+  { "initramfs-etc", RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT,
+    "Track initramfs configuration files", rpmostree_ex_builtin_initramfs_etc },
   { NULL, 0, NULL, NULL }
 };
 

--- a/src/app/rpmostree-builtin-initramfs-etc.c
+++ b/src/app/rpmostree-builtin-initramfs-etc.c
@@ -1,0 +1,156 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2020 Jonathan Lebon <jonathan@jlebon.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <glib-unix.h>
+
+#include "rpmostree-ex-builtins.h"
+#include "rpmostree-libbuiltin.h"
+#include "rpmostree-dbus-helpers.h"
+
+#include <libglnx.h>
+
+static char *opt_osname;
+static gboolean opt_force_sync;
+static char **opt_track;
+static char **opt_untrack;
+static gboolean opt_untrack_all;
+static gboolean opt_reboot;
+static gboolean opt_lock_finalization;
+static gboolean opt_unchanged_exit_77;
+
+static GOptionEntry option_entries[] = {
+  { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+  { "force-sync", 0, 0, G_OPTION_ARG_NONE, &opt_force_sync, "Deploy a new tree with the latest tracked /etc files", NULL },
+  { "track", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_track, "Track root /etc file", "FILE" },
+  { "untrack", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_untrack, "Untrack root /etc file", "FILE" },
+  { "untrack-all", 0, 0, G_OPTION_ARG_NONE, &opt_untrack_all, "Untrack all root /etc files", NULL },
+  { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot, "Initiate a reboot after operation is complete", NULL },
+  { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization, "Prevent automatic deployment finalization on shutdown", NULL },
+  { "unchanged-exit-77", 0, 0, G_OPTION_ARG_NONE, &opt_unchanged_exit_77, "If no new deployment made, exit 77", NULL },
+
+  { NULL }
+};
+
+gboolean
+rpmostree_ex_builtin_initramfs_etc (int             argc,
+                                    char          **argv,
+                                    RpmOstreeCommandInvocation *invocation,
+                                    GCancellable   *cancellable,
+                                    GError        **error)
+{
+  g_autoptr(GOptionContext) context = g_option_context_new ("");
+
+  _cleanup_peer_ GPid peer_pid = 0;
+  glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
+  if (!rpmostree_option_context_parse (context,
+                                       option_entries,
+                                       &argc, &argv,
+                                       invocation,
+                                       cancellable,
+                                       NULL, NULL,
+                                       &sysroot_proxy,
+                                       &peer_pid,
+                                       NULL,
+                                       error))
+    return FALSE;
+
+  glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
+  if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname,
+                                cancellable, &os_proxy, error))
+    return FALSE;
+
+  g_autoptr(GVariant) previous_deployment = rpmostree_os_dup_default_deployment (os_proxy);
+
+  if (!(opt_track || opt_untrack || opt_untrack_all || opt_force_sync))
+    {
+      if (opt_reboot)
+        return glnx_throw (error, "Cannot use ---reboot without --track, --untrack, --untrack-all, or --force-sync");
+
+      g_autofree char **files = NULL;
+      g_autoptr(GVariant) deployments = rpmostree_sysroot_dup_deployments (sysroot_proxy);
+      if (g_variant_n_children (deployments) > 0)
+        {
+          g_autoptr(GVariant) pending = g_variant_get_child_value (deployments, 0);
+          g_auto(GVariantDict) dict;
+          g_variant_dict_init (&dict, pending);
+
+          g_variant_dict_lookup (&dict, "initramfs-etc", "^a&s", &files);
+        }
+
+      if (!files || !*files)
+        g_print ("No tracked files.\n");
+      else
+        {
+          g_print ("Tracked files:\n");
+          for (char **it = files; it && *it; it++)
+            g_print ("  %s\n", *it);
+        }
+
+      return TRUE; /* note early return */
+    }
+
+  char *empty_strv[] = {NULL};
+  if (!opt_track)
+    opt_track = empty_strv;
+  if (!opt_untrack)
+    opt_untrack = empty_strv;
+
+  GVariantDict dict;
+  g_variant_dict_init (&dict, NULL);
+  g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
+  g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
+  g_variant_dict_insert (&dict, "lock-finalization", "b", opt_lock_finalization);
+  g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
+
+  g_autofree char *transaction_address = NULL;
+  if (!rpmostree_os_call_initramfs_etc_sync (os_proxy,
+                                             (const char *const*)opt_track,
+                                             (const char *const*)opt_untrack,
+                                             opt_untrack_all,
+                                             opt_force_sync,
+                                             options,
+                                             &transaction_address,
+                                             cancellable,
+                                             error))
+    return FALSE;
+
+  if (!rpmostree_transaction_get_response_sync (sysroot_proxy,
+                                                transaction_address,
+                                                cancellable,
+                                                error))
+    return FALSE;
+
+  if (!opt_reboot)
+    {
+      if (!rpmostree_has_new_default_deployment (os_proxy, previous_deployment))
+        {
+          if (opt_unchanged_exit_77)
+            invocation->exit_code = RPM_OSTREE_EXIT_UNCHANGED;
+          return TRUE;
+        }
+
+      g_print ("Run \"systemctl reboot\" to start a reboot\n");
+    }
+
+  return TRUE;
+}

--- a/src/app/rpmostree-builtin-reset.c
+++ b/src/app/rpmostree-builtin-reset.c
@@ -42,7 +42,7 @@ static GOptionEntry option_entries[] = {
   { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot, "Initiate a reboot after transaction is complete", NULL },
   { "overlays", 'l', 0, G_OPTION_ARG_NONE, &opt_overlays, "Remove all overlayed packages", NULL },
   { "overrides", 'o', 0, G_OPTION_ARG_NONE, &opt_overrides, "Remove all overrides", NULL },
-  { "initramfs", 'i', 0, G_OPTION_ARG_NONE, &opt_initramfs, "Stop regenerating initramfs", NULL },
+  { "initramfs", 'i', 0, G_OPTION_ARG_NONE, &opt_initramfs, "Stop regenerating initramfs or tracking files", NULL },
   { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization, "Prevent automatic deployment finalization on shutdown", NULL },
   { NULL }
 };

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -870,6 +870,13 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
         g_string_append (buf, "regenerate");
       rpmostree_print_kv ("Initramfs", max_key_len, buf->str);
     }
+
+  g_autofree char **initramfs_etc_files = NULL;
+  g_variant_dict_lookup (dict, "initramfs-etc", "^a&s", &initramfs_etc_files);
+  if (initramfs_etc_files && *initramfs_etc_files)
+    /* XXX: not really packages but it works... should just rename that function */
+    print_packages ("InitramfsEtc", max_key_len, (const char**)initramfs_etc_files, NULL);
+
   gboolean pinned = FALSE;
   g_variant_dict_lookup (dict, "pinned", "b", &pinned);
   if (pinned)

--- a/src/app/rpmostree-ex-builtins.h
+++ b/src/app/rpmostree-ex-builtins.h
@@ -37,6 +37,7 @@ BUILTINPROTO(commit2rojig);
 BUILTINPROTO(rojig2commit);
 #endif
 BUILTINPROTO(history);
+BUILTINPROTO(initramfs_etc);
 
 #undef BUILTINPROTO
 

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -253,6 +253,15 @@
       <arg type="s" name="transaction_address" direction="out"/>
     </method>
 
+    <method name="InitramfsEtc">
+      <arg type="as" name="track" direction="in"/>
+      <arg type="as" name="untrack" direction="in"/>
+      <arg type="b" name="untrack_all" direction="in"/>
+      <arg type="b" name="force_sync" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="s" name="transaction_address" direction="out"/>
+    </method>
+
    <!-- Available options:
         "reboot" (type 'b')
     -->

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -21,6 +21,7 @@
 #include "config.h"
 
 #include <libglnx.h>
+#include <gio/gunixoutputstream.h>
 #include <systemd/sd-journal.h>
 #include "rpmostreed-utils.h"
 #include "rpmostree-util.h"
@@ -948,6 +949,15 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self,
 {
   g_assert (!self->ctx);
 
+  /* before doing any serious work; do some basic sanity checks that the origin is valid */
+
+  /* If initramfs regeneration is enabled, it's silly to support /etc overlays on top of
+   * that. Just point users at dracut's -I instead. I guess we could auto-convert
+   * ourselves? */
+  if (rpmostree_origin_get_regenerate_initramfs (self->origin) &&
+      g_hash_table_size (rpmostree_origin_get_initramfs_etc_files (self->origin)) > 0)
+    return glnx_throw (error, "initramfs regeneration and /etc overlay not compatible; use dracut arg -I instead");
+
   if (!checkout_base_tree (self, cancellable, error))
     return FALSE;
 
@@ -1036,6 +1046,186 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self,
     /* Otherwise, we're transitioning from not-layered to layered, so it
        definitely changed */
     self->layering_changed = TRUE;
+
+  return TRUE;
+}
+
+static gboolean
+add_etc_files_recurse (const char         *path,
+                       GPtrArray          *filelist,
+                       GCancellable       *cancellable,
+                       GError            **error)
+{
+  struct stat stbuf;
+  if (!glnx_fstatat (AT_FDCWD, path, &stbuf, AT_SYMLINK_NOFOLLOW, error))
+    return FALSE;
+
+  if (!(S_ISDIR (stbuf.st_mode) || S_ISREG (stbuf.st_mode) || S_ISLNK (stbuf.st_mode)))
+    return glnx_throw (error, "Invalid file type for %s", path);
+
+  g_ptr_array_add (filelist, g_strdup (path));
+
+  /* cpio doesn't automatically recurse into directories, so we need to do it */
+  if (S_ISDIR (stbuf.st_mode))
+    {
+      g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
+      if (!glnx_dirfd_iterator_init_at (AT_FDCWD, path, TRUE, &dfd_iter, error))
+        return FALSE;
+
+      while (TRUE)
+        {
+          struct dirent *dent = NULL;
+          if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&dfd_iter, &dent, cancellable, error))
+            return FALSE;
+          if (!dent)
+            break;
+
+          g_autofree char *subpath = g_build_filename (path, dent->d_name, NULL);
+          if (!add_etc_files_recurse (subpath, filelist, cancellable, error))
+            return FALSE;
+        }
+    }
+
+  return TRUE;
+}
+
+typedef struct {
+  guint counter;
+  GMainLoop *loop;
+  GError **error;
+} InitRamfsOverlayData;
+
+static void
+splice_cb (GObject      *object,
+           GAsyncResult *result,
+           gpointer      user_data)
+{
+  InitRamfsOverlayData *data = user_data;
+  g_autoptr(GError) local_error = NULL;
+
+  (void)g_output_stream_splice_finish ((GOutputStream*)object, result, &local_error);
+
+  /* just keep the first error */
+  if (local_error && !*data->error)
+    *data->error = g_steal_pointer (&local_error);
+
+  data->counter--;
+  if (data->counter == 0)
+    g_main_loop_quit (data->loop);
+}
+
+static int
+compare_strings (gconstpointer a,
+                 gconstpointer b)
+{
+  const gchar *sa = *(const gchar **) a;
+  const gchar *sb = *(const gchar **) b;
+  return strcmp (sa, sb);
+}
+
+static gboolean
+generate_initramfs_overlay (GHashTable    *initramfs_etc_files,
+                            GLnxTmpfile   *out_tmpf,
+                            GCancellable  *cancellable,
+                            GError       **error)
+{
+
+  g_autoptr(GMainLoop) loop = g_main_loop_new (g_main_context_get_thread_default (), TRUE);
+  g_autoptr(GError) local_error = NULL;
+  InitRamfsOverlayData data = { .loop = loop, .error = &local_error };
+
+  g_auto(GLnxTmpfile) tmpf = { 0, };
+  if (!glnx_open_anonymous_tmpfile (O_RDWR | O_CLOEXEC, &tmpf, error))
+    return glnx_prefix_error (error, "Creating tmpfile");
+
+  g_autoptr(GOutputStream) tmpf_stream = g_unix_output_stream_new (tmpf.fd, FALSE);
+
+  g_autoptr(GPtrArray) filelist = g_ptr_array_new_with_free_func (g_free);
+
+  /* could do this async too... though it really shouldn't be that many files */
+  GLNX_HASH_TABLE_FOREACH (initramfs_etc_files, const char*, path)
+    {
+      /* should've been checked already */
+      g_assert (g_str_has_prefix (path, "/etc/"));
+      if (!add_etc_files_recurse (path, filelist, cancellable, error))
+        return FALSE;
+    }
+
+  /* feed into the input stream, but sort first to avoid needlessly changing the checksum */
+  g_ptr_array_sort (filelist, compare_strings);
+  g_autoptr(GInputStream) filelist_input = g_memory_input_stream_new ();
+
+  /* keep a hash of the previous path so we don't archive the same file multiple times */
+  guint last_path_hash = 0;
+  for (guint i = 0; i < filelist->len; i++)
+    {
+      g_autofree char *path = g_steal_pointer (&filelist->pdata[i]); /* steal in-place */
+      guint path_hash = g_str_hash (path);
+      if (path_hash == last_path_hash)
+        continue;
+      g_memory_input_stream_add_data (G_MEMORY_INPUT_STREAM (filelist_input),
+                                      g_steal_pointer (&path), (strlen (path))+1, g_free);
+      last_path_hash = path_hash;
+    }
+
+  const char *cpio_argv[] = {"cpio", "--create", "--format", "newc", "--quiet",
+                             "--reproducible", "--null", NULL};
+  g_autoptr(GSubprocess) cpio = g_subprocess_newv ((const char *const*)cpio_argv,
+                                                   G_SUBPROCESS_FLAGS_STDIN_PIPE |
+                                                   G_SUBPROCESS_FLAGS_STDOUT_PIPE,
+                                                   error);
+  if (!cpio)
+    return FALSE;
+
+  const char *gzip_argv[] = {"gzip", "-1", NULL};
+  g_autoptr(GSubprocess) gzip = g_subprocess_newv ((const char *const*)gzip_argv,
+                                                   G_SUBPROCESS_FLAGS_STDIN_PIPE |
+                                                   G_SUBPROCESS_FLAGS_STDOUT_PIPE,
+                                                   error);
+  if (!gzip)
+    return FALSE;
+
+  GOutputStream *cpio_input = g_subprocess_get_stdin_pipe (cpio);
+  g_output_stream_splice_async (cpio_input, filelist_input,
+                                G_OUTPUT_STREAM_SPLICE_CLOSE_SOURCE |
+                                G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET,
+                                G_PRIORITY_DEFAULT, cancellable, splice_cb, &data);
+  data.counter++;
+
+  GInputStream *cpio_output = g_subprocess_get_stdout_pipe (cpio);
+  GOutputStream *gzip_input = g_subprocess_get_stdin_pipe (gzip);
+  g_output_stream_splice_async (gzip_input, cpio_output,
+                                G_OUTPUT_STREAM_SPLICE_CLOSE_SOURCE |
+                                G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET,
+                                G_PRIORITY_DEFAULT, cancellable, splice_cb, &data);
+  data.counter++;
+
+  GInputStream *gzip_output = g_subprocess_get_stdout_pipe (gzip);
+  g_output_stream_splice_async (tmpf_stream, gzip_output,
+                                G_OUTPUT_STREAM_SPLICE_CLOSE_SOURCE |
+                                G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET,
+                                G_PRIORITY_DEFAULT, cancellable, splice_cb, &data);
+  data.counter++;
+
+  g_main_loop_run (data.loop);
+
+  const gboolean cpio_success = g_subprocess_wait_check (cpio, cancellable, error);
+  const gboolean gzip_success = g_subprocess_wait_check (gzip, cancellable, error);
+  if (local_error)
+    {
+      g_propagate_error (error, g_steal_pointer (&local_error));
+      return FALSE;
+    }
+  /* stderr is inherited; so it's in the journal */
+  if (!cpio_success)
+    return glnx_throw (error, "cpio failed; check daemon output in journal");
+  if (!gzip_success)
+    return glnx_throw (error, "gzip failed; check daemon output in journal");
+
+  if (lseek (tmpf.fd, 0, SEEK_SET) < 0)
+    return glnx_throw_errno_prefix (error, "lseek");
+
+  *out_tmpf = tmpf; tmpf.initialized = FALSE; /* Transfer */
 
   return TRUE;
 }
@@ -1407,6 +1597,28 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
   g_autoptr(GKeyFile) origin = rpmostree_origin_dup_keyfile (self->origin);
   g_autoptr(OstreeDeployment) new_deployment = NULL;
 
+  g_autofree char *overlay_initrd_checksum = NULL;
+  const char *overlay_v[] = { NULL, NULL };
+  if (g_hash_table_size (rpmostree_origin_get_initramfs_etc_files (self->origin)) > 0)
+    {
+      g_auto(GLnxTmpfile) tmpf = { 0, };
+      if (!generate_initramfs_overlay (rpmostree_origin_get_initramfs_etc_files (self->origin),
+                                       &tmpf, cancellable, error))
+        return glnx_prefix_error (error, "Generating initramfs overlay");
+
+      if (!ostree_sysroot_stage_overlay_initrd (self->sysroot, tmpf.fd,
+                                                &overlay_initrd_checksum,
+                                                cancellable, error))
+        return glnx_prefix_error (error, "Staging initramfs overlay");
+
+      overlay_v[0] = overlay_initrd_checksum;
+    }
+
+  OstreeSysrootDeployTreeOpts opts = {
+    .override_kernel_argv = self->kargs_strv,
+    .overlay_initrds = (char**)overlay_v,
+  };
+
   if (use_staging)
     {
       /* touch file *before* we stage to avoid races */
@@ -1426,22 +1638,20 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
 
       g_auto(RpmOstreeProgress) task = { 0, };
       rpmostree_output_task_begin (&task, "Staging deployment");
-      if (!ostree_sysroot_stage_tree (self->sysroot, self->osname,
-                                      target_revision, origin,
-                                      self->cfg_merge_deployment,
-                                      self->kargs_strv,
-                                      &new_deployment,
-                                      cancellable, error))
+      if (!ostree_sysroot_stage_tree_with_options (self->sysroot, self->osname,
+                                                   target_revision, origin,
+                                                   self->cfg_merge_deployment,
+                                                   &opts, &new_deployment,
+                                                   cancellable, error))
         return FALSE;
     }
   else
     {
-      if (!ostree_sysroot_deploy_tree (self->sysroot, self->osname,
-                                       target_revision, origin,
-                                       self->cfg_merge_deployment,
-                                       self->kargs_strv,
-                                       &new_deployment,
-                                       cancellable, error))
+      if (!ostree_sysroot_deploy_tree_with_options (self->sysroot, self->osname,
+                                                    target_revision, origin,
+                                                    self->cfg_merge_deployment,
+                                                    &opts, &new_deployment,
+                                                    cancellable, error))
         return FALSE;
     }
 

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -412,6 +412,9 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
       g_variant_dict_insert (&dict, "initramfs-args", "^as", args);
   }
 
+  variant_add_from_hash_table (&dict, "initramfs-etc",
+                               rpmostree_origin_get_initramfs_etc_files (origin));
+
   if (booted_id != NULL)
     g_variant_dict_insert (&dict, "booted", "b", g_strcmp0 (booted_id, id) == 0);
 

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -78,6 +78,18 @@ rpmostreed_transaction_new_finalize_deployment (GDBusMethodInvocation *invocatio
                                                 GError               **error);
 
 RpmostreedTransaction *
+rpmostreed_transaction_new_initramfs_etc (GDBusMethodInvocation *invocation,
+                                          OstreeSysroot         *sysroot,
+                                          const char            *osname,
+                                          char                 **track,
+                                          char                 **untrack,
+                                          gboolean               untrack_all,
+                                          gboolean               force_sync,
+                                          GVariant              *options,
+                                          GCancellable          *cancellable,
+                                          GError               **error);
+
+RpmostreedTransaction *
 rpmostreed_transaction_new_initramfs_state       (GDBusMethodInvocation *invocation,
                                                   OstreeSysroot         *sysroot,
                                                   const char            *osname,

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -95,6 +95,9 @@ rpmostree_origin_get_overrides_local_replace (RpmOstreeOrigin *origin);
 const char *
 rpmostree_origin_get_override_commit (RpmOstreeOrigin *origin);
 
+GHashTable *
+rpmostree_origin_get_initramfs_etc_files (RpmOstreeOrigin *origin);
+
 gboolean
 rpmostree_origin_get_regenerate_initramfs (RpmOstreeOrigin *origin);
 
@@ -119,6 +122,20 @@ rpmostree_origin_get_string (RpmOstreeOrigin *origin,
 
 GKeyFile *
 rpmostree_origin_dup_keyfile (RpmOstreeOrigin *origin);
+
+void
+rpmostree_origin_initramfs_etc_files_track (RpmOstreeOrigin *origin,
+                                            char **paths,
+                                            gboolean *out_changed);
+
+void
+rpmostree_origin_initramfs_etc_files_untrack (RpmOstreeOrigin *origin,
+                                              char **paths,
+                                              gboolean *out_changed);
+
+void
+rpmostree_origin_initramfs_etc_files_untrack_all (RpmOstreeOrigin *origin,
+                                                  gboolean *out_changed);
 
 void
 rpmostree_origin_set_regenerate_initramfs (RpmOstreeOrigin *origin,

--- a/tests/kolainst/Makefile
+++ b/tests/kolainst/Makefile
@@ -10,4 +10,6 @@ all:
 install:
 	install -d -m 0755 $(KOLA_TESTDIR)
 	rsync -prlv ./nondestructive $(KOLA_TESTDIR)/
-	rsync -prlv ../common/ $(KOLA_TESTDIR)/nondestructive/data
+	rsync -prlv ./destructive $(KOLA_TESTDIR)/
+	rsync -prlv ../common/*.sh $(KOLA_TESTDIR)/nondestructive/data/
+	rsync -prlv ../common/*.sh $(KOLA_TESTDIR)/destructive/data/

--- a/tests/kolainst/destructive/initramfs-etc
+++ b/tests/kolainst/destructive/initramfs-etc
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -euo pipefail
+
+. ${KOLA_EXT_DATA}/libtest.sh
+cd $(mktemp -d)
+
+# From https://github.com/ostreedev/ostree/blob/95a6d1514/tests/kolainst/destructive/overlay-initrds.sh#L23
+check_for_dracut_karg() {
+  local karg=$1; shift
+  # https://github.com/dracutdevs/dracut/blob/38ea7e821b/modules.d/98dracut-systemd/dracut-cmdline.sh#L17
+  journalctl -b 0 -t dracut-cmdline \
+    --grep "Using kernel command line parameters:.* ${karg} "
+}
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+    mkdir -p /etc/cmdline.d
+    echo 'foobar' > /etc/cmdline.d/foobar.conf
+
+    rpm-ostree ex initramfs-etc --track /etc/cmdline.d/foobar.conf
+    rpm-ostree status > status.txt
+    assert_file_has_content_literal status.txt "InitramfsEtc: /etc/cmdline.d/foobar.conf"
+    rpm-ostree status --json > status.json
+    assert_jq status.json \
+      '.deployments[0]["initramfs-etc"]|length == 1' \
+      '.deployments[0]["initramfs-etc"][0] == "/etc/cmdline.d/foobar.conf"'
+
+    /tmp/autopkgtest-reboot 1
+    ;;
+  1)
+    check_for_dracut_karg foobar
+    rpm-ostree ex initramfs-etc --track /etc/cmdline.d/foobar.conf > out.txt
+    assert_file_has_content_literal out.txt "No changes."
+
+    # right now we don't rechecksum all the files so changing the file alone
+    # isn't noticed, but we could in the future
+    echo 'barbaz' > /etc/cmdline.d/foobar.conf
+    rpm-ostree ex initramfs-etc --track /etc/cmdline.d/foobar.conf > out.txt
+    assert_file_has_content_literal out.txt "No changes."
+
+    # but --force-sync should also plow through
+    rpm-ostree ex initramfs-etc --force-sync > out.txt
+    assert_file_has_content_literal out.txt "Staging deployment"
+
+    /tmp/autopkgtest-reboot 2
+    ;;
+  2)
+    check_for_dracut_karg barbaz
+    if check_for_dracut_karg foobar; then
+      assert_not_reached "Found karg foobar; expected barbaz"
+    fi
+
+    # let's try tracking a whole directory instead
+    echo 'bazboo' > /etc/cmdline.d/bazboo.conf
+    # and for fun, let's use the the locked finalization flow
+    rpm-ostree ex initramfs-etc --lock-finalization \
+      --untrack /etc/cmdline.d/foobar.conf \
+      --track /etc/cmdline.d
+    rpm-ostree status > status.txt
+    assert_file_has_content_literal status.txt "InitramfsEtc: /etc/cmdline.d"
+    rpm-ostree status --json > status.json
+    assert_jq status.json \
+      '.deployments[0]["initramfs-etc"]|length == 1' \
+      '.deployments[0]["initramfs-etc"][0] == "/etc/cmdline.d"'
+
+    /tmp/autopkgtest-reboot-prepare 3
+    rpm-ostree finalize-deployment --allow-missing-checksum
+    ;;
+  3)
+    check_for_dracut_karg barbaz
+    check_for_dracut_karg bazboo
+
+    # finally, check that passing no args prints the tracked files
+    rpm-ostree ex initramfs-etc > out.txt
+    assert_file_has_content_literal out.txt "Tracked files:"
+    assert_file_has_content_literal out.txt "/etc/cmdline.d"
+    ;;
+  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac


### PR DESCRIPTION
This command allows users to cheaply inject configuration files in the
initramfs stage without having to regenerate the whole initramfs (or
even a new OSTree commit). This will be useful for configuring services
involved in bringing up the root block device.

```
$ echo 'hello world' > /etc/foobar
$ rpm-ostree ex initramfs-etc --track /etc/foobar
Staging deployment... done
Run "systemctl reboot" to start a reboot
$ rpm-ostree status
State: idle
Deployments:
  ostree://fedora:fedora/x86_64/coreos/testing-devel
                   Version: 32.20200716.dev.1 (2020-07-16T02:47:29Z)
                    Commit: 9a817d75bef81b955179be6e602d1e6ae350645b6323231a62ba2ee6e5b9644b
              GPGSignature: (unsigned)
              InitramfsEtc: /etc/foobar
                  Unlocked: development

● ostree://fedora:fedora/x86_64/coreos/testing-devel
                   Version: 32.20200716.dev.1 (2020-07-16T02:47:29Z)
                    Commit: 9a817d75bef81b955179be6e602d1e6ae350645b6323231a62ba2ee6e5b9644b
              GPGSignature: (unsigned)
$ reboot
(boot into rd.break)
sh-5.0# cat /etc/foobar
hello world
```

See the libostree side of this at:
ostreedev/ostree#2155

Lots more discussions in:
coreos/fedora-coreos-tracker#94