### PR TITLE
Rework shared library and build system

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -1,3 +1,7 @@
+# This file used to declare a separate libtool static library.
+# Now that the daemon and binary are the same thing, we have
+# Makefile-rpm-ostree.am reuse these variables.
+
 dbus_built_sources = rpm-ostreed-generated.h rpm-ostreed-generated.c
 
 # TODO: Add --c-generate-autocleanup=all once we depend on GLib 2.50+
@@ -19,10 +23,7 @@ CLEANFILES += rpm-ostreed-generated-org.projectatomic.rpmostree1.OS.xml \
 	rpm-ostreed-generated-org.projectatomic.rpmostree1.Transaction.xml \
 	$(NULL)
 
-noinst_LTLIBRARIES += librpmostreed.la
-nodist_librpmostreed_la_SOURCES = $(dbus_built_sources)
-
-librpmostreed_la_SOURCES = \
+librpmostreed_sources = \
 	src/daemon/rpmostreed-types.h \
 	src/daemon/rpmostreed-daemon.h \
 	src/daemon/rpmostreed-daemon.c \
@@ -49,25 +50,6 @@ librpmostreed_la_SOURCES = \
 	src/daemon/rpmostreed-os.cxx \
 	src/daemon/rpmostreed-os-experimental.h \
 	src/daemon/rpmostreed-os-experimental.c \
-	$(NULL)
-
-rpmostreed_common_cflags = $(PKGDEP_RPMOSTREE_CFLAGS) \
-	-DG_LOG_DOMAIN=\"rpm-ostreed\" \
-	-fvisibility=hidden \
-	-D_RPMOSTREE_EXTERN= \
-	-I$(srcdir)/src/daemon \
-	-I$(srcdir)/src/lib \
-	-I$(srcdir)/src/libpriv \
-	-I$(libglnx_srcpath) \
-	$(NULL)
-librpmostreed_la_CFLAGS = $(AM_CFLAGS) $(rpmostreed_common_cflags)
-librpmostreed_la_CXXFLAGS = $(AM_CXXFLAGS) $(rpmostree_common_cflags)
-
-librpmostreed_la_LIBADD = \
-	$(PKGDEP_RPMOSTREE_LIBS) \
-	librpmostreepriv.la \
-	librpmostree-1.la \
-	$(CAP_LIBS)
 	$(NULL)
 
 dbusconf_DATA = $(srcdir)/src/daemon/org.projectatomic.rpmostree1.conf

--- a/Makefile-lib.am
+++ b/Makefile-lib.am
@@ -34,7 +34,8 @@ librpmostree_1_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/libglnx -I$(srcdir)/src/libp
 	-fvisibility=hidden '-D_RPMOSTREE_EXTERN=__attribute((visibility("default"))) extern' \
 	$(PKGDEP_RPMOSTREE_CFLAGS)
 librpmostree_1_la_LDFLAGS = $(AM_LDFLAGS) -version-number 1:0:0 -Bsymbolic-functions
-librpmostree_1_la_LIBADD =  $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la $(librpmostree_rust_path)
+librpmostree_1_la_LIBADD =  $(PKGDEP_RPMOSTREE_LIBS) libglnx.la
+EXTRA_librpmostree_1_la_DEPENDENCIES = libdnf.so.2
 
 # The g-ir-scanner creates a stub executable (to help introspect type information) which
 # links to our stuff. We want to make sure it picks up our fresh libdnf and not a possibly

--- a/Makefile-libpriv.am
+++ b/Makefile-libpriv.am
@@ -15,9 +15,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-noinst_LTLIBRARIES += librpmostreepriv.la
-
-librpmostreepriv_la_SOURCES = \
+librpmostreepriv_sources = \
 	src/libpriv/rpmostree-postprocess.cxx \
 	src/libpriv/rpmostree-postprocess.h \
 	src/libpriv/rpmostree-json-parsing.c \
@@ -61,7 +59,7 @@ librpmostreepriv_la_SOURCES = \
 	$(NULL)
 
 if BUILDOPT_ROJIG
-librpmostreepriv_la_SOURCES += \
+librpmostreepriv_sources += \
 	src/libpriv/rpmostree-rojig-build.c \
 	src/libpriv/rpmostree-rojig-build.h \
 	src/libpriv/rpmostree-rojig-assembler.c \
@@ -71,36 +69,16 @@ librpmostreepriv_la_SOURCES += \
 	$(NULL)
 endif
 
