### PR TITLE
compose: Use static enablement for ostree systemd services

### DIFF
--- a/tests/compose/test-basic.sh
+++ b/tests/compose/test-basic.sh
@@ -54,9 +54,8 @@ assert_file_has_content_literal autovar.txt 'd /var/cache 0755 root root - -'
 assert_file_has_content_literal autovar.txt 'd /var/log/chrony 0755 chrony chrony - -'
 echo "ok autovar"
 
-ostree --repo="${repo}" cat "${treeref}" /usr/lib/systemd/system-preset/40-rpm-ostree-auto.preset > preset.txt
-assert_file_has_content preset.txt '^enable ostree-remount.service$'
-assert_file_has_content preset.txt '^enable ostree-finalize-staged.path$'
+# Validate this exists
+ostree --repo="${repo}" ls "${treeref}" /usr/lib/systemd/system/multi-user.target.wants/ostree-remount.service
 
 python3 <<EOF
 import json, yaml


### PR DESCRIPTION
I was looking at the output of `ostree admin config-diff`
on a base FCOS boot.  It'd be really nice to trim that down
as much as possible, so we can cleanly capture the difference
between user config and system config.

Let's use static enablement rather than presets.
