### PR TITLE
Add --enable-rojig, disable by default

### DIFF
--- a/Makefile-libpriv.am
+++ b/Makefile-libpriv.am
@@ -46,12 +46,6 @@ librpmostreepriv_la_SOURCES = \
 	src/libpriv/rpmostree-rpm-util.h \
 	src/libpriv/rpmostree-importer.c \
 	src/libpriv/rpmostree-importer.h \
-	src/libpriv/rpmostree-rojig-build.c \
-	src/libpriv/rpmostree-rojig-build.h \
-	src/libpriv/rpmostree-rojig-assembler.c \
-	src/libpriv/rpmostree-rojig-assembler.h \
-	src/libpriv/rpmostree-rojig-core.h \
-	src/libpriv/rpmostree-rojig-client.c \
 	src/libpriv/rpmostree-unpacker-core.c \
 	src/libpriv/rpmostree-unpacker-core.h \
 	src/libpriv/rpmostree-output.c \
@@ -65,6 +59,17 @@ librpmostreepriv_la_SOURCES = \
 	src/libpriv/rpmostree-libarchive-input-stream.c \
 	src/libpriv/rpmostree-libarchive-input-stream.h \
 	$(NULL)
+
+if BUILDOPT_ROJIG
+librpmostreepriv_la_SOURCES += \
+	src/libpriv/rpmostree-rojig-build.c \
+	src/libpriv/rpmostree-rojig-build.h \
+	src/libpriv/rpmostree-rojig-assembler.c \
+	src/libpriv/rpmostree-rojig-assembler.h \
+	src/libpriv/rpmostree-rojig-core.h \
+	src/libpriv/rpmostree-rojig-client.c \
+	$(NULL)
+endif
 
 librpmostreepriv_la_CFLAGS = \
 	$(AM_CFLAGS) \

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -43,8 +43,6 @@ rpm_ostree_SOURCES = src/app/main.c \
 	src/app/rpmostree-builtin-coreos-rootfs.c \
 	src/app/rpmostree-builtin-testutils.c \
 	src/app/rpmostree-builtin-container.c \
-	src/app/rpmostree-ex-builtin-commit2rojig.c \
-	src/app/rpmostree-ex-builtin-rojig2commit.c \
 	src/app/rpmostree-builtin-db.c \
 	src/app/rpmostree-builtin-start-daemon.c \
 	src/app/rpmostree-builtin-finalize-deployment.c \
@@ -63,11 +61,18 @@ rpm_ostree_SOURCES = src/app/main.c \
 	src/app/rpmostree-polkit-agent.h \
 	src/app/rpmostree-builtin-kargs.c \
 	src/app/rpmostree-compose-builtin-tree.c \
-	src/app/rpmostree-compose-builtin-rojig.c \
 	src/app/rpmostree-composeutil.c \
 	src/app/rpmostree-composeutil.h \
 	src/app/rpmostree-builtin-compose.c \
 	$(NULL)
+
+if BUILDOPT_ROJIG
+rpm_ostree_SOURCES += \
+	src/app/rpmostree-ex-builtin-commit2rojig.c \
+	src/app/rpmostree-ex-builtin-rojig2commit.c \
+	src/app/rpmostree-compose-builtin-rojig.c \
+	$(NULL)
+endif
 
 rpm_ostree_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
 	-I$(srcdir)/src/lib -I$(srcdir)/src/libpriv -I$(libglnx_srcpath) \

--- a/configure.ac
+++ b/configure.ac
@@ -249,6 +249,15 @@ if test "${enable_lto}" = yes; then
     fi
 fi
 
+AC_ARG_ENABLE(rojig,
+  AC_HELP_STRING([--enable-rojig],
+    [Support for shipping ostree commits via RPMs [default=no]]))
+AM_CONDITIONAL([BUILDOPT_ROJIG], test x$enable_rojig = xyes)
+AM_COND_IF([BUILDOPT_ROJIG], [
+  RPM_OSTREE_FEATURES="$RPM_OSTREE_FEATURES rojig"
+  AC_DEFINE([BUILDOPT_ROJIG], 1, [Define if rojig is enabled])
+])
+
 dnl And propagate the release/debug type to cmake
 cmake_args=-DCMAKE_BUILD_TYPE=RelWithDebugInfo
 if test ${debug_release} = debug; then
@@ -291,6 +300,7 @@ echo "
     $PACKAGE $VERSION
 
     introspection:                           $found_introspection
+    rojig:                                   ${enable_rojig:-no}
     bubblewrap:                              $with_bubblewrap
     gtk-doc:                                 $enable_gtk_doc
     rust:                                    $rust_debug_release (lto: ${enable_lto:-no})