-rpmostreepriv_common_cflags = -I$(srcdir)/src/lib \
-	-I$(srcdir)/src/libpriv \
-	-I$(libglnx_srcpath) \
-	-DLIBDIR=\"$(libdir)\" \
-	-DPKGLIBDIR=\"$(pkglibdir)\" \
-	-fvisibility=hidden \
-	$(PKGDEP_RPMOSTREE_CFLAGS) \
-	$(NULL)
-librpmostreepriv_la_CFLAGS = $(AM_CFLAGS) $(rpmostreepriv_common_cflags)
-librpmostreepriv_la_CXXFLAGS = $(AM_CXXFLAGS) $(rpmostreepriv_common_cflags)
-
-librpmostreepriv_la_LIBADD = \
-	$(PKGDEP_RPMOSTREE_LIBS) \
-	libglnx.la \
-	$(CAP_LIBS) \
-	$(NULL)
-
-# bundled libdnf
-EXTRA_librpmostreepriv_la_DEPENDENCIES = libdnf.so.2
-
 gperf_gperf_sources = src/libpriv/rpmostree-script-gperf.gperf
 BUILT_SOURCES += $(gperf_gperf_sources:-gperf.gperf=-gperf.c)
 CLEANFILES += $(gperf_gperf_sources:-gperf.gperf=-gperf.c)
 
-nodist_librpmostreepriv_la_SOURCES = src/libpriv/rpmostree-script-gperf.c
+nodist_librpmostreepriv_sources = src/libpriv/rpmostree-script-gperf.c
 
 rpmostree-libpriv-gresources.c: src/libpriv/gresources.xml Makefile $(shell glib-compile-resources --sourcedir=$(srcdir)/src/libpriv --generate-dependencies $(srcdir)/src/libpriv/gresources.xml)
 	$(AM_V_GEN) glib-compile-resources --target=$@ --sourcedir=$(srcdir)/src/libpriv --generate-source --c-name _rpmostree_ $<
 BUILT_SOURCES += rpmostree-libpriv-gresources.c
-librpmostreepriv_la_SOURCES += rpmostree-libpriv-gresources.c
+librpmostreepriv_sources += rpmostree-libpriv-gresources.c
 
 AM_V_GPERF = $(AM_V_GPERF_$(V))
 AM_V_GPERF_ = $(AM_V_GPERF_$(AM_DEFAULT_VERBOSITY))

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -18,8 +18,6 @@
 bin_PROGRAMS += rpm-ostree
 
 rpm_ostree_SOURCES = src/app/main.cxx \
-	rpm-ostreed-generated.h \
-	rpm-ostreed-generated.c \
 	src/app/rpmostree-builtins.h \
 	src/app/rpmostree-db-builtins.h \
 	src/app/rpmostree-compose-builtins.h \
@@ -62,6 +60,7 @@ rpm_ostree_SOURCES = src/app/main.cxx \
 	src/app/rpmostree-composeutil.c \
 	src/app/rpmostree-composeutil.h \
 	src/app/rpmostree-builtin-compose.c \
+	$(librpmostreed_sources) \
 	$(NULL)
 
 if BUILDOPT_ROJIG
@@ -72,12 +71,18 @@ rpm_ostree_SOURCES += \
 	$(NULL)
 endif
 
+nodist_rpm_ostree_SOURCES = $(dbus_built_sources)
+
 rpmostree_common_cflags = -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
 	-I$(srcdir)/src/lib -I$(srcdir)/src/libpriv -I$(libglnx_srcpath) \
-	-fvisibility=hidden -DPKGLIBDIR=\"$(pkglibdir)\" $(PKGDEP_RPMOSTREE_CFLAGS)
+	-fvisibility=hidden \
+	-DG_LOG_DOMAIN=\"rpm-ostreed\" \
+	-DLIBDIR=\"$(libdir)\" -DPKGLIBDIR=\"$(pkglibdir)\" \
+	$(PKGDEP_RPMOSTREE_CFLAGS)
 rpm_ostree_CFLAGS = $(AM_CFLAGS) $(rpmostree_common_cflags)
 rpm_ostree_CXXFLAGS = $(AM_CXXFLAGS) $(rpmostree_common_cflags)
-rpm_ostree_LDADD = $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la librpmostree-1.la librpmostreed.la
+rpm_ostree_LDADD = $(PKGDEP_RPMOSTREE_LIBS) $(CAP_LIBS) libglnx.la librpmostreepriv.la librpmostree-1.la
+EXTRA_rpm_ostree_DEPENDENCIES = libdnf.so.2
 
 privdatadir=$(pkglibdir)
 privdata_DATA = src/app/rpm-ostree-0-integration.conf

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -42,6 +42,7 @@ rpm_ostree_SOURCES = src/app/main.cxx \
 	src/app/rpmostree-builtin-status.c \
 	src/app/rpmostree-builtin-ex.c \
 	src/app/rpmostree-builtin-testutils.c \
+	src/app/rpmostree-builtin-shlib-backend.c \
 	src/app/rpmostree-builtin-db.c \
 	src/app/rpmostree-builtin-start-daemon.c \
 	src/app/rpmostree-builtin-finalize-deployment.c \

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -61,6 +61,7 @@ rpm_ostree_SOURCES = src/app/main.cxx \
 	src/app/rpmostree-composeutil.h \
 	src/app/rpmostree-builtin-compose.c \
 	$(librpmostreed_sources) \
