### PR TITLE
libpriv/passwd: move entries deduplication logic to Rust

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -176,6 +176,11 @@ pub mod ffi {
         fn passwd_cleanup(rootfd: i32) -> Result<()>;
         fn migrate_group_except_root(rootfd: i32, preserved_groups: &Vec<String>) -> Result<()>;
         fn migrate_passwd_except_root(rootfd: i32) -> Result<()>;
+        fn concat_fs_content(
+            rootfs_dfd: i32,
+            repo: Pin<&mut OstreeRepo>,
+            previous_checksum: &str,
+        ) -> Result<()>;
 
         type PasswdDB;
         fn lookup_user(self: &PasswdDB, uid: u32) -> Result<String>;

--- a/rust/src/passwd.rs
+++ b/rust/src/passwd.rs
@@ -1,13 +1,18 @@
-use crate::cxxrsutil;
+use crate::cxxrsutil::{self, FFIGObjectWrapper};
 use crate::ffiutil;
 use crate::nameservice;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
+use gio::prelude::InputStreamExtManual;
+use gio::FileExt;
 use nix::unistd::{Gid, Uid};
 use openat_ext::OpenatDirExt;
 use std::collections::HashMap;
+use std::collections::HashSet;
+use std::fs::File;
 use std::io::{BufReader, BufWriter, Write};
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
+use std::pin::Pin;
 
 static PWGRP_SHADOW_FILES: &[&str] = &["shadow", "gshadow", "subuid", "subgid"];
 static USRLIB_PWGRP_FILES: &[&str] = &["passwd", "group"];
@@ -162,6 +167,102 @@ pub fn migrate_group_except_root(rootfs_dfd: i32, preserved_groups: &Vec<String>
         Ok(())
     })?;
 
+    Ok(())
+}
+
+/// Merge and deduplicate entries from /usr/etc and /usr/lib.
+pub fn concat_fs_content(
+    rootfs_dfd: i32,
+    mut ffi_repo: Pin<&mut crate::ffi::OstreeRepo>,
+    previous_checksum: &str,
+) -> Result<()> {
+    anyhow::ensure!(!previous_checksum.is_empty(), "missing previous reference");
+
+    let rootfs = ffiutil::ffi_view_openat_dir(rootfs_dfd);
+    let repo = ffi_repo.gobj_wrap();
+    let (prev_root, _name) = repo.read_commit(previous_checksum, gio::NONE_CANCELLABLE)?;
+
+    concat_files(&rootfs, &prev_root, "passwd")
+        .context("failed to merge entries into /etc/passwd")?;
+    concat_files(&rootfs, &prev_root, "group")
+        .context("failed to merge entries into /etc/group")?;
+
+    Ok(())
+}
+
+fn concat_files(rootfs: &openat::Dir, prev_root: &gio::File, target: &str) -> Result<()> {
+    let append_unique_fn = match target {
+        "passwd" => passwd_append_unique,
+        "group" => group_append_unique,
+        x => anyhow::bail!("invalid merge target '{}'", x),
+    };
+
+    let orig_usretc_content = {
+        let usretc_src = format!("usr/etc/{}", &target);
+        prev_root.resolve_relative_path(usretc_src)
+    };
+    let orig_usrlib_content = {
+        let usrlib_src = format!("usr/lib/{}", &target);
+        prev_root.resolve_relative_path(usrlib_src)
+    };
+    if orig_usretc_content.is_none() && orig_usrlib_content.is_none() {
+        // This could actually happen after we transition to systemd-sysusers;
+        // we won't have a need for preallocated user data in the tree.
+        return Ok(());
+    }
+
+    let etc_target = format!("etc/{}", target);
+    rootfs
+        .write_file_with_sync(&etc_target, 0o664, |dest_bufwr| -> Result<()> {
+            let mut seen_names = HashSet::new();
+            if let Some(ref src_file) = orig_usretc_content {
+                append_unique_fn(src_file, &mut seen_names, dest_bufwr)
+                    .with_context(|| format!("failed to process /usr/etc/{}", &target))?;
+            }
+            if let Some(ref src_file) = orig_usrlib_content {
+                append_unique_fn(src_file, &mut seen_names, dest_bufwr)
+                    .with_context(|| format!("failed to process /usr/lib/{}", &target))?;
+            };
+            Ok(())
+        })
+        .with_context(|| format!("failed to write /etc/{}", &target))?;
+
+    Ok(())
+}
+
+fn passwd_append_unique(
+    src: &gio::File,
+    seen: &mut HashSet<String>,
+    dest: &mut BufWriter<File>,
+) -> Result<()> {
+    let src_stream = src.read(gio::NONE_CANCELLABLE)?.into_read();
+    let mut buf_rd = BufReader::new(src_stream);
+    let entries = nameservice::passwd::parse_passwd_content(&mut buf_rd)?;
+    for passwd in entries {
+        if seen.contains(&passwd.name) {
+            continue;
+        }
+        seen.insert(passwd.name.clone());
+        passwd.to_writer(dest)?;
+    }
+    Ok(())
+}
+
+fn group_append_unique(
+    src: &gio::File,
+    seen: &mut HashSet<String>,
+    dest: &mut BufWriter<File>,
+) -> Result<()> {
+    let src_stream = src.read(gio::NONE_CANCELLABLE)?.into_read();
+    let mut buf_rd = BufReader::new(src_stream);
+    let entries = nameservice::group::parse_group_content(&mut buf_rd)?;
+    for group in entries {
+        if seen.contains(&group.name) {
+            continue;
+        }
+        seen.insert(group.name.clone());
+        group.to_writer(dest)?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
This moves `group` and `passwd` merging/deduplication to Rust.
