### PR TITLE
tooling/cargo: move profile settings

### DIFF
--- a/tooling/Cargo.toml
+++ b/tooling/Cargo.toml
@@ -1,2 +1,7 @@
 [workspace]
 members = ["bindgen"]
+
+# Might as well keep these from the main Rust source
+[profile.release]
+panic = "abort"
+debug = true

--- a/tooling/bindgen/Cargo.toml
+++ b/tooling/bindgen/Cargo.toml
@@ -5,8 +5,3 @@ authors = ["Colin Walters <walters@verbum.org>"]
 
 [dependencies]
 cbindgen = "0.15.0"
-
-# Might as well keep these from the main Rust source
-[profile.release]
-panic = "abort"
-debug = true


### PR DESCRIPTION
This moves settings for the `release` profile into the
parent `tooling` workspace.
It fixes the following warning:
```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   [...]/rpm-ostree/tooling/bindgen/Cargo.toml
workspace: [...]/rpm-ostree/tooling/Cargo.toml
```
