### PR TITLE
Complete move to cxx-rs for utils

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -55,6 +55,20 @@ mod ffi {
         fn script_is_ignored(pkg: &str, script: &str) -> bool;
     }
 
+    /// Currently cxx-rs doesn't support mappings; like probably most projects,
+    /// by far our most common case is a mapping from string -> string and since
+    /// our data sizes aren't large, we serialize this as a vector of strings pairs.
+    #[derive(Clone, Debug)]
+    struct StringMapping {
+        k: String,
+        v: String,
+    }
+
+    // utils.rs
+    extern "Rust" {
+        fn varsubstitute(s: &str, vars: &Vec<StringMapping>) -> Result<String>;
+    }
+
     #[derive(Default)]
     /// A copy of LiveFsState that is bridged to C++; the main
     /// change here is we can't use Option<> yet, so empty values

--- a/src/app/rpmostree-builtin-shlib-backend.cxx
+++ b/src/app/rpmostree-builtin-shlib-backend.cxx
@@ -106,11 +106,9 @@ rpmostree_builtin_shlib_backend (int             argc,
     {
       const char *src = argv[2];
       g_autoptr(DnfContext) ctx = dnf_context_new ();
-      g_autoptr(GHashTable) varsubsts = rpmostree_dnfcontext_get_varsubsts (ctx);
-      g_autofree char *rets = _rpmostree_varsubst_string (src, varsubsts, error);
-      if (rets == NULL)
-        return FALSE;
-      ret = g_variant_new_string (rets);
+      auto varsubsts = rpmostree_dnfcontext_get_varsubsts (ctx);
+      auto rets = rpmostreecxx::varsubstitute (src, *varsubsts);
+      ret = g_variant_new_string (rets.c_str());
     }
    else if (g_str_equal (arg, "packagelist-from-commit"))
     {

--- a/src/app/rpmostree-composeutil.cxx
+++ b/src/app/rpmostree-composeutil.cxx
@@ -225,7 +225,7 @@ rpmostree_composeutil_get_treespec (RpmOstreeContext  *ctx,
                                     GError     **error)
 {
   GLNX_AUTO_PREFIX_ERROR ("Parsing treefile", error);
-  g_autoptr(GHashTable) varsubsts = rpmostree_dnfcontext_get_varsubsts (rpmostree_context_get_dnf (ctx));
+  auto varsubsts = rpmostree_dnfcontext_get_varsubsts (rpmostree_context_get_dnf (ctx));
   g_autoptr(GKeyFile) treespec = g_key_file_new ();
 
   // TODO: Rework things so we always use this data going forward
@@ -277,10 +277,8 @@ rpmostree_composeutil_get_treespec (RpmOstreeContext  *ctx,
     return NULL;
   if (input_ref)
     {
-      g_autofree char *ref = _rpmostree_varsubst_string (input_ref, varsubsts, error);
-      if (!ref)
-        return NULL;
-      g_key_file_set_string (treespec, "tree", "ref", ref);
+      auto ref = rpmostreecxx::varsubstitute (input_ref, *varsubsts);
+      g_key_file_set_string (treespec, "tree", "ref", ref.c_str());
     }
 
   return rpmostree_treespec_new_from_keyfile (treespec, error);

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -623,13 +623,11 @@ rpmostree_context_get_rpmmd_repo_commit_metadata (RpmOstreeContext  *self)
   return g_variant_ref_sink (g_variant_builder_end (&repo_list_builder));
 }
 
-GHashTable *
+std::unique_ptr<rust::Vec<rpmostreecxx::StringMapping>> 
 rpmostree_dnfcontext_get_varsubsts (DnfContext *context)
 {
-  GHashTable *r = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
-
-  g_hash_table_insert (r, g_strdup ("basearch"), g_strdup (dnf_context_get_base_arch (context)));
-
+  auto r = std::make_unique<rust::Vec<rpmostreecxx::StringMapping>>();
+  r->push_back(rpmostreecxx::StringMapping {k: "basearch", v: dnf_context_get_base_arch (context) });
   return r;
 }
 

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -23,10 +23,17 @@
 #include <gio/gio.h>
 #include <libdnf/libdnf.h>
 #include <ostree.h>
+#include <memory>
 
 #include "rpmostree-rust.h"
+#include "rpmostree-cxxrs.h"
 #include "libglnx.h"
 
+
+// C++ APIs
+std::unique_ptr<rust::Vec<rpmostreecxx::StringMapping>> rpmostree_dnfcontext_get_varsubsts (DnfContext *context);
+
+// Begin C APIs
 G_BEGIN_DECLS
 
 #define RPMOSTREE_CORE_CACHEDIR "/var/cache/rpm-ostree/"
@@ -101,8 +108,6 @@ DnfContext * rpmostree_context_get_dnf (RpmOstreeContext *self);
 RpmOstreeTreespec *rpmostree_treespec_new_from_keyfile (GKeyFile *keyfile, GError  **error);
 RpmOstreeTreespec *rpmostree_treespec_new_from_path (const char *path, GError  **error);
 RpmOstreeTreespec *rpmostree_treespec_new (GVariant   *variant);
-
-GHashTable *rpmostree_dnfcontext_get_varsubsts (DnfContext *context);
 
 GVariant *rpmostree_context_get_rpmmd_repo_commit_metadata (RpmOstreeContext  *self);
 

--- a/src/libpriv/rpmostree-util.cxx
+++ b/src/libpriv/rpmostree-util.cxx
@@ -61,18 +61,6 @@ _rpmostree_vardict_lookup_value_required (GVariantDict *dict,
   return r;
 }
 
-/* Given a string of the form
- * "bla blah ${foo} blah ${bar}"
- * and a hash table of variables, substitute the variable values.
- */
-char *
-_rpmostree_varsubst_string (const char *instr,
-                            GHashTable *substitutions,
-                            GError **error)
-{
-  return ror_util_varsubst (instr, substitutions, error);
-}
-
 gboolean
 _rpmostree_util_update_checksum_from_file (GChecksum    *checksum,
                                            int           dfd,

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -79,11 +79,6 @@ GVariant *_rpmostree_vardict_lookup_value_required (GVariantDict *dict,
                                                     const GVariantType *fmt,
                                                     GError     **error);
 
-char *
-_rpmostree_varsubst_string (const char *instr,
-                            GHashTable *substitutions,
-                            GError **error);
-
 gboolean
 _rpmostree_util_update_checksum_from_file (GChecksum    *checksum,
                                            int           rootfs_dfd,

--- a/tests/check/test-utils.c
+++ b/tests/check/test-utils.c
@@ -12,53 +12,6 @@
 #include "libtest.h"
 
 static void
-test_substs_eq (const char *str,
-                GHashTable *substs,
-                const char *expected_str)
-{
-  g_autoptr(GError) error = NULL;
-  g_autofree char *res = _rpmostree_varsubst_string (str, substs, &error);
-  g_assert_no_error (error);
-  g_assert_cmpstr (expected_str, ==, res);
-}
-
-static void
-test_substs_err (const char *str,
-                 GHashTable *substs,
-                 const char *expected_err)
-{
-  g_autoptr(GError) error = NULL;
-  g_autofree char *res = _rpmostree_varsubst_string (str, substs, &error);
-  g_assert_null (res);
-  g_assert (error != NULL);
-  g_assert (strstr (error->message, expected_err));
-}
-
-static void
-test_varsubst_string (void)
-{
-  g_autoptr(GHashTable) substs1 = g_hash_table_new (g_str_hash, g_str_equal);
-  g_hash_table_insert (substs1, "basearch", "bacon");
-  g_hash_table_insert (substs1, "v", "42");
-
-  test_substs_eq ("${basearch}", substs1, "bacon");
-  test_substs_eq ("foo/${basearch}/bar", substs1, "foo/bacon/bar");
-  test_substs_eq ("${basearch}/bar", substs1, "bacon/bar");
-  test_substs_eq ("foo/${basearch}", substs1, "foo/bacon");
-  test_substs_eq ("foo/${basearch}/${v}/bar", substs1, "foo/bacon/42/bar");
-  test_substs_eq ("${v}", substs1, "42");
-
-  g_autoptr(GHashTable) substs_empty = g_hash_table_new (g_str_hash, g_str_equal);
-  static const char unknown_v[] = "Unknown variable reference ${v}";
-  test_substs_err ("${v}", substs_empty, unknown_v);
-  test_substs_err ("foo/${v}/bar", substs_empty, unknown_v);
-
-  static const char unclosed_err[] = "Unclosed variable";
-  test_substs_err ("${", substs_empty, unclosed_err);
-  test_substs_err ("foo/${", substs_empty, unclosed_err);
-}
-
-static void
 test_one_cache_branch_to_nevra (const char *cache_branch,
                                 const char *expected_nevra)
 {
@@ -226,7 +179,6 @@ main (int   argc,
 {
   g_test_init (&argc, &argv, NULL);
 
-  g_test_add_func ("/utils/varsubst", test_varsubst_string);
   g_test_add_func ("/utils/cachebranch_to_nevra", test_cache_branch_to_nevra);
   g_test_add_func ("/utils/bsearch_str", test_bsearch_str);
   g_test_add_func ("/importer/variant_to_nevra", test_variant_to_nevra);


### PR DESCRIPTION
This makes the C++ side a bit uglier because the "variable mapping"
is more Rust-native but we only use it Rust side anyways.
(We can't yet move the basearch bits to rust because it depends on
 libdnf, which requires buildsystem unification)

But all the unsafe FFI conversion drops out, as do the duplicated
C unit tests.
