### PR TITLE
Make /run a directory in scripts

### DIFF
--- a/scripts/bwrap-script-shell.sh
+++ b/scripts/bwrap-script-shell.sh
@@ -5,7 +5,7 @@ rootfs=$1
 shift
 cd ${rootfs}
 # ⚠⚠⚠ If you change this, also update src/libpriv/rpmostree-scripts.c ⚠⚠⚠
-BWRAP_ARGV="--dev /dev --proc /proc --dir /tmp --chdir / \
+BWRAP_ARGV="--dev /dev --proc /proc --dir /tmp --dir /run --chdir / \
      --unshare-pid --unshare-uts \
      --unshare-ipc --unshare-cgroup-try \
 "

--- a/src/libpriv/rpmostree-bwrap.c
+++ b/src/libpriv/rpmostree-bwrap.c
@@ -283,6 +283,7 @@ rpmostree_bwrap_new_base (int rootfs_fd, GError **error)
                                      WITH_BUBBLEWRAP_PATH,
                                      "--dev", "/dev",
                                      "--proc", "/proc",
+                                     "--dir", "/run",
                                      "--dir", "/tmp",
                                      "--chdir", "/",
                                      "--ro-bind", "/sys/block", "/sys/block",

--- a/tests/compose/test-misc-tweaks.sh
+++ b/tests/compose/test-misc-tweaks.sh
@@ -62,6 +62,7 @@ treefile_set "postprocess" '["""#!/bin/bash
 touch /usr/share/postprocess-testing""",
 """#!/bin/bash
 set -xeuo pipefail
+mkdir /run/somedir
 touch /usr/share/included-postprocess-test
 rm /usr/share/postprocess-testing
 touch /usr/share/postprocess-testing-done"""]'


### PR DESCRIPTION
It's part of the expected standard environment, and its omission
ended up breaking some bootupd work.
See https://github.com/coreos/bootupd/pull/84#issuecomment-709414840
