### PR TITLE
service: Explicitly RequiresMountsFor=/boot

### DIFF
--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -2,6 +2,7 @@
 Description=rpm-ostree System Management Daemon
 Documentation=man:rpm-ostree(1)
 ConditionPathExists=/ostree
+RequiresMountsFor=/boot
 
 [Service]
 Type=dbus


### PR DESCRIPTION
See https://github.com/ostreedev/ostree/commit/82679ce834732ba4941b097cd83c43902c0d6092

I've seen at least one user report a bunch of failing
services on CoreOS that might be due to `/boot` not mounting.
Let's make it explicitly clear this is required.

The error would then be systemd saying a dependency failed, rather
than ostree confusingly saying it can't invoke `readlinkat()`.
