### PR TITLE
 ci: Re-enable `make check`

### DIFF
--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -12,13 +12,7 @@ dn=$(dirname $0)
 export PATH="$HOME/.cargo/bin:$PATH"
 
 ${dn}/build.sh
-# NB: avoid make function because our RPM building doesn't
-# support parallel runs right now
-# See https://github.com/containers/fuse-overlayfs/pull/105 for the fuse-overlayfs workaround
-if ! [ "$(findmnt -n -o SOURCE /)" != fuse-overlayfs ]; then
-    /usr/bin/make check
-fi
-make rust-test
+make check
 make install
 
 # And now a clang build with -Werror turned on. We can't do this with gcc (in

--- a/tests/check/postprocess.cxx
+++ b/tests/check/postprocess.cxx
@@ -70,7 +70,7 @@ test_postprocess_altfiles (void)
     {
       AltfilesTest *test = &altfiles_tests[i];
       g_autofree char *newbuf = rpmostree_postprocess_replace_nsswitch (test->input, error);
-      g_assert_no_error (error);
+      g_assert_no_error (local_error);
       g_assert (newbuf);
       g_assert_cmpstr (newbuf, ==, test->output);
     }


### PR DESCRIPTION

This seems to work for me; we want to run the C unit tests.