### PR TITLE
rust: Add CxxResult

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,5 +1,5 @@
+use crate::cxxrsutil::*;
 use crate::utils;
-use anyhow::Result;
 use std::os::unix::io::IntoRawFd;
 
 fn is_http(arg: &str) -> bool {
@@ -10,14 +10,14 @@ fn is_http(arg: &str) -> bool {
 /// RPM URLs we need to fetch, and if so download those URLs and return file
 /// descriptors for the content.
 /// TODO(cxx-rs): This would be slightly more elegant as Result<Option<Vec<i32>>>
-pub(crate) fn client_handle_fd_argument(arg: &str, arch: &str) -> Result<Vec<i32>> {
+pub(crate) fn client_handle_fd_argument(arg: &str, arch: &str) -> CxxResult<Vec<i32>> {
     #[cfg(feature = "fedora-integration")]
     if let Some(fds) = crate::fedora_integration::handle_cli_arg(arg, arch)? {
         return Ok(fds.into_iter().map(|f| f.into_raw_fd()).collect());
     }
 
     if is_http(arg) {
-        utils::download_url_to_tmpfile(arg, true).map(|f| vec![f.into_raw_fd()])
+        Ok(utils::download_url_to_tmpfile(arg, true).map(|f| vec![f.into_raw_fd()])?)
     } else if arg.ends_with(".rpm") {
         Ok(vec![std::fs::File::open(arg)?.into_raw_fd()])
     } else {

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
+use crate::cxxrsutil::CxxResult;
 use anyhow::Result;
 use openat;
 use openat_ext::OpenatDirExt;
@@ -84,12 +85,12 @@ fn postprocess_subs_dist(rootfs_dfd: &openat::Dir) -> Result<()> {
 
 // This function is called from rpmostree_postprocess_final(); think of
 // it as the bits of that function that we've chosen to implement in Rust.
-pub(crate) fn compose_postprocess_final(rootfs_dfd: i32) -> Result<()> {
+pub(crate) fn compose_postprocess_final(rootfs_dfd: i32) -> CxxResult<()> {
     let rootfs_dfd = crate::ffiutil::ffi_view_openat_dir(rootfs_dfd);
     let tasks = [
         postprocess_useradd,
         postprocess_presets,
         postprocess_subs_dist,
     ];
-    tasks.par_iter().try_for_each(|f| f(&rootfs_dfd))
+    Ok(tasks.par_iter().try_for_each(|f| f(&rootfs_dfd))?)
 }

--- a/rust/src/fedora_integration.rs
+++ b/rust/src/fedora_integration.rs
@@ -1,3 +1,4 @@
+use crate::cxxrsutil::CxxResult;
 use anyhow::{Context, Result};
 use serde_derive::Deserialize;
 use std::borrow::Cow;
@@ -153,7 +154,7 @@ fn is_debug_rpm(rpm: &str) -> bool {
     rpm.contains("-debuginfo-") || rpm.contains("-debugsource-")
 }
 
-pub(crate) fn handle_cli_arg(url: &str, arch: &str) -> Result<Option<Vec<File>>> {
+pub(crate) fn handle_cli_arg(url: &str, arch: &str) -> CxxResult<Option<Vec<File>>> {
     if url.starts_with(BODHI_URL_PREFIX) {
         let urls = bodhi::get_rpm_urls_from_update(url, arch)?;
         Ok(Some(

--- a/rust/src/initramfs.rs
+++ b/rust/src/initramfs.rs
@@ -1,6 +1,6 @@
 //! Generate an "overlay" initramfs image
 
-use crate::cxx_bridge_gobject::*;
+use crate::cxxrsutil::*;
 use anyhow::{Context, Result};
 use gio::prelude::*;
 use openat::SimpleType;
@@ -130,7 +130,7 @@ pub(crate) fn get_dracut_random_cpio() -> &'static [u8] {
 pub(crate) fn initramfs_overlay_generate(
     files: &Vec<String>,
     mut cancellable: Pin<&mut crate::FFIGCancellable>,
-) -> Result<i32> {
+) -> CxxResult<i32> {
     let cancellable = &cancellable.gobj_wrap();
     let files: HashSet<String> = files.iter().cloned().collect();
     let r = generate_initramfs_overlay_etc(&files, Some(cancellable))?;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,9 +7,9 @@
 #![deny(unused_must_use)]
 
 // pub(crate) utilities
-mod cxx_bridge_gobject;
+mod cxxrsutil;
 mod ffiutil;
-pub use cxx_bridge_gobject::*;
+pub(crate) use cxxrsutil::*;
 mod includes;
 
 #[cxx::bridge(namespace = "rpmostreecxx")]

--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -7,9 +7,9 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use crate::cxx_bridge_gobject::*;
+use crate::cxxrsutil::*;
 use crate::ffi::LiveApplyState;
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use nix::sys::statvfs;
 use openat_ext::OpenatDirExt;
 use ostree::DeploymentUnlockedState;
@@ -341,7 +341,7 @@ fn rerun_tmpfiles() -> Result<()> {
 pub(crate) fn transaction_apply_live(
     mut sysroot: Pin<&mut crate::ffi::OstreeSysroot>,
     target: &str,
-) -> Result<()> {
+) -> CxxResult<()> {
     let sysroot = &sysroot.gobj_wrap();
     let target = if target.len() > 0 { Some(target) } else { None };
     let repo = &sysroot.repo().expect("repo");
@@ -349,7 +349,7 @@ pub(crate) fn transaction_apply_live(
     let booted = if let Some(b) = sysroot.get_booted_deployment() {
         b
     } else {
-        bail!("Not booted into an OSTree system")
+        return Err(anyhow!("Not booted into an OSTree system").into());
     };
     let osname = booted.get_osname().expect("osname");
     let booted_commit = booted.get_csum().expect("csum");
@@ -365,7 +365,7 @@ pub(crate) fn transaction_apply_live(
                 Cow::Owned(pending_commit.to_string())
             }
             (None, _) => {
-                anyhow::bail!("No target commit specified and no pending deployment");
+                return Err(anyhow!("No target commit specified and no pending deployment").into());
             }
         }
     };
@@ -378,14 +378,14 @@ pub(crate) fn transaction_apply_live(
             }
             DeploymentUnlockedState::Transient | DeploymentUnlockedState::Development => {}
             s => {
-                bail!("apply-live is incompatible with unlock state: {}", s);
+                return Err(anyhow!("apply-live is incompatible with unlock state: {}", s).into());
             }
         };
     } else {
         match booted.get_unlocked() {
             DeploymentUnlockedState::Transient | DeploymentUnlockedState::Development => {}
             s => {
-                bail!("deployment not unlocked, is in state: {}", s);
+                return Err(anyhow!("deployment not unlocked, is in state: {}", s).into());
             }
         };
     }
@@ -410,11 +410,11 @@ pub(crate) fn transaction_apply_live(
     if let Some(ref state) = state {
         if !state.inprogress.is_empty() {
             if state.inprogress.as_str() != target_commit {
-                bail!(
+                Err(anyhow::anyhow!(
                     "Previously interrupted while targeting commit {}, cannot change target to {}",
                     state.inprogress,
                     target_commit
-                )
+                ))?;
             }
         }
     }
@@ -494,7 +494,7 @@ mod test {
 pub(crate) fn get_live_apply_state(
     mut _sysroot: Pin<&mut crate::ffi::OstreeSysroot>,
     mut deployment: Pin<&mut crate::ffi::OstreeDeployment>,
-) -> Result<LiveApplyState> {
+) -> CxxResult<LiveApplyState> {
     let deployment = deployment.gobj_wrap();
     if let Some(state) = get_live_state(&deployment)? {
         Ok(state)
@@ -506,7 +506,7 @@ pub(crate) fn get_live_apply_state(
 pub(crate) fn has_live_apply_state(
     sysroot: Pin<&mut crate::ffi::OstreeSysroot>,
     deployment: Pin<&mut crate::ffi::OstreeDeployment>,
-) -> Result<bool> {
+) -> CxxResult<bool> {
     let state = get_live_apply_state(sysroot, deployment)?;
     Ok(!(state.commit.is_empty() && state.inprogress.is_empty()))
 }

--- a/rust/src/passwd.rs
+++ b/rust/src/passwd.rs
@@ -1,6 +1,6 @@
 use crate::ffiutil;
 use crate::includes::*;
-use anyhow::{anyhow, bail};
+use anyhow::anyhow;
 use c_utf8::CUtf8Buf;
 use nix::unistd::{Gid, Uid};
 use std::collections::HashMap;

--- a/rust/src/testutils.rs
+++ b/rust/src/testutils.rs
@@ -9,6 +9,7 @@
 //! This backs the hidden `rpm-ostree testutils` CLI.  Subject
 //! to change.
 
+use crate::cxxrsutil::*;
 use anyhow::{Context, Result};
 use openat;
 use openat_ext::{FileExt, OpenatDirExt};
@@ -208,7 +209,7 @@ fn update_os_tree(opts: &SyntheticUpgradeOpts) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn testutils_entrypoint(args: Vec<String>) -> Result<()> {
+pub(crate) fn testutils_entrypoint(args: Vec<String>) -> CxxResult<()> {
     let opt = Opt::from_iter(args.iter());
     match opt {
         Opt::GenerateSyntheticUpgrade(ref opts) => update_os_tree(opts)?,


### PR DESCRIPTION
This is a workaround for the non-customizability of the cxx-rs
propagation of Rust result to C++ exception.  Right now we're
losing context.  Work around this by formatting on the Rust
side at exit points, explicitly converting an `anyhow::Error`
by printing it in "single line context".

Since we're likely to gain more things like this, unify
this with `cxx_bridge_gobject::` into a single `cxxrsutil::`.
