### PR TITLE
Port rpmostree-kernel to C++

### DIFF
--- a/Makefile-libpriv.am
+++ b/Makefile-libpriv.am
@@ -34,7 +34,7 @@ librpmostreepriv_la_SOURCES = \
 	src/libpriv/rpmostree-core-private.h \
 	src/libpriv/rpmostree-bwrap.cxx \
 	src/libpriv/rpmostree-bwrap.h \
-	src/libpriv/rpmostree-kernel.c \
+	src/libpriv/rpmostree-kernel.cxx \
 	src/libpriv/rpmostree-kernel.h \
 	src/libpriv/rpmostree-origin.c \
 	src/libpriv/rpmostree-origin.h \


### PR DESCRIPTION
Prep for reworking `core.rs` to use cxx-rs

(Notable in this is the dropping of `goto out` by writing
 a small struct with a destructor to handle the cleanup `unlinkat()` for us)
