### PR TITLE
ci: Make msrv test do full build + unit tests

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -45,7 +45,7 @@ unit: {
   cosaPod(buildroot: true, runAsUser: 0, memory: "2Gi", cpu: "${n}") {
       checkout scm
       shwrap("""
-        MAKE_JOBS=${n} CARGO_BUILD_JOBS=${n} ci/msrv.sh
+        MAKE_JOBS=${n} CARGO_BUILD_JOBS=${n} ci/unit.sh
       """)
   }
 }}

--- a/ci/unit.sh
+++ b/ci/unit.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 MINIMUM_SUPPORTED_RUST_VERSION=1.48
 
 ci/installdeps.sh
-dnf remove -y cargo
+dnf remove -y cargo rust
 curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain ${MINIMUM_SUPPORTED_RUST_VERSION} -y
 export PATH="$HOME/.cargo/bin:$PATH"
+ci/build.sh
 cargo +${MINIMUM_SUPPORTED_RUST_VERSION} test


### PR DESCRIPTION
I think we did this at some point, but then stopped.
Prep for https://github.com/coreos/rpm-ostree/pull/2413
because we'll need a full build of the C++ side too in order
to `cargo test`.
