### PR TITLE
treefile: Directly write to String

### DIFF
--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -482,11 +482,8 @@ impl Treefile {
     }
 
     fn serialize_json_string(config: &TreeComposeConfig) -> Result<CUtf8Buf> {
-        let mut output = vec![];
-        serde_json::to_writer_pretty(&mut output, config)?;
-        Ok(CUtf8Buf::from_string(
-            String::from_utf8(output).expect("utf-8 json"),
-        ))
+        let output = serde_json::to_string_pretty(config)?;
+        Ok(CUtf8Buf::from_string(output))
     }
 
     /// Given a treefile, print warnings about items which are deprecated.


### PR DESCRIPTION
I happened to scroll past this code while doing something
else and noticed what we were doing here was silly - no need
to re-validate UTF-8 etc when serde can hand us a `String` directly.
