### PR TITLE
sh: fix bash shebang

### DIFF
--- a/ci/codestyle.sh
+++ b/ci/codestyle.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -euo pipefail
 
 echo -n "Checking for tabs..."

--- a/packaging/make-git-snapshot.sh
+++ b/packaging/make-git-snapshot.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -xeuo pipefail
 
 srcdir=$1


### PR DESCRIPTION
This updates a couple of shebangs for scripts using bash `pipefail`
option.