### PR TITLE
ci: Introduce install-extra-builddeps.sh

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -7,6 +7,7 @@ parallel rpms: {
       shwrap("""
         # fetch tags so `git describe` gives a nice NEVRA when building the RPM
         git fetch origin --tags
+        ci/install-extra-builddeps.sh
         ci/installdeps.sh
         git submodule update --init
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -6,6 +6,7 @@ set -xeuo pipefail
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
 
+${dn}/install-extra-builddeps.sh
 ${dn}/installdeps.sh
 
 # create an unprivileged user for testing

--- a/ci/install-extra-builddeps.sh
+++ b/ci/install-extra-builddeps.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/bash
+# Install build dependencies not in the cosa buildroot already
+set -xeuo pipefail
+if ! command -v cxxbridge; then
+    cargo install --root=/usr cxxbridge-cmd
+fi


### PR DESCRIPTION
We need to cleanly split off "test dependencies" that we
install inside the cosa pod from builds (where we won't
have `cargo`) from the build time where we use the cosa
buildroot image.

Prep for using https://cxx.rs
