### PR TITLE
Run rustfmt, and fix CI check for it

### DIFF
--- a/ci/codestyle.sh
+++ b/ci/codestyle.sh
@@ -11,12 +11,10 @@ fi
 echo "ok"
 
 echo -n "checking rustfmt..."
-cd rust
 for crate in $(find -iname Cargo.toml); do
     if ! cargo fmt --manifest-path ${crate} -- --check; then
         echo "cargo fmt failed; run: cd $(dirname ${crate}) && cargo fmt" 1>&2
         exit 1
     fi
 done
-cd ..
 echo "ok"

--- a/rust/src/testutils.rs
+++ b/rust/src/testutils.rs
@@ -181,10 +181,7 @@ fn update_os_tree(opts: &SyntheticUpgradeOpts) -> Result<()> {
     }
     assert!(mutated > 0);
     println!("Mutated ELF files: {}", mutated);
-    let src_ref = opts
-        .src_ref
-        .as_deref()
-        .unwrap_or(opts.ostref.as_str());
+    let src_ref = opts.src_ref.as_deref().unwrap_or(opts.ostref.as_str());
     let mut cmd = Command::new("ostree");
     cmd.arg(format!("--repo={}", repo_path.to_str().unwrap()))
         .args(&["commit", "--consume", "-b"])

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -535,7 +535,13 @@ impl Treefile {
         let description = r
             .description
             .as_ref()
-            .and_then(|v| if !v.is_empty() { Some(v.as_str()) } else { None })
+            .and_then(|v| {
+                if !v.is_empty() {
+                    Some(v.as_str())
+                } else {
+                    None
+                }
+            })
             .unwrap_or(r.summary.as_str());
         let name: String = format!("{}.spec", r.name);
         {
@@ -1413,11 +1419,7 @@ mod ffi {
         // Run code, map error if any, otherwise extract raw pointer, passing
         // ownership back to C.
         ptr_glib_error(
-            Treefile::new_boxed(
-                filename.as_ref(),
-                basearch.as_deref(),
-                workdir,
-            ),
+            Treefile::new_boxed(filename.as_ref(), basearch.as_deref(), workdir),
             gerror,
         )
     }


### PR DESCRIPTION
Moving the crate to the toplevel broke the CI check for `rustfmt`.
Fix it and run `cargo fmt`.
