### PR TITLE
 buildsys: Unify build of binary and internal shared library

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -1,3 +1,7 @@
+# This file used to declare a separate libtool static library.
+# Now that the daemon and binary are the same thing, we have
+# Makefile-rpm-ostree.am reuse these variables.
+
 dbus_built_sources = rpm-ostreed-generated.h rpm-ostreed-generated.c
 
 # TODO: Add --c-generate-autocleanup=all once we depend on GLib 2.50+
@@ -19,10 +23,7 @@ CLEANFILES += rpm-ostreed-generated-org.projectatomic.rpmostree1.OS.xml \
 	rpm-ostreed-generated-org.projectatomic.rpmostree1.Transaction.xml \
 	$(NULL)
 
-noinst_LTLIBRARIES += librpmostreed.la
-nodist_librpmostreed_la_SOURCES = $(dbus_built_sources)
-
-librpmostreed_la_SOURCES = \
+librpmostreed_sources = \
 	src/daemon/rpmostreed-types.h \
 	src/daemon/rpmostreed-daemon.h \
 	src/daemon/rpmostreed-daemon.c \
@@ -49,25 +50,6 @@ librpmostreed_la_SOURCES = \
 	src/daemon/rpmostreed-os.cxx \
 	src/daemon/rpmostreed-os-experimental.h \
 	src/daemon/rpmostreed-os-experimental.c \
-	$(NULL)
-
-rpmostreed_common_cflags = $(PKGDEP_RPMOSTREE_CFLAGS) \
-	-DG_LOG_DOMAIN=\"rpm-ostreed\" \
-	-fvisibility=hidden \
-	-D_RPMOSTREE_EXTERN= \
-	-I$(srcdir)/src/daemon \
-	-I$(srcdir)/src/lib \
-	-I$(srcdir)/src/libpriv \
-	-I$(libglnx_srcpath) \
-	$(NULL)
-librpmostreed_la_CFLAGS = $(AM_CFLAGS) $(rpmostreed_common_cflags)
-librpmostreed_la_CXXFLAGS = $(AM_CXXFLAGS) $(rpmostree_common_cflags)
-
-librpmostreed_la_LIBADD = \
-	$(PKGDEP_RPMOSTREE_LIBS) \
-	librpmostreepriv.la \
-	librpmostree-1.la \
-	$(CAP_LIBS)
 	$(NULL)
 
 dbusconf_DATA = $(srcdir)/src/daemon/org.projectatomic.rpmostree1.conf

--- a/Makefile-lib.am
+++ b/Makefile-lib.am
@@ -34,7 +34,8 @@ librpmostree_1_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/libglnx -I$(srcdir)/src/libp
 	-fvisibility=hidden '-D_RPMOSTREE_EXTERN=__attribute((visibility("default"))) extern' \
 	$(PKGDEP_RPMOSTREE_CFLAGS)
 librpmostree_1_la_LDFLAGS = $(AM_LDFLAGS) -version-number 1:0:0 -Bsymbolic-functions
-librpmostree_1_la_LIBADD =  $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la $(librpmostree_rust_path)
+librpmostree_1_la_LIBADD =  $(PKGDEP_RPMOSTREE_LIBS) libglnx.la
+EXTRA_librpmostree_1_la_DEPENDENCIES = libdnf.so.2
 
 # The g-ir-scanner creates a stub executable (to help introspect type information) which
 # links to our stuff. We want to make sure it picks up our fresh libdnf and not a possibly

--- a/Makefile-libpriv.am
+++ b/Makefile-libpriv.am
@@ -15,9 +15,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-noinst_LTLIBRARIES += librpmostreepriv.la
-
-librpmostreepriv_la_SOURCES = \
+librpmostreepriv_sources = \
 	src/libpriv/rpmostree-postprocess.cxx \
 	src/libpriv/rpmostree-postprocess.h \
 	src/libpriv/rpmostree-json-parsing.c \
@@ -61,7 +59,7 @@ librpmostreepriv_la_SOURCES = \
 	$(NULL)
 
 if BUILDOPT_ROJIG
-librpmostreepriv_la_SOURCES += \
+librpmostreepriv_sources += \
 	src/libpriv/rpmostree-rojig-build.c \
 	src/libpriv/rpmostree-rojig-build.h \
 	src/libpriv/rpmostree-rojig-assembler.c \
