### PR TITLE
scripts: Neuter RHEL8 nvme-cli %post

### DIFF
--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -209,6 +209,11 @@ static const RpmOstreeScriptReplacement script_replacements[] = {
    * https://src.fedoraproject.org/rpms/pam/pull-request/3
    */
   { "pam.post", ".el7", NULL, NULL },
+  /* EL8 is broken: https://bugzilla.redhat.com/show_bug.cgi?id=1900691
+   * Fedora is currently fine.
+   */
+  { "nvme-cli.post", ".el8_2", NULL, NULL },
+  { "nvme-cli.post", ".el8", NULL, NULL },
 };
 
 static gboolean


### PR DESCRIPTION
There's some crazy stuff going on there with udev rules
that we don't need.  See some discussion in
https://bugzilla.redhat.com/show_bug.cgi?id=1742764
