### PR TITLE
rust: Add deny(unused_must_use)

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
+#![deny(unused_must_use)]
+
 // pub(crate) utilities
 mod ffiutil;
 mod includes;


### PR DESCRIPTION
We're maintaining the operating system, let's hard require
that errors are checked.
