### PR TITLE
build-sys: Rebuild on C++ changes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -20,6 +20,10 @@ fn main() -> Result<()> {
     let cwd = cwd.to_str().expect("utf8 pwd");
     println!("cargo:rustc-link-search={}/.libs", cwd);
     println!("cargo:rustc-link-lib=static=rpmostreeinternals");
+    println!(
+        "cargo:rerun-if-changed={}/.libs/librpmostreeinternals.a",
+        cwd
+    );
     println!("cargo:rustc-link-lib=cap");
     println!("cargo:rustc-link-search={}/libdnf-build/libdnf", cwd);
     println!("cargo:rustc-link-lib=dnf");


### PR DESCRIPTION
Not running the code you think you are is an evil trap.
Fixes fallout from https://github.com/coreos/rpm-ostree/pull/2502/commits/b122579222892eb19555087adb0e026316d0d9f7
