### PR TITLE
treefile: Fix hashing of externals

### DIFF
--- a/src/app/rpmostree-composeutil.c
+++ b/src/app/rpmostree-composeutil.c
@@ -61,17 +61,14 @@ rpmostree_composeutil_checksum (HyGoal             goal,
 
   /* Hash in the treefile inputs (this includes all externals like postprocess, add-files,
    * etc... and the final flattened treefile -- see treefile.rs for more details). */
-  g_checksum_update (checksum, (guint8*)ror_treefile_get_checksum (tf), -1);
+  g_autofree char *tf_checksum = ror_treefile_get_checksum (tf, repo, error);
+  if (!tf_checksum)
+    return FALSE;
+  g_checksum_update (checksum, (guint8*) tf_checksum, -1);
 
   /* Hash in each package */
   if (!rpmostree_dnf_add_checksum_goal (checksum, goal, NULL, error))
     return FALSE;
-
-  if (tf)
-    {
-      if (!ror_treefile_update_checksum (tf, repo, checksum, error))
-        return FALSE;
-    }
 
   *out_checksum = g_strdup (g_checksum_get_string (checksum));
   return TRUE;


### PR DESCRIPTION
See https://github.com/coreos/rpm-ostree/pull/2206#issuecomment-721372634

The commit 7f579a55d3fb7ec1cb9f74f8ec6bc36675df2ccc broke hashing
of overlay commits; this is a super evil bug because it causes us
to silently do the wrong thing.

The cause here is the GLib bindings don't (AFAICS) support getting
a `&mut` for a GLib boxed value.

Move all of the treefile checksum code into one place - this is
far saner.  The reason I didn't do this before is that it
will cause a spurious rebuild when one updates rpm-ostree, but...eh.
