### PR TITLE
ci: Use ostree from lockfile

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -62,11 +62,6 @@ parallel insttests: {
           coreos-assembler init --force https://github.com/coreos/fedora-coreos-config
           # include our built rpm-ostree in the image
           mkdir -p overrides/rpm
-          # Let's make sure we're always composing with the latest ostree. This could be
-          # from the continuous repo (which for now we manually use to fast-track ostree
-          # builds which are needed to get rpm-ostree patches in, but eventually will be
-          # automated) or from the regular repos.
-          dnf download ostree ostree-libs --arch x86_64
           mv *.rpm overrides/rpm
           coreos-assembler fetch
           coreos-assembler build


### PR DESCRIPTION
In the scenario where ostree is in the fcos overrides but *not*
bodhi, *and* a new test requires it, our CI will fail.

We aren't hard requiring the latest ostree right now.
