### PR TITLE
 Demo of first use of `extern "C++"`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 1.3.2",
  "winapi",
 ]
 
@@ -529,7 +529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e9b997a66e9a23d073f2b1abb4dbfc3925e0b8952f67efd8d9b6e168e4cdc1"
 dependencies = [
  "libc",
- "system-deps",
+ "system-deps 1.3.2",
 ]
 
 [[package]]
@@ -540,7 +540,7 @@ checksum = "952133b60c318a62bf82ee75b93acc7e84028a093e06b9e27981c2b6fe68218c"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 1.3.2",
 ]
 
 [[package]]
@@ -860,7 +860,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 1.3.2",
 ]
 
 [[package]]
@@ -1197,6 +1197,7 @@ dependencies = [
  "serde_yaml",
  "structopt",
  "subprocess",
+ "system-deps 2.0.3",
  "systemd",
  "tempfile",
 ]
@@ -1336,10 +1337,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b"
 
 [[package]]
+name = "strum"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+
+[[package]]
 name = "strum_macros"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1376,11 +1395,26 @@ checksum = "0f3ecc17269a19353b3558b313bba738b25d82993e30d62a18406a24aba4649b"
 dependencies = [
  "heck",
  "pkg-config",
- "strum",
- "strum_macros",
+ "strum 0.18.0",
+ "strum_macros 0.18.0",
  "thiserror",
  "toml",
- "version-compare",
+ "version-compare 0.0.10",
+]
+
+[[package]]
+name = "system-deps"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b59b8aafd652f3c1469f16e6c223121e8a8dbe40c71475209c1401cff3a67ef"
+dependencies = [
+ "heck",
+ "pkg-config",
+ "strum 0.20.0",
+ "strum_macros 0.20.1",
+ "thiserror",
+ "toml",
+ "version-compare 0.0.11",
 ]
 
 [[package]]
@@ -1512,6 +1546,12 @@ name = "version-compare"
 version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d63556a25bae6ea31b52e640d7c41d1ab27faba4ccb600013837a3d0b3994ca1"
+
+[[package]]
+name = "version-compare"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c18c859eead79d8b95d09e4678566e8d70105c4e7b251f707a03df32442661b"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,17 @@ name = "rpmostree-rust"
 version = "0.1.0"
 authors = ["Colin Walters <walters@verbum.org>", "Jonathan Lebon <jonathan@jlebon.com>"]
 edition = "2018"
+links = "rpmostreeinternals"
+
+# This currently needs to duplicate the libraries in configure.ac
+# until we unify on Cargo as our build system
+[package.metadata.system-deps]
+libarchive = "3.0"
+jsonglib = { name = "json-glib-1.0", version = "1" }
+polkitgobject = { name = "polkit-gobject-1", version = "0" }
+rpm = "4"
+librepo = "1"
+libsolv = "0.7"
 
 [dependencies]
 anyhow = "1.0.38"
@@ -43,6 +54,7 @@ os-release = "0.1.0"
 
 [build-dependencies]
 cbindgen = "0.16.0"
+system-deps = "2.0"
 anyhow = "1.0"
 
 [lib]

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -86,14 +86,15 @@ rpmostree_common_cflags = -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
 	-DLIBDIR=\"$(libdir)\" -DPKGLIBDIR=\"$(pkglibdir)\" \
 	$(PKGDEP_RPMOSTREE_CFLAGS) $(PKGDEP_RPMOSTREE_RS_CFLAGS)
 rpmostree_bin_common_cflags = $(rpmostree_common_cflags)
-rpmostree_bin_common_libs = $(PKGDEP_RPMOSTREE_LIBS) $(CAP_LIBS) libglnx.la librpmostree-1.la librpmostreecxxrs.la $(librpmostree_rust_path) $(PKGDEP_RPMOSTREE_RS_LIBS) -lstdc++ -lrt
+rpmostree_common_libs = $(PKGDEP_RPMOSTREE_LIBS) $(CAP_LIBS) libglnx.la librpmostree-1.la librpmostreecxxrs.la $(PKGDEP_RPMOSTREE_RS_LIBS) -lstdc++ -lrt
+rpmostree_bin_common_libs = librpmostreeinternals.la $(librpmostree_rust_path) $(rpmostree_common_libs)
 rpm_ostree_CFLAGS = $(AM_CFLAGS) $(rpmostree_bin_common_cflags)
 rpm_ostree_CXXFLAGS = $(AM_CXXFLAGS) $(rpmostree_bin_common_cflags)
 rpm_ostree_LDADD = librpmostreeinternals.la $(rpmostree_bin_common_libs)
 EXTRA_rpm_ostree_DEPENDENCIES = libdnf.so.2
 librpmostreeinternals_la_CFLAGS = $(AM_CFLAGS) $(rpmostree_common_cflags)
 librpmostreeinternals_la_CXXFLAGS = $(AM_CXXFLAGS) $(rpmostree_common_cflags)
