### PR TITLE
Rust is main prep

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -122,7 +122,7 @@ $(librpmostree_rust_path): Makefile $(LIBRPMOSTREE_RUST_SRCS) librpmostreeintern
 EXTRA_DIST += $(LIBRPMOSTREE_RUST_SRCS)
 
 # cbindgen + cxx.rs
-binding_generated_sources = rpmostree-rust.h rpmostree-cxxrs.h rpmostree-cxxrs.cxx
+binding_generated_sources = rpmostree-rust.h rpmostree-cxxrs.h rpmostree-cxxrs.cxx rust/cxx.h
 if BUILDOPT_PREBUILT_BINDINGS
 # In this case we shipped prebuilt versions in the source tarball
 rpmostree-rust.h:
@@ -131,6 +131,8 @@ rpmostree-cxxrs.h:
 	ln -sfr rpmostree-cxxrs-prebuilt.h $@
 rpmostree-cxxrs.cxx:
 	ln -sfr rpmostree-cxxrs-prebuilt.cxx $@
+rust/cxx.h:
+	ln -sfr rust/cxx-prebuilt.h $@
 else
 include Makefile.bindings
 endif

--- a/Makefile.bindings
+++ b/Makefile.bindings
@@ -12,8 +12,11 @@ rpmostree-rust.h: $(binding_rust_sources)
 	else \
 	  echo cbindgen failed; exit 1; \
 	fi
-
 BUILT_SOURCES += rpmostree-rust.h
+
+rust/cxx.h: Makefile.bindings
+	cxxbridge --header >$@
+
 rpmostree-cxxrs.h: $(binding_rust_sources)
 	$(AM_V_GEN) if cxxbridge rust/src/lib.rs --header > $@.tmp; then \
 	  if test -f $@ && cmp $@.tmp $@ 2>/dev/null; then rm -f $@.tmp; else \
@@ -26,5 +29,5 @@ rpmostree-cxxrs.cxx: $(binding_rust_sources) rpmostree-cxxrs.h
 	$(AM_V_GEN) cxxbridge --include rpmostree-cxxrs.h rust/src/lib.rs > $@
 
 # Invoked in CI
-bindings: rpmostree-rust.h rpmostree-cxxrs.h rpmostree-cxxrs.cxx
+bindings: rpmostree-rust.h rpmostree-cxxrs.h rpmostree-cxxrs.cxx rust/cxx.h
 .PHONY: bindings

--- a/packaging/make-git-snapshot.sh
+++ b/packaging/make-git-snapshot.sh
@@ -66,6 +66,7 @@ open(checksum_file, "w").write(json.dumps(j))' $crate_subdir
  cp rpmostree-rust{,-prebuilt}.h
  cp rpmostree-cxxrs{,-prebuilt}.h
  cp rpmostree-cxxrs{,-prebuilt}.cxx
- tar --transform "s,^,${PKG_VER}/," -rf ${TARFILE_TMP} rpmostree-{rust,cxxrs}-prebuilt.h rpmostree-cxxrs-prebuilt.cxx)
+ cp rust/cxx.h rust/cxx-prebuilt.h
+ tar --transform "s,^,${PKG_VER}/," -rf ${TARFILE_TMP} rpmostree-{rust,cxxrs}-prebuilt.h rpmostree-cxxrs-prebuilt.cxx rust/cxx-prebuilt.h)
 
 mv ${TARFILE_TMP} ${TARFILE}

--- a/rust/src/lockfile.rs
+++ b/rust/src/lockfile.rs
@@ -49,7 +49,7 @@ fn lockfile_parse_multiple<P: AsRef<Path>>(filenames: &[P]) -> Result<LockfileCo
 
 /// Lockfile format:
 ///
-/// ```
+/// ```json
 /// {
 ///    "metatada": {
 ///        "generated": "<rfc3339-timestamp>",


### PR DESCRIPTION
 Makefile.bindings: Also generate pure rust/cxx.h

This is necessary in order to use `rust::` in our header files
that are also used by bindings.

---

 lockfile: Note that comment is JSON

Otherwise rustc tries compile and run it as a doctest.