### PR TITLE
build-sys: Explicit workspace, move libdnf deps to crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,9 @@ checksum = "1cca32fa0182e8c0989459524dc356b8f2b5c10f1b9eb521b7d182c03cf8c5ff"
 name = "libdnf-sys"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "libc",
+ "system-deps 2.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+# Explicitly create a workspace since we have libdnf-sys as a path
+# dependency, and in the future we may use other sub-crates.
+[workspace]
+
 [package]
 name = "rpmostree-rust"
 version = "0.1.0"
@@ -18,16 +22,7 @@ libarchive = "3.0"
 jsonglib = { name = "json-glib-1.0", version = "1" }
 polkitgobject = { name = "polkit-gobject-1", version = "0" }
 rpm = "4"
-# libdnf dependencies
-librepo = "1"
-libsolv = "0.7"
-libsolvext = "0.7"
-gpgme = "1"
-openssl = "1"
 libcurl = "7"
-sqlite3 = "3"
-modulemd = { name = "modulemd-2.0", version = "2" }
-jsonc = { name = "json-c", version = "0" }
 
 [dependencies]
 anyhow = "1.0.38"

--- a/rust/libdnf-sys/Cargo.toml
+++ b/rust/libdnf-sys/Cargo.toml
@@ -10,3 +10,21 @@ libc = "0.2"
 [lib]
 name = "libdnf_sys"
 path = "lib.rs"
+
+[build-dependencies]
+system-deps = "2.0"
+anyhow = "1.0"
+
+# This currently needs to duplicate the libraries from libdnf
+[package.metadata.system-deps]
+rpm = "4"
+# libdnf dependencies
+librepo = "1"
+libsolv = "0.7"
+libsolvext = "0.7"
+gpgme = "1"
+openssl = "1"
+libcurl = "7"
+sqlite3 = "3"
+modulemd = { name = "modulemd-2.0", version = "2" }
+jsonc = { name = "json-c", version = "0" }

--- a/rust/libdnf-sys/build.rs
+++ b/rust/libdnf-sys/build.rs
@@ -1,0 +1,6 @@
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    system_deps::Config::new().probe()?;
+    Ok(())
+}


### PR DESCRIPTION
First explicitly state that we're a workspace.  AIUI
this is actually implicit today via our use of a `path`
dependency, but in the future we may have other sub-crates.
So let's make it explicit now.

Also move the libdnf dependencies directly to that sub-crate.
