### PR TITLE
build: Use -std=c++17

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,7 +49,7 @@ warn_only_c_flags = -Werror=strict-prototypes \
 # that project for more information about e.g. -fno-strict-aliasing
 AM_CFLAGS += -std=gnu11 -fno-strict-aliasing $(WARN_CFLAGS) $(warn_only_c_flags)
 # Our default CXX flags
-AM_CXXFLAGS += -std=c++14 -fno-strict-aliasing $(WARN_CFLAGS)
+AM_CXXFLAGS += -std=c++17 -fno-strict-aliasing $(WARN_CFLAGS)
 # bundled libdnf; --enable-new-dtags emits DT_RUNPATH instead of deprecated DT_RPATH, which
 # can't be overridden by LD_LIBRARY_PATH; which is useful for uninstalled runs/tests
 AM_LDFLAGS += "-Wl,-rpath=$(libdir)/rpm-ostree,--enable-new-dtags"


### PR DESCRIPTION
Notably this includes [std::optional](https://en.cppreference.com/w/cpp/utility/optional)
which I'd like to use.

The dnf-5-devel branch uses this too, and C++-17 is now well
supported in current GCC, which is available in RHEL8 DTS too.
