### PR TITLE
lib: Cleanup `#include <>`s

### DIFF
--- a/src/lib/rpmostree-db.c
+++ b/src/lib/rpmostree-db.c
@@ -19,13 +19,9 @@
  */
 
 #include "config.h"
-
 #include "string.h"
-
 #include "rpmostree-db.h"
-#include "rpmostree-rpm-util.h"
 #include "rpmostree-package-priv.h"
-#include "rpmostree-refsack.h"
 
 /**
  * SECTION:librpmostree-dbquery

--- a/src/lib/rpmostree-package-priv.h
+++ b/src/lib/rpmostree-package-priv.h
@@ -23,11 +23,8 @@
 
 #include <ostree.h>
 #include "rpmostree-package.h"
-#include "rpmostree-refsack.h"
 
 G_BEGIN_DECLS
-
-RpmOstreePackage * _rpm_ostree_package_new (RpmOstreeRefSack *rsack, DnfPackage *hypkg);
 
 RpmOstreePackage * _rpm_ostree_package_new_from_variant (GVariant *gv_nevra);
 

--- a/src/lib/rpmostree-package.c
+++ b/src/lib/rpmostree-package.c
@@ -30,11 +30,13 @@
 
 #include "config.h"
 
-#include "rpmostree-shlib-ipc-private.h"
-#include "rpmostree-package-priv.h"
-
 #include <string.h>
 #include <stdlib.h>
+#include <libdnf/libdnf.h>
+#include "libglnx.h"
+
+#include "rpmostree-shlib-ipc-private.h"
+#include "rpmostree-package-priv.h"
 
 typedef GObjectClass RpmOstreePackageClass;
 


### PR DESCRIPTION
We previously severed the dependency between the shared library
and our internal code, but the library still included internal
headers even though they weren't used.

This broke my attempt to natively use C++ in some headers.

Drop the unused headers and clean up the `#include`s.
