### PR TITLE
daemon: Drop CreateOSName

### DIFF
--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -59,11 +59,6 @@
     <!-- none, check, stage -->
     <property name="AutomaticUpdatePolicy" type="s" access="read"/>
 
-    <method name="CreateOSName">
-      <arg type="s" name="name"/>
-      <arg type="o" name="result" direction="out"/>
-    </method>
-
     <method name="GetOS">
       <arg name="name" type="s"/>
       <arg name="object_path" type="o" direction="out"/>

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -195,42 +195,6 @@ sysroot_output_cb (RpmOstreeOutputType type, void *data, void *opaque)
 }
 
 static gboolean
-handle_create_osname (RPMOSTreeSysroot *object,
-                      GDBusMethodInvocation *invocation,
-                      const gchar *osname)
-{
-  RpmostreedSysroot *self = RPMOSTREED_SYSROOT (object);
-  GError *error = NULL;
-  g_autofree gchar *dbus_path = NULL;
-
-  if (!ostree_sysroot_ensure_initialized (self->ot_sysroot, NULL, &error))
-    goto out;
-
-  if (strchr (osname, '/') != 0)
-    {
-      g_set_error_literal (&error,
-                           RPM_OSTREED_ERROR,
-                           RPM_OSTREED_ERROR_FAILED,
-                           "Invalid osname");
-      goto out;
-    }
-
-  if (!ostree_sysroot_init_osname (self->ot_sysroot, osname, NULL, &error))
-    goto out;
-
-  dbus_path = rpmostreed_generate_object_path (BASE_DBUS_PATH, osname, NULL);
-
-  rpmostree_sysroot_complete_create_osname (RPMOSTREE_SYSROOT (self),
-                                            invocation,
-                                            g_strdup (dbus_path));
-out:
-  if (error)
-    g_dbus_method_invocation_take_error (invocation, error);
-
-  return TRUE;
-}
-
-static gboolean
 handle_get_os (RPMOSTreeSysroot *object,
                GDBusMethodInvocation *invocation,
                const char *arg_name)
@@ -758,7 +722,6 @@ on_deploy_changed (GFileMonitor *monitor,
 static void
 rpmostreed_sysroot_iface_init (RPMOSTreeSysrootIface *iface)
 {
-  iface->handle_create_osname = handle_create_osname;
   iface->handle_get_os = handle_get_os;
   iface->handle_register_client = handle_register_client;
   iface->handle_unregister_client = handle_unregister_client;


### PR DESCRIPTION
This is technically an API break, but that method has never really been
very useful and I doubt it was ever seriously used. There is no wrapper
for it in the CLI client. Let's just delete it and pretend it never
existed.

In the end, I don't think the ability of supporting multiple separate
stateroots is widely used in practice.

Closes: #551