@@ -71,36 +69,16 @@ librpmostreepriv_la_SOURCES += \
 	$(NULL)
 endif
 
-rpmostreepriv_common_cflags = -I$(srcdir)/src/lib \
-	-I$(srcdir)/src/libpriv \
-	-I$(libglnx_srcpath) \
-	-DLIBDIR=\"$(libdir)\" \
-	-DPKGLIBDIR=\"$(pkglibdir)\" \
-	-fvisibility=hidden \
-	$(PKGDEP_RPMOSTREE_CFLAGS) \
-	$(NULL)
-librpmostreepriv_la_CFLAGS = $(AM_CFLAGS) $(rpmostreepriv_common_cflags)
-librpmostreepriv_la_CXXFLAGS = $(AM_CXXFLAGS) $(rpmostreepriv_common_cflags)
-
-librpmostreepriv_la_LIBADD = \
-	$(PKGDEP_RPMOSTREE_LIBS) \
-	libglnx.la \
-	$(CAP_LIBS) \
-	$(NULL)
-
-# bundled libdnf
-EXTRA_librpmostreepriv_la_DEPENDENCIES = libdnf.so.2
-
 gperf_gperf_sources = src/libpriv/rpmostree-script-gperf.gperf
 BUILT_SOURCES += $(gperf_gperf_sources:-gperf.gperf=-gperf.c)
 CLEANFILES += $(gperf_gperf_sources:-gperf.gperf=-gperf.c)
 
-nodist_librpmostreepriv_la_SOURCES = src/libpriv/rpmostree-script-gperf.c
+nodist_librpmostreepriv_sources = src/libpriv/rpmostree-script-gperf.c
 
 rpmostree-libpriv-gresources.c: src/libpriv/gresources.xml Makefile $(shell glib-compile-resources --sourcedir=$(srcdir)/src/libpriv --generate-dependencies $(srcdir)/src/libpriv/gresources.xml)
 	$(AM_V_GEN) glib-compile-resources --target=$@ --sourcedir=$(srcdir)/src/libpriv --generate-source --c-name _rpmostree_ $<
 BUILT_SOURCES += rpmostree-libpriv-gresources.c
-librpmostreepriv_la_SOURCES += rpmostree-libpriv-gresources.c
+librpmostreepriv_sources += rpmostree-libpriv-gresources.c
 
 AM_V_GPERF = $(AM_V_GPERF_$(V))
 AM_V_GPERF_ = $(AM_V_GPERF_$(AM_DEFAULT_VERBOSITY))

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -18,8 +18,6 @@
 bin_PROGRAMS += rpm-ostree
 
 rpm_ostree_SOURCES = src/app/main.cxx \
-	rpm-ostreed-generated.h \
-	rpm-ostreed-generated.c \
 	src/app/rpmostree-builtins.h \
 	src/app/rpmostree-db-builtins.h \
 	src/app/rpmostree-compose-builtins.h \
@@ -62,6 +60,7 @@ rpm_ostree_SOURCES = src/app/main.cxx \
 	src/app/rpmostree-composeutil.c \
 	src/app/rpmostree-composeutil.h \
 	src/app/rpmostree-builtin-compose.c \
+	$(librpmostreed_sources) \
 	$(NULL)
 
 if BUILDOPT_ROJIG
@@ -72,12 +71,18 @@ rpm_ostree_SOURCES += \
 	$(NULL)
 endif
 
+nodist_rpm_ostree_SOURCES = $(dbus_built_sources)
+
 rpmostree_common_cflags = -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
 	-I$(srcdir)/src/lib -I$(srcdir)/src/libpriv -I$(libglnx_srcpath) \
-	-fvisibility=hidden -DPKGLIBDIR=\"$(pkglibdir)\" $(PKGDEP_RPMOSTREE_CFLAGS)
+	-fvisibility=hidden \
+	-DG_LOG_DOMAIN=\"rpm-ostreed\" \
+	-DLIBDIR=\"$(libdir)\" -DPKGLIBDIR=\"$(pkglibdir)\" \
+	$(PKGDEP_RPMOSTREE_CFLAGS)
 rpm_ostree_CFLAGS = $(AM_CFLAGS) $(rpmostree_common_cflags)
 rpm_ostree_CXXFLAGS = $(AM_CXXFLAGS) $(rpmostree_common_cflags)
