### PR TITLE
Port rpmostreed-transaction to C++

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -39,7 +39,7 @@ librpmostreed_la_SOURCES = \
 	src/daemon/rpmostreed-deployment-utils.h \
 	src/daemon/rpmostreed-deployment-utils.c \
 	src/daemon/rpmostreed-transaction.h \
-	src/daemon/rpmostreed-transaction.c \
+	src/daemon/rpmostreed-transaction.cxx \
 	src/daemon/rpmostreed-transaction-types.h \
 	src/daemon/rpmostreed-transaction-types.c \
 	src/daemon/rpmostreed-transaction-livefs.c \
@@ -51,9 +51,7 @@ librpmostreed_la_SOURCES = \
 	src/daemon/rpmostreed-os-experimental.c \
 	$(NULL)
 
-librpmostreed_la_CFLAGS = \
-	$(AM_CFLAGS) \
-	$(PKGDEP_RPMOSTREE_CFLAGS) \
+rpmostreed_common_cflags = $(PKGDEP_RPMOSTREE_CFLAGS) \
 	-DG_LOG_DOMAIN=\"rpm-ostreed\" \
 	-fvisibility=hidden \
 	-D_RPMOSTREE_EXTERN= \
@@ -62,6 +60,8 @@ librpmostreed_la_CFLAGS = \
 	-I$(srcdir)/src/libpriv \
 	-I$(libglnx_srcpath) \
 	$(NULL)
+librpmostreed_la_CFLAGS = $(AM_CFLAGS) $(rpmostreed_common_cflags)
+librpmostreed_la_CXXFLAGS = $(AM_CXXFLAGS) $(rpmostree_common_cflags)
 
 librpmostreed_la_LIBADD = \
 	$(PKGDEP_RPMOSTREE_LIBS) \

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -743,7 +743,7 @@ rpmostreed_sysroot_populate (RpmostreedSysroot *self,
 {
   g_return_val_if_fail (self != NULL, FALSE);
 
-  /* See also related code in rpmostred-transaction.c */
+  /* See also related code in rpmostred-transaction.cxx */
   const char *sysroot_path = rpmostree_sysroot_get_path (RPMOSTREE_SYSROOT (self));
   g_autoptr(GFile) sysroot_file = g_file_new_for_path (sysroot_path);
   self->ot_sysroot = ostree_sysroot_new (sysroot_file);


### PR DESCRIPTION
And add a try/catch-convert-to-GError here too.  This will
allow us to throw exceptions from transaction implementations.
