### PR TITLE
msrv: Bump to Rust 1.48

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -47,7 +47,6 @@ unit: {
       checkout scm
       shwrap("""
         MAKE_JOBS=${n} CARGO_BUILD_JOBS=${n} ci/msrv.sh
-        PATH="\$HOME/.cargo/bin:\$PATH" make check
       """)
   }
 }}

--- a/ci/msrv.sh
+++ b/ci/msrv.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
-# this corresponds to the latest Rust module available in el8
-MINIMUM_SUPPORTED_RUST_VERSION=1.45.2
+# Usually, we try to keep this to no newer than current RHEL8 rust-toolset version.
+# You can find the current versions from here:
+# https://access.redhat.com/documentation/en-us/red_hat_developer_tools/1/
+# However, right now we are bumping to 1.48 so we can use https://cxx.rs
+MINIMUM_SUPPORTED_RUST_VERSION=1.48
 
 ci/installdeps.sh
 dnf remove -y cargo
 curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain ${MINIMUM_SUPPORTED_RUST_VERSION} -y
 export PATH="$HOME/.cargo/bin:$PATH"
-SKIP_INSTALLDEPS=1 ci/build.sh |& tee out.txt
-grep ${MINIMUM_SUPPORTED_RUST_VERSION} out.txt
-grep "checking for cargo... $HOME/.cargo/bin/cargo" out.txt
-grep "checking for rustc... $HOME/.cargo/bin/rustc" out.txt
+cargo +${MINIMUM_SUPPORTED_RUST_VERSION} test


### PR DESCRIPTION


We need this for https://cxx.rs

While we're here:

 - Add some more comments/links
 - Since the Rust bits are now at the toplevel, we can explicitly
   invoke `cargo`
 - And since we can do that, use the `+` syntax to specify the
   toolchain explicitly