### PR TITLE
Remove some uses of `goto out`

### DIFF
--- a/src/app/rpmostree-builtin-start-daemon.cxx
+++ b/src/app/rpmostree-builtin-start-daemon.cxx
@@ -100,21 +100,20 @@ on_peer_acquired (GObject *source,
                   GAsyncResult *result,
                   gpointer user_data)
 {
-  g_autoptr(GDBusConnection) connection = NULL;
   g_autoptr(GError) error = NULL;
-
-  connection = g_dbus_connection_new_finish (result, &error);
+  g_autoptr(GDBusConnection) connection = g_dbus_connection_new_finish (result, &error);
   if (!connection)
-    goto out;
+    {
+      state_transition_fatal_err (error);
+      return;
+    }
 
   if (!start_daemon (connection, &error))
-    goto out;
-
- out:
-  if (error)
-    state_transition_fatal_err (error);
+    {
+      state_transition_fatal_err (error);
+      return;
+    }
 }
-
 
 static gboolean
 on_sigint (gpointer user_data)

--- a/src/libpriv/rpmostree-util.cxx
+++ b/src/libpriv/rpmostree-util.cxx
@@ -1190,3 +1190,13 @@ rpmostree_maybe_shell_quote (const char *s)
     return NULL;
   return g_shell_quote (s);
 }
+
+/* Given an error, log it to the systemd journal; use this
+ * for code paths where we can't easily propagate it back
+ * up the stack - particularly "shouldn't happen" errors.
+ */
+void
+rpmostree_journal_error (GError *error)
+{
+  sd_journal_print (LOG_WARNING, "%s", error->message);
+}

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -287,4 +287,7 @@ rpmostree_relative_path_is_ostree_compliant (const char *path);
 char*
 rpmostree_maybe_shell_quote (const char *s);
 
+void
+rpmostree_journal_error (GError *error);
+
 G_END_DECLS

--- a/tests/check/postprocess.cxx
+++ b/tests/check/postprocess.cxx
@@ -70,15 +70,10 @@ test_postprocess_altfiles (void)
     {
       AltfilesTest *test = &altfiles_tests[i];
       g_autofree char *newbuf = rpmostree_postprocess_replace_nsswitch (test->input, error);
-
-      if (!newbuf)
-        goto out;
-
+      g_assert_no_error (error);
+      g_assert (newbuf);
       g_assert_cmpstr (newbuf, ==, test->output);
     }
-
- out:
-  g_assert_no_error (local_error);
 }
 
 int


### PR DESCRIPTION
All of these cases are actually fine, but in general we
can't use `goto out` since we started using C++ exceptions
which will skip that control flow.
