### PR TITLE
vmcheck/test-misc-2: Fix $cursor variable

### DIFF
--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -53,12 +53,10 @@ if vm_rpmostree finalize-deployment; then
 elif vm_rpmostree finalize-deployment WRONG_CHECKSUM; then
   assert_not_reached "finalized with wrong checksum"
 fi
-vm_cmd journalctl --after-cursor "'$from_cursor'" -u rpm-ostreed -o json | jq -r '.AGENT//""' > agent.txt
+vm_cmd journalctl --after-cursor "'$cursor'" -u rpm-ostreed -o json | jq -r '.AGENT//""' > agent.txt
 assert_file_has_content agent.txt testing-agent-id
-cursor=$(vm_get_journal_cursor)
-vm_cmd journalctl --after-cursor "'$from_cursor'" -u rpm-ostreed -o json | jq -r '.AGENT_SD_UNIT//""' > agent_sd_unit.txt
+vm_cmd journalctl --after-cursor "'$cursor'" -u rpm-ostreed -o json | jq -r '.AGENT_SD_UNIT//""' > agent_sd_unit.txt
 assert_file_has_content agent_sd_unit.txt sshd.service
-cursor=$(vm_get_journal_cursor)
 vm_reboot_cmd rpm-ostree finalize-deployment "${commit}"
 assert_streq "$(vm_get_booted_csum)" "${commit}"
 vm_assert_journal_has_content $cursor "Finalized deployment; rebooting into ${commit}"


### PR DESCRIPTION
Minor cleanup.

Follow up from https://github.com/coreos/rpm-ostree/pull/2461/.