### PR TITLE
rust: Move to new systemd journal API for opening

### DIFF
--- a/rust/src/journal.rs
+++ b/rust/src/journal.rs
@@ -26,7 +26,11 @@ fn print_staging_failure_msg(msg: Option<&str>) -> Result<()> {
 
 /// Look for a failure from ostree-finalized-stage.service in the journal of the previous boot.
 fn journal_print_staging_failure() -> Result<()> {
-    let mut j = journal::Journal::open(journal::JournalFiles::System, false, true)?;
+    let mut j = journal::OpenOptions::default()
+        .system(true)
+        .local_only(true)
+        .runtime_only(false)
+        .open()?;
     j.seek(journal::JournalSeek::Head)?;
 
     // first, go to the first entry of the current boot


### PR DESCRIPTION
The `Journal::open` API has been deprecated in favour of the new
`OpenOptions` builder pattern.

We could dedupe this a bit more, though the mock journal in the history
code makes it trickier and there's little value in mocking the builder
pattern too.