### PR TITLE
util: Remove an (effectively) unused GCancellable

### DIFF
--- a/src/app/rpmostree-db-builtin-list.c
+++ b/src/app/rpmostree-db-builtin-list.c
@@ -50,7 +50,7 @@ _builtin_db_list (OstreeRepo      *repo,
           if (!*mrev)
             mrev = NULL;
 
-          range_revs = _rpmostree_util_get_commit_hashes (repo, revdup, mrev, cancellable, error);
+          range_revs = _rpmostree_util_get_commit_hashes (repo, revdup, mrev, error);
           if (!range_revs)
             return FALSE;
 

--- a/src/app/rpmostree-db-builtin-version.c
+++ b/src/app/rpmostree-db-builtin-version.c
@@ -51,7 +51,7 @@ _builtin_db_version (OstreeRepo *repo, GPtrArray *revs,
           if (!*mrev)
             mrev = NULL;
 
-          range_revs = _rpmostree_util_get_commit_hashes (repo, revdup, mrev, cancellable, error);
+          range_revs = _rpmostree_util_get_commit_hashes (repo, revdup, mrev, error);
           if (!range_revs)
             return FALSE;
 

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -111,7 +111,6 @@ GPtrArray *
 _rpmostree_util_get_commit_hashes (OstreeRepo    *repo,
                                    const char    *beg,
                                    const char    *end,
-                                   GCancellable  *cancellable,
                                    GError       **error)
 {
   GPtrArray *ret = NULL;
@@ -121,14 +120,14 @@ _rpmostree_util_get_commit_hashes (OstreeRepo    *repo,
   char *checksum = NULL;
   gboolean worked = FALSE;
 
-  if (!ostree_repo_read_commit (repo, beg, NULL, &beg_checksum, cancellable, error))
+  if (!ostree_repo_read_commit (repo, beg, NULL, &beg_checksum, NULL, error))
     goto out;
 
   ret = g_ptr_array_new_with_free_func (g_free);
   g_ptr_array_add (ret, g_strdup (beg));  /* Add the user defined REFSPEC. */
 
   if (end &&
-      !ostree_repo_read_commit (repo, end, NULL, &end_checksum, cancellable, error))
+      !ostree_repo_read_commit (repo, end, NULL, &end_checksum, NULL, error))
       goto out;
 
   if (end && g_str_equal (end_checksum, beg_checksum))

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -59,7 +59,6 @@ GPtrArray *
 _rpmostree_util_get_commit_hashes (OstreeRepo *repo,
                                    const char *beg,
                                    const char *end,
-                                   GCancellable *cancellable,
                                    GError **error);
 
 gboolean


### PR DESCRIPTION
This will be fully obsoleted with https://github.com/coreos/rpm-ostree/pull/2206
