### PR TITLE
Port Rust journal bits to cxx-rs

### DIFF
--- a/rust/src/journal.rs
+++ b/rust/src/journal.rs
@@ -25,7 +25,7 @@ fn print_staging_failure_msg(msg: Option<&str>) -> Result<()> {
 }
 
 /// Look for a failure from ostree-finalized-stage.service in the journal of the previous boot.
-fn journal_print_staging_failure() -> Result<()> {
+fn impl_journal_print_staging_failure() -> Result<()> {
     let mut j = journal::OpenOptions::default()
         .system(true)
         .local_only(true)
@@ -138,18 +138,9 @@ fn journal_print_staging_failure() -> Result<()> {
     print_staging_failure_msg(None)
 }
 
-mod ffi {
-    use super::*;
-    use glib_sys;
-    use libc;
-
-    use crate::ffiutil::*;
-
-    #[no_mangle]
-    pub extern "C" fn ror_journal_print_staging_failure(
-        gerror: *mut *mut glib_sys::GError,
-    ) -> libc::c_int {
-        int_glib_error(journal_print_staging_failure(), gerror)
+pub(crate) fn journal_print_staging_failure() {
+    if let Err(e) = impl_journal_print_staging_failure() {
+        // Let's not make this fatal
+        eprintln!("warning: Failed to query journal: {}", e);
     }
 }
-pub use self::ffi::*;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -62,6 +62,11 @@ mod ffi {
         ) -> Result<i32>;
     }
 
+    // journal.rs
+    extern "Rust" {
+        fn journal_print_staging_failure();
+    }
+
     // scripts.rs
     extern "Rust" {
         fn script_is_ignored(pkg: &str, script: &str) -> bool;
@@ -116,7 +121,7 @@ use crate::core::*;
 mod history;
 pub use self::history::*;
 mod journal;
-pub use self::journal::*;
+pub(crate) use self::journal::*;
 mod initramfs;
 pub(crate) use self::initramfs::*;
 mod lockfile;

--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -287,13 +287,7 @@ print_daemon_state (RPMOSTreeSysroot *sysroot_proxy,
 
   g_print ("State: %s\n", txn_proxy ? "busy" : "idle");
 
-  /* this is a bit of a hack; it's just to avoid duplicating this logic Rust side */
-  g_print ("%s%s", get_red_start (), get_bold_start ());
-  g_autoptr(GError) local_error = NULL;
-  if (!ror_journal_print_staging_failure (&local_error))
-    /* let's not make it fatal if somehow this fails */
-    g_print ("Warning: failed to query journal: %s\n", local_error->message);
-  g_print ("%s%s", get_bold_end (), get_red_end ());
+  rpmostreecxx::journal_print_staging_failure ();
 
   if (g_str_equal (policy, "none"))
     {


### PR DESCRIPTION
This is cleaner if we move the "catch and print errors" into
the Rust side.  We lose the "print errors as red" part but
eh we can readd that later Rust side.
