### PR TITLE
deploy: Allow empty string argument if `--register-driver`

### DIFF
--- a/src/app/rpmostree-builtin-deploy.cxx
+++ b/src/app/rpmostree-builtin-deploy.cxx
@@ -50,7 +50,7 @@ static GOptionEntry option_entries[] = {
   { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization, "Prevent automatic deployment finalization on shutdown", NULL },
   { "disallow-downgrade", 0, 0, G_OPTION_ARG_NONE, &opt_disallow_downgrade, "Forbid deployment of chronologically older trees", NULL },
   { "unchanged-exit-77", 0, 0, G_OPTION_ARG_NONE, &opt_unchanged_exit_77, "If no new deployment made, exit 77", NULL },
-  { "register-driver", 0, 0, G_OPTION_ARG_STRING, &opt_register_driver, "Register the calling agent as the driver for updates. Takes a human-readable string as name for driver", "DRIVERNAME" },
+  { "register-driver", 0, 0, G_OPTION_ARG_STRING, &opt_register_driver, "Register the calling agent as the driver for updates; if REVISION is an empty string, register driver without deploying", "DRIVERNAME" },
   { NULL }
 };
 

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -71,6 +71,18 @@ assert_streq "$(vm_get_booted_csum)" "${commit}"
 vm_assert_journal_has_content $cursor "Finalized deployment; rebooting into ${commit}"
 echo "ok finalize-deployment"
 
+# Test `deploy --register-driver` option with empty string as revision.
+vm_cmd rpm-ostree deploy \'\' \
+       --register-driver=OtherTestDriver
+vm_cmd test -f /run/rpm-ostree/update-driver.gv
+vm_cmd rpm-ostree status > status.txt
+assert_file_has_content status.txt 'driven by OtherTestDriver'
+vm_cmd rpm-ostree status -v > verbose_status.txt
+assert_file_has_content verbose_status.txt 'driven by OtherTestDriver (sshd.service)'
+vm_assert_status_jq ".\"update-driver\"[\"driver-name\"] == \"OtherTestDriver\"" \
+                    ".\"update-driver\"[\"driver-sd-unit\"] == \"sshd.service\""
+echo "ok deploy --register-driver with empty string revision"
+
 # Custom origin and local repo rebases. This is essentially the RHCOS workflow.
 # https://github.com/projectatomic/rpm-ostree/pull/1406
 # https://github.com/projectatomic/rpm-ostree/pull/1732


### PR DESCRIPTION
It is sometimes useful to only register an update driver without
actually deploying anything. If the argument for `deploy` is an
empty string, only register driver and then no-op.