### PR TITLE
tree-wide: Convert g_return.*if_fail to g_assert

### DIFF
--- a/src/app/rpmostree-dbus-helpers.cxx
+++ b/src/app/rpmostree-dbus-helpers.cxx
@@ -993,7 +993,7 @@ pkg_diff_variant_print (GVariant *variant)
   gboolean have_new = FALSE;
 
   details = g_variant_get_child_value (variant, 2);
-  g_return_if_fail (details != NULL);
+  g_assert (details != NULL);
 
   have_old = g_variant_lookup (details,
                                "PreviousPackage", "(&s&s&s)",
@@ -1027,7 +1027,7 @@ rpmostree_print_package_diffs (GVariant *variant)
 
   /* GVariant format should be a(sua{sv}) */
 
-  g_return_if_fail (variant != NULL);
+  g_assert (variant != NULL);
 
   g_variant_iter_init (&iter, variant);
 

--- a/src/app/rpmostree-libbuiltin.cxx
+++ b/src/app/rpmostree-libbuiltin.cxx
@@ -50,8 +50,8 @@ rpmostree_usage_error (GOptionContext  *context,
                        const char      *message,
                        GError         **error)
 {
-  g_return_if_fail (context != NULL);
-  g_return_if_fail (message != NULL);
+  g_assert (context != NULL);
+  g_assert (message != NULL);
 
   g_autofree char *help = g_option_context_get_help (context, TRUE, NULL);
   g_printerr ("%s\n", help);

--- a/src/app/rpmostree-polkit-agent.cxx
+++ b/src/app/rpmostree-polkit-agent.cxx
@@ -56,7 +56,7 @@ fork_agent (pid_t *pid, const char *path, ...)
   va_list ap;
   char **l;
 
-  g_return_val_if_fail (pid != 0, 0);
+  g_assert (pid != 0);
   g_assert (path);
 
   parent_pid = getpid ();

--- a/src/daemon/rpmostreed-daemon.cxx
+++ b/src/daemon/rpmostreed-daemon.cxx
@@ -794,8 +794,8 @@ rpmostreed_daemon_publish (RpmostreedDaemon *self,
   GDBusObjectSkeleton *object = NULL;
   g_autoptr(GDBusObjectSkeleton) owned_object = NULL;
 
-  g_return_if_fail (RPMOSTREED_IS_DAEMON (self));
-  g_return_if_fail (path != NULL);
+  g_assert (RPMOSTREED_IS_DAEMON (self));
+  g_assert (path != NULL);
 
   if (G_IS_DBUS_INTERFACE (thing))
     {
@@ -845,8 +845,8 @@ rpmostreed_daemon_unpublish (RpmostreedDaemon *self,
   gboolean unexport = FALSE;
   GList *interfaces, *l;
 
-  g_return_if_fail (RPMOSTREED_IS_DAEMON (self));
-  g_return_if_fail (path != NULL);
+  g_assert (RPMOSTREED_IS_DAEMON (self));
+  g_assert (path != NULL);
 
   if (self->object_manager == NULL)
     return;

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -41,7 +41,7 @@
 char *
 rpmostreed_deployment_generate_id (OstreeDeployment *deployment)
 {
-  g_return_val_if_fail (OSTREE_IS_DEPLOYMENT (deployment), NULL);
+  g_assert (OSTREE_IS_DEPLOYMENT (deployment));
   return g_strdup_printf ("%s-%s.%u",
                           ostree_deployment_get_osname (deployment),
                           ostree_deployment_get_csum (deployment),

--- a/src/daemon/rpmostreed-os-experimental.cxx
+++ b/src/daemon/rpmostreed-os-experimental.cxx
@@ -179,8 +179,8 @@ rpmostreed_osexperimental_new (OstreeSysroot *sysroot,
                                OstreeRepo *repo,
                                const char *name)
 {
-  g_return_val_if_fail (OSTREE_IS_SYSROOT (sysroot), NULL);
-  g_return_val_if_fail (name != NULL, NULL);
+  g_assert (OSTREE_IS_SYSROOT (sysroot));
+  g_assert (name != NULL);
 
   g_autofree char *path = rpmostreed_generate_object_path (BASE_DBUS_PATH, name, NULL);
 

--- a/src/daemon/rpmostreed-os.cxx
+++ b/src/daemon/rpmostreed-os.cxx
@@ -1867,8 +1867,8 @@ rpmostreed_os_new (OstreeSysroot *sysroot,
                    OstreeRepo *repo,
                    const char *name)
 {
-  g_return_val_if_fail (OSTREE_IS_SYSROOT (sysroot), NULL);
-  g_return_val_if_fail (name != NULL, NULL);
+  g_assert (OSTREE_IS_SYSROOT (sysroot));
+  g_assert (name != NULL);
 
   g_autofree char *path = rpmostreed_generate_object_path (BASE_DBUS_PATH, name, NULL);
 

--- a/src/daemon/rpmostreed-sysroot.cxx
+++ b/src/daemon/rpmostreed-sysroot.cxx
@@ -741,7 +741,7 @@ rpmostreed_sysroot_populate (RpmostreedSysroot *self,
                              GCancellable *cancellable,
                              GError **error)
 {
-  g_return_val_if_fail (self != NULL, FALSE);
+  g_assert (self != NULL);
 
   /* See also related code in rpmostred-transaction.cxx */
   const char *sysroot_path = rpmostree_sysroot_get_path (RPMOSTREE_SYSROOT (self));

--- a/src/daemon/rpmostreed-transaction-applylive.cxx
+++ b/src/daemon/rpmostreed-transaction-applylive.cxx
@@ -113,8 +113,8 @@ rpmostreed_transaction_new_livefs (GDBusMethodInvocation *invocation,
                                    GCancellable          *cancellable,
                                    GError               **error)
 {
-  g_return_val_if_fail (G_IS_DBUS_METHOD_INVOCATION (invocation), NULL);
-  g_return_val_if_fail (OSTREE_IS_SYSROOT (sysroot), NULL);
+  g_assert (G_IS_DBUS_METHOD_INVOCATION (invocation));
+  g_assert (OSTREE_IS_SYSROOT (sysroot));
 
   auto self = (LiveFsTransaction *)g_initable_new (livefs_transaction_get_type (),
                          cancellable, error,

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -434,9 +434,9 @@ rpmostreed_transaction_new_package_diff (GDBusMethodInvocation *invocation,
                                          GError **error)
 {
 
-  g_return_val_if_fail (G_IS_DBUS_METHOD_INVOCATION (invocation), NULL);
-  g_return_val_if_fail (OSTREE_IS_SYSROOT (sysroot), NULL);
-  g_return_val_if_fail (osname != NULL, NULL);
+  g_assert (G_IS_DBUS_METHOD_INVOCATION (invocation));
+  g_assert (OSTREE_IS_SYSROOT (sysroot));
+  g_assert (osname != NULL);
 
   auto self = (PackageDiffTransaction *)
      g_initable_new (package_diff_transaction_get_type (),
@@ -572,9 +572,9 @@ rpmostreed_transaction_new_rollback (GDBusMethodInvocation *invocation,
                                      GError **error)
 {
 
-  g_return_val_if_fail (G_IS_DBUS_METHOD_INVOCATION (invocation), NULL);
-  g_return_val_if_fail (OSTREE_IS_SYSROOT (sysroot), NULL);
-  g_return_val_if_fail (osname != NULL, NULL);
+  g_assert (G_IS_DBUS_METHOD_INVOCATION (invocation));
+  g_assert (OSTREE_IS_SYSROOT (sysroot));
+  g_assert (osname != NULL);
 
   auto self = (RollbackTransaction *)
   g_initable_new (rollback_transaction_get_type (),
@@ -1665,9 +1665,9 @@ rpmostreed_transaction_new_deploy (GDBusMethodInvocation *invocation,
                                    GCancellable *cancellable,
                                    GError **error)
 {
-  g_return_val_if_fail (G_IS_DBUS_METHOD_INVOCATION (invocation), NULL);
-  g_return_val_if_fail (OSTREE_IS_SYSROOT (sysroot), NULL);
-  g_return_val_if_fail (osname != NULL, NULL);
+  g_assert (G_IS_DBUS_METHOD_INVOCATION (invocation));
+  g_assert (OSTREE_IS_SYSROOT (sysroot));
+  g_assert (osname != NULL);
 
   /* Parse this one early as it's used by an object property */
   g_autoptr(GVariantDict) options_dict = g_variant_dict_new (options);
@@ -1948,8 +1948,8 @@ rpmostreed_transaction_new_initramfs_etc (GDBusMethodInvocation *invocation,
                                           GError               **error)
 {
 
-  g_return_val_if_fail (G_IS_DBUS_METHOD_INVOCATION (invocation), NULL);
-  g_return_val_if_fail (OSTREE_IS_SYSROOT (sysroot), NULL);
+  g_assert (G_IS_DBUS_METHOD_INVOCATION (invocation));
+  g_assert (OSTREE_IS_SYSROOT (sysroot));
 
   auto self = (InitramfsEtcTransaction *)
     g_initable_new (initramfs_etc_transaction_get_type (),
@@ -2084,8 +2084,8 @@ rpmostreed_transaction_new_initramfs_state (GDBusMethodInvocation *invocation,
                                             GError               **error)
 {
   
-  g_return_val_if_fail (G_IS_DBUS_METHOD_INVOCATION (invocation), NULL);
-  g_return_val_if_fail (OSTREE_IS_SYSROOT (sysroot), NULL);
+  g_assert (G_IS_DBUS_METHOD_INVOCATION (invocation));
+  g_assert (OSTREE_IS_SYSROOT (sysroot));
 
   auto self = (InitramfsStateTransaction *)
     g_initable_new (initramfs_state_transaction_get_type (),
@@ -2244,8 +2244,8 @@ rpmostreed_transaction_new_cleanup (GDBusMethodInvocation *invocation,
                                     GCancellable          *cancellable,
                                     GError               **error)
 {
-  g_return_val_if_fail (G_IS_DBUS_METHOD_INVOCATION (invocation), NULL);
-  g_return_val_if_fail (OSTREE_IS_SYSROOT (sysroot), NULL);
+  g_assert (G_IS_DBUS_METHOD_INVOCATION (invocation));
+  g_assert (OSTREE_IS_SYSROOT (sysroot));
 
   auto self = (CleanupTransaction *)
     g_initable_new (cleanup_transaction_get_type (),
@@ -2362,8 +2362,8 @@ rpmostreed_transaction_new_refresh_md (GDBusMethodInvocation *invocation,
                                        GCancellable          *cancellable,
                                        GError               **error)
 {
-  g_return_val_if_fail (G_IS_DBUS_METHOD_INVOCATION (invocation), NULL);
-  g_return_val_if_fail (OSTREE_IS_SYSROOT (sysroot), NULL);
+  g_assert (G_IS_DBUS_METHOD_INVOCATION (invocation));
+  g_assert (OSTREE_IS_SYSROOT (sysroot));
 
   auto self = (RefreshMdTransaction *)
     g_initable_new (refresh_md_transaction_get_type (),
@@ -2511,8 +2511,8 @@ rpmostreed_transaction_new_modify_yum_repo (GDBusMethodInvocation *invocation,
                                             GCancellable          *cancellable,
                                             GError               **error)
 {
-  g_return_val_if_fail (G_IS_DBUS_METHOD_INVOCATION (invocation), NULL);
-  g_return_val_if_fail (OSTREE_IS_SYSROOT (sysroot), NULL);
+  g_assert (G_IS_DBUS_METHOD_INVOCATION (invocation));
+  g_assert (OSTREE_IS_SYSROOT (sysroot));
 
   auto self = (ModifyYumRepoTransaction*)
     g_initable_new (modify_yum_repo_transaction_get_type (),
@@ -2643,8 +2643,8 @@ rpmostreed_transaction_new_finalize_deployment (GDBusMethodInvocation *invocatio
                                                 GCancellable          *cancellable,
                                                 GError               **error)
 {
-  g_return_val_if_fail (G_IS_DBUS_METHOD_INVOCATION (invocation), NULL);
-  g_return_val_if_fail (OSTREE_IS_SYSROOT (sysroot), NULL);
+  g_assert (G_IS_DBUS_METHOD_INVOCATION (invocation));
+  g_assert (OSTREE_IS_SYSROOT (sysroot));
 
   g_autoptr(GVariantDict) options_dict = g_variant_dict_new (options);
 
@@ -2797,8 +2797,8 @@ rpmostreed_transaction_new_kernel_arg (GDBusMethodInvocation *invocation,
                                        GCancellable          *cancellable,
                                        GError               **error)
 {
-  g_return_val_if_fail (G_IS_DBUS_METHOD_INVOCATION (invocation), NULL);
-  g_return_val_if_fail (OSTREE_IS_SYSROOT (sysroot), NULL);
+  g_assert (G_IS_DBUS_METHOD_INVOCATION (invocation));
+  g_assert (OSTREE_IS_SYSROOT (sysroot));
 
   auto self = (KernelArgTransaction*)g_initable_new (kernel_arg_transaction_get_type (),
                          cancellable, error,

--- a/src/daemon/rpmostreed-transaction.cxx
+++ b/src/daemon/rpmostreed-transaction.cxx
@@ -820,7 +820,7 @@ rpmostreed_transaction_init (RpmostreedTransaction *self)
 gboolean
 rpmostreed_transaction_get_active (RpmostreedTransaction *transaction)
 {
-  g_return_val_if_fail (RPMOSTREED_IS_TRANSACTION (transaction), FALSE);
+  g_assert (RPMOSTREED_IS_TRANSACTION (transaction));
 
   RpmostreedTransactionPrivate *priv = rpmostreed_transaction_get_private (transaction);
   return (priv->finished_params == NULL);
@@ -829,7 +829,7 @@ rpmostreed_transaction_get_active (RpmostreedTransaction *transaction)
 OstreeSysroot *
 rpmostreed_transaction_get_sysroot (RpmostreedTransaction *transaction)
 {
-  g_return_val_if_fail (RPMOSTREED_IS_TRANSACTION (transaction), NULL);
+  g_assert (RPMOSTREED_IS_TRANSACTION (transaction));
 
   RpmostreedTransactionPrivate *priv = rpmostreed_transaction_get_private (transaction);
   return priv->sysroot;
@@ -838,7 +838,7 @@ rpmostreed_transaction_get_sysroot (RpmostreedTransaction *transaction)
 const char *
 rpmostreed_transaction_get_client (RpmostreedTransaction *transaction)
 {
-  g_return_val_if_fail (RPMOSTREED_IS_TRANSACTION (transaction), NULL);
+  g_assert (RPMOSTREED_IS_TRANSACTION (transaction));
 
   RpmostreedTransactionPrivate *priv = rpmostreed_transaction_get_private (transaction);
   return priv->client_description;
@@ -847,7 +847,7 @@ rpmostreed_transaction_get_client (RpmostreedTransaction *transaction)
 const char *
 rpmostreed_transaction_get_agent_id (RpmostreedTransaction *transaction)
 {
-  g_return_val_if_fail (RPMOSTREED_IS_TRANSACTION (transaction), NULL);
+  g_assert (RPMOSTREED_IS_TRANSACTION (transaction));
 
   RpmostreedTransactionPrivate *priv = rpmostreed_transaction_get_private (transaction);
   return priv->agent_id;
@@ -856,7 +856,7 @@ rpmostreed_transaction_get_agent_id (RpmostreedTransaction *transaction)
 const char *
 rpmostreed_transaction_get_sd_unit (RpmostreedTransaction *transaction)
 {
-  g_return_val_if_fail (RPMOSTREED_IS_TRANSACTION (transaction), NULL);
+  g_assert (RPMOSTREED_IS_TRANSACTION (transaction));
 
   RpmostreedTransactionPrivate *priv = rpmostreed_transaction_get_private (transaction);
   return priv->sd_unit;
@@ -865,7 +865,7 @@ rpmostreed_transaction_get_sd_unit (RpmostreedTransaction *transaction)
 GDBusMethodInvocation *
 rpmostreed_transaction_get_invocation (RpmostreedTransaction *transaction)
 {
-  g_return_val_if_fail (RPMOSTREED_IS_TRANSACTION (transaction), NULL);
+  g_assert (RPMOSTREED_IS_TRANSACTION (transaction));
 
   RpmostreedTransactionPrivate *priv = rpmostreed_transaction_get_private (transaction);
   return priv->invocation;
@@ -875,7 +875,7 @@ const char *
 rpmostreed_transaction_get_client_address (RpmostreedTransaction *transaction)
 {
 
-  g_return_val_if_fail (RPMOSTREED_IS_TRANSACTION (transaction), NULL);
+  g_assert (RPMOSTREED_IS_TRANSACTION (transaction));
 
   RpmostreedTransactionPrivate *priv = rpmostreed_transaction_get_private (transaction);
   return g_dbus_server_get_client_address (priv->server);
@@ -885,8 +885,8 @@ gboolean
 rpmostreed_transaction_is_compatible (RpmostreedTransaction *transaction,
                                       GDBusMethodInvocation *invocation)
 {
-  g_return_val_if_fail (RPMOSTREED_IS_TRANSACTION (transaction), FALSE);
-  g_return_val_if_fail (G_IS_DBUS_METHOD_INVOCATION (invocation), FALSE);
+  g_assert (RPMOSTREED_IS_TRANSACTION (transaction));
+  g_assert (G_IS_DBUS_METHOD_INVOCATION (invocation));
 
   RpmostreedTransactionPrivate *priv = rpmostreed_transaction_get_private (transaction);
 

--- a/src/daemon/rpmostreed-utils.cxx
+++ b/src/daemon/rpmostreed-utils.cxx
@@ -94,9 +94,9 @@ rpmostreed_generate_object_path_from_va (const gchar *base,
 {
   GString *path;
 
-  g_return_val_if_fail (base != NULL, NULL);
-  g_return_val_if_fail (g_variant_is_object_path (base), NULL);
-  g_return_val_if_fail (!g_str_has_suffix (base, "/"), NULL);
+  g_assert (base != NULL);
+  g_assert (g_variant_is_object_path (base));
+  g_assert (!g_str_has_suffix (base, "/"));
 
   path = g_string_new (base);
 
@@ -261,8 +261,8 @@ rpmostreed_repo_pull_ancestry (OstreeRepo               *repo,
    * https://github.com/projectatomic/rpm-ostree/pull/557 */
   gboolean first_pass = TRUE;
 
-  g_return_val_if_fail (OSTREE_IS_REPO (repo), FALSE);
-  g_return_val_if_fail (refspec != NULL, FALSE);
+  g_assert (OSTREE_IS_REPO (repo));
+  g_assert (refspec != NULL);
 
   if (!ostree_parse_refspec (refspec, &remote, &ref, error))
     goto out;
@@ -405,9 +405,9 @@ rpmostreed_repo_lookup_version (OstreeRepo           *repo,
 {
   VersionVisitorClosure closure = { version, NULL };
 
-  g_return_val_if_fail (OSTREE_IS_REPO (repo), FALSE);
-  g_return_val_if_fail (refspec != NULL, FALSE);
-  g_return_val_if_fail (version != NULL, FALSE);
+  g_assert (OSTREE_IS_REPO (repo));
+  g_assert (refspec != NULL);
+  g_assert (version != NULL);
 
   if (!rpmostreed_repo_pull_ancestry (repo, refspec,
                                       version_visitor, &closure,
@@ -470,9 +470,9 @@ rpmostreed_repo_lookup_checksum (OstreeRepo           *repo,
 {
   ChecksumVisitorClosure closure = { checksum, FALSE };
 
-  g_return_val_if_fail (OSTREE_IS_REPO (repo), FALSE);
-  g_return_val_if_fail (refspec != NULL, FALSE);
-  g_return_val_if_fail (checksum != NULL, FALSE);
+  g_assert (OSTREE_IS_REPO (repo));
+  g_assert (refspec != NULL);
+  g_assert (checksum != NULL);
 
   if (!rpmostreed_repo_pull_ancestry (repo, refspec,
                                       checksum_visitor, &closure,
@@ -516,9 +516,9 @@ rpmostreed_repo_lookup_cached_version (OstreeRepo    *repo,
   g_autofree char *checksum = NULL;
   gboolean ret = FALSE;
 
-  g_return_val_if_fail (OSTREE_IS_REPO (repo), FALSE);
-  g_return_val_if_fail (refspec != NULL, FALSE);
-  g_return_val_if_fail (version != NULL, FALSE);
+  g_assert (OSTREE_IS_REPO (repo));
+  g_assert (refspec != NULL);
+  g_assert (version != NULL);
 
   if (!ostree_repo_resolve_rev (repo, refspec, FALSE, &checksum, error))
     return FALSE;
@@ -582,7 +582,7 @@ rpmostreed_parse_revision (const char  *revision,
   const char *version = NULL;
   gboolean ret = FALSE;
 
-  g_return_val_if_fail (revision != NULL, FALSE);
+  g_assert (revision != NULL);
 
   if (g_ascii_strncasecmp (revision, "revision=", 9) == 0)
     {

--- a/src/lib/rpmostree-package.c
+++ b/src/lib/rpmostree-package.c
@@ -282,7 +282,7 @@ _rpm_ostree_diff_package_lists (GPtrArray  *a,
                                 GPtrArray **out_modified_b,
                                 GPtrArray **out_common)
 {
-  g_return_val_if_fail (a != NULL && b != NULL, FALSE);
+  g_assert (a != NULL && b != NULL);
   g_return_val_if_fail (out_unique_a || out_unique_b ||
                         out_modified_a || out_modified_b || out_common, FALSE);
 

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -397,7 +397,7 @@ rpmostree_context_new_system (OstreeRepo   *repo,
                               GCancellable *cancellable,
                               GError      **error)
 {
-  g_return_val_if_fail (repo != NULL, FALSE);
+  g_assert (repo != NULL);
 
   auto self = static_cast<RpmOstreeContext*>(g_object_new (RPMOSTREE_TYPE_CONTEXT, NULL));
   self->is_system = TRUE;
@@ -2654,7 +2654,7 @@ rpmostree_context_import_rojig (RpmOstreeContext *self,
     return TRUE;
 
   OstreeRepo *repo = get_pkgcache_repo (self);
-  g_return_val_if_fail (repo != NULL, FALSE);
+  g_assert (repo != NULL);
 
   if (!dnf_transaction_import_keys (dnf_context_get_transaction (dnfctx), error))
     return FALSE;
@@ -3389,7 +3389,7 @@ relabel_package_async_finish (RpmOstreeContext   *self,
                               GAsyncResult       *result,
                               GError            **error)
 {
-  g_return_val_if_fail (g_task_is_valid (result, self), FALSE);
+  g_assert (g_task_is_valid (result, self));
   return g_task_propagate_int ((GTask*)result, error);
 }
 
@@ -3443,7 +3443,7 @@ relabel_if_necessary (RpmOstreeContext *self,
 
   g_assert (self->sepolicy);
 
-  g_return_val_if_fail (ostreerepo != NULL, FALSE);
+  g_assert (ostreerepo != NULL);
 
   /* Prep a txn and tmpdir for all of the relabels */
   g_auto(RpmOstreeRepoAutoTransaction) txn = { 0, };

--- a/src/libpriv/rpmostree-importer.cxx
+++ b/src/libpriv/rpmostree-importer.cxx
@@ -1052,7 +1052,7 @@ rpmostree_importer_run_async_finish (RpmOstreeImporter  *self,
                                      GAsyncResult       *result,
                                      GError            **error)
 {
-  g_return_val_if_fail (g_task_is_valid (result, self), FALSE);
+  g_assert (g_task_is_valid (result, self));
   return static_cast<char*>(g_task_propagate_pointer ((GTask*)result, error));
 }
 

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -557,8 +557,8 @@ rpmostree_origin_set_rebase_custom (RpmOstreeOrigin *origin,
   /* Require non-empty strings */
   if (custom_origin_url)
     {
-      g_return_val_if_fail (*custom_origin_url, FALSE);
-      g_return_val_if_fail (custom_origin_description && *custom_origin_description, FALSE);
+      g_assert (*custom_origin_url);
+      g_assert (custom_origin_description && *custom_origin_description);
     }
 
    /* We don't want to carry any commit overrides or version pinning during a

--- a/src/libpriv/rpmostree-passwd-util.cxx
+++ b/src/libpriv/rpmostree-passwd-util.cxx
@@ -149,7 +149,7 @@ rpmostree_passwd_data2passwdents (const char *data)
   struct passwd *ent = NULL;
   GPtrArray *ret = g_ptr_array_new_with_free_func (conv_passwd_ent_free);
 
-  g_return_val_if_fail (data != NULL, NULL);
+  g_assert (data != NULL);
 
   g_autoptr(FILE) mf = fmemopen ((void *)data, strlen (data), "r");
 
@@ -201,7 +201,7 @@ sysuser_ent_free (void *vptr)
 GPtrArray *
 rpmostree_passwd_data2groupents (const char *data)
 {
-  g_return_val_if_fail (data != NULL, NULL);
+  g_assert (data != NULL);
 
   g_autoptr(FILE) mf = fmemopen ((void *)data, strlen (data), "r");
   GPtrArray *ret = g_ptr_array_new_with_free_func (conv_group_ent_free);

--- a/src/libpriv/rpmostree-rpm-util.cxx
+++ b/src/libpriv/rpmostree-rpm-util.cxx
@@ -832,7 +832,7 @@ get_sack_for_root (int               dfd,
                    GError          **error)
 {
   GLNX_AUTO_PREFIX_ERROR ("Loading sack", error);
-  g_return_val_if_fail (out_sack != NULL, FALSE);
+  g_assert (out_sack != NULL);
 
   g_autofree char *fullpath = glnx_fdrel_abspath (dfd, path);
 


### PR DESCRIPTION
See https://github.com/rpm-software-management/libdnf/pull/1127

Basically IMO the "return if fail" pattern is a carry-over
from C GTK+ apps where the idea is it's better to try to stumble
forward than have the app crash for the user.

In our case though, IMO we absolutely should just crash
if our assertions trip, because we're maintaining the user's
root filesystem.
