### PR TITLE
spec: Propagate Fedora default rustflags

### DIFF
--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -17,6 +17,7 @@ ExclusiveArch: %{rust_arches}
 %if 0%{?rhel} && !0%{?eln}
 BuildRequires: rust-toolset
 %else
+BuildRequires: rust-packaging
 BuildRequires: cargo
 BuildRequires: rust
 %endif
@@ -130,6 +131,10 @@ The %{name}-devel package includes the header files for %{name}-libs.
 %define _lto_cflags %{nil}
 
 env NOCONFIGURE=1 ./autogen.sh
+# Since we're hybrid C++/Rust we need to propagate this manually;
+# the %%configure macro today assumes (reasonably) that one is building
+# C/C++ and sets C{,XX}FLAGS
+export RUSTFLAGS="%{build_rustflags}"
 %configure --disable-silent-rules --enable-gtk-doc
 %make_build
 


### PR DESCRIPTION
We got annobin (hardening) warnings in a downstream RPM analysis,
I think this will help ensure that the Rust code is built with
things like `-znow` etc.
