### PR TITLE
 Use cxx-rs for live-apply

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c76e80fb6d39f044d141223d7b56c468beaab53e7698a45cc535b780c2382b3c"
+checksum = "a9615c89d0b2177de13e42c16baf3e5a5f6614af361ee7cd001e03b0abc2d9ca"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -248,15 +248,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f3bfe71a2767344b8ca945162df2445ed5a0a8244992723b9c68dd98a98ab32"
+checksum = "6b8c8eb327a5cd189223cfdd5fc6ee8a2270097fcdaf8ea813c22f4c3542ade0"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a66e61d3db394b82ffa7e7849732d57e38e1bc25509527a5d30bfc2c39b5e6"
+checksum = "35002f70d61f451bbd172868be7016074e971b542ad79e5b189c7a1a4c12e02e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d65c4d95931acda4498f675e332fcbdc9a06705cd07086c510e9b6009cd1c1"
+
+[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1098,7 @@ dependencies = [
  "openat-ext",
  "ostree",
  "ostree-sys",
+ "paste",
  "phf",
  "rand",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.35"
+paste = "1.0"
 serde = "1.0.118"
 serde_derive = "1.0.118"
 serde_json = "1.0.60"

--- a/rust/src/cxx_bridge_gobject.rs
+++ b/rust/src/cxx_bridge_gobject.rs
@@ -1,0 +1,53 @@
+//! Wrappers that bridge the world of cxx.rs and GObject-introspect based crate bindings.
+//! See https://github.com/dtolnay/cxx/issues/544
+//! While cxx.rs supports including externally-bound types (like ostree::Repo),
+//! two things make this more complicated.  First, cxx.rs requires implementing
+//! a trait, and due to the orphan rule we can't implement foreign traits on
+//! foreign types.  Second, what we *actually* want on the Rust side isn't
+//! the *_sys type (e.g. ostree_sys::OstreeRepo) but the `ostree::Repo` type.
+//! So for now, we define a `FFIGObjectWrapper` trait that helps with this.
+//! In the future though hopefully cxx.rs improves this situation.
+
+use cxx::{type_id, ExternType};
+use paste::paste;
+
+/// A custom trait used to translate a *_sys C type wrapper
+/// to its GObject version.
+pub trait FFIGObjectWrapper {
+    type Wrapper;
+
+    fn gobj_wrap(&mut self) -> Self::Wrapper;
+}
+
+/// Implement FFIGObjectWrapper given a pair of wrapper type
+/// and sys type.
+macro_rules! impl_wrap {
+    ($w:ident, $bound:path) => {
+        impl FFIGObjectWrapper for $w {
+            type Wrapper = $bound;
+            fn gobj_wrap(&mut self) -> Self::Wrapper {
+                unsafe { glib::translate::from_glib_none(&mut self.0 as *mut _) }
+            }
+        }
+    };
+}
+
+/// Custom macro to bind an OSTree GObject type.
+macro_rules! bind_ostree_obj {
+    ($w:ident) => {
+        paste! {
+            #[repr(transparent)]
+            pub struct [<FFIOstree $w>](ostree_sys::[<Ostree $w>]);
+
+            unsafe impl ExternType for [<FFIOstree $w>] {
+                type Id = type_id!(rpmostreecxx::[<Ostree $w>]);
+                type Kind = cxx::kind::Trivial;
+            }
+            impl_wrap!([<FFIOstree $w>], ostree::$w);
+        }
+    };
+}
+
+bind_ostree_obj!(Sysroot);
+bind_ostree_obj!(Repo);
+bind_ostree_obj!(Deployment);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,7 +7,9 @@
 #![deny(unused_must_use)]
 
 // pub(crate) utilities
+mod cxx_bridge_gobject;
 mod ffiutil;
+pub use cxx_bridge_gobject::*;
 mod includes;
 
 #[cxx::bridge(namespace = "rpmostreecxx")]
@@ -35,6 +37,14 @@ mod ffi {
     // utils.rs
     extern "Rust" {
         fn download_to_fd(url: &str) -> Result<i32>;
+    }
+
+    extern "C++" {
+        include!("src/libpriv/rpmostree-cxxrs-prelude.h");
+
+        type OstreeSysroot = crate::FFIOstreeSysroot;
+        type OstreeRepo = crate::FFIOstreeRepo;
+        type OstreeDeployment = crate::FFIOstreeDeployment;
     }
 }
 

--- a/src/daemon/rpmostree-sysroot-core.h
+++ b/src/daemon/rpmostree-sysroot-core.h
@@ -47,8 +47,6 @@ OstreeDeployment *rpmostree_syscore_get_origin_merge_deployment (OstreeSysroot *
 
 gboolean rpmostree_syscore_bump_mtime (OstreeSysroot *self, GError **error);
 
-gboolean rpmostree_syscore_livefs_query (OstreeSysroot *self, OstreeDeployment *deployment, gboolean *out_is_live, GError **error);
-
 GPtrArray *rpmostree_syscore_filter_deployments (OstreeSysroot      *sysroot,
                                                  const char         *osname,
                                                  gboolean            remove_pending,

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -38,6 +38,7 @@
 #include "rpmostree-output.h"
 #include "rpmostree-scripts.h"
 #include "rpmostree-rust.h"
+#include "rpmostree-cxxrs.h"
 
 #include "ostree-repo.h"
 
@@ -603,10 +604,7 @@ try_load_base_rsack_from_pending (RpmOstreeSysrootUpgrader *self,
                                   GCancellable             *cancellable,
                                   GError                  **error)
 {
-  gboolean is_live;
-  if (!rpmostree_syscore_livefs_query (self->sysroot, self->origin_merge_deployment, &is_live, error))
-    return FALSE;
-
+  auto is_live = rpmostreecxx::has_live_apply_state(*self->sysroot, *self->origin_merge_deployment);
   /* livefs invalidates the deployment */
   if (is_live)
     return TRUE;

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -31,6 +31,7 @@
 #include "rpmostree-core.h"
 #include "rpmostree-package-variants.h"
 #include "rpmostreed-utils.h"
+#include "rpmostree-cxxrs.h"
 #include "rpmostreed-errors.h"
 
 /* Get a currently unique (for this host) identifier for the
@@ -369,15 +370,12 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
 
   if (is_booted)
     {
-      g_autofree char *live_inprogress = NULL;
-      g_autofree char *live_replaced = NULL;
-      if (!ror_livefs_get_state (sysroot, deployment, &live_inprogress, &live_replaced, error))
-        return FALSE;
+      auto live_state = rpmostreecxx::get_live_apply_state(*sysroot, *deployment);
 
-      if (live_inprogress)
-        g_variant_dict_insert (&dict, "live-inprogress", "s", live_inprogress);
-      if (live_replaced)
-        g_variant_dict_insert (&dict, "live-replaced", "s", live_replaced);
+      if (live_state.inprogress.length() > 0)
+        g_variant_dict_insert (&dict, "live-inprogress", "s", live_state.inprogress.c_str());
+      if (live_state.commit.length() > 0)
+        g_variant_dict_insert (&dict, "live-replaced", "s", live_state.commit.c_str());
     }
 
   if (ostree_deployment_is_staged (deployment))

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -34,6 +34,7 @@
 #include "rpmostree-core.h"
 #include "rpmostree-importer.h"
 #include "rpmostreed-utils.h"
+#include "rpmostree-cxxrs.h"
 
 static gboolean
 vardict_lookup_bool (GVariantDict *dict,
@@ -1231,10 +1232,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
           OstreeDeployment *deployment =
             rpmostree_sysroot_upgrader_get_merge_deployment (upgrader);
 
-          gboolean is_live;
-          if (!rpmostree_syscore_livefs_query (sysroot, deployment, &is_live, error))
-            return FALSE;
-
+          auto is_live = rpmostreecxx::has_live_apply_state(*sysroot, *deployment);
           if (is_live)
             changed = TRUE;
         }

--- a/src/libpriv/rpmostree-cxxrs-prelude.h
+++ b/src/libpriv/rpmostree-cxxrs-prelude.h
@@ -1,0 +1,29 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <ostree.h>
+
+namespace rpmostreecxx {
+    typedef ::OstreeSysroot OstreeSysroot;
+    typedef ::OstreeRepo OstreeRepo;
+    typedef ::OstreeDeployment OstreeDeployment;
+}


### PR DESCRIPTION
(I'm going to start calling it `live-apply` instead of "livefs")

On one hand, this drops the unsafe bindgen glue.  On the other
hand it demonstrates a notable current ergonomic shortfall of
cxx-rs in that it doesn't support `Option<T>`, so we represent
optional strings by converting them to empty strings.

(Relatedly I discovered in C++ there is `std::optional<>` but it's in C++17.
 I assume we can depend on that but let's for now match libdnf's
 usage of `-std=c++14` because we know that works everywhere)
