### PR TITLE
app/history: Limit entries to print to 3

### DIFF
--- a/rust/src/history.rs
+++ b/rust/src/history.rs
@@ -257,7 +257,7 @@ impl HistoryCtx {
         journal.seek(journal::JournalSeek::Tail)?;
 
         Ok(Box::new(HistoryCtx {
-            journal: journal,
+            journal,
             marker_queue: VecDeque::new(),
             current_entry: None,
             search_mode: None,


### PR DESCRIPTION
I've been meaning to hook up `ex history` to a pager a-la-journalctl,
though it's not high-priority, and it'd be nice to do it in Rust instead
(I think this command would be a good candidate for more oxidation if we
move the CLI entrypoint to Rust.)

For now at least, let's not spam the full history by default. Instead,
limit it to 3, and add `--limit` and `--all` options to tweak that if
wanted (I thought about making `--limit -1` just mean all entries,
though I think I'd still want an explicit `--all` anyway.)