### PR TITLE
Rework some origin APIs to allocate

### DIFF
--- a/src/daemon/rpmostree-sysroot-core.c
+++ b/src/daemon/rpmostree-sysroot-core.c
@@ -202,7 +202,7 @@ generate_pkgcache_refs (OstreeSysroot            *sysroot,
         }
 
       /* also add any inactive local replacements */
-      GHashTable *local_replace = rpmostree_origin_get_overrides_local_replace (origin);
+      g_autoptr(GHashTable) local_replace = rpmostree_origin_get_overrides_local_replace (origin);
       GLNX_HASH_TABLE_FOREACH (local_replace, const char*, nevra)
         {
           g_autofree char *cachebranch = NULL;

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -863,10 +863,10 @@ finalize_overlays (RpmOstreeSysrootUpgrader *self,
     }
 
   GHashTable *removals = rpmostree_origin_get_overrides_remove (self->origin);
+  g_autoptr(GHashTable) packages = rpmostree_origin_get_packages (self->origin);
 
   /* check for each package if we have a provides or a path match */
-  GLNX_HASH_TABLE_FOREACH (rpmostree_origin_get_packages (self->origin),
-                           const char*, pattern)
+  GLNX_HASH_TABLE_FOREACH (packages, const char*, pattern)
     {
       g_autoptr(GPtrArray) matches =
         rpmostree_get_matching_packages (self->rsack->sack, pattern);

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1135,7 +1135,7 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self,
   if (kernel_or_initramfs_changed)
     {
       /* append the extra args */
-      const char *const* add_dracut_argv = NULL;
+      g_auto(GStrv) add_dracut_argv = NULL;
       if (rpmostree_origin_get_regenerate_initramfs (self->origin))
          add_dracut_argv = rpmostree_origin_get_initramfs_args (self->origin);
       for (char **it = (char**)add_dracut_argv; it && *it; it++)

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -390,7 +390,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
   const gboolean synthetic =
     (self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_SYNTHETIC_PULL) > 0;
 
-  const char *override_commit = rpmostree_origin_get_override_commit (self->origin);
+  g_autofree char *override_commit = rpmostree_origin_get_override_commit (self->origin);
 
   RpmOstreeRefspecType refspec_type;
   const char *refspec;

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -721,7 +721,7 @@ finalize_removal_overrides (RpmOstreeSysrootUpgrader *self,
 {
   g_assert (self->rsack);
 
-  GHashTable *removals = rpmostree_origin_get_overrides_remove (self->origin);
+  g_autoptr(GHashTable) removals = rpmostree_origin_get_overrides_remove (self->origin);
   g_autoptr(GPtrArray) ret_final_removals = g_ptr_array_new_with_free_func (g_free);
 
   g_autoptr(GPtrArray) inactive_removals = g_ptr_array_new ();
@@ -862,7 +862,7 @@ finalize_overlays (RpmOstreeSysrootUpgrader *self,
         }
     }
 
-  GHashTable *removals = rpmostree_origin_get_overrides_remove (self->origin);
+  g_autoptr(GHashTable) removals = rpmostree_origin_get_overrides_remove (self->origin);
   g_autoptr(GHashTable) packages = rpmostree_origin_get_packages (self->origin);
 
   /* check for each package if we have a provides or a path match */

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -670,7 +670,7 @@ generate_treespec (RpmOstreeSysrootUpgrader *self)
                                   self->overlay_packages->len);
     }
 
-  GHashTable *local_packages = rpmostree_origin_get_local_packages (self->origin);
+  g_autoptr(GHashTable) local_packages = rpmostree_origin_get_local_packages (self->origin);
   if (g_hash_table_size (local_packages) > 0)
     {
       g_autoptr(GPtrArray) sha256_nevra = g_ptr_array_new_with_free_func (g_free);
@@ -829,7 +829,7 @@ finalize_overlays (RpmOstreeSysrootUpgrader *self,
    * layered, we treat them as part of the base wrt regular requested pkgs. E.g.
    * you can have foo-1.0-1.x86_64 layered, and foo or /usr/bin/foo as dormant.
    * */
-  GHashTable *local_pkgs = rpmostree_origin_get_local_packages (self->origin);
+  g_autoptr(GHashTable) local_pkgs = rpmostree_origin_get_local_packages (self->origin);
   if (g_hash_table_size (local_pkgs) > 0)
     {
       if (!initialize_metatmpdir (self, error))
@@ -969,7 +969,7 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self,
   if (!prepare_context_for_assembly (self, tmprootfs_abspath, cancellable, error))
     return FALSE;
 
-  GHashTable *local_pkgs = rpmostree_origin_get_local_packages (self->origin);
+  g_autoptr(GHashTable) local_pkgs = rpmostree_origin_get_local_packages (self->origin);
 
   /* NB: We're pretty much using the defaults for the other treespec values like
    * instlang and docs since it would be hard to expose the cli for them because
@@ -1191,10 +1191,11 @@ requires_local_assembly (RpmOstreeSysrootUpgrader *self)
    * https://github.com/projectatomic/rpm-ostree/issues/753
    */
 
+  g_autoptr(GHashTable) local_pkgs = rpmostree_origin_get_local_packages (self->origin);
   return self->overlay_packages->len > 0 ||
          self->override_remove_packages->len > 0 ||
          self->override_replace_local_packages->len > 0 ||
-         g_hash_table_size (rpmostree_origin_get_local_packages (self->origin)) > 0 ||
+         g_hash_table_size (local_pkgs) > 0 ||
          rpmostree_origin_get_regenerate_initramfs (self->origin);
 }
 

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -756,7 +756,7 @@ finalize_replacement_overrides (RpmOstreeSysrootUpgrader *self,
 {
   g_assert (self->rsack);
 
-  GHashTable *local_replacements =
+  g_autoptr(GHashTable) local_replacements =
     rpmostree_origin_get_overrides_local_replace (self->origin);
   g_autoptr(GPtrArray) ret_final_local_replacements =
     g_ptr_array_new_with_free_func (g_free);

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1332,6 +1332,7 @@ write_history (RpmOstreeSysrootUpgrader *self,
       return FALSE;
     version = rpmostree_checksum_version (commit);
   }
+  g_autofree char *refspec = rpmostree_origin_get_refspec (self->origin);
 
   sd_journal_send ("MESSAGE_ID=" SD_ID128_FORMAT_STR,
                    SD_ID128_FORMAT_VAL(RPMOSTREE_NEW_DEPLOYMENT_MSG),
@@ -1341,7 +1342,7 @@ write_history (RpmOstreeSysrootUpgrader *self,
                    "DEPLOYMENT_DEVICE=%" PRIu64, (uint64_t) stbuf.st_dev,
                    "DEPLOYMENT_INODE=%" PRIu64, (uint64_t) stbuf.st_ino,
                    "DEPLOYMENT_CHECKSUM=%s", ostree_deployment_get_csum (new_deployment),
-                   "DEPLOYMENT_REFSPEC=%s", rpmostree_origin_get_refspec (self->origin),
+                   "DEPLOYMENT_REFSPEC=%s", refspec,
                    /* we could use iovecs here and sd_journal_sendv to make these truly
                     * conditional, but meh, empty field works fine too */
                    "DEPLOYMENT_VERSION=%s", version ?: "",

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -116,13 +116,14 @@ parse_origin_deployment (RpmOstreeSysrootUpgrader *self,
     return FALSE;
   rpmostree_origin_remove_transient_state (self->origin);
 
-  if (rpmostree_origin_get_unconfigured_state (self->origin) &&
+  g_autofree char *unconfigured = rpmostree_origin_get_unconfigured_state (self->origin);
+  if (unconfigured &&
       !(self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED))
     {
       /* explicit action is required OS creator to upgrade, print their text as an error */
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                    "origin unconfigured-state: %s",
-                   rpmostree_origin_get_unconfigured_state (self->origin));
+                   unconfigured);
       return FALSE;
     }
 

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -215,7 +215,7 @@ rpmostree_sysroot_upgrader_finalize (GObject *object)
 
   g_clear_object (&self->cfg_merge_deployment);
   g_clear_object (&self->origin_merge_deployment);
-  g_clear_pointer (&self->origin, (GDestroyNotify)rpmostree_origin_unref);
+  g_clear_pointer (&self->origin, (GDestroyNotify)rpmostree_origin_free);
   g_free (self->base_revision);
   g_free (self->final_revision);
   g_strfreev (self->kargs_strv);
@@ -349,7 +349,7 @@ void
 rpmostree_sysroot_upgrader_set_origin (RpmOstreeSysrootUpgrader *self,
                                        RpmOstreeOrigin          *new_origin)
 {
-  rpmostree_origin_unref (self->origin);
+  rpmostree_origin_free (self->origin);
   self->origin = rpmostree_origin_dup (new_origin);
 }
 

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -398,8 +398,8 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
   variant_add_from_hash_table (&dict, "requested-local-packages", local_packages);
   g_autoptr(GHashTable) overrides_remove = rpmostree_origin_get_overrides_remove (origin);
   variant_add_from_hash_table (&dict, "requested-base-removals", overrides_remove);
-  variant_add_from_hash_table (&dict, "requested-base-local-replacements",
-                               rpmostree_origin_get_overrides_local_replace (origin));
+  g_autoptr(GHashTable) overrides_local_replace = rpmostree_origin_get_overrides_local_replace (origin);
+  variant_add_from_hash_table (&dict, "requested-base-local-replacements", overrides_local_replace);
 
   g_variant_dict_insert (&dict, "packages", "^as", layered_pkgs);
   g_variant_dict_insert_value (&dict, "base-removals", removed_base_pkgs);

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -412,7 +412,7 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
 
   g_variant_dict_insert (&dict, "regenerate-initramfs", "b",
                          rpmostree_origin_get_regenerate_initramfs (origin));
-  { const char *const* args = rpmostree_origin_get_initramfs_args (origin);
+  { g_auto(GStrv) args = rpmostree_origin_get_initramfs_args (origin);
     if (args && *args)
       g_variant_dict_insert (&dict, "initramfs-args", "^as", args);
   }

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -396,8 +396,8 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
   variant_add_from_hash_table (&dict, "requested-packages", packages);
   g_autoptr(GHashTable) local_packages = rpmostree_origin_get_local_packages (origin);
   variant_add_from_hash_table (&dict, "requested-local-packages", local_packages);
-  variant_add_from_hash_table (&dict, "requested-base-removals",
-                               rpmostree_origin_get_overrides_remove (origin));
+  g_autoptr(GHashTable) overrides_remove = rpmostree_origin_get_overrides_remove (origin);
+  variant_add_from_hash_table (&dict, "requested-base-removals", overrides_remove);
   variant_add_from_hash_table (&dict, "requested-base-local-replacements",
                                rpmostree_origin_get_overrides_local_replace (origin));
 

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -392,8 +392,8 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
   if (refspec)
     g_variant_dict_insert (&dict, "origin", "s", refspec);
 
-  variant_add_from_hash_table (&dict, "requested-packages",
-                               rpmostree_origin_get_packages (origin));
+  g_autoptr(GHashTable) packages = rpmostree_origin_get_packages (origin);
+  variant_add_from_hash_table (&dict, "requested-packages", packages);
   variant_add_from_hash_table (&dict, "requested-local-packages",
                                rpmostree_origin_get_local_packages (origin));
   variant_add_from_hash_table (&dict, "requested-base-removals",
@@ -1173,7 +1173,7 @@ rpmostreed_update_generate_variant (OstreeDeployment  *booted_deployment,
         }
 
       /* now we look at the rpm-md/layering side */
-      GHashTable *layered_pkgs = rpmostree_origin_get_packages (origin);
+      g_autoptr(GHashTable) layered_pkgs = rpmostree_origin_get_packages (origin);
 
       /* check that it's actually layered (i.e. the requests are not all just dormant) */
       if (sack && is_new_layered && g_hash_table_size (layered_pkgs) > 0)

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -394,8 +394,8 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
 
   g_autoptr(GHashTable) packages = rpmostree_origin_get_packages (origin);
   variant_add_from_hash_table (&dict, "requested-packages", packages);
-  variant_add_from_hash_table (&dict, "requested-local-packages",
-                               rpmostree_origin_get_local_packages (origin));
+  g_autoptr(GHashTable) local_packages = rpmostree_origin_get_local_packages (origin);
+  variant_add_from_hash_table (&dict, "requested-local-packages", local_packages);
   variant_add_from_hash_table (&dict, "requested-base-removals",
                                rpmostree_origin_get_overrides_remove (origin));
   variant_add_from_hash_table (&dict, "requested-base-local-replacements",

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -1063,7 +1063,8 @@ rpmostreed_update_generate_variant (OstreeDeployment  *booted_deployment,
   if (!origin)
     return FALSE;
 
-  const char *refspec = rpmostree_origin_get_refspec (origin);
+  g_autofree char *refspec_owned = rpmostree_origin_get_refspec (origin);
+  const char *refspec = refspec_owned;
   { RpmOstreeRefspecType refspectype = RPMOSTREE_REFSPEC_TYPE_OSTREE;
     const char *refspec_data;
     if (!rpmostree_refspec_classify (refspec, &refspectype, &refspec_data, error))

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -392,6 +392,7 @@ os_handle_get_cached_update_rpm_diff (RPMOSTreeOS *interface,
   GCancellable *cancellable = NULL;
   g_autoptr(GVariant) value = NULL;
   g_autoptr(GVariant) details = NULL;
+  g_autofree char *refspec = NULL;
   GError *local_error = NULL;
 
   global_sysroot = rpmostreed_sysroot_get ();
@@ -426,14 +427,15 @@ os_handle_get_cached_update_rpm_diff (RPMOSTreeOS *interface,
   origin = rpmostree_origin_parse_deployment (base_deployment, &local_error);
   if (!origin)
     goto out;
+  refspec = rpmostree_origin_get_refspec (origin);
 
   if (!rpm_ostree_db_diff_variant (ot_repo, ostree_deployment_get_csum (base_deployment),
-                                   rpmostree_origin_get_refspec (origin), FALSE, &value,
+                                   refspec, FALSE, &value,
                                    cancellable, &local_error))
     goto out;
 
   details = rpmostreed_commit_generate_cached_details_variant (base_deployment, ot_repo,
-                                                               rpmostree_origin_get_refspec (origin),
+                                                               refspec,
                                                                NULL,
                                                                &local_error);
   if (!details)
@@ -1427,6 +1429,7 @@ os_handle_get_cached_rebase_rpm_diff (RPMOSTreeOS *interface,
   g_autoptr(RpmOstreeOrigin) origin = NULL;
   g_autofree gchar *comp_ref = NULL;
   GError *local_error = NULL;
+  g_autofree char *refspec = NULL;
   g_autoptr(GVariant) value = NULL;
   g_autoptr(GVariant) details = NULL;
 
@@ -1449,9 +1452,10 @@ os_handle_get_cached_rebase_rpm_diff (RPMOSTreeOS *interface,
   origin = rpmostree_origin_parse_deployment (base_deployment, &local_error);
   if (!origin)
     goto out;
+  refspec = rpmostree_origin_get_refspec (origin);
 
   if (!rpmostreed_refspec_parse_partial (arg_refspec,
-                                         rpmostree_origin_get_refspec (origin),
+                                         refspec,
                                          &comp_ref,
                                          &local_error))
     goto out;
@@ -1555,6 +1559,7 @@ os_handle_get_cached_deploy_rpm_diff (RPMOSTreeOS *interface,
   g_autoptr(GCancellable) cancellable = NULL;
   g_autoptr(GVariant) value = NULL;
   g_autoptr(GVariant) details = NULL;
+  g_autofree char *refspec = NULL;
   GError *local_error = NULL;
   GError **error = &local_error;
 
@@ -1575,6 +1580,7 @@ os_handle_get_cached_deploy_rpm_diff (RPMOSTreeOS *interface,
   origin = rpmostree_origin_parse_deployment (base_deployment, error);
   if (!origin)
     goto out;
+  refspec = rpmostree_origin_get_refspec (origin);
 
   base_checksum = ostree_deployment_get_csum (base_deployment);
 
@@ -1587,7 +1593,7 @@ os_handle_get_cached_deploy_rpm_diff (RPMOSTreeOS *interface,
   if (version != NULL)
     {
       if (!rpmostreed_repo_lookup_cached_version (ot_repo,
-                                                  rpmostree_origin_get_refspec (origin),
+                                                  refspec,
                                                   version,
                                                   cancellable,
                                                   &checksum,
@@ -1601,7 +1607,7 @@ os_handle_get_cached_deploy_rpm_diff (RPMOSTreeOS *interface,
 
   details = rpmostreed_commit_generate_cached_details_variant (base_deployment,
                                                                ot_repo,
-                                                               rpmostree_origin_get_refspec (origin),
+                                                               refspec,
                                                                checksum,
                                                                &local_error);
   if (!details)

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -1012,7 +1012,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
     }
 
   gboolean changed = FALSE;
-  GHashTable *initrd_etc_files = rpmostree_origin_get_initramfs_etc_files (origin);
+  g_autoptr(GHashTable) initrd_etc_files = rpmostree_origin_get_initramfs_etc_files (origin);
   if (no_initramfs && (rpmostree_origin_get_regenerate_initramfs (origin) ||
                        g_hash_table_size (initrd_etc_files) > 0))
     {
@@ -1783,7 +1783,7 @@ initramfs_etc_transaction_execute (RpmostreedTransaction *transaction,
       return TRUE; /* Note early return */
     }
 
-  GHashTable *files = rpmostree_origin_get_initramfs_etc_files (origin);
+  g_autoptr(GHashTable) files = rpmostree_origin_get_initramfs_etc_files (origin);
   GLNX_HASH_TABLE_FOREACH (files, const char*, file)
     {
       if (!g_str_has_prefix (file, "/etc/"))

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -94,8 +94,7 @@ change_origin_refspec (GVariantDict    *options,
   /* Now here we "peel" it since the rest of the code assumes libostree */
   const char *refspec = refspecdata;
 
-  g_autofree gchar *current_refspec =
-    g_strdup (rpmostree_origin_get_refspec (origin));
+  g_autofree gchar *current_refspec = rpmostree_origin_get_refspec (origin);
   g_autofree gchar *new_refspec = NULL;
 
   if (!rpmostreed_refspec_parse_partial (refspec,
@@ -189,6 +188,8 @@ apply_revision_override (RpmostreedTransaction    *transaction,
   if (!rpmostreed_parse_revision (revision, &checksum, &version, error))
     return FALSE;
 
+  g_autofree char *refspec = rpmostree_origin_get_refspec (origin);
+
   if (version != NULL)
     {
       switch (refspectype)
@@ -198,7 +199,7 @@ apply_revision_override (RpmostreedTransaction    *transaction,
             /* Perhaps down the line we'll drive history traversal into libostree */
             rpmostree_output_message ("Resolving version '%s'", version);
 
-            if (!rpmostreed_repo_lookup_version (repo, rpmostree_origin_get_refspec (origin),
+            if (!rpmostreed_repo_lookup_version (repo, refspec,
                                                  version, progress,
                                                  cancellable, &checksum, error))
               return FALSE;
@@ -222,7 +223,7 @@ apply_revision_override (RpmostreedTransaction    *transaction,
         {
         case RPMOSTREE_REFSPEC_TYPE_OSTREE:
           rpmostree_output_message ("Validating checksum '%s'", checksum);
-          if (!rpmostreed_repo_lookup_checksum (repo, rpmostree_origin_get_refspec (origin),
+          if (!rpmostreed_repo_lookup_checksum (repo, refspec,
                                                 checksum, progress, cancellable, error))
             return FALSE;
           break;

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -1908,7 +1908,7 @@ initramfs_state_transaction_execute (RpmostreedTransaction *transaction,
 
   g_autoptr(RpmOstreeOrigin) origin = rpmostree_sysroot_upgrader_dup_origin (upgrader);
   gboolean current_regenerate = rpmostree_origin_get_regenerate_initramfs (origin);
-  const char *const* current_initramfs_args = rpmostree_origin_get_initramfs_args (origin);
+  g_auto(GStrv) current_initramfs_args = rpmostree_origin_get_initramfs_args (origin);
 
   /* We don't deep-compare the args right now, we assume if you were using them
    * you want to rerun. This can be important if you edited a config file, which

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -1313,7 +1313,8 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
 
       /* XXX: in rojig mode we'll want to do this unconditionally */
       g_autoptr(DnfSack) sack = NULL;
-      if (g_hash_table_size (rpmostree_origin_get_packages (origin)) > 0)
+      g_autoptr(GHashTable) packages = rpmostree_origin_get_packages (origin);
+      if (g_hash_table_size (packages) > 0)
         {
           if (!get_sack_for_booted (sysroot, repo, booted_deployment, &sack,
                                     cancellable, error))

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -363,14 +363,6 @@ rpmostree_origin_dup_keyfile (RpmOstreeOrigin *origin)
   return keyfile_dup (origin->kf);
 }
 
-char *
-rpmostree_origin_get_string (RpmOstreeOrigin *origin,
-                             const char *section,
-                             const char *value)
-{
-  return g_key_file_get_string (origin->kf, section, value, NULL);
-}
-
 void
 rpmostree_origin_free (RpmOstreeOrigin *origin)
 {

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -310,7 +310,7 @@ rpmostree_origin_get_overrides_remove (RpmOstreeOrigin *origin)
 GHashTable *
 rpmostree_origin_get_overrides_local_replace (RpmOstreeOrigin *origin)
 {
-  return origin->cached_overrides_local_replace;
+  return g_hash_table_ref (origin->cached_overrides_local_replace);
 }
 
 const char *

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -298,7 +298,7 @@ rpmostree_origin_get_packages (RpmOstreeOrigin *origin)
 GHashTable *
 rpmostree_origin_get_local_packages (RpmOstreeOrigin *origin)
 {
-  return origin->cached_local_packages;
+  return g_hash_table_ref (origin->cached_local_packages);
 }
 
 GHashTable *

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -292,7 +292,7 @@ rpmostree_origin_get_custom_description (RpmOstreeOrigin *origin,
 GHashTable *
 rpmostree_origin_get_packages (RpmOstreeOrigin *origin)
 {
-  return origin->cached_packages;
+  return g_hash_table_ref (origin->cached_packages);
 }
 
 GHashTable *

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -313,10 +313,10 @@ rpmostree_origin_get_overrides_local_replace (RpmOstreeOrigin *origin)
   return g_hash_table_ref (origin->cached_overrides_local_replace);
 }
 
-const char *
+char *
 rpmostree_origin_get_override_commit (RpmOstreeOrigin *origin)
 {
-  return origin->cached_override_commit;
+  return g_strdup (origin->cached_override_commit);
 }
 
 GHashTable *

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -304,7 +304,7 @@ rpmostree_origin_get_local_packages (RpmOstreeOrigin *origin)
 GHashTable *
 rpmostree_origin_get_overrides_remove (RpmOstreeOrigin *origin)
 {
-  return origin->cached_overrides_remove;
+  return g_hash_table_ref (origin->cached_overrides_remove);
 }
 
 GHashTable *

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -197,10 +197,10 @@ rpmostree_origin_remove_transient_state (RpmOstreeOrigin *origin)
   rpmostree_origin_set_override_commit (origin, NULL, NULL);
 }
 
-const char *
+char *
 rpmostree_origin_get_refspec (RpmOstreeOrigin *origin)
 {
-  return origin->cached_refspec;
+  return g_strdup (origin->cached_refspec);
 }
 
 /* For rojig:// refspecs, includes the prefix. */
@@ -239,10 +239,10 @@ rpmostree_origin_classify_refspec (RpmOstreeOrigin      *origin,
     *out_refspecdata = origin->cached_refspec;
 }
 
-const char *
+char *
 rpmostree_origin_get_rojig_version (RpmOstreeOrigin *origin)
 {
-  return origin->cached_rojig_version;
+  return g_strdup (origin->cached_rojig_version);
 }
 
 /* Returns a new (floating) variant of type a{sv} with fields:

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -337,10 +337,10 @@ rpmostree_origin_get_initramfs_args (RpmOstreeOrigin *origin)
   return g_strdupv (origin->cached_initramfs_args);
 }
 
-const char*
+char*
 rpmostree_origin_get_unconfigured_state (RpmOstreeOrigin *origin)
 {
-  return origin->cached_unconfigured_state;
+  return g_strdup (origin->cached_unconfigured_state);
 }
 
 /* Determines whether the origin hints at local assembly being required. In some

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -331,10 +331,10 @@ rpmostree_origin_get_regenerate_initramfs (RpmOstreeOrigin *origin)
   return g_key_file_get_boolean (origin->kf, "rpmostree", "regenerate-initramfs", NULL);
 }
 
-const char *const*
+char **
 rpmostree_origin_get_initramfs_args (RpmOstreeOrigin *origin)
 {
-  return (const char * const*)origin->cached_initramfs_args;
+  return g_strdupv (origin->cached_initramfs_args);
 }
 
 const char*

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -322,7 +322,7 @@ rpmostree_origin_get_override_commit (RpmOstreeOrigin *origin)
 GHashTable *
 rpmostree_origin_get_initramfs_etc_files (RpmOstreeOrigin *origin)
 {
-  return origin->cached_initramfs_etc_files;
+  return g_hash_table_ref (origin->cached_initramfs_etc_files);
 }
 
 gboolean

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -29,8 +29,6 @@
 #include "rpmostree-rpm-util.h"
 
 struct RpmOstreeOrigin {
-  guint refcount;
-
   /* this is the single source of truth */
   GKeyFile *kf;
 
@@ -102,7 +100,6 @@ rpmostree_origin_parse_keyfile (GKeyFile         *origin,
   g_autoptr(RpmOstreeOrigin) ret = NULL;
 
   ret = g_new0 (RpmOstreeOrigin, 1);
-  ret->refcount = 1;
   ret->kf = keyfile_dup (origin);
 
   ret->cached_packages = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
@@ -374,22 +371,10 @@ rpmostree_origin_get_string (RpmOstreeOrigin *origin,
   return g_key_file_get_string (origin->kf, section, value, NULL);
 }
 
-RpmOstreeOrigin*
-rpmostree_origin_ref (RpmOstreeOrigin *origin)
-{
-  g_assert (origin);
-  origin->refcount++;
-  return origin;
-}
-
 void
-rpmostree_origin_unref (RpmOstreeOrigin *origin)
+rpmostree_origin_free (RpmOstreeOrigin *origin)
 {
   g_assert (origin);
-  g_assert_cmpint (origin->refcount, >, 0);
-  origin->refcount--;
-  if (origin->refcount > 0)
-    return;
   g_key_file_unref (origin->kf);
   g_free (origin->cached_refspec);
   g_free (origin->cached_rojig_version);

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -104,7 +104,7 @@ rpmostree_origin_get_regenerate_initramfs (RpmOstreeOrigin *origin);
 char **
 rpmostree_origin_get_initramfs_args (RpmOstreeOrigin *origin);
 
-const char *
+char *
 rpmostree_origin_get_unconfigured_state (RpmOstreeOrigin *origin);
 
 gboolean

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -55,7 +55,7 @@ rpmostree_origin_dup (RpmOstreeOrigin *origin);
 void
 rpmostree_origin_remove_transient_state (RpmOstreeOrigin *origin);
 
-const char *
+char *
 rpmostree_origin_get_refspec (RpmOstreeOrigin *origin);
 
 void
@@ -69,7 +69,7 @@ rpmostree_origin_get_full_refspec (RpmOstreeOrigin *origin,
 
 gboolean rpmostree_origin_is_rojig (RpmOstreeOrigin *origin);
 
-const char *
+char *
 rpmostree_origin_get_rojig_version (RpmOstreeOrigin *origin);
 
 GVariant *

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -109,11 +109,6 @@ rpmostree_origin_get_unconfigured_state (RpmOstreeOrigin *origin);
 gboolean
 rpmostree_origin_may_require_local_assembly (RpmOstreeOrigin *origin);
 
-char *
-rpmostree_origin_get_string (RpmOstreeOrigin *origin,
-                             const char *section,
-                             const char *value);
-
 GKeyFile *
 rpmostree_origin_dup_keyfile (RpmOstreeOrigin *origin);
 

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -101,7 +101,7 @@ rpmostree_origin_get_initramfs_etc_files (RpmOstreeOrigin *origin);
 gboolean
 rpmostree_origin_get_regenerate_initramfs (RpmOstreeOrigin *origin);
 
-const char *const*
+char **
 rpmostree_origin_get_initramfs_args (RpmOstreeOrigin *origin);
 
 const char *

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -92,7 +92,7 @@ rpmostree_origin_get_overrides_remove (RpmOstreeOrigin *origin);
 GHashTable *
 rpmostree_origin_get_overrides_local_replace (RpmOstreeOrigin *origin);
 
-const char *
+char *
 rpmostree_origin_get_override_commit (RpmOstreeOrigin *origin);
 
 GHashTable *

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -24,9 +24,8 @@
 #include "rpmostree-core.h"
 
 typedef struct RpmOstreeOrigin RpmOstreeOrigin;
-RpmOstreeOrigin *rpmostree_origin_ref (RpmOstreeOrigin *origin);
-void rpmostree_origin_unref (RpmOstreeOrigin *origin);
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeOrigin, rpmostree_origin_unref)
+void rpmostree_origin_free (RpmOstreeOrigin *origin);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeOrigin, rpmostree_origin_free)
 
 RpmOstreeOrigin *
 rpmostree_origin_parse_keyfile (GKeyFile *keyfile,


### PR DESCRIPTION
Part of the reason we had `RpmOstreeOrigin` in the first place
is so that we can cache values we parse from the keyfile.  However
this is a barrier to oxidizing becuase it requires the Rust side
to hold C-compatible `GString` values and worse `GHashTable`.

This isn't a performance sensitive area and it's really not that
bad to switch over all callsites to use autofree, and that will
allow the Rust side to be pure Rust data structures.
