### PR TITLE
ci: Ensure HOME is set

### DIFF
--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/bash
 
+# OpenShift Prow jobs don't set $HOME, but we need
+# one for cargo right now.
+if test -z "$HOME"; then
+    export HOME=$(mktemp -d -t --suffix .prowhome)
+fi
+
 pkg_upgrade() {
     echo "Running dnf -y distro-sync... $(date)"
     dnf -y distro-sync


### PR DESCRIPTION
Prow doesn't set this and it breaks our `cargo install`.
