### PR TITLE
ci: Also test for HOME being writable

### DIFF
--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -2,7 +2,7 @@
 
 # OpenShift Prow jobs don't set $HOME, but we need
 # one for cargo right now.
-if test -z "$HOME"; then
+if test -z "$HOME" || test ! -w "$HOME"; then
     export HOME=$(mktemp -d -t --suffix .prowhome)
 fi
 


### PR DESCRIPTION
Actually it seems OpenShift sets HOME=/ for some reason; probably
related to the non-root uid default.

And whole lot of the Prow jobs do `export HOME=$(mktemp -d)` today.

I am tempted to add a `cosa entrypoint` command or something
that sanitizes the environment setup.
