### PR TITLE
daemon/deploy: Finish OstreeAsyncProgress after pull

### DIFF
--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -975,6 +975,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
       if (!ostree_repo_pull (repo, local_repo_uri, (char**)refs_to_fetch,
                              OSTREE_REPO_PULL_FLAGS_NONE, progress, cancellable, error))
         return glnx_prefix_error (error, "Pulling commit %s from local repo", rev);
+      ostree_async_progress_finish (progress);
       rpmostree_transaction_emit_progress_end (RPMOSTREE_TRANSACTION (transaction));
 
       /* as far as the rest of the code is concerned, we're rebasing to :SHA256 now */


### PR DESCRIPTION
Otherwise it might still own tasks on the main context when reusing it
later on. And because it was already cleared, we can get `SIGSEGV`. See
also c9cbad94 (#1676).

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1859269