### PR TITLE
ci: fix install-extra logic

### DIFF
--- a/ci/install-extra-builddeps.sh
+++ b/ci/install-extra-builddeps.sh
@@ -1,14 +1,13 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 # cxx.rs (cxxbridge) isn't packaged in Fedora today.  Both it and cbindgen generate
 # source code, which we vendor along with our dependent crates into release
 # tarballs.  Note in the future it's likely we stop using cbindgen entirely in
 # favor of cxx.rs.
-set -xeuo pipefail
-if ! command -v cxxbridge; then
-    ver=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name == "cxx").version')
-    cargo install cxxbridge-cmd --version "${ver}"
-fi
-if ! command -v cbindgen; then
-    ver=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name == "cbindgen").version')
-    cargo install cbindgen --version "${ver}"
-fi
+
+set -euo pipefail
+
+CXX_VER=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name == "cxx").version')
+cargo install cxxbridge-cmd --version "${CXX_VER}"
+
+CBINDGEN_VER=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name == "cbindgen").version')
+cargo install cbindgen --version "${CBINDGEN_VER}"


### PR DESCRIPTION
This fixes `install-extra-builddeps.sh` helper, by letting cargo
detect whether the target binary is already present in the
environment with the expected version.
This is in order to avoid mismatches in generated code when the
library version is bumped, and stale binaries are present on
the system.