### PR TITLE
libpriv/core: add a guard for temporary-etc context and move to Rust

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -1,0 +1,70 @@
+pub use self::ffi::*;
+use crate::ffiutil;
+use openat_ext::OpenatDirExt;
+
+/// Guard for running logic in a context with temporary /etc.
+///
+/// We have a messy dance in dealing with /usr/etc and /etc; the
+/// current model is basically to have it be /etc whenever we're running
+/// any code.
+#[derive(Debug)]
+pub struct TempEtcGuard {
+    rootfs: openat::Dir,
+    renamed_etc: bool,
+}
+
+impl TempEtcGuard {
+    /// Create a context with a temporary /etc, and return a guard to it.
+    pub fn undo_usretc(rootfs: openat::Dir) -> anyhow::Result<Self> {
+        let has_usretc = rootfs.exists("usr/etc")?;
+        if has_usretc {
+            // In general now, we place contents in /etc when running scripts
+            rootfs.local_rename("usr/etc", "etc")?;
+            // But leave a compat symlink, as we used to bind mount, so scripts
+            // could still use that too.
+            rootfs.symlink("usr/etc", "../etc")?;
+        }
+
+        let guard = Self {
+            rootfs,
+            renamed_etc: has_usretc,
+        };
+        Ok(guard)
+    }
+
+    /// Remove the temporary /etc, and destroy the guard.
+    pub fn redo_usretc(self) -> anyhow::Result<()> {
+        if self.renamed_etc {
+            /* Remove the symlink and swap back */
+            self.rootfs.remove_file("usr/etc")?;
+            self.rootfs.local_rename("etc", "usr/etc")?;
+        }
+        Ok(())
+    }
+}
+
+mod ffi {
+    use super::*;
+    use glib_sys::GError;
+
+    #[no_mangle]
+    pub extern "C" fn ror_tempetc_undo_usretc(
+        rootfs: libc::c_int,
+        gerror: *mut *mut GError,
+    ) -> *mut TempEtcGuard {
+        let fd = ffiutil::ffi_view_openat_dir(rootfs);
+        let res = TempEtcGuard::undo_usretc(fd).map(|guard| Box::new(guard));
+        ffiutil::ptr_glib_error(res, gerror)
+    }
+
+    #[no_mangle]
+    pub extern "C" fn ror_tempetc_redo_usretc(
+        guard_ptr: *mut TempEtcGuard,
+        gerror: *mut *mut GError,
+    ) -> libc::c_int {
+        assert!(!guard_ptr.is_null());
+        let guard = unsafe { Box::from_raw(guard_ptr) };
+        let res = guard.redo_usretc();
+        ffiutil::int_glib_error(res, gerror)
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,6 +12,7 @@ mod cliwrap;
 pub use cliwrap::*;
 mod composepost;
 pub use self::composepost::*;
+mod core;
 mod history;
 pub use self::history::*;
 mod journal;

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -236,13 +236,5 @@ gboolean rpmostree_context_commit (RpmOstreeContext      *self,
                                    char                 **out_commit,
                                    GCancellable          *cancellable,
                                    GError               **error);
-gboolean
-rpmostree_core_undo_usretc (int              rootfs_dfd,
-                            gboolean        *renamed_etc,
-                            GError         **error);
-
-gboolean
-rpmostree_core_redo_usretc (int           rootfs_dfd,
-                            GError      **error);
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-kernel.c
+++ b/src/libpriv/rpmostree-kernel.c
@@ -521,8 +521,8 @@ rpmostree_run_dracut (int     rootfs_dfd,
    * today.  Though maybe in the future we should add it, but
    * in the end we want to use systemd-sysusers of course.
    **/
-  gboolean renamed_etc = FALSE;
-  if (!rpmostree_core_undo_usretc (rootfs_dfd, &renamed_etc, error))
+  RORTempEtcGuard * etc_guard = ror_tempetc_undo_usretc (rootfs_dfd, error);
+  if (etc_guard == NULL)
     return FALSE;
   gboolean have_passwd = FALSE;
   if (!rpmostree_passwd_prepare_rpm_layering (rootfs_dfd,
@@ -640,7 +640,7 @@ rpmostree_run_dracut (int     rootfs_dfd,
   if (have_passwd && !rpmostree_passwd_complete_rpm_layering (rootfs_dfd, error))
     goto out;
 
-  if (renamed_etc && !rpmostree_core_redo_usretc (rootfs_dfd, error))
+  if (!ror_tempetc_redo_usretc (etc_guard, error))
     goto out;
 
   ret = TRUE;


### PR DESCRIPTION
This adds a guard around the postprocessing logic dealing with
creating/destroying a temporary-etc context, and moves it to Rust.
