### PR TITLE
Add a helper move_nullify

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -34,6 +34,7 @@
 #include <sys/vfs.h>
 #include <libglnx.h>
 #include <rpm/rpmmacro.h>
+#include <utility>
 
 #include "rpmostree-compose-builtins.h"
 #include "rpmostree-util.h"
@@ -498,7 +499,7 @@ install_packages (RpmOstreeTreeComposeContext  *self,
 
   if (out_unmodified)
     *out_unmodified = FALSE;
-  *out_new_inputhash = (char*) g_steal_pointer (&ret_new_inputhash);
+  *out_new_inputhash = util::move_nullify (ret_new_inputhash);
   return TRUE;
 }
 
@@ -519,8 +520,8 @@ parse_treefile_to_json (const char    *treefile_path,
   if (!json_parser_load_from_data (parser, serialized, -1, error))
     return FALSE;
 
-  *out_parser = static_cast<JsonParser*>(g_steal_pointer (&parser));
-  *out_treefile_rs = static_cast<RORTreefile*>(g_steal_pointer (&treefile_rs));
+  *out_parser = util::move_nullify (parser);
+  *out_treefile_rs = util::move_nullify (treefile_rs);
   return TRUE;
 }
 
@@ -792,7 +793,7 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
     return FALSE;
   self->ref = rpmostree_treespec_get_ref (self->treespec);
 
-  *out_context = static_cast<RpmOstreeTreeComposeContext*>(g_steal_pointer (&self));
+  *out_context = util::move_nullify (self);
   return TRUE;
 }
 

--- a/src/libpriv/rpmostree-bwrap.cxx
+++ b/src/libpriv/rpmostree-bwrap.cxx
@@ -24,6 +24,8 @@
 #include <err.h>
 #include <stdio.h>
 #include <systemd/sd-journal.h>
+#include "rpmostree-util.h"
+#include <utility>
 
 static void
 teardown_rofiles (GLnxTmpDir *mnt_tmp);
@@ -351,7 +353,7 @@ rpmostree_bwrap_new_base (int rootfs_fd, GError **error)
       rpmostree_bwrap_append_bwrap_argv (ret, "--symlink", srcpath, destpath, NULL);
     }
 
-  return (RpmOstreeBwrap*)g_steal_pointer (&ret);
+  return util::move_nullify (ret);
 }
 
 RpmOstreeBwrap *
@@ -383,7 +385,7 @@ rpmostree_bwrap_new (int rootfs_fd,
       break;
     }
 
-  return (RpmOstreeBwrap*) g_steal_pointer (&ret);
+  return util::move_nullify (ret);
 }
 
 static void
@@ -489,7 +491,7 @@ rpmostree_bwrap_run (RpmOstreeBwrap *bwrap,
 GSubprocess *
 rpmostree_bwrap_execute (RpmOstreeBwrap *bwrap, GError **error)
 {
-  g_autoptr(GSubprocessLauncher) launcher = (GSubprocessLauncher*)g_steal_pointer (&bwrap->launcher);
+  g_autoptr(GSubprocessLauncher) launcher = util::move_nullify (bwrap->launcher);
   g_assert (!bwrap->executed);
   bwrap->executed = TRUE;
 

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -29,6 +29,20 @@
 #include "rpmostree.h"
 #include "rpmostree-types.h"
 
+#ifdef __cplusplus
+namespace util {
+// Sadly std::move() doesn't do anything for raw pointer types by default.
+// This is our C++ equivalent of g_steal_pointer().
+template<typename T>
+  T move_nullify(T& v) noexcept
+  {
+    auto p = v;
+    v = nullptr;
+    return p;
+  }
+}
+#endif
+
 G_BEGIN_DECLS
 
 #define _N(single, plural, n) ( (n) == 1 ? (single) : (plural) )


### PR DESCRIPTION
This avoids the casts required for `g_steal_pointer()`.
