### PR TITLE
daemon: Record the agent ID in the journal

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.h
+++ b/src/daemon/rpmostree-sysroot-upgrader.h
@@ -78,6 +78,8 @@ RpmOstreeSysrootUpgrader *rpmostree_sysroot_upgrader_new (OstreeSysroot         
                                                           GCancellable               *cancellable,
                                                           GError                    **error);
 
+void rpmostree_sysroot_upgrader_set_caller_info (RpmOstreeSysrootUpgrader *self, const char *initiating_command_line, const char *agent);
+
 OstreeDeployment* rpmostree_sysroot_upgrader_get_merge_deployment (RpmOstreeSysrootUpgrader *self);
 
 RpmOstreeOrigin *
@@ -128,7 +130,6 @@ rpmostree_sysroot_upgrader_pull_repos (RpmOstreeSysrootUpgrader  *self,
 
 gboolean
 rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
-                                   const char               *initiating_command_line,
                                    OstreeDeployment        **out_deployment,
                                    GCancellable             *cancellable,
                                    GError                  **error);

--- a/src/daemon/rpmostreed-daemon.c
+++ b/src/daemon/rpmostreed-daemon.c
@@ -721,6 +721,17 @@ rpmostreed_daemon_client_get_string (RpmostreedDaemon *self, const char *client)
     return rpmostree_client_to_string (clientdata);
 }
 
+/* Returns the caller's agent ID string; may be NULL if it's unset or the default */
+char *
+rpmostreed_daemon_client_get_agent_id (RpmostreedDaemon *self, const char *client)
+{
+  struct RpmOstreeClient *clientdata = g_hash_table_lookup (self->bus_clients, client);
+  if (!clientdata || clientdata->id == NULL || g_str_equal (clientdata->id, "cli"))
+    return NULL;
+  else
+    return g_strdup (clientdata->id);
+}
+
 void
 rpmostreed_daemon_remove_client (RpmostreedDaemon *self,
                                  const char       *client)

--- a/src/daemon/rpmostreed-daemon.h
+++ b/src/daemon/rpmostreed-daemon.h
@@ -42,6 +42,8 @@ void               rpmostreed_daemon_remove_client  (RpmostreedDaemon *self,
                                                      const char *client);
 char *             rpmostreed_daemon_client_get_string (RpmostreedDaemon *self,
                                                         const char *client);
+char *             rpmostreed_daemon_client_get_agent_id (RpmostreedDaemon *self,
+                                                        const char *client);
 void               rpmostreed_daemon_exit_now       (RpmostreedDaemon *self);
 void               rpmostreed_daemon_run_until_idle_exit (RpmostreedDaemon *self);
 void               rpmostreed_daemon_publish        (RpmostreedDaemon *self,

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1344,6 +1344,8 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
         return FALSE;
     }
 
+  rpmostree_sysroot_upgrader_set_caller_info (upgrader, command_line, rpmostreed_transaction_get_agent_id (RPMOSTREED_TRANSACTION(self)));
+
   /* TODO - better logic for "changed" based on deployments */
   if (changed || self->refspec)
     {
@@ -1359,7 +1361,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
         }
 
       g_autoptr(OstreeDeployment) new_deployment = NULL;