--- a/src/app/rpmostree-builtin-compose.c
+++ b/src/app/rpmostree-builtin-compose.c
@@ -41,9 +41,11 @@ static RpmOstreeCommand compose_subcommands[] = {
   { "commit", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT,
     "Commit a target path to an OSTree repository",
     rpmostree_compose_builtin_commit },
+#ifdef BUILDOPT_ROJIG
   { "rojig", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD | RPM_OSTREE_BUILTIN_FLAG_HIDDEN,
     "EXPERIMENTAL: Build a rojig RPM from a treefile, output to a local rpm-md repo",
     rpmostree_compose_builtin_rojig },
+#endif
   { NULL, 0, NULL, NULL }
 };
 

--- a/src/app/rpmostree-builtin-ex.c
+++ b/src/app/rpmostree-builtin-ex.c
@@ -28,10 +28,12 @@ static RpmOstreeCommand ex_subcommands[] = {
     rpmostree_ex_builtin_livefs },
   { "container", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
     "Assemble local unprivileged containers", rpmostree_builtin_container },
+#ifdef BUILDOPT_ROJIG
   { "commit2rojig", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
     "Convert an OSTree commit into an rpm-ostree rojig", rpmostree_ex_builtin_commit2rojig },
   { "rojig2commit", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
     "Convert an rpm-ostree rojig into an OSTree commit", rpmostree_ex_builtin_rojig2commit },
+#endif
   { "history", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
     "Inspect rpm-ostree history of the system", rpmostree_ex_builtin_history },
   { NULL, 0, NULL, NULL }

--- a/src/app/rpmostree-ex-builtins.h
+++ b/src/app/rpmostree-ex-builtins.h
@@ -32,8 +32,10 @@ G_BEGIN_DECLS
 
 BUILTINPROTO(unpack);
 BUILTINPROTO(livefs);
+#ifdef BUILDOPT_ROJIG
 BUILTINPROTO(commit2rojig);
 BUILTINPROTO(rojig2commit);
+#endif
 BUILTINPROTO(history);
 
 #undef BUILTINPROTO

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -460,6 +460,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
       break;
     case RPMOSTREE_REFSPEC_TYPE_ROJIG:
       {
+#ifdef BUILDOPT_ROJIG
         // Not implemented yet, though we could do a query for the provides
         if (override_commit)
           return glnx_throw (error, "Specifying commit overrides for rojig:// is not implemented yet");
@@ -502,6 +503,9 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
 
         if (rojig_changed)
           rpmostree_origin_set_rojig_description (self->origin, rojig_pkg);
+#else
+        return glnx_throw (error, "rojig is not supported in this build of rpm-ostree");
+#endif
       }
     }
 

--- a/tests/compose/test-rojig-e2e.sh
+++ b/tests/compose/test-rojig-e2e.sh
@@ -5,6 +5,12 @@ dn=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=libcomposetest.sh
 . "${dn}/libcomposetest.sh"
 
+rpm-ostree --version > version.txt
+if ! grep -q rojig version.txt; then
+    echo "ok skip no rojig support"
+    exit 0
+fi
+
 # Add a local rpm-md repo so we can mutate local test packages
 treefile_append "repos" '["test-repo"]'
 build_rpm test-pkg \

--- a/tests/compose/test-rojig-pure.sh
+++ b/tests/compose/test-rojig-pure.sh
@@ -5,6 +5,12 @@ dn=$(cd "$(dirname "$0")" && pwd)
 # shellcheck source=libcomposetest.sh
 . "${dn}/libcomposetest.sh"
 
+rpm-ostree --version > version.txt
+if ! grep -q rojig version.txt; then
+    echo "ok skip no rojig support"
+    exit 0
+fi
+
 treefile_set "automatic-version-prefix" '"42"'
 treefile_set "documentation" 'True'
 mkdir rojig-repo

--- a/tests/vmcheck/test-rojig-client.sh
+++ b/tests/vmcheck/test-rojig-client.sh
@@ -30,6 +30,12 @@ if test "${osid}" != 'ID=fedora'; then
     exit 0
 fi
 
+vm_rpmostree --version > version.txt
+if ! grep -q rojig version.txt; then
+    echo "ok skip no rojig support"
+    exit 0
+fi
+
 # Test rebasing to https://pagure.io/fedora-atomic-host-continuous
 # in rojig:// mode.
 


### PR DESCRIPTION
We're seeing some CI failures that I think are a bug in rojig.
In the bigger picture...we never actually started using this,
and I think longer term shipping os updates via containers
probably makes more sense.

I put a *lot* of effort into this code and it's pretty cool
so it's hard to just delete it.  And *maybe* someone out there
is using it (but I doubt it).  So rather than just deleting
it entirely let's make it a build-time option.

I verified that it builds at least.
