### PR TITLE
build-sys: Rollup rework v1

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -82,7 +82,7 @@ rpmostree_common_cflags = -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
 	-I $(top_srcdir)/libdnf -I $(top_srcdir)/libdnf-build \
 	$(PKGDEP_RPMOSTREE_CFLAGS) $(PKGDEP_RPMOSTREE_RS_CFLAGS)
 rpmostree_bin_common_cflags = $(rpmostree_common_cflags)
-rpmostree_common_libs = $(CAP_LIBS) libglnx.la librpmostree-1.la librpmostreecxxrs.la $(PKGDEP_RPMOSTREE_RS_LIBS) $(PKGDEP_RPMOSTREE_LIBS) -L$(top_srcdir)/libdnf-build/libdnf -ldnf -lstdc++ -lrt
+rpmostree_common_libs = libglnx.la librpmostree-1.la librpmostreecxxrs.la $(PKGDEP_RPMOSTREE_RS_LIBS) $(PKGDEP_RPMOSTREE_LIBS)
 
 rpmostree_bin_common_libs = librpmostreeinternals.la $(rpmostree_common_libs)
 librpmostreeinternals_la_CFLAGS = $(AM_CFLAGS) $(rpmostree_common_cflags)

--- a/build.rs
+++ b/build.rs
@@ -23,6 +23,12 @@ fn main() -> Result<()> {
     println!("cargo:rustc-link-lib=cap");
     println!("cargo:rustc-link-search={}/libdnf-build/libdnf", cwd);
     println!("cargo:rustc-link-lib=dnf");
+    println!("cargo:rustc-link-lib=rt");
+    println!("cargo:rustc-link-lib=stdc++");
+    // https://github.com/ostreedev/ostree/commit/1f832597fc83fda6cb8daf48c4495a9e1590774c
+    // https://github.com/rust-lang/rust/issues/47714
+    println!("cargo:rustc-link-lib=dl");
+    println!("cargo:rustc-link-lib=m");
     println!("cargo:rustc-link-lib=rpmostree-1");
     system_deps::Config::new().probe()?;
     detect_fedora_feature()?;

--- a/configure.ac
+++ b/configure.ac
@@ -65,13 +65,6 @@ AC_SUBST([RPM_OSTREE_FEATURES])
 
 PKG_PROG_PKG_CONFIG
 
-save_LIBS="$LIBS"
-LIBS=
-AC_SEARCH_LIBS([cap_init], [cap], [], [AC_MSG_ERROR([*** POSIX caps library not found])])
-CAP_LIBS="$LIBS"
-AC_SUBST(CAP_LIBS)
-LIBS="$save_LIBS"
-
 # Remember to update AM_CPPFLAGS in Makefile.am when bumping GIO req.
 PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 # librepo libsolv etc. are libdnf dependencies
@@ -81,12 +74,6 @@ PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [gio-unix-2.0 >= 2.50.0 json-glib-1.0
 				     polkit-gobject-1
 				     rpm librepo libsolv libsolvext sqlite3 gpgme modulemd-2.0 json-c libcurl openssl
 				     libarchive])
-
-dnl -ldl: https://github.com/ostreedev/ostree/commit/1f832597fc83fda6cb8daf48c4495a9e1590774c
-dnl -ldl: https://github.com/rust-lang/rust/issues/47714
-dnl -lm: needed for rand crate in debug mode
-dnl See also rpmostree_core_linkage_for_rust()
-PKGDEP_RPMOSTREE_LIBS="$PKGDEP_RPMOSTREE_LIBS -Wl,--push-state,--no-as-needed,-ldl,-lm,--pop-state"
 
 # We just keep rust-specific deps separate for better tracking
 # The `libcurl` one is redundant since we already require it for libostree. `openssl`


### PR DESCRIPTION
Move libdnf build over to Cargo

This is now further migration towards Cargo/Rust possible
because we switched our main binary.  We've had an internal
`libdnf-sys` crate for a while, but now it can take over
the build of the underlying library too (like many `-sys`
crates support).

This itself is just an incremental step towards migrating
the main rpm-ostree build system to e.g. cmake too (or
perhaps directly with the `cc` crate, not sure yet) and
driving it via `cargo` too.

---

build-sys: Move -lcap linkage purely to Rust

Now that we are generating solely a Rust binary, we can
have the canonical list of things to link on the Rust side.

---

build-sys: Move -lstdc++ -lrt into Cargo

More draining.

---

build-sys: Move -lm -ldl linkage into Cargo

More Rust, less shell/m4 - the world gets slightly better.

---

build-sys: Drop Fedora 25+ rpm version check

I think we can just assume this nowadays.

