### PR TITLE
rust: Enable lto by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -236,19 +236,6 @@ AM_CONDITIONAL(RUST_DEBUG, [test "x$rust_debug_release" = "xdebug"])
 dnl Unconditional now.
 RPM_OSTREE_FEATURES="$RPM_OSTREE_FEATURES rust"
 
-dnl Only use this for package builds, as it will hackily edit Cargo.toml right now
-AC_ARG_ENABLE(lto,
-AC_HELP_STRING([--enable-lto],
-               [Build code with Link Time Optimization [default=no]]))
-dnl https://github.com/rust-lang/cargo/issues/4349
-dnl https://bugzilla.mozilla.org/show_bug.cgi?id=1386371
-if test "${enable_lto}" = yes; then
-    if ! grep -q '^lto.*=true' rust/Cargo.toml 2>/dev/null; then
-        echo '# Inserted by configure --enable-lto' >> rust/Cargo.toml
-        echo "lto = true" >> rust/Cargo.toml
-    fi
-fi
-
 AC_ARG_ENABLE(rojig,
   AC_HELP_STRING([--enable-rojig],
     [Support for shipping ostree commits via RPMs [default=no]]))
@@ -303,6 +290,6 @@ echo "
     rojig:                                   ${enable_rojig:-no}
     bubblewrap:                              $with_bubblewrap
     gtk-doc:                                 $enable_gtk_doc
-    rust:                                    $rust_debug_release (lto: ${enable_lto:-no})
+    rust:                                    $rust_debug_release
     cbindgen:                                ${cbindgen:-internal}
 "

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -46,7 +46,6 @@ crate-type = ["staticlib"]
 panic = "abort"
 # We assume we're being delivered via e.g. RPM which supports split debuginfo
 debug = true
-# For true release builds, we do suggest you enable LTO via e.g.
-# env RUSTFLAGS='-C lto=true' as part of the outer build.  It's just
-# off by default because it's quite slow and the default is more oriented
-# towards local development.
+# We need this to avoid leaking symbols, see
+# https://internals.rust-lang.org/t/rust-staticlibs-and-optimizing-for-size/5746
+lto = true


### PR DESCRIPTION
This avoids us leaking all of the Rust symbols as public
into our shared library.

Came up in team chat since one person tried to copy just `/usr/bin/rpm-ostree`
from the dev container into a target and got a linker crash; but
really we want to avoid all the duplicated symbols entirely.

(And we should investigate cross-language LTO because that's the
 only way to get full savings)
