### PR TITLE
tests: Fix rsync of base rpmdb with sqlite

### DIFF
--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -705,8 +705,7 @@ vm_ostree_repo_commit_layered_as_base() {
   vm_shell_inline_sysroot_rw <<EOF
   ostree checkout --repo=$repo -H --fsync=no $from_rev $d
   # need to update the base rpmdb
-  mkdir -p $d/usr/lib/sysimage/rpm-ostree-base-db
-  rsync -qa --delete $d/usr/share/rpm/ $d/usr/lib/sysimage/rpm-ostree-base-db
+  rsync -qIa --delete $d/usr/share/rpm/ $d/usr/lib/sysimage/rpm-ostree-base-db/
   ostree commit --repo=$repo -b $to_ref --link-checkout-speedup --fsync=no --consume $d
   # and inject pkglist metadata
   rpm-ostree testutils inject-pkglist $repo $to_ref >/dev/null


### PR DESCRIPTION
Apparently small rpmdb changes can cause the size to stay the
same due to preallocation, and rsync defaults to skipping files
based on (name, size, mtime).  It's really ostree's mtime canonicalization
that's unfortunate here.

Anyways, we obviously don't care about performance here so use
`-I` to disable that rsync check.

(Also remove the `mkdir -p` since it's not necessary since a long time)

Closes: https://github.com/coreos/rpm-ostree/issues/2435
