### PR TITLE
build-sys: A few cleanup patches

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -87,7 +87,7 @@ rpm-ostreed: $(srcdir)/src/daemon/rpm-ostreed-stub.sh.in Makefile
 # We don't yet rename the DBus related items
 service_in_files = $(srcdir)/src/daemon/org.projectatomic.rpmostree1.service.in
 service_DATA     = $(service_in_files:.service.in=.service)
-servicedir       = $(dbusservicedir)
+servicedir       = $(datadir)/dbus-1/system-services
 %.service: %.service.in Makefile
 	$(SED_SUBST) $@.in > $@.tmp && mv $@.tmp $@
 

--- a/configure.ac
+++ b/configure.ac
@@ -27,19 +27,6 @@ dnl if not set, which we definitely want; cmake doesn't do that.
 AC_PROG_CXX
 AM_PROG_CC_C_O
 
-# dbus system dir
-AC_MSG_CHECKING(for dbus system services directory)
-if test "$enable_prefix_only" = "yes"; then
-  dbusservicedir='${datadir}/dbus-1/system-services'
-else
-  dbusservicedir='${datadir}/dbus-1/system-services'
-  if test "$dbusservicedir" = ""; then
-    AC_MSG_ERROR(Couldn't find dbus services directory. Try installing dbus-devel)
-  fi
-fi
-AC_SUBST([dbusservicedir], [$dbusservicedir])
-AC_MSG_RESULT(dbusservicedir)
-
 dnl Keep this in sync with the version in ostree
 AS_IF([echo "$CFLAGS" | grep -q -E -e '-Werror($| )'], [], [
 CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\

--- a/configure.ac
+++ b/configure.ac
@@ -164,12 +164,6 @@ GTK_DOC_CHECK([1.15], [--flavour no-tmpl])
 AM_CONDITIONAL([ENABLE_GTK_DOC],[false])
 ])
 
-AC_ARG_WITH(bubblewrap,
-              AS_HELP_STRING([--with-bubblewrap],
-                             [Path to bubblewrap binary (default: /usr/bin/bwrap)]),,
-              [with_bubblewrap=/usr/bin/bwrap])
-AC_DEFINE_UNQUOTED(WITH_BUBBLEWRAP_PATH, ["$with_bubblewrap"], [Define to bubblewrap path])
-
 AC_ARG_ENABLE(sqlite_rpmdb_default,
               AS_HELP_STRING([--enable-sqlite-rpmdb-default],
                              [Default to sqlite rpmdb backend (default: no)]),,
@@ -286,7 +280,6 @@ echo "
 
     introspection:                           $found_introspection
     rojig:                                   ${enable_rojig:-no}
-    bubblewrap:                              $with_bubblewrap
     gtk-doc:                                 $enable_gtk_doc
     rust:                                    $rust_debug_release
     cbindgen:                                ${cbindgen:-internal}

--- a/configure.ac
+++ b/configure.ac
@@ -164,12 +164,6 @@ GTK_DOC_CHECK([1.15], [--flavour no-tmpl])
 AM_CONDITIONAL([ENABLE_GTK_DOC],[false])
 ])
 
-AC_ARG_ENABLE(installed_tests,
-              AS_HELP_STRING([--enable-installed-tests],
-                             [Install test programs (default: no)]),,
-              [enable_installed_tests=no])
-AM_CONDITIONAL(BUILDOPT_INSTALL_TESTS, test x$enable_installed_tests = xyes)
-
 AC_ARG_WITH(bubblewrap,
               AS_HELP_STRING([--with-bubblewrap],
                              [Path to bubblewrap binary (default: /usr/bin/bwrap)]),,

--- a/configure.ac
+++ b/configure.ac
@@ -172,14 +172,6 @@ AM_CONDITIONAL(BUILDOPT_ENABLE_SQLITE_RPMDB_DEFAULT, test x$enable_sqlite_rpmdb_
 
 RPM_OSTREE_FEATURES="$RPM_OSTREE_FEATURES compose"
 
-dnl PKG_CHECK_VAR added to pkg-config 0.28 (though it's already in the new pkgconf; this
-dnl backport is more for el7)
-m4_define_default(
-    [PKG_CHECK_VAR],
-    [AC_ARG_VAR([$1], [value of $3 for $2, overriding pkg-config])
-     AS_IF([test -z "$$1"], [$1=`$PKG_CONFIG --variable="$3" "$2"`])
-     AS_IF([test -n "$$1"], [$4], [$5])])
-
 PKG_CHECK_VAR(BASH_COMPLETIONSDIR, [bash-completion], [completionsdir],,
   BASH_COMPLETIONSDIR="${datadir}/bash-completion/completions")
 AC_SUBST(BASH_COMPLETIONSDIR)

--- a/src/libpriv/rpmostree-bwrap.cxx
+++ b/src/libpriv/rpmostree-bwrap.cxx
@@ -282,7 +282,7 @@ rpmostree_bwrap_new_base (int rootfs_fd, GError **error)
 
   /* ⚠⚠⚠ If you change this, also update scripts/bwrap-script-shell.sh ⚠⚠⚠ */
   rpmostree_bwrap_append_bwrap_argv (ret,
-                                     WITH_BUBBLEWRAP_PATH,
+                                     "bwrap",
                                      "--dev", "/dev",
                                      "--proc", "/proc",
                                      "--dir", "/run",


### PR DESCRIPTION
Work on dropping cruft from our Autotools build system
in preparation for moving to `build.rs`.