### PR TITLE
Move some client argument handling to Rust

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,0 +1,21 @@
+use crate::utils;
+use anyhow::Result;
+use std::os::unix::io::IntoRawFd;
+
+fn is_http(arg: &str) -> bool {
+    arg.starts_with("https://") || arg.starts_with("http://")
+}
+
+/// Given a string from the command line, determine if it represents one or more
+/// RPM URLs we need to fetch, and if so download those URLs and return file
+/// descriptors for the content.
+/// TODO(cxx-rs): This would be slightly more elegant as Result<Option<Vec<i32>>>
+pub(crate) fn client_handle_fd_argument(arg: &str, _arch: &str) -> Result<Vec<i32>> {
+    if is_http(arg) {
+        utils::download_url_to_tmpfile(arg, true).map(|f| vec![f.into_raw_fd()])
+    } else if arg.ends_with(".rpm") {
+        Ok(vec![std::fs::File::open(arg)?.into_raw_fd()])
+    } else {
+        Ok(Vec::new())
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -26,6 +26,11 @@ mod ffi {
         type GCancellable = crate::FFIGCancellable;
     }
 
+    // client.rs
+    extern "Rust" {
+        fn client_handle_fd_argument(arg: &str, arch: &str) -> Result<Vec<i32>>;
+    }
+
     // core.rs
     extern "Rust" {
         type TempEtcGuard;
@@ -48,11 +53,6 @@ mod ffi {
     // scripts.rs
     extern "Rust" {
         fn script_is_ignored(pkg: &str, script: &str) -> bool;
-    }
-
-    // utils.rs
-    extern "Rust" {
-        fn download_to_fd(url: &str) -> Result<i32>;
     }
 
     #[derive(Default)]
@@ -79,6 +79,8 @@ mod ffi {
     }
 }
 
+mod client;
+pub(crate) use client::*;
 mod cliwrap;
 pub use cliwrap::*;
 mod composepost;

--- a/src/app/rpmostree-dbus-helpers.cxx
+++ b/src/app/rpmostree-dbus-helpers.cxx
@@ -1055,44 +1055,27 @@ rpmostree_sort_pkgs_strv (const char *const* pkgs,
 {
   g_autoptr(GPtrArray) repo_pkgs = g_ptr_array_new_with_free_func (g_free);
   g_auto(GVariantBuilder) builder;
+  // TODO: better API/cache for this
+  g_autoptr(DnfContext) ctx = dnf_context_new ();
+  auto basearch = dnf_context_get_base_arch (ctx);
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("ah"));
   for (const char *const* pkgiter = pkgs; pkgiter && *pkgiter; pkgiter++)
     {
       auto pkg = *pkgiter;
-      if (g_str_has_prefix (pkg, "http://") ||
-          g_str_has_prefix (pkg, "https://"))
+      auto fds = rpmostreecxx::client_handle_fd_argument(pkg, basearch);
+      if (fds.size() > 0)
         {
-          g_print ("Downloading '%s'... ", pkg);
-          glnx_autofd int fd = -1;
-          try {
-            fd = rpmostreecxx::download_to_fd (pkg);
-          } catch (std::exception& e) {
-            g_print ("failed!\n");
-            throw;
-          }
-          g_print ("done!\n");
-
-          int idx = g_unix_fd_list_append (fd_list, fd, error);
-          if (idx < 0)
-            return FALSE;
-
-          g_variant_builder_add (&builder, "h", idx);
+          for (auto fd: fds)
+            {
+              auto idx = g_unix_fd_list_append (fd_list, fd, error);
+              if (idx < 0)
+                return FALSE;
+              g_variant_builder_add (&builder, "h", idx);
+            }
         }
-      else if (!g_str_has_suffix (pkg, ".rpm"))
-        g_ptr_array_add (repo_pkgs, g_strdup (pkg));
       else
-        {
-          glnx_autofd int fd = -1;
-          if (!glnx_openat_rdonly (AT_FDCWD, pkg, TRUE, &fd, error))
-            return FALSE;
-
-          int idx = g_unix_fd_list_append (fd_list, fd, error);
-          if (idx < 0)
-            return FALSE;
-
-          g_variant_builder_add (&builder, "h", idx);
-        }
+        g_ptr_array_add (repo_pkgs, g_strdup (pkg));
     }
 
   *out_fd_idxs = g_variant_ref_sink (g_variant_new ("ah", &builder));


### PR DESCRIPTION
Prep for the [fedora-integration PR](https://github.com/coreos/rpm-ostree/pull/2420).

This also generalizes the "fetch URL to tempfile" code into
supporting multiple at once - it's much more efficient to do
it that way because we can reuse a TCP connection to servers,
parsed certificates etc.