+	$(librpmostreepriv_sources) \
 	$(NULL)
 
 if BUILDOPT_ROJIG
@@ -71,7 +72,7 @@ rpm_ostree_SOURCES += \
 	$(NULL)
 endif
 
-nodist_rpm_ostree_SOURCES = $(dbus_built_sources)
+nodist_rpm_ostree_SOURCES = $(dbus_built_sources) $(nodist_librpmostreepriv_sources)
 
 rpmostree_common_cflags = -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
 	-I$(srcdir)/src/lib -I$(srcdir)/src/libpriv -I$(libglnx_srcpath) \
@@ -81,7 +82,7 @@ rpmostree_common_cflags = -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
 	$(PKGDEP_RPMOSTREE_CFLAGS)
 rpm_ostree_CFLAGS = $(AM_CFLAGS) $(rpmostree_common_cflags)
 rpm_ostree_CXXFLAGS = $(AM_CXXFLAGS) $(rpmostree_common_cflags)
-rpm_ostree_LDADD = $(PKGDEP_RPMOSTREE_LIBS) $(CAP_LIBS) libglnx.la librpmostreepriv.la librpmostree-1.la
+rpm_ostree_LDADD = $(PKGDEP_RPMOSTREE_LIBS) $(CAP_LIBS) libglnx.la librpmostree-1.la
 EXTRA_rpm_ostree_DEPENDENCIES = libdnf.so.2
 
 privdatadir=$(pkglibdir)

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -20,38 +20,39 @@ endif
 
 GITIGNOREFILES += ssh-config ansible-inventory.yml vmcheck-logs/ test-compose-logs/ tests/vmcheck/image.qcow2
 
-testbin_cppflags = $(AM_CPPFLAGS) -I $(srcdir)/src/lib -I $(srcdir)/src/libpriv -I $(srcdir)/libglnx -I $(srcdir)/tests/common
-testbin_cflags = $(AM_CFLAGS) -fvisibility=hidden $(PKGDEP_RPMOSTREE_CFLAGS)
-testbin_ldadd = $(PKGDEP_RPMOSTREE_LIBS) librpmostree-1.la librpmostreepriv.la -lstdc++
-
-noinst_LTLIBRARIES += libtest.la
-libtest_la_SOURCES = tests/common/libtest.c
-libtest_la_CPPFLAGS = $(testbin_cppflags)
-libtest_la_CFLAGS = $(testbin_cflags)
-libtest_la_LIBADD = $(testbin_ldadd)
-
-tests_check_jsonutil_CPPFLAGS = $(testbin_cppflags)
-tests_check_jsonutil_CFLAGS = $(testbin_cflags)
-tests_check_jsonutil_LDADD = $(testbin_ldadd) libtest.la
-
-tests_check_postprocess_CPPFLAGS = $(testbin_cppflags)
-tests_check_postprocess_CFLAGS = $(testbin_cflags)
-tests_check_postprocess_LDADD = $(testbin_ldadd) libtest.la
-
-tests_check_test_utils_CPPFLAGS = $(testbin_cppflags)
-tests_check_test_utils_CFLAGS = $(testbin_cflags)
-tests_check_test_utils_LDADD = $(testbin_ldadd) libtest.la
-
-tests_check_test_sysusers_CPPFLAGS = $(testbin_cppflags)
-tests_check_test_sysusers_CFLAGS = $(testbin_cflags)
-tests_check_test_sysusers_LDADD = $(testbin_ldadd) libtest.la
-
-uninstalled_test_programs = \
-	tests/check/jsonutil			\
-	tests/check/postprocess			\
-	tests/check/test-utils			\
-	tests/check/test-sysusers		\
-	$(NULL)
+# Disabled for now because we dropped librpmostreepriv.la
+# testbin_cppflags = $(AM_CPPFLAGS) -I $(srcdir)/src/lib -I $(srcdir)/src/libpriv -I $(srcdir)/libglnx -I $(srcdir)/tests/common
+# testbin_cflags = $(AM_CFLAGS) -fvisibility=hidden $(PKGDEP_RPMOSTREE_CFLAGS)
+# testbin_ldadd = $(PKGDEP_RPMOSTREE_LIBS) librpmostree-1.la librpmostreepriv.la -lstdc++
+# 
+# noinst_LTLIBRARIES += libtest.la
+# libtest_la_SOURCES = tests/common/libtest.c
+# libtest_la_CPPFLAGS = $(testbin_cppflags)
+# libtest_la_CFLAGS = $(testbin_cflags)
+# libtest_la_LIBADD = $(testbin_ldadd)
+# 
+# tests_check_jsonutil_CPPFLAGS = $(testbin_cppflags)
+# tests_check_jsonutil_CFLAGS = $(testbin_cflags)
+# tests_check_jsonutil_LDADD = $(testbin_ldadd) libtest.la
+# 
+# tests_check_postprocess_CPPFLAGS = $(testbin_cppflags)
+# tests_check_postprocess_CFLAGS = $(testbin_cflags)
+# tests_check_postprocess_LDADD = $(testbin_ldadd) libtest.la
+# 
+# tests_check_test_utils_CPPFLAGS = $(testbin_cppflags)
+# tests_check_test_utils_CFLAGS = $(testbin_cflags)
+# tests_check_test_utils_LDADD = $(testbin_ldadd) libtest.la
+# 
+# tests_check_test_sysusers_CPPFLAGS = $(testbin_cppflags)
+# tests_check_test_sysusers_CFLAGS = $(testbin_cflags)
+# tests_check_test_sysusers_LDADD = $(testbin_ldadd) libtest.la
+# 
+# uninstalled_test_programs = \
+# 	tests/check/jsonutil			\
+# 	tests/check/postprocess			\
+# 	tests/check/test-utils			\
+# 	tests/check/test-sysusers		\
+# 	$(NULL)
 
 uninstalled_test_scripts = \
 	tests/check/test-lib-introspection.sh \

