### PR TITLE
tests: Remove "invalid format specifier" for GDateTime test

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -65,8 +65,6 @@ parallel insttests: {
         shwrap("""
           dnf install -y *.rpm
           coreos-assembler init --force https://github.com/coreos/fedora-coreos-config
-          # XXX: temporarily keep using f32 FCOS until we move cosa
-          git -C src/config checkout ff607c16562340b9caf2c8128b1d3573abbaccec
           # include our built rpm-ostree in the image
           mkdir -p overrides/rpm
           mv *.rpm overrides/rpm

--- a/tests/check/jsonutil.c
+++ b/tests/check/jsonutil.c
@@ -164,8 +164,6 @@ test_auto_version (void)
   _VER_TST("10.<date:>",      "10.20001010", "10..0");
   _VER_TST("10.<wrongtag: >", "10.20001010", "10.<wrongtag: >");
 
-  /* Test invalid datetime specifier given. */
-  _VER_TST("10.<date:%f>", "10.20001010", NULL);
 }
 
 int

--- a/tests/vmcheck/test-override-kernel.sh
+++ b/tests/vmcheck/test-override-kernel.sh
@@ -43,6 +43,7 @@ vm_cmd rpm-ostree db list "${current}" > current-dblist.txt
 case $versionid in
   31) kernel_release=5.3.7-301.fc31.x86_64;;
   32) kernel_release=5.6.6-300.fc32.x86_64;;
+  33) kernel_release=5.8.15-301.fc33.x86_64;;
   *) assert_not_reached "Unsupported Fedora version: $versionid";;
 esac
 assert_not_file_has_content current-dblist.txt $kernel_release


### PR DESCRIPTION
Newer GLib (in F33) added `%f`, which made this test start
failing when coreos-assembler was updated to F33.

We can't really rely on GLib never adding more letters, and
it's not like we're going to start adding invalid ones
in our code without seeing it, so just drop the test.
