### PR TITLE
Extensions prep patches

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -85,7 +85,7 @@ rpmostree_common_cflags = -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
 	-DLIBDIR=\"$(libdir)\" -DPKGLIBDIR=\"$(pkglibdir)\" \
 	$(PKGDEP_RPMOSTREE_CFLAGS) $(PKGDEP_RPMOSTREE_RS_CFLAGS)
 rpmostree_bin_common_cflags = $(rpmostree_common_cflags)
-rpmostree_bin_common_libs = $(PKGDEP_RPMOSTREE_LIBS) $(CAP_LIBS) libglnx.la librpmostree-1.la $(librpmostree_rust_path) $(PKGDEP_RPMOSTREE_RS_LIBS) -lstdc++
+rpmostree_bin_common_libs = $(PKGDEP_RPMOSTREE_LIBS) $(CAP_LIBS) libglnx.la librpmostree-1.la $(librpmostree_rust_path) $(PKGDEP_RPMOSTREE_RS_LIBS) -lstdc++ -lrt
 rpm_ostree_CFLAGS = $(AM_CFLAGS) $(rpmostree_bin_common_cflags)
 rpm_ostree_CXXFLAGS = $(AM_CXXFLAGS) $(rpmostree_bin_common_cflags)
 rpm_ostree_LDADD = librpmostreeinternals.la $(rpmostree_bin_common_libs)