--- a/src/app/main.cxx
+++ b/src/app/main.cxx
@@ -119,6 +119,9 @@ static RpmOstreeCommand commands[] = {
   { "testutils", static_cast<RpmOstreeBuiltinFlags>(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD |
                  RPM_OSTREE_BUILTIN_FLAG_HIDDEN),
     NULL, rpmostree_builtin_testutils },
+  { "shlib-backend", static_cast<RpmOstreeBuiltinFlags>(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD |
+                 RPM_OSTREE_BUILTIN_FLAG_HIDDEN),
+    NULL, rpmostree_builtin_shlib_backend },
   { "start-daemon", static_cast<RpmOstreeBuiltinFlags>(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD |
                     RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT |
                     RPM_OSTREE_BUILTIN_FLAG_HIDDEN),

--- a/src/app/rpmostree-builtin-shlib-backend.c
+++ b/src/app/rpmostree-builtin-shlib-backend.c
@@ -1,0 +1,107 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <glib-unix.h>
+#include <gio/gio.h>
+#include <gio/gunixfdmessage.h>
+#include <gio/gunixsocketaddress.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "rpmostree-builtins.h"
+#include "rpmostree-libbuiltin.h"
+#include "rpmostree-rust.h"
+#include "rpmostree.h"
+#include "rpmostree-core.h"
+#include "src/lib/rpmostree-shlib-ipc-private.h"
+
+#include <libglnx.h>
+
+static gboolean
+send_memfd_result (int ret_memfd, GError **error)
+{
+  int fdarray[] = {ret_memfd, -1 };
+  g_autoptr(GUnixFDList) list = g_unix_fd_list_new_from_array (fdarray, 1);
+  g_autoptr(GUnixFDMessage) message = G_UNIX_FD_MESSAGE (g_unix_fd_message_new_with_fd_list (list));
+  g_autoptr(GSocket) ipc_sock = g_socket_new_from_fd (RPMOSTREE_SHLIB_IPC_FD, error);
+  if (!ipc_sock)
+    return FALSE;
+  GOutputVector ov;
+  char buffer[1];
+  buffer[0] = 0xFF;
+  ov.buffer = buffer;
+  ov.size = G_N_ELEMENTS (buffer);
+  gssize r = g_socket_send_message (ipc_sock, NULL, &ov, 1,
+                                    (GSocketControlMessage **) &message,
+                                    1, 0, NULL, error);
+  if (r < 0)
+    return FALSE;
+  g_assert_cmpint (r, ==, 1);
+
+  return TRUE;
+}
+
+gboolean
+rpmostree_builtin_shlib_backend (int             argc,
+                                 char          **argv,
+                                 RpmOstreeCommandInvocation *invocation,
+                                 GCancellable   *cancellable,
+                                 GError        **error)
+{
+  if (argc < 2)
+    return glnx_throw (error, "missing required subcommand");
+
+  const char *arg = argv[1];
+
+  g_autoptr(GVariant) ret = NULL;
+
+  if (g_str_equal (arg, "get-basearch"))
+    {
+      g_autoptr(DnfContext) ctx = dnf_context_new ();
+      ret = g_variant_new_string (dnf_context_get_base_arch (ctx));
+    }
+  else if (g_str_equal (arg, "varsubst-basearch"))
+    {
+      const char *src = argv[2];
+      g_autoptr(DnfContext) ctx = dnf_context_new ();
+      g_autoptr(GHashTable) varsubsts = rpmostree_dnfcontext_get_varsubsts (ctx);
+      g_autofree char *rets = _rpmostree_varsubst_string (src, varsubsts, error);
+      if (rets == NULL)
+        return FALSE;
+      ret = g_variant_new_string (rets);
+    }
+  else
+    return glnx_throw (error, "unknown shlib-backend %s", arg);
+
+  glnx_fd_close int ret_memfd = memfd_create ("rpm-ostree-shlib-backend", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+  if (ret_memfd < 0)
+    return glnx_throw_errno_prefix (error, "memfd_create");
+  if (glnx_loop_write (ret_memfd, g_variant_get_data (ret), g_variant_get_size (ret)) < 0)
+    return glnx_throw_errno_prefix (error, "Failed to write to memfd");
+  const int seals = (F_SEAL_GROW | F_SEAL_SHRINK | F_SEAL_WRITE);
+  if (fcntl (ret_memfd, F_ADD_SEALS, seals) == -1)
+    return glnx_throw_errno_prefix (error, "fcntl(sealing)");
+
+  return send_memfd_result (glnx_steal_fd (&ret_memfd), error);
+}

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -52,6 +52,7 @@ BUILTINPROTO(override);
 BUILTINPROTO(kargs);
 BUILTINPROTO(reset);
 BUILTINPROTO(start_daemon);
+BUILTINPROTO(shlib_backend);
 BUILTINPROTO(coreos_rootfs);
 BUILTINPROTO(testutils);
 BUILTINPROTO(ex);

--- a/src/lib/rpmostree-package.c
+++ b/src/lib/rpmostree-package.c
@@ -30,8 +30,8 @@
 
 #include "config.h"
 
+#include "rpmostree-shlib-ipc-private.h"
 #include "rpmostree-package-priv.h"
-#include "rpmostree-rpm-util.h"
 
 #include <string.h>
 #include <stdlib.h>
@@ -44,10 +44,6 @@ typedef GObjectClass RpmOstreePackageClass;
 struct RpmOstreePackage
 {
   GObject parent_instance;
-  /* libdnf-based pkg */
-  RpmOstreeRefSack *sack;
-  DnfPackage *hypkg;
-  /* gvariant-based pkg */
   GVariant *gv_nevra;
   /* deconstructed/cached values */
   char *nevra;
@@ -63,8 +59,6 @@ static void
 rpm_ostree_package_finalize (GObject *object)
 {
   RpmOstreePackage *pkg = (RpmOstreePackage*)object;
-  g_clear_pointer (&pkg->hypkg, g_object_unref);
-  g_clear_pointer (&pkg->sack, rpmostree_refsack_unref);
   g_clear_pointer (&pkg->gv_nevra, g_variant_unref);
 
   g_clear_pointer (&pkg->nevra, g_free);
@@ -150,9 +144,6 @@ rpm_ostree_package_get_arch (RpmOstreePackage *p)
 int
 rpm_ostree_package_cmp (RpmOstreePackage *p1, RpmOstreePackage *p2)
 {
-  if (p1->hypkg && p2->hypkg)
-    return dnf_package_cmp (p1->hypkg, p2->hypkg);
-
   int ret = strcmp (p1->name, p2->name);
   if (ret)
     return ret;
@@ -167,25 +158,6 @@ rpm_ostree_package_cmp (RpmOstreePackage *p1, RpmOstreePackage *p2)
     return ret;
 
   return strcmp (p1->arch, p2->arch);
-}
-
-RpmOstreePackage *
-_rpm_ostree_package_new (RpmOstreeRefSack *rsack, DnfPackage *hypkg)
-{
-  RpmOstreePackage *p = g_object_new (RPM_OSTREE_TYPE_PACKAGE, NULL);
-  /* We do internal refcounting of the sack because hawkey doesn't */
-  p->sack = rpmostree_refsack_ref (rsack);
-  p->hypkg = g_object_ref (hypkg);
-
-  /* we deconstruct now to make accessors simpler */
-
-  /* cache nevra internally because we can't rely on libsolv
-   * https://github.com/rpm-software-management/libdnf/pull/388 */
-  p->nevra = g_strdup (dnf_package_get_nevra (p->hypkg));
-  p->name = dnf_package_get_name (p->hypkg);
-  p->evr = dnf_package_get_evr (p->hypkg);
-  p->arch = dnf_package_get_arch (p->hypkg);
-  return p;
 }
 
 RpmOstreePackage*
@@ -220,22 +192,6 @@ get_commit_rpmdb_pkglist (GVariant *commit)
                                       G_VARIANT_TYPE ("a(sssss)"));
 }
 
-static GPtrArray *
-query_all_packages_in_sack (RpmOstreeRefSack *rsack)
-{
-  g_autoptr(GPtrArray) result = g_ptr_array_new_with_free_func (g_object_unref);
-  g_autoptr(GPtrArray) pkglist = rpmostree_sack_get_sorted_packages (rsack->sack);
-
-  const guint c = pkglist->len;
-  for (guint i = 0; i < c; i++)
-    {
-      DnfPackage *pkg = pkglist->pdata[i];
-      g_ptr_array_add (result, _rpm_ostree_package_new (rsack, pkg));
-    }
-
-  return g_steal_pointer (&result);
-}
-
 /* Opportunistically try to use the new rpmostree.rpmdb.pkglist metadata, otherwise fall
  * back to commit rpmdb if available.
  *
@@ -258,29 +214,36 @@ _rpm_ostree_package_list_for_commit (OstreeRepo   *repo,
   if (!ostree_repo_load_variant (repo, OSTREE_OBJECT_TYPE_COMMIT, checksum, &commit, error))
     return FALSE;
 
+  /* We used to have a fallback here to checking out the rpmdb from the commit,
+   * but that currently drags in our internal Rust code which bloats this
+   * shared library and causes other problems since the main executable
+   * wants to link to this shared library too.  So for now if we don't
+   * find the pkglist in the commit metadata, just return as if it's
+   * empty.
+   *
+   * TODO: Rework this to run via the special shlib-ipc that is used
+   * in rpmostree.c.
+   */
   g_autoptr(GVariant) pkglist_v = get_commit_rpmdb_pkglist (commit);
   if (!pkglist_v)
     {
-      /* file-based rpmdb fallback; let fail if rpmdb not available */
-      g_autoptr(GError) local_error = NULL;
-      g_autoptr(RpmOstreeRefSack) rsack =
-        rpmostree_get_refsack_for_commit (repo, rev, cancellable, &local_error);
-      if (!rsack)
+      /* Yeah we could extend the IPC to support sending a fd too but for
+       * now communicating via the working directory is easier.
+       */
+      int fd = ostree_repo_get_dfd (repo);
+      g_autofree char *fdpath = g_strdup_printf ("/proc/self/fd/%d", fd);
+      char *args[] = { "packagelist-from-commit", (char*)rev, NULL };
+      g_autoptr(GVariant) maybe_pkglist_v = _rpmostree_shlib_ipc_send ("m" RPMOSTREE_SHLIB_IPC_PKGLIST, args, fdpath, error);
+      if (!maybe_pkglist_v)
+        return FALSE;
+      pkglist_v = g_variant_get_maybe (maybe_pkglist_v);
+      if (!pkglist_v)
         {
-          if (allow_noent &&
-              g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
-            {
-              *out_pkglist = NULL;
-              return TRUE; /* NB: early return */
-            }
-
-          g_propagate_error (error, g_steal_pointer (&local_error));
-          return FALSE;
+          if (!allow_noent)
+            return glnx_throw (error, "No package database found");
+          *out_pkglist = NULL;
+          return TRUE; /* Note early return */
         }
-
-      /* Note early return */
-      *out_pkglist = query_all_packages_in_sack (rsack);
-      return TRUE;
     }
 
   g_autoptr(GPtrArray) pkglist = g_ptr_array_new_with_free_func (g_object_unref);

--- a/src/lib/rpmostree-package.c
+++ b/src/lib/rpmostree-package.c
@@ -220,9 +220,6 @@ _rpm_ostree_package_list_for_commit (OstreeRepo   *repo,
    * wants to link to this shared library too.  So for now if we don't
    * find the pkglist in the commit metadata, just return as if it's
    * empty.
-   *
-   * TODO: Rework this to run via the special shlib-ipc that is used
-   * in rpmostree.c.
    */
   g_autoptr(GVariant) pkglist_v = get_commit_rpmdb_pkglist (commit);
   if (!pkglist_v)

--- a/src/lib/rpmostree-shlib-ipc-private.h
+++ b/src/lib/rpmostree-shlib-ipc-private.h
@@ -1,0 +1,29 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2020 Colin Walters <walters@verbum.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+G_BEGIN_DECLS
+
+#define RPMOSTREE_SHLIB_IPC_FD 3
+
+GVariant *_rpmostree_shlib_ipc_send (const char *variant_type, char **args, GError **error);
+
+G_END_DECLS

--- a/src/lib/rpmostree-shlib-ipc-private.h
+++ b/src/lib/rpmostree-shlib-ipc-private.h
@@ -20,10 +20,13 @@
 
 #pragma once
 
+#include <gio/gio.h>
+
 G_BEGIN_DECLS
 
 #define RPMOSTREE_SHLIB_IPC_FD 3
+#define RPMOSTREE_SHLIB_IPC_PKGLIST "a(sssss)"
 
-GVariant *_rpmostree_shlib_ipc_send (const char *variant_type, char **args, GError **error);
+GVariant *_rpmostree_shlib_ipc_send (const char *variant_type, char **args, const char *wd, GError **error);
 
 G_END_DECLS

--- a/src/lib/rpmostree.c
+++ b/src/lib/rpmostree.c
@@ -130,10 +130,10 @@ rpm_ostree_get_basearch (void)
 char *
 rpm_ostree_varsubst_basearch (const char *src, GError **error)
 {
-  g_autoptr(GError) local_error = NULL;
   char *args[] = { "varsubst-basearch", (char*)src, NULL };
-  g_autoptr(GVariant) ret = _rpmostree_shlib_ipc_send ("s", args, NULL, &local_error);
-  g_assert_no_error (local_error);
+  g_autoptr(GVariant) ret = _rpmostree_shlib_ipc_send ("s", args, NULL, error);
+  if (!ret)
+    return NULL;
   return g_variant_dup_string (ret, NULL);
 }
 

--- a/src/lib/rpmostree.c
+++ b/src/lib/rpmostree.c
@@ -20,11 +20,15 @@
 
 #include "config.h"
 
+#include <gio/gio.h>
+#include <gio/gunixfdmessage.h>
+#include <gio/gunixsocketaddress.h>
 #include "string.h"
 
 #include "rpmostree.h"
 #include "rpmostree-core.h"
 #include "rpmostree-util.h"
+#include "rpmostree-shlib-ipc-private.h"
 
 /**
  * SECTION:librpmostree
@@ -33,6 +37,69 @@
  *
  * These APIs access generic global state.
  */
+
+#define IPC_FD 3
+
+GVariant *
+_rpmostree_shlib_ipc_send (const char *variant_type, char **args, GError **error)
+{
+  g_autoptr(GSubprocessLauncher) launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_STDOUT_SILENCE | G_SUBPROCESS_FLAGS_STDERR_PIPE);
+  int pair[2];
+  if (socketpair (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, pair) < 0)
+    return (GVariant*)glnx_null_throw_errno_prefix (error, "couldn't create socket pair");
+  glnx_fd_close int my_sock_fd = glnx_steal_fd (&pair[0]);
+  g_subprocess_launcher_take_fd (launcher, pair[1], IPC_FD);
+
+  g_autoptr(GSocket) my_sock = g_socket_new_from_fd (my_sock_fd, error);
+  if (!my_sock)
+    return NULL;
+  my_sock_fd = -1; /* Ownership was transferred */
+  g_autoptr(GPtrArray) full_args = g_ptr_array_new ();
+  g_ptr_array_add (full_args, "rpm-ostree");
+  g_ptr_array_add (full_args, "shlib-backend");
+  for (char **it = args; it && *it; it++)
+    g_ptr_array_add (full_args, *it);
+  g_ptr_array_add (full_args, NULL);
+  g_autoptr(GSubprocess) proc = g_subprocess_launcher_spawnv (launcher, (const char*const*)full_args->pdata, error);
+  if (!proc)
+    return NULL;
+  
+  g_autofree char *stderr = NULL;
+  if (!g_subprocess_communicate_utf8 (proc, NULL, NULL, NULL, &stderr, error))
+    return NULL;
+
+  if (!g_subprocess_get_successful (proc))
+    return glnx_null_throw (error, "Failed to invoke rpm-ostree shlib-backend: %s", stderr);
+  int flags = 0;
+  int nm = 0;
+  GInputVector iv;
+  GUnixFDMessage **mv;
+  guint8 buffer[1024];
+  iv.buffer = buffer;
+  iv.size = 1;
+  gssize r = g_socket_receive_message (my_sock, NULL, &iv, 1,
+                                       (GSocketControlMessage ***) &mv,
+                                       &nm, &flags, NULL, error);
+  if (r < 0)
+    return NULL;
+  g_assert_cmpint (r, ==, 1);
+
+  if (nm != 1)
+    return glnx_null_throw (error, "Got %d control messages, expected 1", nm);
+  GUnixFDMessage *message = mv[0];
+  g_assert (G_IS_UNIX_FD_MESSAGE (message));
+  GUnixFDList *fdlist = g_unix_fd_message_get_fd_list (message);
+  const int nfds = g_unix_fd_list_get_length (fdlist);
+  if (nfds != 1)
+    return glnx_null_throw (error, "Got %d fds, expected 1", nfds);
+  const int *fds = g_unix_fd_list_peek_fds (fdlist, NULL);
+  const int result_memfd = fds[0];
+  g_assert_cmpint (result_memfd, !=, -1);
+  g_autoptr(GMappedFile) retmap = g_mapped_file_new_from_fd (result_memfd, FALSE, error);
+  if (!retmap)
+    return FALSE;
+  return g_variant_new_from_bytes ((GVariantType*) variant_type, g_mapped_file_get_bytes (retmap), FALSE);
+}
 
 /**
  * rpm_ostree_get_basearch:
@@ -43,9 +110,11 @@
 char *
 rpm_ostree_get_basearch (void)
 {
-  g_autoptr(DnfContext) ctx = dnf_context_new ();
-  /* Need to strdup since we unref the context */
-  return g_strdup (dnf_context_get_base_arch (ctx));
+  g_autoptr(GError) local_error = NULL;
+  char *args[] = { "get-basearch", NULL };
+  g_autoptr(GVariant) ret = _rpmostree_shlib_ipc_send ("s", args, &local_error);
+  g_assert_no_error (local_error);
+  return g_variant_dup_string (ret, NULL);
 }
 
 /**
@@ -58,9 +127,11 @@ rpm_ostree_get_basearch (void)
 char *
 rpm_ostree_varsubst_basearch (const char *src, GError **error)
 {
-  g_autoptr(DnfContext) ctx = dnf_context_new ();
-  g_autoptr(GHashTable) varsubsts = rpmostree_dnfcontext_get_varsubsts (ctx);
-  return _rpmostree_varsubst_string (src, varsubsts, error);
+  g_autoptr(GError) local_error = NULL;
+  char *args[] = { "varsubst-basearch", (char*)src, NULL };
+  g_autoptr(GVariant) ret = _rpmostree_shlib_ipc_send ("s", args, &local_error);
+  g_assert_no_error (local_error);
+  return g_variant_dup_string (ret, NULL);
 }
 
 /**

--- a/src/lib/rpmostree.c
+++ b/src/lib/rpmostree.c
@@ -39,8 +39,6 @@
  * These APIs access generic global state.
  */
 
-#define IPC_FD 3
-
 GVariant *
 _rpmostree_shlib_ipc_send (const char *variant_type, char **args, const char *wd, GError **error)
 {
@@ -49,7 +47,7 @@ _rpmostree_shlib_ipc_send (const char *variant_type, char **args, const char *wd
   if (socketpair (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, pair) < 0)
     return (GVariant*)glnx_null_throw_errno_prefix (error, "couldn't create socket pair");
   glnx_fd_close int my_sock_fd = glnx_steal_fd (&pair[0]);
-  g_subprocess_launcher_take_fd (launcher, pair[1], IPC_FD);
+  g_subprocess_launcher_take_fd (launcher, pair[1], RPMOSTREE_SHLIB_IPC_FD);
 
   if (wd != NULL)
     g_subprocess_launcher_set_cwd (launcher, wd);
@@ -87,6 +85,7 @@ _rpmostree_shlib_ipc_send (const char *variant_type, char **args, const char *wd
   if (r < 0)
     return NULL;
   g_assert_cmpint (r, ==, 1);
+  g_assert_cmphex (buffer[0], ==, 0xFF);
 
   if (nm != 1)
     return glnx_null_throw (error, "Got %d control messages, expected 1", nm);

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -1221,17 +1221,9 @@ rpmostree_sack_get_sorted_packages (DnfSack *sack)
   return g_steal_pointer (&pkglist);
 }
 
-gboolean
-rpmostree_create_rpmdb_pkglist_variant (int              dfd,
-                                        const char      *path,
-                                        GVariant       **out_variant,
-                                        GCancellable    *cancellable,
-                                        GError         **error)
+GVariant *
+rpmostree_variant_pkgs_from_sack (RpmOstreeRefSack *refsack)
 {
-  g_autoptr(RpmOstreeRefSack) refsack = rpmostree_get_refsack_for_root (dfd, path, error);
-  if (!refsack)
-    return FALSE;
-
   /* we insert it sorted here so it can efficiently be searched on retrieval */
   g_autoptr(GPtrArray) pkglist = rpmostree_sack_get_sorted_packages (refsack->sack);
 
@@ -1253,7 +1245,21 @@ rpmostree_create_rpmdb_pkglist_variant (int              dfd,
                              dnf_package_get_arch (pkg));
     }
 
-  *out_variant = g_variant_ref_sink (g_variant_builder_end (&pkglist_v_builder));
+  return g_variant_ref_sink (g_variant_builder_end (&pkglist_v_builder));
+}
+
+gboolean
+rpmostree_create_rpmdb_pkglist_variant (int              dfd,
+                                        const char      *path,
+                                        GVariant       **out_variant,
+                                        GCancellable    *cancellable,
+                                        GError         **error)
+{
+  g_autoptr(RpmOstreeRefSack) refsack = rpmostree_get_refsack_for_root (dfd, path, error);
+  if (!refsack)
+    return FALSE;
+
+  *out_variant = rpmostree_variant_pkgs_from_sack (refsack);
   return TRUE;
 }
 

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -127,6 +127,8 @@ rpmostree_get_refts_for_commit (OstreeRepo                *repo,
                                 GCancellable              *cancellable,
                                 GError                   **error);
 
+GVariant *rpmostree_variant_pkgs_from_sack (RpmOstreeRefSack *sack);
+
 gint
 rpmostree_pkg_array_compare (DnfPackage **p_pkg1,
                              DnfPackage **p_pkg2);


### PR DESCRIPTION
This is a potential path to fix
https://github.com/coreos/rpm-ostree/issues/2391

Basically our shared library and executable duplicate too much
code (particularly Rust).  Since most of the shlib APIs aren't
performance sensitive, let's have them fork off the binary
via a hidden CLI entrypoint and parse the output.
