### PR TITLE
compose: Remove unused treefile_rs parameter

### DIFF
--- a/src/app/rpmostree-compose-builtin-rojig.cxx
+++ b/src/app/rpmostree-compose-builtin-rojig.cxx
@@ -528,7 +528,7 @@ impl_write_rojig (RpmOstreeRojigCompose *self,
     return FALSE;
   if (!rpmostree_rootfs_postprocess_common (self->rootfs_dfd, cancellable, error))
     return FALSE;
-  if (!rpmostree_postprocess_final (self->rootfs_dfd, self->treefile_rs, self->treefile, TRUE,
+  if (!rpmostree_postprocess_final (self->rootfs_dfd, self->treefile, TRUE,
                                     cancellable, error))
     return FALSE;
 

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1087,7 +1087,7 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
     return FALSE;
   if (!rpmostree_rootfs_postprocess_common (self->rootfs_dfd, cancellable, error))
     return FALSE;
-  if (!rpmostree_postprocess_final (self->rootfs_dfd, self->treefile_rs,
+  if (!rpmostree_postprocess_final (self->rootfs_dfd,
                                     self->treefile, self->unified_core_and_fuse,
                                     cancellable, error))
     return FALSE;
@@ -1327,7 +1327,7 @@ rpmostree_compose_builtin_postprocess (int             argc,
     return FALSE;
   if (!rpmostree_rootfs_postprocess_common (rootfs_dfd, cancellable, error))
     return FALSE;
-  if (!rpmostree_postprocess_final (rootfs_dfd, treefile_rs, treefile, opt_unified_core,
+  if (!rpmostree_postprocess_final (rootfs_dfd, treefile, opt_unified_core,
                                     cancellable, error))
     return FALSE;
   return TRUE;

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -953,7 +953,6 @@ postprocess_selinux_policy_store_location (int rootfs_dfd,
  */
 gboolean
 rpmostree_postprocess_final (int            rootfs_dfd,
-                             RORTreefile   *treefile_rs,
                              JsonObject    *treefile,
                              gboolean       unified_core_mode,
                              GCancellable  *cancellable,

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -89,7 +89,6 @@ rpmostree_prepare_rootfs_for_commit (int            src_rootfs_dfd,
 
 gboolean
 rpmostree_postprocess_final (int            rootfs_dfd,
-                             RORTreefile   *treefile_rs,
                              JsonObject    *treefile,
                              gboolean       unified_core_mode,
                              GCancellable  *cancellable,


### PR DESCRIPTION
Prep for further cleanup.
