### PR TITLE
docs: Update links to the OSTree documentation

### DIFF
--- a/docs/administrator-handbook.md
+++ b/docs/administrator-handbook.md
@@ -150,7 +150,7 @@ your changes on top.  This means that upgrades will receive new
 default files in `/etc`, which is quite a critical feature.
 
 For more information, see
-[OSTree: Adapting](https://ostree.readthedocs.io/en/latest/manual/adapting-existing/).
+[OSTree: Adapting](https://ostreedev.github.io/ostree/adapting-existing/).
 
 ## Operating system changes
 

--- a/docs/compose-server.md
+++ b/docs/compose-server.md
@@ -24,8 +24,8 @@ and bootable disk images is [coreos-assembler](https://github.com/coreos/coreos-
 Before you get started, it's recommended to read (at least) these two sections
 of the OSTree manual:
 
- - [buildsystem-and-repos](https://ostree.readthedocs.io/en/latest/manual/buildsystem-and-repos/)
- - [repository-management](https://ostree.readthedocs.io/en/latest/manual/repository-management/)
+ - [buildsystem-and-repos](https://ostreedev.github.io/ostree/buildsystem-and-repos/)
+ - [repository-management](https://ostreedev.github.io/ostree/repository-management/)
 
 ## Generating OSTree commits from a CentOS base
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ nav_order: 1
 {:toc}
 
 rpm-ostree is a hybrid image/package system.  It combines
-[libostree](https://ostree.readthedocs.io/en/latest/) as a base image format,
+[libostree](https://ostreedev.github.io/ostree/) as a base image format,
 and accepts RPM on both the client and server side, sharing code with the
 [dnf](https://en.wikipedia.org/wiki/DNF_(software)) project; specifically
 [libdnf](https://github.com/rpm-software-management/libdnf). and thus bringing

--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -287,7 +287,7 @@ It supports the following parameters:
    Note that in the OSTree model, not all directories are managed by OSTree. In
    short, only files in `/usr` (or UsrMove symlinks into `/usr`) and `/etc` are
    supported. For more details, see the OSTree manual:
-   https://ostree.readthedocs.io/en/latest/manual/deployment/
+   https://ostreedev.github.io/ostree/deployment/
 
  * `tmp-is-dir`: boolean, optional: Defaults to `false`.  By default,
    rpm-ostree creates symlink `/tmp` → `sysroot/tmp`.  When set to `true`,


### PR DESCRIPTION
Those got moved to GitHub from readthedocs.io, meaning links pointing to specific pages return a 404, so this fixes that along with skipping the redirect for the links that just point to the main page.
