### PR TITLE
Default to sqlite rpmdb backend on f34

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,8 @@ debug = true
 # We need this to avoid leaking symbols, see
 # https://internals.rust-lang.org/t/rust-staticlibs-and-optimizing-for-size/5746
 lto = true
+
+[features]
+sqlite-rpmdb-default = []
+
+default = []

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -91,6 +91,10 @@ privdata_DATA = src/app/rpm-ostree-0-integration.conf
 # Propagate automake verbose mode
 cargo_build = $(cargo) build $(if $(subst 0,,$(V)),--verbose,)
 
+if BUILDOPT_ENABLE_SQLITE_RPMDB_DEFAULT
+cargo_build += --features sqlite-rpmdb-default
+endif
+
 tooling_src = bindgen/Cargo.toml bindgen/src/main.rs
 tooling-build:
 	cd $(top_srcdir)/tooling && $(cargo_build) --release --all-targets

--- a/configure.ac
+++ b/configure.ac
@@ -176,6 +176,12 @@ AC_ARG_WITH(bubblewrap,
               [with_bubblewrap=/usr/bin/bwrap])
 AC_DEFINE_UNQUOTED(WITH_BUBBLEWRAP_PATH, ["$with_bubblewrap"], [Define to bubblewrap path])
 
+AC_ARG_ENABLE(sqlite_rpmdb_default,
+              AS_HELP_STRING([--enable-sqlite-rpmdb-default],
+                             [Default to sqlite rpmdb backend (default: no)]),,
+              [enable_sqlite_rpmdb_default=no])
+AM_CONDITIONAL(BUILDOPT_ENABLE_SQLITE_RPMDB_DEFAULT, test x$enable_sqlite_rpmdb_default = xyes)
+
 RPM_OSTREE_FEATURES="$RPM_OSTREE_FEATURES compose"
 
 dnl PKG_CHECK_VAR added to pkg-config 0.28 (though it's already in the new pkgconf; this
@@ -290,4 +296,5 @@ echo "
     gtk-doc:                                 $enable_gtk_doc
     rust:                                    $rust_debug_release
     cbindgen:                                ${cbindgen:-internal}
+    sqlite rpmdb default:                    ${enable_sqlite_rpmdb_default}
 "

--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -99,7 +99,8 @@ It supports the following parameters:
 
  * `rpmdb`: String, optional: The RPM database backend.  Can be one of
     `bdb`, `ndb`, or `sqlite`.  If unspecified, defaults to `bdb` for
-    compatibility.
+    compatibility. The default can be set to `sqlite` at compile-time
+    via `--enable-sqlite-rpmdb-default`.
 
  * `cliwrap`: boolean, optional.  Defaults to `false`.  If enabled,
     rpm-ostree will replace binaries such as `/usr/bin/rpm` with

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -31,6 +31,10 @@ BuildRequires: rust
 %bcond_without zchunk
 %endif
 
+%if 0%{?fedora} >= 34
+%define sqlite_rpmdb_default "--enable-sqlite-rpmdb-default"
+%endif
+
 # For the autofiles bits below
 BuildRequires: /usr/bin/python3
 # We always run autogen.sh
@@ -135,7 +139,7 @@ env NOCONFIGURE=1 ./autogen.sh
 # the %%configure macro today assumes (reasonably) that one is building
 # C/C++ and sets C{,XX}FLAGS
 export RUSTFLAGS="%{build_rustflags}"
-%configure --disable-silent-rules --enable-gtk-doc
+%configure --disable-silent-rules --enable-gtk-doc %{?sqlite_rpmdb_default}
 %make_build
 
 %install

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -24,6 +24,11 @@ use crate::utils;
 
 const INCLUDE_MAXDEPTH: u32 = 50;
 
+#[cfg(not(feature = "sqlite-rpmdb-default"))]
+const DEFAULT_RPMDB_BACKEND: RpmdbBackend = RpmdbBackend::BDB;
+#[cfg(feature = "sqlite-rpmdb-default")]
+const DEFAULT_RPMDB_BACKEND: RpmdbBackend = RpmdbBackend::Sqlite;
+
 /// This struct holds file descriptors for any external files/data referenced by
 /// a TreeComposeConfig.
 struct TreefileExternals {
@@ -1558,7 +1563,7 @@ mod ffi {
     #[no_mangle]
     pub extern "C" fn ror_treefile_get_rpmdb(tf: *mut Treefile) -> *mut libc::c_char {
         let tf = ref_from_raw_ptr(tf);
-        let s: &str = match tf.parsed.rpmdb.as_ref().unwrap_or(&RpmdbBackend::BDB) {
+        let s: &str = match tf.parsed.rpmdb.as_ref().unwrap_or(&DEFAULT_RPMDB_BACKEND) {
             RpmdbBackend::BDB => "bdb",
             RpmdbBackend::Sqlite => "sqlite",
             RpmdbBackend::NDB => "ndb",


### PR DESCRIPTION
There won't be any support for writing to the bdb backend in f34, so
e.g. pkglayering won't work (and obviously even composes wouldn't work
once the buildroot moves to f34).

Instead of requiring the whole world to add an `rpmdb` key in their
manifests, let's just add a compile flag for it, and tweak the spec file
to use this flag on f34.