### PR TITLE
core: Set _dbpath back to /usr/share/rpm after writing rpmdb

### DIFF
--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -4668,6 +4668,10 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
 
   rpmostree_output_progress_end (&task);
 
+  /* And finally revert the _dbpath setting because libsolv relies on it as well
+   * to find the rpmdb and RPM macros are global state. */
+  set_rpm_macro_define ("_dbpath", "/" RPMOSTREE_RPMDB_LOCATION);
+
   /* And now also sanity check the rpmdb */
   if (!skip_sanity_check)
     {


### PR DESCRIPTION
We temporarily set the rpmdb path to be an absolute path pointing under
the tmprootfs when writing the rpmdb. This throws off libsolv 0.7.17,
which learned to give the `_dbpath` macro precedence on where the rpmdb
is located:

https://github.com/openSUSE/libsolv/commit/04d4d036b275693a23eef75fba634e7cea2f1a6d

So then the rpmdb sanity-check we do when exiting
`rpmostree_context_assemble()` breaks because it can't find the expected
packages.

Because RPM macros are in global state, there's no elegant way of
setting it just for the rpmdb write operation (short of forking), so
just fix this by setting `_dbpath` back to the correct value after we're
done writing the rpmdb.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/723