-      if (!rpmostree_sysroot_upgrader_deploy (upgrader, command_line, &new_deployment,
+      if (!rpmostree_sysroot_upgrader_deploy (upgrader, &new_deployment,
                                               cancellable, error))
         return FALSE;
 
@@ -1751,6 +1753,7 @@ initramfs_etc_transaction_execute (RpmostreedTransaction *transaction,
     rpmostree_sysroot_upgrader_new (sysroot, self->osname, static_cast<RpmOstreeSysrootUpgraderFlags>(upgrader_flags), cancellable, error);
   if (upgrader == NULL)
     return FALSE;
+  rpmostree_sysroot_upgrader_set_caller_info (upgrader, command_line, rpmostreed_transaction_get_agent_id (RPMOSTREED_TRANSACTION(self)));
 
   g_autoptr(RpmOstreeOrigin) origin = rpmostree_sysroot_upgrader_dup_origin (upgrader);
 
@@ -1790,7 +1793,7 @@ initramfs_etc_transaction_execute (RpmostreedTransaction *transaction,
     }
 
   rpmostree_sysroot_upgrader_set_origin (upgrader, origin);
-  if (!rpmostree_sysroot_upgrader_deploy (upgrader, command_line, NULL, cancellable, error))
+  if (!rpmostree_sysroot_upgrader_deploy (upgrader, NULL, cancellable, error))
     return FALSE;
 
   if (vardict_lookup_bool (self->options, "reboot", FALSE))
@@ -1924,8 +1927,9 @@ initramfs_state_transaction_execute (RpmostreedTransaction *transaction,
 
   rpmostree_origin_set_regenerate_initramfs (origin, self->regenerate, self->args);
   rpmostree_sysroot_upgrader_set_origin (upgrader, origin);
+  rpmostree_sysroot_upgrader_set_caller_info (upgrader, command_line, rpmostreed_transaction_get_agent_id (RPMOSTREED_TRANSACTION(self)));
 
-  if (!rpmostree_sysroot_upgrader_deploy (upgrader, command_line, NULL, cancellable, error))
+  if (!rpmostree_sysroot_upgrader_deploy (upgrader, NULL, cancellable, error))
     return FALSE;
 
   if (vardict_lookup_bool (self->options, "reboot", FALSE))
@@ -2599,6 +2603,7 @@ kernel_arg_transaction_execute (RpmostreedTransaction *transaction,
   g_autoptr(RpmOstreeSysrootUpgrader) upgrader =
     rpmostree_sysroot_upgrader_new (sysroot, self->osname, static_cast<RpmOstreeSysrootUpgraderFlags>(upgrader_flags),
                                     cancellable, error);
+  rpmostree_sysroot_upgrader_set_caller_info (upgrader, command_line, rpmostreed_transaction_get_agent_id (RPMOSTREED_TRANSACTION(self)));
 
   /* We need the upgrader to perform the deployment */
   if (upgrader == NULL)
@@ -2634,7 +2639,7 @@ kernel_arg_transaction_execute (RpmostreedTransaction *transaction,
   g_auto(GStrv) kargs_strv = ostree_kernel_args_to_strv (kargs);
   rpmostree_sysroot_upgrader_set_kargs (upgrader, kargs_strv);
 
-  if (!rpmostree_sysroot_upgrader_deploy (upgrader, command_line, NULL, cancellable, error))
+  if (!rpmostree_sysroot_upgrader_deploy (upgrader, NULL, cancellable, error))
     return FALSE;
 
   if (vardict_lookup_bool (self->options, "reboot", FALSE))

--- a/src/daemon/rpmostreed-transaction.cxx
+++ b/src/daemon/rpmostreed-transaction.cxx
@@ -41,8 +41,9 @@ struct _RpmostreedTransactionPrivate {
   char *sysroot_path;
   OstreeSysroot *sysroot;
   gboolean sysroot_locked;
-  /* Capture of the client description at txn creation time */
+  /* Capture of the client description and agent at txn creation time */
   char *client_description;
+  char *agent_id;
 
   gboolean redirect_output;
 
@@ -505,6 +506,7 @@ transaction_finalize (GObject *object)
   g_hash_table_destroy (priv->peer_connections);
 
   g_free (priv->client_description);
+  g_free (priv->agent_id);
 
   G_OBJECT_CLASS (rpmostreed_transaction_parent_class)->finalize (object);
 }
@@ -538,6 +540,7 @@ transaction_constructed (GObject *object)
                                                        NULL);
 
       priv->client_description = rpmostreed_daemon_client_get_string (rpmostreed_daemon_get(), sender);
+      priv->agent_id = rpmostreed_daemon_client_get_agent_id (rpmostreed_daemon_get(), sender);
       rpmostree_transaction_set_initiating_client_description ((RPMOSTreeTransaction*)self, priv->client_description);
     }
 }
@@ -836,6 +839,15 @@ rpmostreed_transaction_get_client (RpmostreedTransaction *transaction)
 
   RpmostreedTransactionPrivate *priv = rpmostreed_transaction_get_private (transaction);
   return priv->client_description;
+}
+
+const char *
+rpmostreed_transaction_get_agent_id (RpmostreedTransaction *transaction)
+{
+  g_return_val_if_fail (RPMOSTREED_IS_TRANSACTION (transaction), NULL);
+
+  RpmostreedTransactionPrivate *priv = rpmostreed_transaction_get_private (transaction);
+  return priv->agent_id;
 }
 
 GDBusMethodInvocation *

--- a/src/daemon/rpmostreed-transaction.h
+++ b/src/daemon/rpmostreed-transaction.h
@@ -48,6 +48,7 @@ GType           rpmostreed_transaction_get_type            (void) G_GNUC_CONST;
 gboolean        rpmostreed_transaction_get_active          (RpmostreedTransaction *transaction);
 OstreeSysroot * rpmostreed_transaction_get_sysroot         (RpmostreedTransaction *transaction);
 const char *    rpmostreed_transaction_get_client          (RpmostreedTransaction *transaction);
+const char *    rpmostreed_transaction_get_agent_id        (RpmostreedTransaction *transaction);
 GDBusMethodInvocation *
                 rpmostreed_transaction_get_invocation      (RpmostreedTransaction *transaction);
 const char *    rpmostreed_transaction_get_client_address  (RpmostreedTransaction *transaction);

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -44,13 +44,17 @@ assert_streq "$(vm_get_booted_csum)" "${booted_csum}"
 vm_assert_journal_has_content $cursor 'Not finalizing; found /run/ostree/staged-deployment-locked'
 echo "ok locked rebase staging"
 
-vm_rpmostree deploy revision="${commit}" --lock-finalization
+# This also now tests custom client IDs in the journal
+cursor=$(vm_get_journal_cursor)
+vm_cmd env RPMOSTREE_CLIENT_ID=testing-agent-id rpm-ostree deploy revision="${commit}" --lock-finalization
 vm_cmd test -f /run/ostree/staged-deployment-locked
 if vm_rpmostree finalize-deployment; then
   assert_not_reached "finalized without expected checksum"
 elif vm_rpmostree finalize-deployment WRONG_CHECKSUM; then
   assert_not_reached "finalized with wrong checksum"
 fi
+vm_cmd journalctl --after-cursor "'$from_cursor'" -u rpm-ostreed -o json | jq -r '.AGENT//""' > agent.txt
+assert_file_has_content agent.txt testing-agent-id
 cursor=$(vm_get_journal_cursor)
 vm_reboot_cmd rpm-ostree finalize-deployment "${commit}"
 assert_streq "$(vm_get_booted_csum)" "${commit}"


### PR DESCRIPTION
Related to https://github.com/coreos/rpm-ostree/issues/1747

Basically after this we can have `rpm-ostree status` output
e.g. `Agent: zincati` at least *after* an upgrade has happened.
