### PR TITLE
spec: Add BuildRequires: make

### DIFF
--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -13,6 +13,7 @@ Source0: https://github.com/coreos/rpm-ostree/releases/download/v%{version}/rpm-
 
 ExclusiveArch: %{rust_arches}
 
+BuildRequires: make
 %if 0%{?rhel} && !0%{?eln}
 BuildRequires: rust-toolset
 %else


### PR DESCRIPTION
https://fedoraproject.org/wiki/Changes/Remove_make_from_BuildRoot

(Upstreamed from https://src.fedoraproject.org/rpms/rpm-ostree/c/6e99dd065de3277de2b5027fb8b81c3743ba6d68?branch=master)

Really, libdnf's `cmake` BR does pull it into the buildroot anyway right
now. Though we do still need it as well.