### PR TITLE
A few CI patches

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -48,7 +48,16 @@ unit: {
         MAKE_JOBS=${n} CARGO_BUILD_JOBS=${n} ci/unit.sh
       """)
   }
-}}
+},
+clang: {
+  // Build with clang/clang++
+  def n = 5
+  cosaPod(buildroot: true, runAsUser: 0, memory: "2Gi", cpu: "${n}") {
+      checkout scm
+      shwrap("ci/clang-build-check.sh")
+  }
+}
+}
 
 stage("Test") {
 parallel insttests: {

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -39,8 +39,7 @@ codestyle: {
   }
 },
 unit: {
-  // this branch runs unit tests (both Rust-based and C-based) and makes sure we compile
-  // fine against the MSRV
+  // this branch runs unit tests (both Rust-based and C-based)
   def n = 5
   cosaPod(buildroot: true, runAsUser: 0, memory: "2Gi", cpu: "${n}") {
       checkout scm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,12 @@ name = "rpmostree-rust"
 version = "0.1.0"
 authors = ["Colin Walters <walters@verbum.org>", "Jonathan Lebon <jonathan@jlebon.com>"]
 edition = "2018"
+# See https://rust-lang.github.io/rfcs/2495-min-rust-version.html
+# Usually, we try to keep this to no newer than current RHEL8 rust-toolset version.
+# You can find the current versions from here:
+# https://access.redhat.com/documentation/en-us/red_hat_developer_tools/1/
+# However, right now we are bumping to 1.48 so we can use https://cxx.rs
+#rust = "1.48"
 links = "rpmostreeinternals"
 
 # This currently needs to duplicate the libraries in configure.ac

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -9,11 +9,6 @@ dn=$(dirname $0)
 ${dn}/install-extra-builddeps.sh
 ${dn}/installdeps.sh
 
-# create an unprivileged user for testing
-if ! getent passwd testuser; then
-  adduser testuser
-fi
-
 # make it clear what rustc version we're compiling with (this is grepped in CI)
 rustc --version
 

--- a/ci/clang-build-check.sh
+++ b/ci/clang-build-check.sh
@@ -11,6 +11,6 @@ dn=$(dirname $0)
 # add cargo's directory to the PATH like we do in CoreOS CI
 export PATH="$HOME/.cargo/bin:$PATH"
 
+export CC=clang CXX=clang++
 ${dn}/build.sh
 make check
-make install

--- a/ci/unit.sh
+++ b/ci/unit.sh
@@ -1,15 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# Usually, we try to keep this to no newer than current RHEL8 rust-toolset version.
-# You can find the current versions from here:
-# https://access.redhat.com/documentation/en-us/red_hat_developer_tools/1/
-# However, right now we are bumping to 1.48 so we can use https://cxx.rs
-MINIMUM_SUPPORTED_RUST_VERSION=1.48
-
 ci/installdeps.sh
-dnf remove -y cargo rust
-curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain ${MINIMUM_SUPPORTED_RUST_VERSION} -y
+ci/install-extra-builddeps.sh
 export PATH="$HOME/.cargo/bin:$PATH"
 ci/build.sh
-cargo +${MINIMUM_SUPPORTED_RUST_VERSION} test


### PR DESCRIPTION
ci: Drop testuser creation

Nothing is using this; our unit tests don't change uids and
most of our testing is in VMs.

Dropping this makes it easier to run the scripts outside of CI.

---

ci: Split clang into separate script, run it in CoreOS CI

Let's do a build with clang as a cleanly separate context
instead of serially; and also do it unconditionally.  This
is prep for turning on more `-Werror` flow in both cases,
and also using clang `scan-build` in CI.

---

ci: Drop custom msrv checking

The way this tries to replace the system Rust is hacky and
actually I realized belatedly I may have broken it recently; basically
`installdeps.sh` re-adds the system one, and it's hard to be sure
with our current buildsystem we're using the newer one from `$PATH`.

What we really want to do here is use a CentOS8 buildroot,
which will automatically enforce this in a better way along
with solving other problems.  But right now we've broken
that because libdnf requires a too-new libmodulemd.

So let's just rely on the Fedora rust for now.

