### PR TITLE
ci/install-extra-builddeps: drop --root=/usr arg

### DIFF
--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/bash
 # Install build dependencies, run unit tests and installed tests.
 
+# This script is what Prow runs.
+
 set -xeuo pipefail
 
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
+
+# add cargo's directory to the PATH like we do in CoreOS CI
+export PATH="$HOME/.cargo/bin:$PATH"
 
 ${dn}/build.sh
 # NB: avoid make function because our RPM building doesn't

--- a/ci/install-extra-builddeps.sh
+++ b/ci/install-extra-builddeps.sh
@@ -3,5 +3,5 @@
 set -xeuo pipefail
 if ! command -v cxxbridge; then
     ver=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name == "cxx").version')
-    cargo install --root=/usr cxxbridge-cmd --version "${ver}"
+    cargo install cxxbridge-cmd --version "${ver}"
 fi


### PR DESCRIPTION
AFAICT, we just need `cxxbridge` to be in the `PATH` of the building
user. Let's avoid targeting privileged paths so devs can just run this
script directly without `sudo`.