-rpm_ostree_LDADD = $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la librpmostree-1.la librpmostreed.la
+rpm_ostree_LDADD = $(PKGDEP_RPMOSTREE_LIBS) $(CAP_LIBS) libglnx.la librpmostreepriv.la librpmostree-1.la
+EXTRA_rpm_ostree_DEPENDENCIES = libdnf.so.2
 
 privdatadir=$(pkglibdir)
 privdata_DATA = src/app/rpm-ostree-0-integration.conf

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -42,6 +42,7 @@ rpm_ostree_SOURCES = src/app/main.cxx \
 	src/app/rpmostree-builtin-status.c \
 	src/app/rpmostree-builtin-ex.c \
 	src/app/rpmostree-builtin-testutils.c \
+	src/app/rpmostree-builtin-shlib-backend.c \
 	src/app/rpmostree-builtin-db.c \
 	src/app/rpmostree-builtin-start-daemon.c \
 	src/app/rpmostree-builtin-finalize-deployment.c \

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -61,6 +61,7 @@ rpm_ostree_SOURCES = src/app/main.cxx \
 	src/app/rpmostree-composeutil.h \
 	src/app/rpmostree-builtin-compose.c \
 	$(librpmostreed_sources) \
+	$(librpmostreepriv_sources) \
 	$(NULL)
 
 if BUILDOPT_ROJIG
@@ -71,7 +72,7 @@ rpm_ostree_SOURCES += \
 	$(NULL)
 endif
 
-nodist_rpm_ostree_SOURCES = $(dbus_built_sources)
+nodist_rpm_ostree_SOURCES = $(dbus_built_sources) $(nodist_librpmostreepriv_sources)
 
 rpmostree_common_cflags = -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
 	-I$(srcdir)/src/lib -I$(srcdir)/src/libpriv -I$(libglnx_srcpath) \
@@ -81,7 +82,7 @@ rpmostree_common_cflags = -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
 	$(PKGDEP_RPMOSTREE_CFLAGS)
 rpm_ostree_CFLAGS = $(AM_CFLAGS) $(rpmostree_common_cflags)
 rpm_ostree_CXXFLAGS = $(AM_CXXFLAGS) $(rpmostree_common_cflags)
-rpm_ostree_LDADD = $(PKGDEP_RPMOSTREE_LIBS) $(CAP_LIBS) libglnx.la librpmostreepriv.la librpmostree-1.la
+rpm_ostree_LDADD = $(PKGDEP_RPMOSTREE_LIBS) $(CAP_LIBS) libglnx.la librpmostree-1.la
 EXTRA_rpm_ostree_DEPENDENCIES = libdnf.so.2
 
 privdatadir=$(pkglibdir)

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -20,38 +20,39 @@ endif
 
 GITIGNOREFILES += ssh-config ansible-inventory.yml vmcheck-logs/ test-compose-logs/ tests/vmcheck/image.qcow2
 