-librpmostreeinternals_la_LIBADD = $(rpmostree_bin_common_libs)
+librpmostreeinternals_la_LIBADD = $(rpmostree_common_libs)
 EXTRA_librpmostreeinternals_la_DEPENDENCIES = libdnf.so.2
 
 privdatadir=$(pkglibdir)
@@ -114,7 +115,9 @@ librpmostree_rust_path = $(top_srcdir)/target/@RUST_TARGET_SUBDIR@/librpmostree_
 # we exit with a fatal error, since someone probably did `make && sudo make install`,
 # and in this case cargo will download into ~/.root which we don't want.
 LIBRPMOSTREE_RUST_SRCS = $(shell find rust/src/ -name '*.rs') Cargo.toml Cargo.lock cbindgen.toml
-$(librpmostree_rust_path): Makefile $(LIBRPMOSTREE_RUST_SRCS)
+# FIXME - build all this code in a rpmostree-sys crate, or just move all the C/C++ build
+# to Rust.  Currently this forces build system serialization
+$(librpmostree_rust_path): Makefile $(LIBRPMOSTREE_RUST_SRCS) librpmostreeinternals.la
 	$(cargo_build) $(CARGO_RELEASE_ARGS)
 EXTRA_DIST += $(LIBRPMOSTREE_RUST_SRCS)
 

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -86,7 +86,7 @@ rpmostree_common_cflags = -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
 	-DLIBDIR=\"$(libdir)\" -DPKGLIBDIR=\"$(pkglibdir)\" \
 	$(PKGDEP_RPMOSTREE_CFLAGS) $(PKGDEP_RPMOSTREE_RS_CFLAGS)
 rpmostree_bin_common_cflags = $(rpmostree_common_cflags)
-rpmostree_bin_common_libs = $(PKGDEP_RPMOSTREE_LIBS) $(CAP_LIBS) libglnx.la librpmostree-1.la $(librpmostree_rust_path) $(PKGDEP_RPMOSTREE_RS_LIBS) -lstdc++ -lrt
+rpmostree_bin_common_libs = $(PKGDEP_RPMOSTREE_LIBS) $(CAP_LIBS) libglnx.la librpmostree-1.la librpmostreecxxrs.la $(librpmostree_rust_path) $(PKGDEP_RPMOSTREE_RS_LIBS) -lstdc++ -lrt
 rpm_ostree_CFLAGS = $(AM_CFLAGS) $(rpmostree_bin_common_cflags)
 rpm_ostree_CXXFLAGS = $(AM_CXXFLAGS) $(rpmostree_bin_common_cflags)
 rpm_ostree_LDADD = librpmostreeinternals.la $(rpmostree_bin_common_libs)
@@ -131,9 +131,14 @@ rpmostree-cxxrs.cxx:
 else
 include Makefile.bindings
 endif
+
+noinst_LTLIBRARIES += librpmostreecxxrs.la
+librpmostreecxxrs_la_SOURCES = rpmostree-cxxrs.h rpmostree-cxxrs.cxx
+# Suppress missing-declarations because https://github.com/dtolnay/cxx/issues/590
+librpmostreecxxrs_la_CXXFLAGS = $(AM_CXXFLAGS) $(rpmostree_common_cflags) -Wno-missing-declarations
+librpmostreecxxrs_la_LIBADD = -lstdc++
 GITIGNOREFILES += $(binding_generated_sources)
 BUILT_SOURCES += $(binding_generated_sources)
-librpmostreepriv_sources += $(binding_generated_sources)
 
 # Wraps `cargo test`.  This is always a debug non-release build;
 # the main thing here is we still drop the `target` dir in our build

--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,15 @@ fn detect_fedora_feature() -> Result<()> {
 }
 
 fn main() -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let cwd = cwd.to_str().expect("utf8 pwd");
