### PR TITLE
ci: Run C unit tests too

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -39,11 +39,16 @@ codestyle: {
       """)
   }
 },
-rust: {
+unit: {
+  // this branch runs unit tests (both Rust-based and C-based) and makes sure we compile
+  // fine against the MSRV
   def n = 5
   cosaPod(buildroot: true, runAsUser: 0, memory: "2Gi", cpu: "${n}") {
       checkout scm
-      shwrap("MAKE_JOBS=${n} CARGO_BUILD_JOBS=${n} ci/msrv.sh")
+      shwrap("""
+        MAKE_JOBS=${n} CARGO_BUILD_JOBS=${n} ci/msrv.sh
+        PATH="\$HOME/.cargo/bin:\$PATH" make check
+      """)
   }
 }}
 

--- a/ci/msrv.sh
+++ b/ci/msrv.sh
@@ -12,7 +12,3 @@ SKIP_INSTALLDEPS=1 ci/build.sh |& tee out.txt
 grep ${MINIMUM_SUPPORTED_RUST_VERSION} out.txt
 grep "checking for cargo... $HOME/.cargo/bin/cargo" out.txt
 grep "checking for rustc... $HOME/.cargo/bin/rustc" out.txt
-
-# and run the tests
-cd rust
-cargo test


### PR DESCRIPTION
We lost this during the transition from PAPR to CoreOS CI. We don't have
a lot of new tests there since new unit tests tend to be in Rust, though
we should still run what we do have.

Repurpose the `rust` branch to more generically run all unit tests
and not just the Rust ones. It still also checks that compilation
against the MSRV works fine.