### PR TITLE
github: update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,7 @@ updates:
     interval: weekly
   open-pull-requests-limit: 3
 - package-ecosystem: cargo
-  directory: "/rust"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 3
-- package-ecosystem: cargo
-  directory: "/tooling"
+  directory: "/"
   schedule:
     interval: weekly
   open-pull-requests-limit: 3


### PR DESCRIPTION
This updates dependabot config, dropping the "tooling" subdirectory
and fixing the path to the top-level cargo manifest.

/cc @cgwalters @jlebon @kelvinfan001 