### PR TITLE
ci: Drop clang and unit tests from here

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -22,24 +22,6 @@ codestyle: {
         ci/commit-validation.sh
       """)
   }
-},
-unit: {
-  // this branch runs unit tests (both Rust-based and C-based)
-  def n = 5
-  cosaPod(buildroot: true, runAsUser: 0, memory: "2Gi", cpu: "${n}") {
-      checkout scm
-      shwrap("""
-        MAKE_JOBS=${n} CARGO_BUILD_JOBS=${n} ci/unit.sh
-      """)
-  }
-},
-clang: {
-  // Build with clang/clang++
-  def n = 5
-  cosaPod(buildroot: true, runAsUser: 0, memory: "2Gi", cpu: "${n}") {
-      checkout scm
-      shwrap("MAKE_JOBS=${n} ci/clang-build-check.sh")
-  }
 }
 }
 


### PR DESCRIPTION
We're running them in Prow now and we're hitting capacity
issues in CentOS CI.  Bigger picture, the "just build and unit test"
stuff runs in any cluster, so let's save our bare metal capacity
for our compose/VM testing.
