### PR TITLE
sysroot: Log when forcibly closing a transaction

### DIFF
--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -858,6 +858,7 @@ on_force_close (gpointer data)
 
   if (self->transaction)
     {
+      sd_journal_print (LOG_WARNING, "Forcibly closing transaction due to timeout");
       rpmostreed_transaction_force_close (self->transaction);
       rpmostreed_sysroot_set_txn (self, NULL);
     }


### PR DESCRIPTION
This *shouldn't* be happening but maybe it is somehow in
https://bugzilla.redhat.com/show_bug.cgi?id=1865839
