### PR TITLE
Drop use of `volatile`

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1714,9 +1714,9 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
 GType
 rpmostree_sysroot_upgrader_flags_get_type (void)
 {
-  static volatile gsize g_define_type_id__volatile = 0;
+  static gsize static_g_define_type_id = 0;
 
-  if (g_once_init_enter (&g_define_type_id__volatile))
+  if (g_once_init_enter (&static_g_define_type_id))
     {
       static const GFlagsValue values[] = {
         { RPMOSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED,
@@ -1740,8 +1740,8 @@ rpmostree_sysroot_upgrader_flags_get_type (void)
       };
       GType g_define_type_id =
         g_flags_register_static (g_intern_static_string ("RpmOstreeSysrootUpgraderFlags"), values);
-      g_once_init_leave (&g_define_type_id__volatile, g_define_type_id);
+      g_once_init_leave (&static_g_define_type_id, g_define_type_id);
     }
 
-  return g_define_type_id__volatile;
+  return static_g_define_type_id;
 }

--- a/src/daemon/rpmostreed-errors.c
+++ b/src/daemon/rpmostreed-errors.c
@@ -39,10 +39,10 @@ GQuark
 rpmostreed_error_quark (void)
 {
   G_STATIC_ASSERT (G_N_ELEMENTS (dbus_error_entries) == RPM_OSTREED_ERROR_NUM_ENTRIES);
-  static volatile gsize quark_volatile = 0;
+  static gsize quark = 0;
   g_dbus_error_register_error_domain ("rpmostreed-error-quark",
-                                      &quark_volatile,
+                                      &quark,
                                       dbus_error_entries,
                                       G_N_ELEMENTS (dbus_error_entries));
-  return (GQuark) quark_volatile;
+  return (GQuark) quark;
 }

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1817,10 +1817,10 @@ rpmostree_prepare_rootfs_for_commit (int            src_rootfs_dfd,
 }
 
 struct CommitThreadData {
-  volatile gint done;
+  gint done;  /* atomic */
   off_t n_bytes;
   off_t n_processed;
-  volatile gint percent;
+  gint percent;  /* atomic */
   OstreeRepo *repo;
   int rootfs_fd;
   OstreeMutableTree *mtree;

--- a/src/libpriv/rpmostree-refsack.h
+++ b/src/libpriv/rpmostree-refsack.h
@@ -25,7 +25,7 @@
 #include "libglnx.h"
 
 typedef struct {
-  volatile gint refcount;
+  gint refcount;  /* atomic */
   DnfSack *sack;
   GLnxTmpDir tmpdir;
 } RpmOstreeRefSack;

--- a/src/libpriv/rpmostree-refts.h
+++ b/src/libpriv/rpmostree-refts.h
@@ -25,7 +25,7 @@
 #include "libglnx.h"
 
 typedef struct {
-  volatile gint refcount;
+  gint refcount;  /* atomic */
   rpmts ts;
   GLnxTmpDir tmpdir;
 } RpmOstreeRefTs;


### PR DESCRIPTION
As detailed in
https://gitlab.gnome.org/GNOME/glib/-/issues/600#note_877282, `volatile`
isn't actually needed in these contexts because the atomic operations
already give us strong enough guarantees. In GCC 11, this triggers a
diagnostic due to the `volatile` qualifier getting dropped anyway.

There is a WIP to do the same in glib:
https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1719

This obsoletes this downstream patch:
https://src.fedoraproject.org/rpms/rpm-ostree/c/bbd2d17f