### PR TITLE
rust: Use Borrow<GString> in a few places

### DIFF
--- a/rust/src/lockfile.rs
+++ b/rust/src/lockfile.rs
@@ -194,6 +194,7 @@ mod ffi {
     use crate::ffiutil::*;
     use crate::includes::*;
     use glib::translate::*;
+    use glib::GString;
     use glib_sys;
     use libc;
     use libdnf_sys::*;
@@ -250,9 +251,9 @@ mod ffi {
         };
 
         for pkg in packages {
-            let name: String = unsafe { from_glib_none(dnf_package_get_name(pkg)) };
-            let evr: String = unsafe { from_glib_none(dnf_package_get_evr(pkg)) };
-            let arch: String = unsafe { from_glib_none(dnf_package_get_arch(pkg)) };
+            let name: Borrowed<GString> = unsafe { from_glib_borrow(dnf_package_get_name(pkg)) };
+            let evr: Borrowed<GString> = unsafe { from_glib_borrow(dnf_package_get_evr(pkg)) };
+            let arch: Borrowed<GString> = unsafe { from_glib_borrow(dnf_package_get_arch(pkg)) };
 
             let mut chksum: *mut libc::c_char = ptr::null_mut();
             let r = unsafe { rpmostree_get_repodata_chksum_repr(pkg, &mut chksum, gerror) };
@@ -261,9 +262,9 @@ mod ffi {
             }
 
             lockfile.packages.insert(
-                name,
+                name.as_str().to_string(),
                 LockedPackage {
-                    evra: format!("{}.{}", evr, arch),
+                    evra: format!("{}.{}", evr.as_str(), arch.as_str()),
                     digest: Some(unsafe { from_glib_none(chksum) }),
                 },
             );

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -211,7 +211,7 @@ mod ffi {
         url: *const libc::c_char,
         gerror: *mut *mut glib_sys::GError,
     ) -> libc::c_int {
-        let url: String = unsafe { from_glib_none(url) };
+        let url: Borrowed<glib::GString> = unsafe { from_glib_borrow(url) };
         match download_url_to_tmpfile(url.as_str()) {
             Ok(f) => f.into_raw_fd(),
             Err(e) => {
@@ -227,7 +227,7 @@ mod ffi {
         h: *mut glib_sys::GHashTable,
         gerror: *mut *mut glib_sys::GError,
     ) -> *mut libc::c_char {
-        let s: String = unsafe { from_glib_none(s) };
+        let s: Borrowed<glib::GString> = unsafe { from_glib_borrow(s) };
         let h_rs: HashMap<String, String> =
             unsafe { glib::translate::FromGlibPtrContainer::from_glib_none(h) };
         match varsubst(s.as_str(), &h_rs) {


### PR DESCRIPTION
Particularly in places like the lockfile code where we were iterating
on a list of packages, validating UTF-8 and `memcpy()`ing strings
from C is...well, unnecessary.

I don't think there's any actual real performance concerns right
now but let's use this as a best practice because the patterns
we establish *will* be copy+pasted or at least used as inspiration
for other places where performance might matter.
