### PR TITLE
Bridge "next version" API to Rust, use it for unit tests

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -204,6 +204,17 @@ mod ffi {
         fn cache_branch_to_nevra(nevra: &str) -> String;
     }
 
+    unsafe extern "C++" {
+        include!("rpmostree-util.h");
+        // Currently only used in unit tests
+        #[allow(dead_code)]
+        fn util_next_version(
+            auto_version_prefix: &str,
+            version_suffix: &str,
+            last_version: &str,
+        ) -> Result<String>;
+    }
+
     // rpmostree-rpm-util.h
     unsafe extern "C++" {
         include!("rpmostree-rpm-util.h");

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -34,6 +34,7 @@
 #include "libglnx.h"
 #include "rpmostree.h"
 #include "rpmostree-types.h"
+#include "rust/cxx.h"
 
 // C++ code here
 namespace util {
@@ -69,6 +70,14 @@ throw_gerror (GError *&error)
   error = NULL;
   throw std::runtime_error (s);
 }
+}
+
+namespace rpmostreecxx {
+rust::String
+util_next_version (rust::Str auto_version_prefix,
+                   rust::Str version_suffix,
+                   rust::Str last_version);
+
 }
 
 // Below here is C code
@@ -109,12 +118,6 @@ rpmostree_check_size_within_limit (guint64     actual,
 
 char*
 rpmostree_translate_path_for_ostree (const char *path);
-
-char *
-_rpmostree_util_next_version (const char   *auto_version_prefix,
-                              const char   *version_suffix,
-                              const char   *last_version,
-                              GError      **error);
 
 char *
 rpmostree_str_replace (const char  *buf,

--- a/tests/check/jsonutil.cxx
+++ b/tests/check/jsonutil.cxx
@@ -49,125 +49,6 @@ test_get_optional_string_member (void)
   json_object_unref (obj);
 }
 
-static void
-test_auto_version (void)
-{
-  char *version = NULL;
-  char *final_version = NULL;
-  g_autoptr(GDateTime) date_time_utc = g_date_time_new_now_utc ();
-  char *prev_version = NULL;
-  g_autoptr(GError) local_error = NULL;
-  GError **error = &local_error;
-
-#define _VER_TST_FULL(prefix, suffix, last, expected)                           \
-  g_clear_error (error);                                                        \
-  version = _rpmostree_util_next_version ((prefix), (suffix), (last), error);   \
-  g_assert_cmpstr (version, ==, expected);                                      \
-  g_free (version);                                                             \
-  version = NULL
-#define _VER_TST(prefix, last, expected) _VER_TST_FULL(prefix, NULL, last, expected)
-
-  _VER_TST("10",  NULL,    "10");
-  _VER_TST("10",  "",      "10");
-  _VER_TST("10",  "xyz",   "10");
-  _VER_TST("10",  "9",     "10");
-  _VER_TST("10", "11",     "10");
-
-  _VER_TST("10", "10",     "10.1");
-  _VER_TST("10.1", "10.1",     "10.1.1");
-
-  _VER_TST("10", "10.0",   "10.1");
-  _VER_TST("10", "10.1",   "10.2");
-  _VER_TST("10", "10.2",   "10.3");
-  _VER_TST("10", "10.3",   "10.4");
-  _VER_TST("10", "10.1.5", "10.2");
-  _VER_TST("10.1", "10.1.5",   "10.1.6");
-  _VER_TST("10.1", "10.1.1.5", "10.1.2");
-
-  _VER_TST("10", "10001",  "10");
-  _VER_TST("10", "101.1",  "10");
-  _VER_TST("10", "10x.1",  "10");
-  _VER_TST("10.1", "10",    "10.1");
-  _VER_TST("10.1", "10.",   "10.1");
-  _VER_TST("10.1", "10.0",  "10.1");
-  _VER_TST("10.1", "10.2",  "10.1");
-  _VER_TST("10.1", "10.12", "10.1");
-  _VER_TST("10.1", "10.1x", "10.1");
-  _VER_TST("10.1", "10.1.x", "10.1.1");
-  _VER_TST("10.1", "10.1.2x", "10.1.3");
-
-  _VER_TST_FULL("10", "-", "10", "10-1");
-  _VER_TST_FULL("10", "-", "10-1", "10-2");
-  _VER_TST_FULL("10.1", "-", "10.1-5", "10.1-6");
-
-  /* Like _VER_TST, but renders datetime specifiers in
-   * date_fmt with the current time. The rendered string
-   * is then compared against the result of _rpmostree_util_next_version(). */
-  #define _VER_DATE_TST(pre, last, final_datefmt)   \
-    g_clear_error (error);                          \
-    final_version = g_date_time_format (date_time_utc, (final_datefmt));   \
-    version = _rpmostree_util_next_version ((pre), NULL, (last), error);   \
-    g_assert_cmpstr (version, ==, final_version);                    \
-    g_free (final_version);                                          \
-    g_free (version);                                                \
-    version = NULL;                                                  \
-    final_version = NULL
-
-  /* Test date updates. */
-  _VER_DATE_TST("10.<date:%Y%m%d>", "10.20001010", "10.%Y%m%d.0");
-
-  /* Test increment reset when date changed. */
-  _VER_DATE_TST("10.<date:%Y%m%d>", "10.20001010.5", "10.%Y%m%d.0");
-
-  /* Test increment up when same date. */
-  prev_version = g_date_time_format (date_time_utc, "10.%Y%m%d.1");
-  _VER_DATE_TST("10.<date:%Y%m%d>", prev_version, "10.%Y%m%d.2");
-  g_free (prev_version);
-
-  /* Test append version number. */
-  _VER_DATE_TST("10.<date:%Y%m%d>", NULL, "10.%Y%m%d.0");
-  prev_version = g_date_time_format (date_time_utc, "10.%Y%m%d");
-  _VER_DATE_TST("10.<date:%Y%m%d>.0", prev_version, "10.%Y%m%d.0.0");
-  g_free (prev_version);
-  prev_version = g_date_time_format (date_time_utc, "10.%Y%m%d.0");
-  _VER_DATE_TST("10.<date:%Y%m%d>.0", prev_version, "10.%Y%m%d.0.0");
-  g_free (prev_version);
-  prev_version = g_date_time_format (date_time_utc, "10.%Y%m%d.x");
-  _VER_DATE_TST("10.<date:%Y%m%d>", prev_version, "10.%Y%m%d.1");
-  g_free (prev_version);
-  prev_version = g_date_time_format (date_time_utc, "10.%Y%m%d.2.x");
-  _VER_DATE_TST("10.<date:%Y%m%d>.2", prev_version, "10.%Y%m%d.2.1");
-  g_free (prev_version);
-  prev_version = g_date_time_format (date_time_utc, "10.%Y%m%d.1.2x");
-  _VER_DATE_TST("10.<date:%Y%m%d>.1", prev_version, "10.%Y%m%d.1.3");
-  g_free (prev_version);
-
-  /* Test variations to the formatting. */
-  _VER_DATE_TST("10.<date: %Y%m%d>",          "10.20001010",    "10. %Y%m%d.0");
-  _VER_DATE_TST("10.<date:%Y%m%d>.",          "10.20001010.",   "10.%Y%m%d..0");
-  _VER_DATE_TST("10.<date:%Y%m%d>abc",        "10.20001010abc", "10.%Y%m%dabc.0");
-  _VER_DATE_TST("10.<date:%Y%m%d >",          "10.20001010",    "10.%Y%m%d .0");
-  _VER_DATE_TST("10.<date:text%Y%m%dhere>",   "10.20001010",    "10.text%Y%m%dhere.0");
-  _VER_DATE_TST("10.<date:text %Y%m%d here>", "10.20001010",    "10.text %Y%m%d here.0");
-  _VER_DATE_TST("10.<date:%Y%m%d here>",      "10.20001010",    "10.%Y%m%d here.0");
-
-  /* Test equal last version and prefix. */
-  prev_version = g_date_time_format (date_time_utc, "10.%Y%m%d");
-  _VER_DATE_TST("10.<date:%Y%m%d>", prev_version, "10.%Y%m%d.0");
-  g_free (prev_version);
-
-  /* Test different prefix from last version. */
-  _VER_DATE_TST("10.<date:%Y%m%d>", "10", "10.%Y%m%d.0");
-
-  /* Test no field given. */
-  _VER_TST("10.<date: >",     "10.20001010", "10. .0");
-  _VER_TST("10.<date:>",      "10.20001010", "10..0");
-  _VER_TST("10.<wrongtag: >", "10.20001010", "10.<wrongtag: >");
-
-  /* Test invalid datetime specifier given. */
-  _VER_TST("10.<date:%E>", "10.20001010", NULL);
-}
-
 int
 main (int   argc,
       char *argv[])
@@ -175,7 +56,6 @@ main (int   argc,
   g_test_init (&argc, &argv, NULL);
 
   g_test_add_func ("/jsonparsing/get-optional-member", test_get_optional_string_member);
-  g_test_add_func ("/versioning/automatic", test_auto_version);
 
   return g_test_run ();
 }


### PR DESCRIPTION
This demonstrates well the strength of the cxx-rs approach;
we can keep an API in C++ but add unit tests in Rust which
just works much more nicely.

Prep for https://github.com/coreos/rpm-ostree/pull/2502
which wants to drop the C++ unit tests.