+    println!("cargo:rustc-link-search={}/.libs", cwd);
+    println!("cargo:rustc-link-lib=static=rpmostreeinternals");
+    println!("cargo:rustc-link-lib=cap");
+    println!("cargo:rustc-link-search={}/libdnf-build/libdnf", cwd);
+    println!("cargo:rustc-link-lib=dnf");
+    println!("cargo:rustc-link-lib=rpmostree-1");
+    system_deps::Config::new().probe()?;
     detect_fedora_feature()?;
     Ok(())
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -196,6 +196,17 @@ mod ffi {
         fn state_checksum_changed(&self, chksum: &str, output_dir: &str) -> Result<bool>;
         fn update_state_checksum(&self, chksum: &str, output_dir: &str) -> Result<()>;
     }
+
+    // rpmutils.rs
+    extern "Rust" {
+        fn cache_branch_to_nevra(nevra: &str) -> String;
+    }
+
+    // rpmostree-rpm-util.h
+    unsafe extern "C++" {
+        include!("rpmostree-rpm-util.h");
+        fn nevra_to_cache_branch(nevra: &CxxString) -> Result<UniquePtr<CxxString>>;
+    }
 }
 
 mod client;
@@ -236,6 +247,8 @@ mod progress;
 pub(crate) use self::progress::*;
 mod scripts;
 pub(crate) use self::scripts::*;
+mod rpmutils;
+pub(crate) use self::rpmutils::*;
 mod testutils;
 pub(crate) use self::testutils::*;
 mod treefile;

