### PR TITLE
Allow Update Driver Registration

### DIFF
--- a/src/app/rpmostree-builtin-deploy.cxx
+++ b/src/app/rpmostree-builtin-deploy.cxx
@@ -28,6 +28,7 @@
 #include <libglnx.h>
 
 static char *opt_osname;
+static char *opt_register_driver;
 static gboolean opt_reboot;
 static gboolean opt_preview;
 static gboolean opt_cache_only;
@@ -49,6 +50,7 @@ static GOptionEntry option_entries[] = {
   { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization, "Prevent automatic deployment finalization on shutdown", NULL },
   { "disallow-downgrade", 0, 0, G_OPTION_ARG_NONE, &opt_disallow_downgrade, "Forbid deployment of chronologically older trees", NULL },
   { "unchanged-exit-77", 0, 0, G_OPTION_ARG_NONE, &opt_unchanged_exit_77, "If no new deployment made, exit 77", NULL },
+  { "register-driver", 0, 0, G_OPTION_ARG_STRING, &opt_register_driver, "Register the calling agent as the driver for updates. Takes a human-readable string as name for driver", "DRIVERNAME" },
   { NULL }
 };
 
@@ -125,6 +127,8 @@ rpmostree_builtin_deploy (int            argc,
       g_variant_dict_insert (&dict, "download-only", "b", opt_download_only);
       g_variant_dict_insert (&dict, "lock-finalization", "b", opt_lock_finalization);
       g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
+      if (opt_register_driver)
+        g_variant_dict_insert (&dict, "register-driver", "s", opt_register_driver);
       g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
       /* Use newer D-Bus API only if we have to so we maintain coverage. */

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -321,6 +321,9 @@
             Stop short of deploying the new tree. If layering packages,
             the pkg diff is printed but packages are not downloaded or
             imported.
+         "register-driver" (type 's')
+            Register the calling agent as the driver for updates. Takes
+            a human-readable string as the name for the update driver.
          "no-layering" (type 'b')
             Remove all package requests. Requests in "install-packages"
             are still subsequently processed if specified.

--- a/src/daemon/rpmostreed-daemon.h
+++ b/src/daemon/rpmostreed-daemon.h
@@ -30,6 +30,12 @@ G_BEGIN_DECLS
 #define DBUS_NAME "org.projectatomic.rpmostree1"
 #define BASE_DBUS_PATH "/org/projectatomic/rpmostree1"
 
+/* Update driver info */
+#define RPMOSTREE_RUN_DIR "/run/rpm-ostree/"
+#define RPMOSTREE_DRIVER_STATE RPMOSTREE_RUN_DIR "update-driver.gv"
+#define RPMOSTREE_DRIVER_SD_UNIT "driver-sd-unit"
+#define RPMOSTREE_DRIVER_NAME "driver-name"
+
 GType              rpmostreed_daemon_get_type       (void) G_GNUC_CONST;
 RpmostreedDaemon * rpmostreed_daemon_get            (void);
 gboolean           rpmostreed_get_client_uid        (RpmostreedDaemon *self,

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -157,3 +157,12 @@ rpmostreed_transaction_new_kernel_arg (GDBusMethodInvocation *invocation,
                                        GError               **error);
 
 G_END_DECLS
+
+gboolean
+get_driver_info (char   **name,
+                 char   **sd_unit,
+                 GError **error);
+
+gboolean
+get_driver_g_variant (GVariant **driver_info,
+                      GError   **error);

--- a/src/daemon/rpmostreed-transaction.h
+++ b/src/daemon/rpmostreed-transaction.h
@@ -49,7 +49,7 @@ gboolean        rpmostreed_transaction_get_active          (RpmostreedTransactio
 OstreeSysroot * rpmostreed_transaction_get_sysroot         (RpmostreedTransaction *transaction);
 const char *    rpmostreed_transaction_get_client          (RpmostreedTransaction *transaction);
 const char *    rpmostreed_transaction_get_agent_id        (RpmostreedTransaction *transaction);
-const char *    rpmostreed_transaction_get_sd_unit        (RpmostreedTransaction *transaction);
+const char *    rpmostreed_transaction_get_sd_unit         (RpmostreedTransaction *transaction);
 GDBusMethodInvocation *
                 rpmostreed_transaction_get_invocation      (RpmostreedTransaction *transaction);
 const char *    rpmostreed_transaction_get_client_address  (RpmostreedTransaction *transaction);


### PR DESCRIPTION
Record agent's systemd unit in each transaction and add D-Bus API option (for use by update drivers, e.g. Zincati) for serializing agent information into a JSON file in `/run`. Teach `rpm-ostree status` to read from this JSON file and at least be able to display its update driver's systemd unit for now.

Closes https://github.com/coreos/rpm-ostree/issues/1747.