### PR TITLE
daemon: drop an unused sysroot parameter

### DIFF
--- a/src/daemon/rpmostree-sysroot-core.c
+++ b/src/daemon/rpmostree-sysroot-core.c
@@ -446,8 +446,7 @@ rpmostree_syscore_write_deployment (OstreeSysroot           *sysroot,
       if (booted)
         {
           gboolean is_live;
-          if (!rpmostree_syscore_deployment_is_live (sysroot, booted,
-                                                     &is_live, error))
+          if (!rpmostree_syscore_deployment_is_live (booted, &is_live, error))
             return FALSE;
           if (is_live)
             flags |= OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_RETAIN_ROLLBACK;
@@ -469,8 +468,7 @@ rpmostree_syscore_write_deployment (OstreeSysroot           *sysroot,
  * deployment.
  */
 gboolean
-rpmostree_syscore_deployment_get_live (OstreeSysroot    *sysroot,
-                                       OstreeDeployment *deployment,
+rpmostree_syscore_deployment_get_live (OstreeDeployment *deployment,
                                        char            **out_inprogress_checksum,
                                        char            **out_livereplaced_checksum,
                                        GError          **error)
@@ -484,15 +482,14 @@ rpmostree_syscore_deployment_get_live (OstreeSysroot    *sysroot,
 
 /* Set @out_is_live to %TRUE if the deployment is live-modified */
 gboolean
-rpmostree_syscore_deployment_is_live (OstreeSysroot    *sysroot,
-                                      OstreeDeployment *deployment,
+rpmostree_syscore_deployment_is_live (OstreeDeployment *deployment,
                                       gboolean         *out_is_live,
                                       GError          **error)
 {
   g_autofree char *inprogress_checksum = NULL;
   g_autofree char *livereplaced_checksum = NULL;
 
-  if (!rpmostree_syscore_deployment_get_live (sysroot, deployment, &inprogress_checksum,
+  if (!rpmostree_syscore_deployment_get_live (deployment, &inprogress_checksum,
                                               &livereplaced_checksum, error))
     return FALSE;
 

--- a/src/daemon/rpmostree-sysroot-core.h
+++ b/src/daemon/rpmostree-sysroot-core.h
@@ -48,14 +48,12 @@ gboolean rpmostree_syscore_bump_mtime (OstreeSysroot *self, GError **error);
 #define RPMOSTREE_LIVE_INPROGRESS_XATTR "user.rpmostree-live-inprogress"
 #define RPMOSTREE_LIVE_REPLACED_XATTR "user.rpmostree-live-replaced"
 
-gboolean rpmostree_syscore_deployment_get_live (OstreeSysroot   *sysroot,
-                                                OstreeDeployment *deployment,
+gboolean rpmostree_syscore_deployment_get_live (OstreeDeployment *deployment,
                                                 char            **out_inprogress_checksum,
                                                 char            **out_livereplaced_checksum,
                                                 GError          **error);
 
-gboolean rpmostree_syscore_deployment_is_live (OstreeSysroot   *sysroot,
-                                               OstreeDeployment *deployment,
+gboolean rpmostree_syscore_deployment_is_live (OstreeDeployment *deployment,
                                                gboolean         *out_is_live,
                                                GError          **error);
 

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -592,8 +592,7 @@ try_load_base_rsack_from_pending (RpmOstreeSysrootUpgrader *self,
                                   GError                  **error)
 {
   gboolean is_live;
-  if (!rpmostree_syscore_deployment_is_live (self->sysroot, self->origin_merge_deployment,
-                                             &is_live, error))
+  if (!rpmostree_syscore_deployment_is_live (self->origin_merge_deployment, &is_live, error))
     return FALSE;
 
   /* livefs invalidates the deployment */

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -366,7 +366,7 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
 
   g_autofree char *live_inprogress = NULL;
   g_autofree char *live_replaced = NULL;
-  if (!rpmostree_syscore_deployment_get_live (sysroot, deployment, &live_inprogress,
+  if (!rpmostree_syscore_deployment_get_live (deployment, &live_inprogress,
                                               &live_replaced, error))
     return NULL;
 

--- a/src/daemon/rpmostreed-transaction-livefs.c
+++ b/src/daemon/rpmostreed-transaction-livefs.c
@@ -691,7 +691,7 @@ livefs_transaction_execute_inner (LiveFsTransaction *self,
   /* Find out whether we already have a live overlay */
   g_autofree char *live_inprogress = NULL;
   g_autofree char *live_replaced = NULL;
-  if (!rpmostree_syscore_deployment_get_live (sysroot, booted_deployment, &live_inprogress,
+  if (!rpmostree_syscore_deployment_get_live (booted_deployment, &live_inprogress,
                                               &live_replaced, error))
     return FALSE;
   const char *resuming_overlay = NULL;

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -1229,7 +1229,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
             rpmostree_sysroot_upgrader_get_merge_deployment (upgrader);
 
           gboolean is_live;
-          if (!rpmostree_syscore_deployment_is_live (sysroot, deployment, &is_live, error))
+          if (!rpmostree_syscore_deployment_is_live (deployment, &is_live, error))
             return FALSE;
 
           if (is_live)


### PR DESCRIPTION
This is a minor cleanup, dropping an unused sysroot parameter from
deployment logic in daemon codebase.