### PR TITLE
tree-wide: Add extern "C" wrapping to our headers

### DIFF
--- a/src/app/rpmostree-dbus-helpers.h
+++ b/src/app/rpmostree-dbus-helpers.h
@@ -29,6 +29,8 @@
 #include <string.h>
 #include <ostree.h>
 
+G_BEGIN_DECLS
+
 #define BUS_NAME "org.projectatomic.rpmostree1"
 
 #define _cleanup_peer_ __attribute__((cleanup(rpmostree_cleanup_peer)))
@@ -128,3 +130,5 @@ rpmostree_print_cached_update (GVariant         *cached_update,
                                gboolean          verbose_advisories,
                                GCancellable     *cancellable,
                                GError          **error);
+
+G_END_DECLS

--- a/src/app/rpmostree-polkit-agent.h
+++ b/src/app/rpmostree-polkit-agent.h
@@ -21,5 +21,9 @@
 
 #pragma once
 
+G_BEGIN_DECLS
+
 int rpmostree_polkit_agent_open(void);
 void rpmostree_polkit_agent_close(void);
+
+G_END_DECLS

--- a/src/daemon/rpmostree-package-variants.h
+++ b/src/daemon/rpmostree-package-variants.h
@@ -23,6 +23,8 @@
 #include <ostree.h>
 #include <rpmostree.h>
 
