### PR TITLE
extensions: Write JSON to output dir

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -196,6 +196,7 @@ mod ffi {
         fn get_packages(&self) -> Vec<String>;
         fn state_checksum_changed(&self, chksum: &str, output_dir: &str) -> Result<bool>;
         fn update_state_checksum(&self, chksum: &str, output_dir: &str) -> Result<()>;
+        fn serialize_to_dir(&self, output_dir: &str) -> Result<()>;
     }
 
     // rpmutils.rs

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1612,6 +1612,7 @@ rpmostree_compose_builtin_extensions (int             argc,
     }
 
   extensions->update_state_checksum (state_checksum, opt_extensions_output_dir);
+  extensions->serialize_to_dir (opt_extensions_output_dir);
   if (!process_touch_if_changed (error))
     return FALSE;
 

--- a/tests/compose/test-basic-unified.sh
+++ b/tests/compose/test-basic-unified.sh
@@ -95,6 +95,11 @@ extensions:
     packages:
       - dodo
       - solitaire
+  another-arch:
+    packages:
+      - nonexistent
+    architectures:
+      - badarch
 EOF
 
 # we don't actually need root here, but in CI the cache may be in a qcow2 and
@@ -106,6 +111,9 @@ runasroot rpm-ostree compose extensions --repo=${repo} \
 
 ls extensions/{dodo-1.0,dodo-base-1.0,solitaire-1.0}-*.rpm
 test -f extensions-changed
+assert_jq extensions/extensions.json \
+  '.extensions|length == 1' \
+  '.extensions["extinct-birds"]'
 echo "ok extensions"
 
 rm extensions-changed


### PR DESCRIPTION
Let's include the final extensions file in JSON format as part of the
output directory. A key difference from the input file (apart from YAML
vs JSON) is that this is post-filtering, so any extensions which were
removed because the architecture does not match are not present.

This JSON file will be used by cosa and the MCO. See discussions in:
https://github.com/openshift/os/issues/409