### PR TITLE
Even more CI patches

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -5,22 +5,9 @@ parallel rpms: {
   def n = 5
   cosaPod(buildroot: true, runAsUser: 0, memory: "2Gi", cpu: "${n}") {
       checkout scm
-      shwrap("""
-        # fetch tags so `git describe` gives a nice NEVRA when building the RPM
-        git fetch origin --tags
-        git submodule update --init
-        ci/installdeps.sh
-        ci/install-extra-builddeps.sh
-        # Not in the path by default
-        export PATH="\$HOME/.cargo/bin:\$PATH"
-        # Our primary CI build goes via RPM rather than direct to binaries
-        # to better test that path, including our vendored spec file, etc.
-        # The RPM build expects pre-generated bindings, so do that now.
-        make -f Makefile.bindings bindings
-        cd packaging
-        RPM_BUILD_NCPUS=${n} make -f Makefile.dist-packaging rpm
-        mv \$(find . -name '*.rpm') ..
-      """)
+      shwrap("""RPM_BUILD_NCPUS=${n} ./ci/coreosci-rpmbuild.sh
+                mv packaging/*/*.rpm .
+             """)
       // make it easy for anyone to download the RPMs
       archiveArtifacts '*.rpm'
       stash excludes: '*.src.rpm', includes: '*.rpm', name: 'rpms'

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -38,7 +38,7 @@ clang: {
   def n = 5
   cosaPod(buildroot: true, runAsUser: 0, memory: "2Gi", cpu: "${n}") {
       checkout scm
-      shwrap("ci/clang-build-check.sh")
+      shwrap("MAKE_JOBS=${n} ci/clang-build-check.sh")
   }
 }
 }

--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -7,9 +7,5 @@ set -xeuo pipefail
 
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
-
-# add cargo's directory to the PATH like we do in CoreOS CI
-export PATH="$HOME/.cargo/bin:$PATH"
-
 ${dn}/build.sh
 make check

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -7,7 +7,6 @@ dn=$(dirname $0)
 . ${dn}/libbuild.sh
 
 ${dn}/install-extra-builddeps.sh
-export PATH="$HOME/.cargo/bin:$PATH"
 ${dn}/installdeps.sh
 # make it clear what rustc version we're compiling with (this is grepped in CI)
 rustc --version

--- a/ci/ci-commitmessage-submodules.sh
+++ b/ci/ci-commitmessage-submodules.sh
@@ -16,8 +16,8 @@ dn=$(dirname $0)
 # It's very common for people to accidentally change submodules, and having this
 # requirement is a small hurdle to pass.
 
-# If passed the commit, use that. Otherwise, just use HEAD.
-HEAD=${1:-HEAD}
+# If passed the commit, use that. Otherwise, just use the implicit default.
+HEAD=${1:-}
 
 tmpd=$(mktemp -d)
 touch ${tmpd}/.tmpdir

--- a/ci/clang-build-check.sh
+++ b/ci/clang-build-check.sh
@@ -7,10 +7,6 @@ set -xeuo pipefail
 
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
-
-# add cargo's directory to the PATH like we do in CoreOS CI
-export PATH="$HOME/.cargo/bin:$PATH"
-
 export CC=clang CXX=clang++
 ${dn}/build.sh
 make check

--- a/ci/commit-validation.sh
+++ b/ci/commit-validation.sh
@@ -2,5 +2,6 @@
 set -xeuo pipefail
 # Add cheap (non-building) checks here
 dn=$(dirname $0)
+. ${dn}/libbuild.sh
 ${dn}/codestyle.sh
 ${dn}/ci-commitmessage-submodules.sh

--- a/ci/coreosci-rpmbuild.sh
+++ b/ci/coreosci-rpmbuild.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+dn=$(dirname $0)
+. ${dn}/libbuild.sh
+
+# fetch tags so `git describe` gives a nice NEVRA when building the RPM
+git fetch origin --tags
+git submodule update --init --recursive
+ci/installdeps.sh
+ci/install-extra-builddeps.sh
+# Our primary CI build goes via RPM rather than direct to binaries
+# to better test that path, including our vendored spec file, etc.
+# The RPM build expects pre-generated bindings, so do that now.
+make -f Makefile.bindings bindings
+cd packaging
+make -f Makefile.dist-packaging rpm

--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -5,6 +5,8 @@
 if test -z "$HOME" || test ! -w "$HOME"; then
     export HOME=$(mktemp -d -t --suffix .prowhome)
 fi
+# In some cases we install tools via cargo, ensure that's in PATH
+export PATH="$HOME/.cargo/bin:$PATH"
 
 pkg_upgrade() {
     echo "Running dnf -y distro-sync... $(date)"

--- a/ci/unit.sh
+++ b/ci/unit.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+dn=$(dirname $0)
+. ${dn}/libbuild.sh
+
 ci/installdeps.sh
 ci/install-extra-builddeps.sh
-export PATH="$HOME/.cargo/bin:$PATH"
 ci/build.sh


### PR DESCRIPTION
ci: Don't assume HEAD exists

For some reason the way Prow clones the repo it doesn't exist;
the git default of `..` should work though.

---

ci: Consistently source libbuild

Since we need to set HOME and PATH, let's do that in a central
place rather than scattering it around by having all of
our entrypoint scripts source the `libbuild.sh` shell "library".

Move the CoreOS CI entrypoint into a script like the others.

