### PR TITLE
lib: Don't link to libdnf

### DIFF
--- a/Makefile-lib.am
+++ b/Makefile-lib.am
@@ -35,16 +35,10 @@ librpmostree_1_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/libglnx -I$(srcdir)/src/libp
 	$(PKGDEP_RPMOSTREE_CFLAGS)
 librpmostree_1_la_LDFLAGS = $(AM_LDFLAGS) -version-number 1:0:0 -Bsymbolic-functions
 librpmostree_1_la_LIBADD =  $(PKGDEP_RPMOSTREE_LIBS) libglnx.la
-EXTRA_librpmostree_1_la_DEPENDENCIES = libdnf.so.2
-
-# The g-ir-scanner creates a stub executable (to help introspect type information) which
-# links to our stuff. We want to make sure it picks up our fresh libdnf and not a possibly
-# stale one from a previously installed rpm-ostree's bundled libdnf.
-INTROSPECTION_SCANNER_ENV = env LD_LIBRARY_PATH=$(top_builddir)/libdnf-build/libdnf
 
 # XXX: work around clang being passed -fstack-clash-protection which it doesn't understand
 # https://github.com/projectatomic/rpm-ostree/pull/1787#issuecomment-473971585
-INTROSPECTION_SCANNER_ENV += CC=gcc
+INTROSPECTION_SCANNER_ENV = CC=gcc
 
 if BUILDOPT_INTROSPECTION
 RpmOstree-1.0.gir: librpmostree-1.la Makefile

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -84,9 +84,11 @@ rpmostree_common_cflags = -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
 	-I$(srcdir)/src/lib -I$(srcdir)/src/libpriv -I$(libglnx_srcpath) \
 	-DG_LOG_DOMAIN=\"rpm-ostreed\" \
 	-DLIBDIR=\"$(libdir)\" -DPKGLIBDIR=\"$(pkglibdir)\" \
+	-I $(top_srcdir)/libdnf -I $(top_srcdir)/libdnf-build \
 	$(PKGDEP_RPMOSTREE_CFLAGS) $(PKGDEP_RPMOSTREE_RS_CFLAGS)
 rpmostree_bin_common_cflags = $(rpmostree_common_cflags)
-rpmostree_common_libs = $(PKGDEP_RPMOSTREE_LIBS) $(CAP_LIBS) libglnx.la librpmostree-1.la librpmostreecxxrs.la $(PKGDEP_RPMOSTREE_RS_LIBS) -lstdc++ -lrt
+rpmostree_common_libs = $(PKGDEP_RPMOSTREE_LIBS) -L$(top_srcdir)/libdnf-build/libdnf -ldnf $(CAP_LIBS) libglnx.la librpmostree-1.la librpmostreecxxrs.la $(PKGDEP_RPMOSTREE_RS_LIBS) -lstdc++ -lrt
+
 rpmostree_bin_common_libs = librpmostreeinternals.la $(librpmostree_rust_path) $(rpmostree_common_libs)
 rpm_ostree_CFLAGS = $(AM_CFLAGS) $(rpmostree_bin_common_cflags)
 rpm_ostree_CXXFLAGS = $(AM_CXXFLAGS) $(rpmostree_bin_common_cflags)

--- a/configure.ac
+++ b/configure.ac
@@ -93,10 +93,6 @@ PKGDEP_RPMOSTREE_LIBS="$PKGDEP_RPMOSTREE_LIBS -Wl,--push-state,--no-as-needed,-l
 # curl-rust uses it.
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE_RS, [libcurl openssl])
 
-dnl bundled libdnf
-PKGDEP_RPMOSTREE_CFLAGS="-I $(pwd)/libdnf -I $(pwd)/libdnf-build $PKGDEP_RPMOSTREE_CFLAGS"
-PKGDEP_RPMOSTREE_LIBS="-L$(pwd)/libdnf-build/libdnf -ldnf $PKGDEP_RPMOSTREE_LIBS"
-
 dnl RHEL8.1 has old libarchive
 AS_IF([pkg-config --atleast-version=3.3.3 libarchive],
   [AC_DEFINE([HAVE_LIBARCHIVE_ZSTD], 1, [Define if we have libarchive with zstd])])

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -76,3 +76,7 @@ echo "ok reload"
 # See rpmostree-scripts.c
 grep ^DEFAULT /etc/crypto-policies/config
 echo "ok crypto-policies DEFAULT backend"
+
+ldd /usr/lib64/librpmostree-1.so.1 > rpmostree-lib-deps.txt
+assert_not_file_has_content rpmostree-lib-deps.txt libdnf
+echo "ok lib deps"


### PR DESCRIPTION
Prep for "Rust-as-main", where I want to build libdnf statically.
And this really completes the "library thinout" story because
now we avoid dragging our *private* `libdnf.so` into the caller's
address space, which can cause potential conflicts if they're
also linking the system one. (Which could easily occur with
something like gnome-software)

All we were using libdnf for (indirectly via libsolv) is comparing
version strings but librpm can already do that for us.