--- a/rust/src/rpmutils.rs
+++ b/rust/src/rpmutils.rs
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+fn hexval(c: char) -> Option<u8> {
+    match c {
+        '0'..='9' => Some(c as u8 - ('0' as u8)),
+        'A'..='F' => Some(c as u8 - ('A' as u8) + 10),
+        _ => None,
+    }
+}
+
+pub(crate) fn cache_branch_to_nevra(nevra: &str) -> String {
+    let prefix = "rpmostree/pkg/";
+    let cachebranch = nevra
+        .strip_prefix(prefix)
+        .expect(&format!("{} prefix", prefix));
+    let mut r = String::new();
+    let mut p = cachebranch.chars();
+    loop {
+        let c = match p.next() {
+            Some(c) => c,
+            None => return r,
+        };
+        if c != '_' {
+            match c {
+                '/' => r.push('-'),
+                c => r.push(c),
+            }
+            continue;
+        }
+
+        let c = match p.next() {
+            Some('_') => {
+                r.push('_');
+                continue;
+            }
+            Some(c) => c,
+            None => return r,
+        };
+        let b = if let Some(c) = hexval(c) {
+            c
+        } else {
+            return r;
+        };
+        let l = if let Some(l) = p.next().map(hexval).flatten() {
+            l
+        } else {
+            return r;
+        };
+        let unquoted = (b << 4) + l;
+        r.push(unquoted as char);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn test_one_cache_branch_to_nevra(b: &str, exp_nevra: &str) {
+        let nevra = cache_branch_to_nevra(b);
+        assert_eq!(nevra, exp_nevra);
+        cxx::let_cxx_string!(cxx_exp_nevra = exp_nevra);
+        let actual_branch = crate::ffi::nevra_to_cache_branch(&cxx_exp_nevra).expect("nevra");
+        assert_eq!(b, actual_branch.to_string_lossy());
+    }
+
+    #[test]
+    fn test_cache_branch_to_nevra() {
+        /* pkgs imported from doing install foo git vim-enhanced and outputs of
+         * install and ostree refs massaged with sort and paste and column --table */
+        test_one_cache_branch_to_nevra("rpmostree/pkg/foo/1.0-1.x86__64", "foo-1.0-1.x86_64");
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/git/1.8.3.1-6.el7__2.1.x86__64",
+            "git-1.8.3.1-6.el7_2.1.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/gpm-libs/1.20.7-5.el7.x86__64",
+            "gpm-libs-1.20.7-5.el7.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/libgnome-keyring/3.8.0-3.el7.x86__64",
+            "libgnome-keyring-3.8.0-3.el7.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl/4_3A5.16.3-291.el7.x86__64",
+            "perl-4:5.16.3-291.el7.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Carp/1.26-244.el7.noarch",
+            "perl-Carp-1.26-244.el7.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-constant/1.27-2.el7.noarch",
+            "perl-constant-1.27-2.el7.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Encode/2.51-7.el7.x86__64",
+            "perl-Encode-2.51-7.el7.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Error/1_3A0.17020-2.el7.noarch",
+            "perl-Error-1:0.17020-2.el7.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Exporter/5.68-3.el7.noarch",
+            "perl-Exporter-5.68-3.el7.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-File-Path/2.09-2.el7.noarch",
+            "perl-File-Path-2.09-2.el7.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-File-Temp/0.23.01-3.el7.noarch",
+            "perl-File-Temp-0.23.01-3.el7.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Filter/1.49-3.el7.x86__64",
+            "perl-Filter-1.49-3.el7.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Getopt-Long/2.40-2.el7.noarch",
+            "perl-Getopt-Long-2.40-2.el7.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Git/1.8.3.1-6.el7__2.1.noarch",
+            "perl-Git-1.8.3.1-6.el7_2.1.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-HTTP-Tiny/0.033-3.el7.noarch",
+            "perl-HTTP-Tiny-0.033-3.el7.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-libs/4_3A5.16.3-291.el7.x86__64",
+            "perl-libs-4:5.16.3-291.el7.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-macros/4_3A5.16.3-291.el7.x86__64",
+            "perl-macros-4:5.16.3-291.el7.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-parent/1_3A0.225-244.el7.noarch",
+            "perl-parent-1:0.225-244.el7.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-PathTools/3.40-5.el7.x86__64",
+            "perl-PathTools-3.40-5.el7.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Pod-Escapes/1_3A1.04-291.el7.noarch",
+            "perl-Pod-Escapes-1:1.04-291.el7.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-podlators/2.5.1-3.el7.noarch",
+            "perl-podlators-2.5.1-3.el7.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Pod-Perldoc/3.20-4.el7.noarch",
+            "perl-Pod-Perldoc-3.20-4.el7.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Pod-Simple/1_3A3.28-4.el7.noarch",
+            "perl-Pod-Simple-1:3.28-4.el7.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Pod-Usage/1.63-3.el7.noarch",
+            "perl-Pod-Usage-1.63-3.el7.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Scalar-List-Utils/1.27-248.el7.x86__64",
+            "perl-Scalar-List-Utils-1.27-248.el7.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Socket/2.010-4.el7.x86__64",
+            "perl-Socket-2.010-4.el7.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Storable/2.45-3.el7.x86__64",
+            "perl-Storable-2.45-3.el7.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-TermReadKey/2.30-20.el7.x86__64",
+            "perl-TermReadKey-2.30-20.el7.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Text-ParseWords/3.29-4.el7.noarch",
+            "perl-Text-ParseWords-3.29-4.el7.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-threads/1.87-4.el7.x86__64",
+            "perl-threads-1.87-4.el7.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-threads-shared/1.43-6.el7.x86__64",
+            "perl-threads-shared-1.43-6.el7.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Time-HiRes/4_3A1.9725-3.el7.x86__64",
+            "perl-Time-HiRes-4:1.9725-3.el7.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/perl-Time-Local/1.2300-2.el7.noarch",
+            "perl-Time-Local-1.2300-2.el7.noarch",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/vim-common/2_3A7.4.160-1.el7__3.1.x86__64",
+            "vim-common-2:7.4.160-1.el7_3.1.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/vim-enhanced/2_3A7.4.160-1.el7__3.1.x86__64",
+            "vim-enhanced-2:7.4.160-1.el7_3.1.x86_64",
+        );
+        test_one_cache_branch_to_nevra(
+            "rpmostree/pkg/vim-filesystem/2_3A7.4.160-1.el7__3.1.x86__64",
+            "vim-filesystem-2:7.4.160-1.el7_3.1.x86_64",
+        );
+    }
+}

--- a/src/daemon/rpmostree-sysroot-core.cxx
+++ b/src/daemon/rpmostree-sysroot-core.cxx
@@ -25,6 +25,7 @@
 #include <systemd/sd-journal.h>
 #include "rpmostreed-utils.h"
 #include "rpmostree-util.h"
+#include <string>
 
 #include "rpmostree-sysroot-upgrader.h"
 #include "rpmostree-sysroot-core.h"
