### PR TITLE
Port cliwrap FFI to cxx-rs

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -31,6 +31,13 @@ mod ffi {
         fn client_handle_fd_argument(arg: &str, arch: &str) -> Result<Vec<i32>>;
     }
 
+    // cliwrap.rs
+    extern "Rust" {
+        fn cliwrap_write_wrappers(rootfs: i32) -> Result<()>;
+        fn cliwrap_entrypoint(argv: Vec<String>) -> Result<()>;
+        fn cliwrap_destdir() -> String;
+    }
+
     // core.rs
     extern "Rust" {
         type TempEtcGuard;

--- a/src/app/rpmostree-builtin-cliwrap.cxx
+++ b/src/app/rpmostree-builtin-cliwrap.cxx
@@ -26,7 +26,7 @@
 
 #include "rpmostree-builtins.h"
 #include "rpmostree-libbuiltin.h"
-#include "rpmostree-rust.h"
+#include "rpmostree-cxxrs.h"
 
 #include <libglnx.h>
 
@@ -40,9 +40,9 @@ rpmostree_builtin_cliwrap (int             argc,
   if (argc < 2)
     return glnx_throw (error, "cliwrap: missing required subcommand");
 
-  g_autoptr(GPtrArray) args = g_ptr_array_new ();
+  rust::Vec<rust::String> rustargv;
   for (int i = 1; i < argc; i++)
-    g_ptr_array_add (args, argv[i]);
-  g_ptr_array_add (args, NULL);
-  return ror_cliwrap_entrypoint ((char**)args->pdata, error);
+    rustargv.push_back(std::string(argv[i]));
+  rpmostreecxx::cliwrap_entrypoint (rustargv);
+  return TRUE;
 }

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -4561,10 +4561,7 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
     }
 
   if (self->treefile_rs && ror_treefile_get_cliwrap (self->treefile_rs))
-    {
-      if (!ror_cliwrap_write_wrappers (tmprootfs_dfd, error))
-        return FALSE;
-    }
+    rpmostreecxx::cliwrap_write_wrappers (tmprootfs_dfd);
 
   /* Undo the /etc move above */
   etc_guard->undo();

--- a/src/libpriv/rpmostree-kernel.cxx
+++ b/src/libpriv/rpmostree-kernel.cxx
@@ -507,6 +507,7 @@ rpmostree_run_dracut (int     rootfs_dfd,
                       GError **error)
 {
   gboolean ret = FALSE;
+  auto destdir = rpmostreecxx::cliwrap_destdir();
   /* Shell wrapper around dracut to write to the O_TMPFILE fd;
    * at some point in the future we should add --fd X instead of -f
    * to dracut.
@@ -521,7 +522,7 @@ rpmostree_run_dracut (int     rootfs_dfd,
     "extra_argv=; if (dracut --help; true) | grep -q -e --reproducible; then extra_argv=\"--reproducible --gzip\"; fi\n"
     "mkdir -p /tmp/dracut && dracut $extra_argv -v --add ostree --tmpdir=/tmp/dracut -f /tmp/initramfs.img \"$@\"\n"
     "cat /tmp/initramfs.img >/proc/self/fd/3\n",
-    ror_cliwrap_destdir ());
+    destdir.c_str());
   g_autoptr(RpmOstreeBwrap) bwrap = NULL;
   g_autoptr(GPtrArray) rebuild_argv = NULL;
   g_auto(GLnxTmpfile) tmpf = { 0, };


### PR DESCRIPTION
The example of how the `cliwrap_entrypoint()` function
can just be directly bound with this is a great
example of the cleanup.
