### PR TITLE
Follow-ups to the extensions work

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -36,6 +36,9 @@ extensions:
   # This can be whatever name you'd like. The name itself
   # isn't used by rpm-ostree.
   sooper-dooper-tracers:
+    # Optional; defaults to `os-extension`. An OS extension
+    # is an extension intended to be `rpm-ostree install`ed.
+    kind: os-extension
     # List of packages for this extension
     packages:
         - strace
@@ -47,6 +50,11 @@ extensions:
         - x86_64
         - aarch64
   kernel-dev:
+    # A development extension lists packages useful for
+    # developing for the target OSTree, but won't be layered
+    # on top. A common example is kernel modules. No
+    # depsolving happens, packages listed are downloaded.
+    kind: development
     packages:
       - kernel-devel
       - kernel-headers

--- a/rust/src/extensions.rs
+++ b/rust/src/extensions.rs
@@ -80,10 +80,11 @@ pub(crate) fn extensions_load(
     path: &str,
     basearch: &str,
     base_pkgs: &Vec<StringMapping>,
-) -> Result<Box<Extensions>> {
+) -> CxxResult<Box<Extensions>> {
     let f = utils::open_file(path)?;
     let mut f = std::io::BufReader::new(f);
-    extensions_load_stream(&mut f, basearch, base_pkgs).with_context(|| format!("parsing {}", path))
+    Ok(extensions_load_stream(&mut f, basearch, base_pkgs)
+        .with_context(|| format!("parsing {}", path))?)
 }
 
 impl Extensions {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -196,7 +196,8 @@ mod ffi {
             base_pkgs: &Vec<StringMapping>,
         ) -> Result<Box<Extensions>>;
         fn get_repos(&self) -> Vec<String>;
-        fn get_packages(&self) -> Vec<String>;
+        fn get_os_extension_packages(&self) -> Vec<String>;
+        fn get_development_packages(&self) -> Vec<String>;
         fn state_checksum_changed(&self, chksum: &str, output_dir: &str) -> Result<bool>;
         fn update_state_checksum(&self, chksum: &str, output_dir: &str) -> Result<()>;
         fn serialize_to_dir(&self, output_dir: &str) -> Result<()>;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -195,6 +195,7 @@ mod ffi {
             basearch: &str,
             base_pkgs: &Vec<StringMapping>,
         ) -> Result<Box<Extensions>>;
+        fn get_repos(&self) -> Vec<String>;
         fn get_packages(&self) -> Vec<String>;
         fn state_checksum_changed(&self, chksum: &str, output_dir: &str) -> Result<bool>;
         fn update_state_checksum(&self, chksum: &str, output_dir: &str) -> Result<()>;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -864,9 +864,8 @@ struct TreeComposeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "add-commit-metadata")]
     add_commit_metadata: Option<BTreeMap<String, serde_json::Value>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "rpmdb")]
     // The database backend
+    #[serde(skip_serializing_if = "Option::is_none")]
     rpmdb: Option<RpmdbBackend>,
 
     #[serde(flatten)]

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1559,13 +1559,21 @@ rpmostree_compose_builtin_extensions (int             argc,
     auto pkgs = extensions->get_packages();
     for (auto pkg : pkgs)
       g_ptr_array_add (gpkgs, (gpointer*) g_strdup (pkg.c_str()));
-    char **repos = ror_treefile_get_repos (treefile);
+
+    g_autoptr(GPtrArray) grepos = g_ptr_array_new_with_free_func (g_free);
+    auto repos = extensions->get_repos();
+    for (auto repo : repos)
+      g_ptr_array_add (grepos, (gpointer*) g_strdup (repo.c_str()));
+
+    char **treefile_repos = ror_treefile_get_repos (treefile);
+    for (char **it = treefile_repos; it && *it; it++)
+      g_ptr_array_add (grepos, (gpointer*) g_strdup (*it));
+
     g_autoptr(GKeyFile) treespec = g_key_file_new ();
     g_key_file_set_string_list (treespec, "tree", "packages",
                                 (const char* const*)gpkgs->pdata, gpkgs->len);
     g_key_file_set_string_list (treespec, "tree", "repos",
-                                (const char* const*)repos,
-                                g_strv_length (repos));
+                                (const char* const*)grepos->pdata, grepos->len);
     spec = rpmostree_treespec_new_from_keyfile (treespec, NULL);
   }
 

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1532,6 +1532,11 @@ rpmostree_compose_builtin_extensions (int             argc,
 
   auto extensions = rpmostreecxx::extensions_load (extensions_path, basearch, *packages_mapping);
 
+  // notice we don't use a pkgcache repo here like in the treecompose path: we
+  // want RPMs, so having them already imported isn't useful to us (and anyway,
+  // for OS extensions by definition they're not expected to be cached since
+  // they're not in the base tree)
+
   g_autoptr(RpmOstreeContext) ctx =
       rpmostree_context_new_tree (cachedir_dfd, repo, cancellable, error);
   if (!ctx)

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -2451,6 +2451,11 @@ gather_source_to_packages (GPtrArray *packages)
   for (guint i = 0; i < packages->len; i++)
     {
       auto pkg = static_cast<DnfPackage *>(packages->pdata[i]);
+
+      /* ignore local packages */
+      if (rpmostree_pkg_is_local (pkg))
+        continue;
+
       DnfRepo *src = dnf_package_get_repo (pkg);
       GPtrArray *source_packages;
 

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -190,6 +190,9 @@ gboolean rpmostree_context_download (RpmOstreeContext *self,
                                      GCancellable     *cancellable,
                                      GError           **error);
 
+void rpmostree_set_repos_on_packages (DnfContext *dnfctx,
+                                      GPtrArray  *packages);
+
 gboolean rpmostree_context_execute_rojig (RpmOstreeContext     *self,
                                           gboolean             *out_changed,
                                           GCancellable         *cancellable,

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -186,6 +186,10 @@ rpmostree_context_set_vlockmap (RpmOstreeContext *self,
                                 GHashTable       *map,
                                 gboolean          strict);
 
+gboolean rpmostree_download_packages (GPtrArray      *packages,
+                                      GCancellable   *cancellable,
+                                      GError        **error);
+
 gboolean rpmostree_context_download (RpmOstreeContext *self,
                                      GCancellable     *cancellable,
                                      GError           **error);


### PR DESCRIPTION
See https://github.com/coreos/coreos-assembler/pull/2028#issuecomment-769459160 for background. Testing this on RHCOS with:

```yaml
repos:
  - rhel-8-nfv

extensions:
  usbguard:
    kind: os-extension
    packages:
      # notice how we don't have to specify deps here
      - usbguard
  kernel-rt:
    kind: os-extension
    architectures:
      - x86_64
    packages:
      - kernel-rt-core
      - kernel-rt-kvm
      - kernel-rt-modules
      - kernel-rt-modules-extra
      - kernel-rt-devel
  kernel-devel:
    kind: development
    packages:
      - kernel-devel
      - kernel-core
      - kernel-headers
      - kernel-modules
      - kernel-modules-extra
    match-base-evra: kernel
```

Works fine!

See individual commit messages for details.