@@ -207,11 +208,8 @@ generate_pkgcache_refs (OstreeSysroot            *sysroot,
       GHashTable *local_replace = rpmostree_origin_get_overrides_local_replace (origin);
       GLNX_HASH_TABLE_FOREACH (local_replace, const char*, nevra)
         {
-          g_autofree char *cachebranch = NULL;
-          if (!rpmostree_nevra_to_cache_branch (nevra, &cachebranch, error))
-            return FALSE;
-
-          g_hash_table_add (referenced_pkgs, util::move_nullify (cachebranch));
+          auto cachebranch = rpmostreecxx::nevra_to_cache_branch (std::string(nevra));
+          g_hash_table_add (referenced_pkgs, g_strdup (cachebranch->c_str()));
         }
     }
 

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <memory>
 #include <ostree.h>
 
 #include <rpm/rpmlib.h>
@@ -32,6 +33,12 @@
 
 #include "libglnx.h"
 
+// C++ code
+namespace rpmostreecxx {
+  std::unique_ptr<std::string> nevra_to_cache_branch(const std::string &nevra);
+}
+
+// C code follows
 G_BEGIN_DECLS
 
 struct RpmHeaders
@@ -235,8 +242,6 @@ gboolean
 rpmostree_nevra_to_cache_branch (const char *nevra,
                                  char      **cache_branch,
                                  GError    **error);
-char *
-rpmostree_cache_branch_to_nevra (const char *cachebranch);
 
 GPtrArray *
 rpmostree_get_enabled_rpmmd_repos (DnfContext *dnfctx, DnfRepoEnabled enablement);

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -60,6 +60,15 @@ template<typename T>
     throw std::runtime_error(msg.str());
   }
 
+// Convert a GError into a C++ exception.  Takes ownership of the error.
+static inline void 
+throw_gerror (GError *&error)
+{
+  auto s = std::string (error->message);
+  g_error_free (error);
+  error = NULL;
+  throw std::runtime_error (s);
+}
 }
 
 // Below here is C code

--- a/tests/check/test-utils.cxx
+++ b/tests/check/test-utils.cxx
@@ -12,64 +12,6 @@
 #include "libtest.h"
 
 static void