-testbin_cppflags = $(AM_CPPFLAGS) -I $(srcdir)/src/lib -I $(srcdir)/src/libpriv -I $(srcdir)/libglnx -I $(srcdir)/tests/common
-testbin_cflags = $(AM_CFLAGS) -fvisibility=hidden $(PKGDEP_RPMOSTREE_CFLAGS)
-testbin_ldadd = $(PKGDEP_RPMOSTREE_LIBS) librpmostree-1.la librpmostreepriv.la -lstdc++
-
-noinst_LTLIBRARIES += libtest.la
-libtest_la_SOURCES = tests/common/libtest.c
-libtest_la_CPPFLAGS = $(testbin_cppflags)
-libtest_la_CFLAGS = $(testbin_cflags)
-libtest_la_LIBADD = $(testbin_ldadd)
-
-tests_check_jsonutil_CPPFLAGS = $(testbin_cppflags)
-tests_check_jsonutil_CFLAGS = $(testbin_cflags)
-tests_check_jsonutil_LDADD = $(testbin_ldadd) libtest.la
-
-tests_check_postprocess_CPPFLAGS = $(testbin_cppflags)
-tests_check_postprocess_CFLAGS = $(testbin_cflags)
-tests_check_postprocess_LDADD = $(testbin_ldadd) libtest.la
-
-tests_check_test_utils_CPPFLAGS = $(testbin_cppflags)
-tests_check_test_utils_CFLAGS = $(testbin_cflags)
-tests_check_test_utils_LDADD = $(testbin_ldadd) libtest.la
-
-tests_check_test_sysusers_CPPFLAGS = $(testbin_cppflags)
-tests_check_test_sysusers_CFLAGS = $(testbin_cflags)
-tests_check_test_sysusers_LDADD = $(testbin_ldadd) libtest.la
-
-uninstalled_test_programs = \
-	tests/check/jsonutil			\
-	tests/check/postprocess			\
-	tests/check/test-utils			\
-	tests/check/test-sysusers		\
-	$(NULL)
+# Disabled for now because we dropped librpmostreepriv.la
+# testbin_cppflags = $(AM_CPPFLAGS) -I $(srcdir)/src/lib -I $(srcdir)/src/libpriv -I $(srcdir)/libglnx -I $(srcdir)/tests/common
+# testbin_cflags = $(AM_CFLAGS) -fvisibility=hidden $(PKGDEP_RPMOSTREE_CFLAGS)
+# testbin_ldadd = $(PKGDEP_RPMOSTREE_LIBS) librpmostree-1.la librpmostreepriv.la -lstdc++
+# 
+# noinst_LTLIBRARIES += libtest.la
+# libtest_la_SOURCES = tests/common/libtest.c
+# libtest_la_CPPFLAGS = $(testbin_cppflags)
+# libtest_la_CFLAGS = $(testbin_cflags)
+# libtest_la_LIBADD = $(testbin_ldadd)
+# 
+# tests_check_jsonutil_CPPFLAGS = $(testbin_cppflags)
+# tests_check_jsonutil_CFLAGS = $(testbin_cflags)
+# tests_check_jsonutil_LDADD = $(testbin_ldadd) libtest.la
+# 
+# tests_check_postprocess_CPPFLAGS = $(testbin_cppflags)
+# tests_check_postprocess_CFLAGS = $(testbin_cflags)
+# tests_check_postprocess_LDADD = $(testbin_ldadd) libtest.la
+# 
+# tests_check_test_utils_CPPFLAGS = $(testbin_cppflags)
+# tests_check_test_utils_CFLAGS = $(testbin_cflags)
+# tests_check_test_utils_LDADD = $(testbin_ldadd) libtest.la
+# 
+# tests_check_test_sysusers_CPPFLAGS = $(testbin_cppflags)
+# tests_check_test_sysusers_CFLAGS = $(testbin_cflags)
+# tests_check_test_sysusers_LDADD = $(testbin_ldadd) libtest.la
+# 
+# uninstalled_test_programs = \
+# 	tests/check/jsonutil			\
+# 	tests/check/postprocess			\
+# 	tests/check/test-utils			\
+# 	tests/check/test-sysusers		\
+# 	$(NULL)
 
 uninstalled_test_scripts = \
 	tests/check/test-lib-introspection.sh \