+G_BEGIN_DECLS
+
 #define RPMOSTREE_DB_DIFF_VARIANT_FORMAT G_VARIANT_TYPE ("a(sua{sv})")
 
 typedef enum {
@@ -40,3 +42,5 @@ rpm_ostree_db_diff_variant (OstreeRepo *repo,
                             GVariant  **out_variant,
                             GCancellable *cancellable,
                             GError **error);
+
+G_END_DECLS

--- a/src/daemon/rpmostree-sysroot-core.h
+++ b/src/daemon/rpmostree-sysroot-core.h
@@ -22,6 +22,8 @@
 
 #include "rpmostreed-types.h"
 
+G_BEGIN_DECLS
+
 /* Used by the upgrader to hold a strong ref temporarily to a base commit */
 #define RPMOSTREE_TMP_BASE_REF "rpmostree/base/tmp"
 /* Diretory that is defined to have 0700 mode always, used for checkouts */
@@ -58,3 +60,5 @@ gboolean rpmostree_syscore_write_deployment (OstreeSysroot           *sysroot,
                                              gboolean                 pushing_rollback,
                                              GCancellable            *cancellable,
                                              GError                 **error);
+
+G_END_DECLS

--- a/src/daemon/rpmostreed-daemon.h
+++ b/src/daemon/rpmostreed-daemon.h
@@ -21,6 +21,8 @@
 #include "rpmostreed-types.h"
 #include "rpmostree-util.h"
 
+G_BEGIN_DECLS
+
 #define RPMOSTREED_TYPE_DAEMON   (rpmostreed_daemon_get_type ())
 #define RPMOSTREED_DAEMON(o)     (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_DAEMON, RpmostreedDaemon))
 #define RPMOSTREED_IS_DAEMON(o)  (G_TYPE_CHECK_INSTANCE_TYPE ((o), RPMOSTREED_TYPE_DAEMON))
@@ -55,3 +57,5 @@ gboolean           rpmostreed_daemon_reload_config  (RpmostreedDaemon *self,
 
 RpmostreedAutomaticUpdatePolicy
 rpmostreed_get_automatic_update_policy (RpmostreedDaemon *self);
+
+G_END_DECLS

--- a/src/daemon/rpmostreed-deployment-utils.h
+++ b/src/daemon/rpmostreed-deployment-utils.h
@@ -23,6 +23,8 @@
 
 #include "rpmostreed-types.h"
 
+G_BEGIN_DECLS
+
 char *          rpmostreed_deployment_generate_id (OstreeDeployment *deployment);
 
 OstreeDeployment *
@@ -67,3 +69,5 @@ gboolean        rpmostreed_update_generate_variant (OstreeDeployment  *booted_de
                                                     GVariant         **out_update,
                                                     GCancellable      *cancellable,
                                                     GError           **error);
+
+G_END_DECLS

--- a/src/daemon/rpmostreed-errors.h
+++ b/src/daemon/rpmostreed-errors.h
@@ -20,6 +20,8 @@
 
 #include <gio/gio.h>
 
+G_BEGIN_DECLS
+
 #define RPM_OSTREED_ERROR (rpmostreed_error_quark ())
 
 typedef enum {
@@ -32,3 +34,5 @@ typedef enum {
 } RpmOstreedError;
 
 GQuark rpmostreed_error_quark (void);
+
+G_END_DECLS

--- a/src/daemon/rpmostreed-os-experimental.h
+++ b/src/daemon/rpmostreed-os-experimental.h
@@ -20,6 +20,8 @@
 
 #include "rpmostreed-types.h"
 
+G_BEGIN_DECLS
+
 #define RPMOSTREED_TYPE_OSEXPERIMENTAL   (rpmostreed_osexperimental_get_type ())
 #define RPMOSTREED_OSEXPERIMENTAL(o)     (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_OSEXPERIMENTAL, RpmostreedOSExperimental))
 #define RPMOSTREED_IS_OSEXPERIMENTAL(o)  (G_TYPE_CHECK_INSTANCE_TYPE ((o), RPMOSTREED_TYPE_OSEXPERIMENTAL))
@@ -28,3 +30,4 @@ GType             rpmostreed_osexperimental_get_type           (void) G_GNUC_CON
 RPMOSTreeOSExperimental *     rpmostreed_osexperimental_new                (OstreeSysroot *sysroot,
                                                                 OstreeRepo *repo,
                                                                             const char *name);
+G_END_DECLS

--- a/src/daemon/rpmostreed-os.h
+++ b/src/daemon/rpmostreed-os.h
@@ -20,6 +20,8 @@
 
 #include "rpmostreed-types.h"
 
+G_BEGIN_DECLS
+
 #define RPMOSTREED_TYPE_OS   (rpmostreed_os_get_type ())
 #define RPMOSTREED_OS(o)     (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_OS, RpmostreedOS))
 #define RPMOSTREED_IS_OS(o)  (G_TYPE_CHECK_INSTANCE_TYPE ((o), RPMOSTREED_TYPE_OS))
@@ -31,3 +33,4 @@ GType             rpmostreed_os_get_type           (void) G_GNUC_CONST;
 RPMOSTreeOS *     rpmostreed_os_new                (OstreeSysroot *sysroot,
                                                     OstreeRepo *repo,
                                                     const char *name);
+G_END_DECLS

--- a/src/daemon/rpmostreed-sysroot.h
+++ b/src/daemon/rpmostreed-sysroot.h
@@ -22,6 +22,8 @@
 #include "rpmostreed-types.h"
 #include <polkit/polkit.h>
 
+G_BEGIN_DECLS
+
 #define RPMOSTREED_TYPE_SYSROOT   (rpmostreed_sysroot_get_type ())
 #define RPMOSTREED_SYSROOT(o)     (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_SYSROOT, RpmostreedSysroot))
 #define RPMOSTREED_IS_SYSROOT(o)  (G_TYPE_CHECK_INSTANCE_TYPE ((o), RPMOSTREED_TYPE_SYSROOT))
@@ -63,3 +65,5 @@ void                rpmostreed_sysroot_set_txn (RpmostreedSysroot     *self,
                                                 RpmostreedTransaction *txn);
 
 void                rpmostreed_sysroot_emit_update      (RpmostreedSysroot *self);
+
+G_END_DECLS

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -24,6 +24,8 @@
 
 #include <gio/gunixfdlist.h>
 
+G_BEGIN_DECLS
+
 RpmostreedTransaction *
                 rpmostreed_transaction_new_package_diff    (GDBusMethodInvocation *invocation,
                                                             OstreeSysroot *sysroot,
@@ -154,3 +156,4 @@ rpmostreed_transaction_new_kernel_arg (GDBusMethodInvocation *invocation,
                                        GCancellable          *cancellable,
                                        GError               **error);
 
+G_END_DECLS

--- a/src/daemon/rpmostreed-transaction.h
+++ b/src/daemon/rpmostreed-transaction.h
@@ -20,6 +20,8 @@
 
 #include "rpmostreed-types.h"
 
+G_BEGIN_DECLS
+
 #define RPMOSTREED_TYPE_TRANSACTION          (rpmostreed_transaction_get_type ())
 #define RPMOSTREED_TRANSACTION(o)            (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_TRANSACTION, RpmostreedTransaction))
 #define RPMOSTREED_TRANSACTION_CLASS(c)      (G_TYPE_CHECK_CLASS_CAST ((c), RPMOSTREED_TYPE_TRANSACTION, RpmostreedTransactionClass))
@@ -58,3 +60,5 @@ void            rpmostreed_transaction_connect_signature_progress
                                                            (RpmostreedTransaction *transaction,
                                                             OstreeRepo *repo);
 void            rpmostreed_transaction_force_close         (RpmostreedTransaction *transaction);
+
+G_END_DECLS

--- a/src/daemon/rpmostreed-types.h
+++ b/src/daemon/rpmostreed-types.h
@@ -26,6 +26,8 @@
 #include <stdint.h>
 #include <string.h>
 
+G_BEGIN_DECLS
+
 struct _RpmostreedDaemon;
 typedef struct _RpmostreedDaemon RpmostreedDaemon;
 
@@ -39,3 +41,5 @@ typedef struct _RpmostreedOSExperimental RpmostreedOSExperimental;
 
 struct _RpmostreedTransaction;
 typedef struct _RpmostreedTransaction RpmostreedTransaction;
+
+G_END_DECLS

--- a/src/daemon/rpmostreed-utils.h
+++ b/src/daemon/rpmostreed-utils.h
@@ -22,6 +22,8 @@
 
 #include "rpmostreed-types.h"
 
+G_BEGIN_DECLS
+
 gchar *    rpmostreed_generate_object_path (const gchar  *base,
                                             const gchar  *part,
                                             ...);
@@ -82,3 +84,5 @@ gboolean   rpmostreed_parse_revision (const char  *revision,
                                       char       **out_checksum,
                                       char       **out_version,
                                       GError     **error);
+
+G_END_DECLS

--- a/src/lib/rpmostree-package-priv.h
+++ b/src/lib/rpmostree-package-priv.h
@@ -25,6 +25,8 @@
 #include "rpmostree-package.h"
 #include "rpmostree-refsack.h"
 
+G_BEGIN_DECLS
+
 RpmOstreePackage * _rpm_ostree_package_new (RpmOstreeRefSack *rsack, DnfPackage *hypkg);
 
 RpmOstreePackage * _rpm_ostree_package_new_from_variant (GVariant *gv_nevra);
@@ -44,3 +46,5 @@ _rpm_ostree_diff_package_lists (GPtrArray  *a,
                                 GPtrArray **out_modified_a,
                                 GPtrArray **out_modified_b,
                                 GPtrArray **out_common);
+
+G_END_DECLS

--- a/src/lib/rpmostree-package.h
+++ b/src/lib/rpmostree-package.h
@@ -23,6 +23,8 @@
 
 #include <gio/gio.h>
 
+G_BEGIN_DECLS
+
 typedef struct RpmOstreePackage RpmOstreePackage;
 
 #define RPM_OSTREE_TYPE_PACKAGE         (rpm_ostree_package_get_type ())
@@ -46,3 +48,5 @@ const char *rpm_ostree_package_get_arch (RpmOstreePackage *p);
 
 _RPMOSTREE_EXTERN
 int rpm_ostree_package_cmp (RpmOstreePackage *p1, RpmOstreePackage *p2);
+
+G_END_DECLS

--- a/src/libpriv/libsd-locale-util.h
+++ b/src/libpriv/libsd-locale-util.h
@@ -21,6 +21,8 @@
 
 #include <glib.h>
 
+G_BEGIN_DECLS
+
 typedef enum {
         TREE_VERTICAL,
         TREE_BRANCH,
@@ -34,3 +36,5 @@ typedef enum {
 } SpecialGlyph;
 
 const char *libsd_special_glyph(SpecialGlyph code) __attribute__ ((const));
+
+G_END_DECLS

--- a/src/libpriv/libsd-time-util.h
+++ b/src/libpriv/libsd-time-util.h
@@ -25,6 +25,9 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <time.h>
+#include <glib.h>
+
+G_BEGIN_DECLS
 
 typedef uint64_t usec_t;
 typedef uint64_t nsec_t;
@@ -65,3 +68,5 @@ typedef uint64_t nsec_t;
 #define FORMAT_TIMESPAN_MAX 64
 
 char *libsd_format_timestamp_relative(char *buf, size_t l, usec_t t);
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-bwrap.h
+++ b/src/libpriv/rpmostree-bwrap.h
@@ -24,6 +24,8 @@
 
 #include "libglnx.h"
 
+G_BEGIN_DECLS
+
 typedef enum {
   RPMOSTREE_BWRAP_IMMUTABLE = 0,
   RPMOSTREE_BWRAP_MUTATE_ROFILES,
@@ -75,3 +77,5 @@ gboolean rpmostree_bwrap_run (RpmOstreeBwrap *bwrap,
                               GError        **error);
 
 gboolean rpmostree_bwrap_selftest (GError **error);
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -24,6 +24,8 @@
 #include "rpmostree-rojig-core.h"
 #include "rpmostree-core.h"
 
+G_BEGIN_DECLS
+
 struct _RpmOstreeContext {
   GObject parent;
 
@@ -84,3 +86,4 @@ struct _RpmOstreeContext {
   GLnxTmpDir repo_tmpdir; /* Used to assemble+commit if no base rootfs provided */
 };
 
+G_END_DECLS

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -27,6 +27,8 @@
 #include "rpmostree-rust.h"
 #include "libglnx.h"
 
+G_BEGIN_DECLS
+
 #define RPMOSTREE_CORE_CACHEDIR "/var/cache/rpm-ostree/"
 #define RPMOSTREE_DIR_CACHE_REPOMD "repomd"
 #define RPMOSTREE_DIR_CACHE_SOLV "solv"
@@ -242,3 +244,5 @@ rpmostree_core_undo_usretc (int              rootfs_dfd,
 gboolean
 rpmostree_core_redo_usretc (int           rootfs_dfd,
                             GError      **error);
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-editor.h
+++ b/src/libpriv/rpmostree-editor.h
@@ -25,5 +25,9 @@
 
 #include "ostree.h"
 
+G_BEGIN_DECLS
+
 char *  ot_editor_prompt    (OstreeRepo *repo, const char *input,
                              GCancellable *cancellable, GError **error);
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-importer.h
+++ b/src/libpriv/rpmostree-importer.h
@@ -26,6 +26,8 @@
 #include <rpm/rpmlib.h>
 #include <libdnf/libdnf.h>
 
+G_BEGIN_DECLS
+
 typedef struct RpmOstreeImporter RpmOstreeImporter;
 
 #define RPMOSTREE_TYPE_IMPORTER         (rpmostree_importer_get_type ())
@@ -92,3 +94,5 @@ rpmostree_importer_get_nevra (RpmOstreeImporter *self);
 
 const char *
 rpmostree_importer_get_header_sha256 (RpmOstreeImporter *self);
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-json-parsing.h
+++ b/src/libpriv/rpmostree-json-parsing.h
@@ -23,6 +23,8 @@
 #include <gio/gio.h>
 #include <json-glib/json-glib.h>
 
+G_BEGIN_DECLS
+
 gboolean
 _rpmostree_jsonutil_object_get_optional_string_member (JsonObject     *object,
                                                        const char     *member_name,
@@ -74,3 +76,4 @@ GHashTable *
 _rpmostree_jsonutil_jsarray_strings_to_set (JsonArray  *array);
 
 
+G_END_DECLS

--- a/src/libpriv/rpmostree-kernel.h
+++ b/src/libpriv/rpmostree-kernel.h
@@ -22,6 +22,8 @@
 
 #include <ostree.h>
 
+G_BEGIN_DECLS
+
 typedef enum {
   RPMOSTREE_FINALIZE_KERNEL_AUTO,
   RPMOSTREE_FINALIZE_KERNEL_USRLIB_MODULES,
@@ -59,3 +61,5 @@ rpmostree_run_dracut (int     rootfs_dfd,
                       GLnxTmpfile *out_initramfs_tmpf,
                       GCancellable  *cancellable,
                       GError **error);
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -23,6 +23,8 @@
 #include <ostree.h>
 #include "rpmostree-core.h"
 
+G_BEGIN_DECLS
+
 typedef struct RpmOstreeOrigin RpmOstreeOrigin;
 RpmOstreeOrigin *rpmostree_origin_ref (RpmOstreeOrigin *origin);
 void rpmostree_origin_unref (RpmOstreeOrigin *origin);
@@ -200,3 +202,5 @@ gboolean
 rpmostree_origin_remove_all_overrides (RpmOstreeOrigin  *origin,
                                        gboolean         *out_changed,
                                        GError          **error);
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-output.h
+++ b/src/libpriv/rpmostree-output.h
@@ -20,6 +20,8 @@
 
 #include <stdbool.h>
 
+G_BEGIN_DECLS
+
 typedef enum {
   RPMOSTREE_OUTPUT_MESSAGE,
   RPMOSTREE_OUTPUT_PROGRESS_BEGIN,
@@ -91,3 +93,4 @@ typedef struct {
   const char *msg;
 } RpmOstreeOutputProgressEnd;
 
+G_END_DECLS

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -27,6 +27,8 @@
 
 #include "rpmostree-rust.h"
 
+G_BEGIN_DECLS
+
 gboolean
 rpmostree_check_passwd (OstreeRepo      *repo,
                         int              rootfs_dfd,
@@ -133,3 +135,5 @@ gboolean
 rpmostree_passwd_sysusers2char (GPtrArray *sysusers_entries,
                                 char      **out_content,
                                 GError    **error);
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -24,6 +24,8 @@
 #include "rpmostree-json-parsing.h"
 #include "rpmostree-rust.h"
 
+G_BEGIN_DECLS
+
 /* "public" for unit tests */
 char *
 rpmostree_postprocess_replace_nsswitch (const char *buf,
@@ -103,3 +105,5 @@ rpmostree_compose_commit (int            rootfs_dfd,
                           char         **out_new_revision,
                           GCancellable  *cancellable,
                           GError       **error);
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-refsack.h
+++ b/src/libpriv/rpmostree-refsack.h
@@ -24,6 +24,8 @@
 #include <libdnf/libdnf.h>
 #include "libglnx.h"
 
+G_BEGIN_DECLS
+
 typedef struct {
   gint refcount;  /* atomic */
   DnfSack *sack;
@@ -41,3 +43,4 @@ rpmostree_refsack_unref (RpmOstreeRefSack *rsack);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeRefSack, rpmostree_refsack_unref);
 
+G_END_DECLS

--- a/src/libpriv/rpmostree-refts.h
+++ b/src/libpriv/rpmostree-refts.h
@@ -24,6 +24,8 @@
 #include <libdnf/libdnf.h>
 #include "libglnx.h"
 
+G_BEGIN_DECLS
+
 typedef struct {
   gint refcount;  /* atomic */
   rpmts ts;
@@ -41,3 +43,4 @@ rpmostree_refts_unref (RpmOstreeRefTs *rts);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeRefTs, rpmostree_refts_unref);
 
+G_END_DECLS

--- a/src/libpriv/rpmostree-rojig-assembler.h
+++ b/src/libpriv/rpmostree-rojig-assembler.h
@@ -23,6 +23,8 @@
 #include "libglnx.h"
 #include "rpmostree-rojig-core.h"
 
+G_BEGIN_DECLS
+
 typedef struct RpmOstreeRojigAssembler RpmOstreeRojigAssembler;
 
 #define RPMOSTREE_TYPE_ROJIG_ASSEMBLER         (rpmostree_rojig_assembler_get_type ())
@@ -67,3 +69,5 @@ rpmostree_rojig_assembler_xattr_lookup (GVariant *xattr_table,
                                         GVariant *xattrs,
                                         GVariant **out_xattrs,
                                         GError  **error);
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-rojig-build.h
+++ b/src/libpriv/rpmostree-rojig-build.h
@@ -23,6 +23,8 @@
 #include "libglnx.h"
 #include "rpmostree-rojig-core.h"
 
+G_BEGIN_DECLS
+
 gboolean
 rpmostree_commit2rojig (OstreeRepo   *repo,
                         OstreeRepo   *pkgcache_repo,
@@ -32,3 +34,5 @@ rpmostree_commit2rojig (OstreeRepo   *repo,
                         const char   *outputdir,
                         GCancellable *cancellable,
                         GError      **error);
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-rojig-core.h
+++ b/src/libpriv/rpmostree-rojig-core.h
@@ -26,6 +26,8 @@
 #include <rpm/rpmlib.h>
 #include <libdnf/libdnf.h>
 
+G_BEGIN_DECLS
+
 /* A rojigRPM is structured as an ordered set of files/directories; we use numeric
  * prefixes to ensure ordering. Most of the files are in GVariant format.
  *
@@ -80,3 +82,5 @@
 
 /* This one goes in the spec file to use as our replacement */
 #define RPMOSTREE_ROJIG_SPEC_META_MAGIC "#@@@rpmostree_rojig_meta@@@"
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -32,6 +32,8 @@
 
 #include "libglnx.h"
 
+G_BEGIN_DECLS
+
 struct RpmHeaders
 {
   RpmOstreeRefTs *refts; /* rpm transaction set the headers belong to */
@@ -236,3 +238,5 @@ rpmostree_cache_branch_to_nevra (const char *cachebranch);
 
 GPtrArray *
 rpmostree_get_enabled_rpmmd_repos (DnfContext *dnfctx, DnfRepoEnabled enablement);
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-rust-prelude.h
+++ b/src/libpriv/rpmostree-rust-prelude.h
@@ -22,6 +22,8 @@
 
 #include <gio/gio.h>
 
+G_BEGIN_DECLS
+
 /* Forward declarations */
 typedef struct RpmOstreeOrigin RpmOstreeOrigin;
 
@@ -39,3 +41,5 @@ b(RpmOstreeOrigin)
 b(OstreeDeployment)
 b(OstreeSysroot)
 #undef b
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-scripts.h
+++ b/src/libpriv/rpmostree-scripts.h
@@ -32,6 +32,8 @@
 
 #include "libglnx.h"
 
+G_BEGIN_DECLS
+
 typedef enum {
   RPMOSTREE_SCRIPT_ACTION_DEFAULT = 0,
   RPMOSTREE_SCRIPT_ACTION_IGNORE,
@@ -87,3 +89,5 @@ rpmostree_deployment_sanitycheck_rpmdb (int           rootfs_fd,
                                         GPtrArray     *overrides,
                                         GCancellable *cancellable,
                                         GError      **error);
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-types.h
+++ b/src/libpriv/rpmostree-types.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+G_BEGIN_DECLS
+
 /* These types are used by both the daemon and the client. Some of them should probably be
  * added to the public API eventually. */
 
@@ -62,3 +64,5 @@ typedef enum {
  */
 #define RPMOSTREE_DIFF_MODIFIED_GVARIANT_STRING "a(us(ss)(ss))"
 #define RPMOSTREE_DIFF_MODIFIED_GVARIANT_FORMAT G_VARIANT_TYPE (RPMOSTREE_DIFF_MODIFIED_GVARIANT_STRING)
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-unpacker-core.h
+++ b/src/libpriv/rpmostree-unpacker-core.h
@@ -28,4 +28,8 @@
 #include <archive.h>
 #include <archive_entry.h>
 
+G_BEGIN_DECLS
+
 struct archive * rpmostree_unpack_rpm2cpio (int fd, GError **error);
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -29,6 +29,8 @@
 #include "rpmostree.h"
 #include "rpmostree-types.h"
 
+G_BEGIN_DECLS
+
 #define _N(single, plural, n) ( (n) == 1 ? (single) : (plural) )
 #define _NS(n) _N("", "s", n)
 
@@ -255,3 +257,5 @@ rpmostree_relative_path_is_ostree_compliant (const char *path);
 
 char*
 rpmostree_maybe_shell_quote (const char *s);
+
+G_END_DECLS


### PR DESCRIPTION
Prep for (potentially) using https://cxx.rs
We want our header files to be includable in C++.
