### PR TITLE
Makefile-rpm-ostree: fix path to cbindgen.toml

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -120,7 +120,7 @@ else
 if !HAVE_PREBUILT_CBINDGEN
 if HAVE_EXTERNAL_CBINDGEN
 rpmostree-rust.h:
-	$(AM_V_GEN) cbindgen -c rust/cbindgen.toml -o $@ $(top_srcdir)
+	$(AM_V_GEN) cbindgen -c cbindgen.toml -o $@ $(top_srcdir)
 else
 rpmostree-rust.h: rpmostree-bindgen
 	$(AM_V_GEN) ./rpmostree-bindgen $(top_srcdir)


### PR DESCRIPTION
Minor regression from #2365.