### PR TITLE
rust: Add some allow(dead_code)

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -31,6 +31,7 @@ mod ffi {
         include!("src/libpriv/rpmostree-cxxrs-prelude.h");
 
         type OstreeSysroot = crate::FFIOstreeSysroot;
+        #[allow(dead_code)]
         type OstreeRepo = crate::FFIOstreeRepo;
         type OstreeDeployment = crate::FFIOstreeDeployment;
         type GCancellable = crate::FFIGCancellable;
@@ -205,6 +206,8 @@ mod ffi {
     // rpmostree-rpm-util.h
     unsafe extern "C++" {
         include!("rpmostree-rpm-util.h");
+        // Currently only used in unit tests
+        #[allow(dead_code)]
         fn nevra_to_cache_branch(nevra: &CxxString) -> Result<UniquePtr<CxxString>>;
     }
 }


### PR DESCRIPTION
One is only used in the unit tests right now, the other we'll
likely use soon.

We should try doing something like https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md in CI.