--- a/src/app/main.cxx
+++ b/src/app/main.cxx
@@ -119,6 +119,9 @@ static RpmOstreeCommand commands[] = {
   { "testutils", static_cast<RpmOstreeBuiltinFlags>(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD |
                  RPM_OSTREE_BUILTIN_FLAG_HIDDEN),
     NULL, rpmostree_builtin_testutils },
+  { "shlib-backend", static_cast<RpmOstreeBuiltinFlags>(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD |
+                 RPM_OSTREE_BUILTIN_FLAG_HIDDEN),
+    NULL, rpmostree_builtin_shlib_backend },
   { "start-daemon", static_cast<RpmOstreeBuiltinFlags>(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD |
                     RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT |
                     RPM_OSTREE_BUILTIN_FLAG_HIDDEN),

--- a/src/app/rpmostree-builtin-shlib-backend.c
+++ b/src/app/rpmostree-builtin-shlib-backend.c
@@ -1,0 +1,107 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <glib-unix.h>
+#include <gio/gio.h>
+#include <gio/gunixfdmessage.h>
+#include <gio/gunixsocketaddress.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "rpmostree-builtins.h"
+#include "rpmostree-libbuiltin.h"
+#include "rpmostree-rust.h"
+#include "rpmostree.h"
+#include "rpmostree-core.h"
+#include "src/lib/rpmostree-shlib-ipc-private.h"
+
+#include <libglnx.h>
+
+static gboolean
+send_memfd_result (int ret_memfd, GError **error)
+{
+  int fdarray[] = {ret_memfd, -1 };
+  g_autoptr(GUnixFDList) list = g_unix_fd_list_new_from_array (fdarray, 1);
+  g_autoptr(GUnixFDMessage) message = G_UNIX_FD_MESSAGE (g_unix_fd_message_new_with_fd_list (list));
+  g_autoptr(GSocket) ipc_sock = g_socket_new_from_fd (RPMOSTREE_SHLIB_IPC_FD, error);
+  if (!ipc_sock)
+    return FALSE;
+  GOutputVector ov;
+  char buffer[1];
+  buffer[0] = 0xFF;
+  ov.buffer = buffer;
+  ov.size = G_N_ELEMENTS (buffer);
+  gssize r = g_socket_send_message (ipc_sock, NULL, &ov, 1,
+                                    (GSocketControlMessage **) &message,
+                                    1, 0, NULL, error);
+  if (r < 0)
+    return FALSE;
+  g_assert_cmpint (r, ==, 1);
+
+  return TRUE;
+}
+
+gboolean
+rpmostree_builtin_shlib_backend (int             argc,
+                                 char          **argv,
+                                 RpmOstreeCommandInvocation *invocation,
+                                 GCancellable   *cancellable,
+                                 GError        **error)
+{
+  if (argc < 2)
+    return glnx_throw (error, "missing required subcommand");
+
+  const char *arg = argv[1];
+
+  g_autoptr(GVariant) ret = NULL;
+
+  if (g_str_equal (arg, "get-basearch"))
+    {
+      g_autoptr(DnfContext) ctx = dnf_context_new ();
+      ret = g_variant_new_string (dnf_context_get_base_arch (ctx));
+    }
+  else if (g_str_equal (arg, "varsubst-basearch"))
+    {
+      const char *src = argv[2];
+      g_autoptr(DnfContext) ctx = dnf_context_new ();
+      g_autoptr(GHashTable) varsubsts = rpmostree_dnfcontext_get_varsubsts (ctx);
+      g_autofree char *rets = _rpmostree_varsubst_string (src, varsubsts, error);
+      if (rets == NULL)
+        return FALSE;
+      ret = g_variant_new_string (rets);
+    }
+  else
+    return glnx_throw (error, "unknown shlib-backend %s", arg);
+
+  glnx_fd_close int ret_memfd = memfd_create ("rpm-ostree-shlib-backend", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+  if (ret_memfd < 0)
+    return glnx_throw_errno_prefix (error, "memfd_create");
+  if (glnx_loop_write (ret_memfd, g_variant_get_data (ret), g_variant_get_size (ret)) < 0)
+    return glnx_throw_errno_prefix (error, "Failed to write to memfd");
+  const int seals = (F_SEAL_GROW | F_SEAL_SHRINK | F_SEAL_WRITE);
+  if (fcntl (ret_memfd, F_ADD_SEALS, seals) == -1)
+    return glnx_throw_errno_prefix (error, "fcntl(sealing)");
+
+  return send_memfd_result (glnx_steal_fd (&ret_memfd), error);
+}

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -52,6 +52,7 @@ BUILTINPROTO(override);
 BUILTINPROTO(kargs);
 BUILTINPROTO(reset);
 BUILTINPROTO(start_daemon);
+BUILTINPROTO(shlib_backend);
 BUILTINPROTO(coreos_rootfs);
 BUILTINPROTO(testutils);
 BUILTINPROTO(ex);

--- a/src/lib/rpmostree-shlib-ipc-private.h
+++ b/src/lib/rpmostree-shlib-ipc-private.h
@@ -1,0 +1,29 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2020 Colin Walters <walters@verbum.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+G_BEGIN_DECLS
+
+#define RPMOSTREE_SHLIB_IPC_FD 3
+
+GVariant *_rpmostree_shlib_ipc_send (const char *variant_type, char **args, GError **error);
+
+G_END_DECLS


### PR DESCRIPTION

This completes the task of unifying the build of all of our C/C++
into a single unit, which avoids code duplication and will allow
us to more easily use LTO in the future.