-test_one_cache_branch_to_nevra (const char *cache_branch,
-                                const char *expected_nevra)
-{
-  g_autofree char *actual_nevra =
-    rpmostree_cache_branch_to_nevra (cache_branch);
-  g_print ("comparing %s to %s\n", expected_nevra, actual_nevra);
-  g_assert (g_str_equal (expected_nevra, actual_nevra));
-
-  g_autofree char *actual_branch = NULL;
-  g_assert (rpmostree_nevra_to_cache_branch (expected_nevra, &actual_branch, NULL));
-  g_assert (g_str_equal (cache_branch, actual_branch));
-}
-
-static void
-test_cache_branch_to_nevra (void)
-{
-  /* pkgs imported from doing install foo git vim-enhanced and outputs of
-   * install and ostree refs massaged with sort and paste and column --table */
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/foo/1.0-1.x86__64",                             "foo-1.0-1.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/git/1.8.3.1-6.el7__2.1.x86__64",                "git-1.8.3.1-6.el7_2.1.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/gpm-libs/1.20.7-5.el7.x86__64",                 "gpm-libs-1.20.7-5.el7.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/libgnome-keyring/3.8.0-3.el7.x86__64",          "libgnome-keyring-3.8.0-3.el7.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl/4_3A5.16.3-291.el7.x86__64",               "perl-4:5.16.3-291.el7.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Carp/1.26-244.el7.noarch",                 "perl-Carp-1.26-244.el7.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-constant/1.27-2.el7.noarch",               "perl-constant-1.27-2.el7.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Encode/2.51-7.el7.x86__64",                "perl-Encode-2.51-7.el7.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Error/1_3A0.17020-2.el7.noarch",           "perl-Error-1:0.17020-2.el7.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Exporter/5.68-3.el7.noarch",               "perl-Exporter-5.68-3.el7.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-File-Path/2.09-2.el7.noarch",              "perl-File-Path-2.09-2.el7.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-File-Temp/0.23.01-3.el7.noarch",           "perl-File-Temp-0.23.01-3.el7.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Filter/1.49-3.el7.x86__64",                "perl-Filter-1.49-3.el7.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Getopt-Long/2.40-2.el7.noarch",            "perl-Getopt-Long-2.40-2.el7.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Git/1.8.3.1-6.el7__2.1.noarch",            "perl-Git-1.8.3.1-6.el7_2.1.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-HTTP-Tiny/0.033-3.el7.noarch",             "perl-HTTP-Tiny-0.033-3.el7.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-libs/4_3A5.16.3-291.el7.x86__64",          "perl-libs-4:5.16.3-291.el7.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-macros/4_3A5.16.3-291.el7.x86__64",        "perl-macros-4:5.16.3-291.el7.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-parent/1_3A0.225-244.el7.noarch",          "perl-parent-1:0.225-244.el7.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-PathTools/3.40-5.el7.x86__64",             "perl-PathTools-3.40-5.el7.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Pod-Escapes/1_3A1.04-291.el7.noarch",      "perl-Pod-Escapes-1:1.04-291.el7.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-podlators/2.5.1-3.el7.noarch",             "perl-podlators-2.5.1-3.el7.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Pod-Perldoc/3.20-4.el7.noarch",            "perl-Pod-Perldoc-3.20-4.el7.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Pod-Simple/1_3A3.28-4.el7.noarch",         "perl-Pod-Simple-1:3.28-4.el7.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Pod-Usage/1.63-3.el7.noarch",              "perl-Pod-Usage-1.63-3.el7.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Scalar-List-Utils/1.27-248.el7.x86__64",   "perl-Scalar-List-Utils-1.27-248.el7.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Socket/2.010-4.el7.x86__64",               "perl-Socket-2.010-4.el7.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Storable/2.45-3.el7.x86__64",              "perl-Storable-2.45-3.el7.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-TermReadKey/2.30-20.el7.x86__64",          "perl-TermReadKey-2.30-20.el7.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Text-ParseWords/3.29-4.el7.noarch",        "perl-Text-ParseWords-3.29-4.el7.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-threads/1.87-4.el7.x86__64",               "perl-threads-1.87-4.el7.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-threads-shared/1.43-6.el7.x86__64",        "perl-threads-shared-1.43-6.el7.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Time-HiRes/4_3A1.9725-3.el7.x86__64",      "perl-Time-HiRes-4:1.9725-3.el7.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/perl-Time-Local/1.2300-2.el7.noarch",           "perl-Time-Local-1.2300-2.el7.noarch");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/vim-common/2_3A7.4.160-1.el7__3.1.x86__64",     "vim-common-2:7.4.160-1.el7_3.1.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/vim-enhanced/2_3A7.4.160-1.el7__3.1.x86__64",   "vim-enhanced-2:7.4.160-1.el7_3.1.x86_64");
-  test_one_cache_branch_to_nevra ("rpmostree/pkg/vim-filesystem/2_3A7.4.160-1.el7__3.1.x86__64", "vim-filesystem-2:7.4.160-1.el7_3.1.x86_64");
-}
-
-static void
 test_bsearch_str(void)
 {
   g_auto(GVariantBuilder) builder;
@@ -179,7 +121,6 @@ main (int   argc,
 {
   g_test_init (&argc, &argv, NULL);
 
-  g_test_add_func ("/utils/cachebranch_to_nevra", test_cache_branch_to_nevra);
   g_test_add_func ("/utils/bsearch_str", test_bsearch_str);
   g_test_add_func ("/importer/variant_to_nevra", test_variant_to_nevra);
 


### PR DESCRIPTION
 rust: Link to our C/C++ dependencies and internal library

This allows us to fully use cxx-rs with `extern "C++"`.  Now
we do call back into the C/C++ today, but it only works outside
of cargo/Rust's knowledge.  Most notably, it means we can't
use our C code in `cargo test`.  And that's a problem
for moving some C/C++ code to Rust, because we want to port
the unit tests too.

For now, re-declare our dependencies and part of the build
system inside the Cargo build.  However, this is also
an important step towards using Cargo as our *sole* build
system.

We don't add build dependencies too often, so the short
term duplication should be OK.

However, a major unfortunate side effect of this is that
we now need to serialize the build process; almost all the
C/C++ comes first (`librpmostreeinternals.la`) and then
the Rust build, then we finally generate the executable
with both.

The only way out of this really is to move more of the
C/C++ build into Cargo, and we probably want to refactor
into internal crates.

---

Demo of first use of `extern "C++"

Until now with cxx-rs we'd been using it effectively as a better
cbindgen - we're exposing Rust code to C++ safely.  This is
the first case of having Rust calling back into C++.

There's an in-retrospect obvious problem; until now, the Rust
code has been independent of our C/C++ code.  For example,
`cargo build` and in particular `cargo test` Just Work.

To actually make use of this we probably need to at least
do some hack like add a `build.rs` script that invokes
`make librpmostreeinternals.la` or so.

Or of course, convert the C/C++ build to `build.rs`.  I don't
yet have an idea of how hard that'd be.
