### PR TITLE
make/rust-test: fix linking and loading

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -150,6 +150,8 @@ INSTALL_EXEC_HOOKS += install-rpmostree-hook
 # Wraps `cargo test`.  This is always a debug non-release build;
 # the main thing here is we still drop the `target` dir in our build
 # directory, since we nominally support srcdir != builddir.
-rust-test:
-	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=@abs_top_builddir@/target cargo test
-.PHONY: rust-test
+rust-test: $(binding_generated_sources) $(dbus_built_sources) $(librpmostree_rust_path) librpmostreecxxrs.la librpmostreeinternals.la
+	LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:@abs_top_builddir@/.libs/" cargo test
+rust-test-%: $(binding_generated_sources) $(dbus_built_sources) $(librpmostree_rust_path) librpmostreecxxrs.la librpmostreeinternals.la
+	LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:@abs_top_builddir@/.libs/" cargo test -- $*
+.PHONY: rust-test rust-test-%


### PR DESCRIPTION
This fixes link dependencies and build-libraries path, in order to
make Rust tests work.
It also introduces an additional wildcard target to allow specifying
a test filter to cargo.