### PR TITLE
ci: Set RPM_BUILD_NCPUS when building RPMs

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -2,7 +2,8 @@
 
 stage("Build") {
 parallel rpms: {
-  cosaPod(buildroot: true, runAsUser: 0, memory: "2Gi") {
+  def n = 5
+  cosaPod(buildroot: true, runAsUser: 0, memory: "2Gi", cpu: "${n}") {
       checkout scm
       shwrap("""
         # fetch tags so `git describe` gives a nice NEVRA when building the RPM
@@ -17,7 +18,7 @@ parallel rpms: {
         # The RPM build expects pre-generated bindings, so do that now.
         make -f Makefile.bindings bindings
         cd packaging
-        make -f Makefile.dist-packaging rpm
+        RPM_BUILD_NCPUS=${n} make -f Makefile.dist-packaging rpm
         mv \$(find . -name '*.rpm') ..
       """)
       // make it easy for anyone to download the RPMs


### PR DESCRIPTION
Otherwise, it defaults to `_SC_NPROCESSORS_ONLN` (via `%make_build` ->
`%_smp_mflags` -> `%_smp_build_ncpus` -> `%{getncpus}` ->
https://github.com/rpm-software-management/rpm/blob/48c0f28834eb377a54f27ee0b6950af7e6d537b8/rpmio/macro.c#L583).
And that's going to be wrong in Kubernetes because we're constrained via
cgroups.

The `%_smp_build_ncpus` macro allows overriding this logic via
`RPM_BUILD_NCPUS`.

See: https://github.com/coreos/coreos-ci/issues/23
See: https://github.com/coreos/coreos-assembler/pull/632
See: https://github.com/coreos/coreos-assembler/pull/1287