--- a/src/app/rpmostree-compose-builtin-rojig.cxx
+++ b/src/app/rpmostree-compose-builtin-rojig.cxx
@@ -191,7 +191,7 @@ install_packages (RpmOstreeRojigCompose  *self,
     return FALSE;
 
   /* --- Downloading packages --- */
-  if (!rpmostree_context_download (self->corectx, cancellable, error))
+  if (!rpmostree_context_download (self->corectx, NULL, cancellable, error))
     return FALSE;
   if (!rpmostree_context_import (self->corectx, cancellable, error))
     return FALSE;

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -413,7 +413,7 @@ install_packages (RpmOstreeTreeComposeContext  *self,
     return FALSE;
 
   /* --- Downloading packages --- */
-  if (!rpmostree_context_download (self->corectx, cancellable, error))
+  if (!rpmostree_context_download (self->corectx, NULL, cancellable, error))
     return FALSE;
 
   if (opt_download_only || opt_download_only_rpms)

--- a/src/app/rpmostree-compose-builtins.h
+++ b/src/app/rpmostree-compose-builtins.h
@@ -31,8 +31,6 @@ gboolean rpmostree_compose_builtin_rojig (int argc, char **argv, RpmOstreeComman
 gboolean rpmostree_compose_builtin_install (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
 gboolean rpmostree_compose_builtin_postprocess (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
 gboolean rpmostree_compose_builtin_commit (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
-gboolean rpmostree_compose_builtin_commit2rojig (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
-gboolean rpmostree_compose_builtin_rojig2commit (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
 
 G_END_DECLS
 

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -1281,7 +1281,7 @@ rpmostree_sysroot_upgrader_import_pkgs (RpmOstreeSysrootUpgrader *self,
 
   if (self->layering_type == RPMOSTREE_SYSROOT_UPGRADER_LAYERING_RPMMD_REPOS)
     {
-      if (!rpmostree_context_download (self->ctx, cancellable, error))
+      if (!rpmostree_context_download (self->ctx, NULL, cancellable, error))
         return FALSE;
       if (!rpmostree_context_import (self->ctx, cancellable, error))
         return FALSE;

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -2457,6 +2457,7 @@ gather_source_to_packages (RpmOstreeContext *self)
 
 gboolean
 rpmostree_context_download (RpmOstreeContext *self,
+                            const char       *target_dir,
                             GCancellable     *cancellable,
                             GError          **error)
 {
@@ -2476,7 +2477,9 @@ rpmostree_context_download (RpmOstreeContext *self,
     g_autoptr(GHashTable) source_to_packages = gather_source_to_packages (self);
     GLNX_HASH_TABLE_FOREACH_KV (source_to_packages, DnfRepo*, src, GPtrArray*, src_packages)
       {
-        g_autofree char *target_dir = NULL;
+        const char *final_target_dir = target_dir;
+        g_autofree char *final_target_dir_owned = NULL;
+
         glnx_unref_object DnfState *hifstate = dnf_state_new ();
 
         progress_sigid = g_signal_connect (hifstate, "percentage-changed",
@@ -2486,11 +2489,12 @@ rpmostree_context_download (RpmOstreeContext *self,
         rpmostree_output_progress_percent_begin (&progress, "Downloading from '%s'",
                                                  dnf_repo_get_id (src));
 
-        target_dir = g_build_filename (dnf_repo_get_location (src), "/packages/", NULL);
-        if (!glnx_shutil_mkdir_p_at (AT_FDCWD, target_dir, 0755, cancellable, error))
+        if (!final_target_dir)
+          final_target_dir = final_target_dir_owned = g_build_filename (dnf_repo_get_location (src), "/packages/", NULL);
+        if (!glnx_shutil_mkdir_p_at (AT_FDCWD, final_target_dir, 0755, cancellable, error))
           return FALSE;
 
-        if (!dnf_repo_download_packages (src, src_packages, target_dir,
+        if (!dnf_repo_download_packages (src, src_packages, final_target_dir,
                                          hifstate, error))
           return FALSE;
 

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -187,6 +187,7 @@ rpmostree_context_set_vlockmap (RpmOstreeContext *self,
                                 gboolean          strict);
 
 gboolean rpmostree_context_download (RpmOstreeContext *self,
+                                     const char       *target_dir,
                                      GCancellable     *cancellable,
                                      GError           **error);
 

--- a/src/libpriv/rpmostree-rojig-client.cxx
+++ b/src/libpriv/rpmostree-rojig-client.cxx
@@ -206,7 +206,7 @@ rpmostree_context_execute_rojig (RpmOstreeContext     *self,
       return FALSE;
   }
 
-  if (!rpmostree_context_download (self, cancellable, error))
+  if (!rpmostree_context_download (self, NULL, cancellable, error))
     return FALSE;
 
   glnx_fd_close int oirpm_fd = -1;
@@ -301,7 +301,7 @@ rpmostree_context_execute_rojig (RpmOstreeContext     *self,
   }
 
   /* Start the download and import, using the xattr data from the rojigRPM */
-  if (!rpmostree_context_download (self, cancellable, error))
+  if (!rpmostree_context_download (self, NULL, cancellable, error))
     return FALSE;
   g_autoptr(GVariant) xattr_table = rpmostree_rojig_assembler_get_xattr_table (rojig);
   if (!rpmostree_context_import_rojig (self, xattr_table, pkg_to_xattrs,


### PR DESCRIPTION
Split out of #2439.

```
commit a56bdf532e395059aaf264d9117c228ec5526164
Date:   Mon Jan 11 16:47:01 2021 -0500

    Makefile-rpm-ostree: Link to librt

    For some reason, when building with `-g -Og`, I get a linker error for
    a missing `lio_listio`. Adding `-lrt` fixes it. (We already link against
    this transitively, so it's not actually a net new `DT_NEEDED`.)

commit 43a14866649efed77a04b271ad9cd126a86490aa
Date:   Mon Jan 11 16:50:11 2021 -0500

    core: Allow overriding downloaded RPMs target dir

    This will be useful for a follow-up patch which adds `rpm-ostree compose
    extensions` where we'll want to download to a separate directory.

commit d5c090fa4517694251e8e477f1085bb8fc0c558f
Date:   Mon Jan 11 16:51:16 2021 -0500

    app/compose: Drop rojig-related prototypes

    Those functions don't actually exist (they're conditionally built under
    the `ex` command now).
```