### PR TITLE
libdnf: Various buildsys fixes

### DIFF
--- a/rust/libdnf-sys/build.rs
+++ b/rust/libdnf-sys/build.rs
@@ -18,14 +18,15 @@ fn main() -> Result<()> {
         .define("SHARE_INSTALL_PREFIX:PATH", "/usr/libexec/rpm-ostree/share")
         .define("ENABLE_STATIC:BOOL", "1")
         .define("CMAKE_POSITION_INDEPENDENT_CODE", "ON")
-        // rpm-ostree maintains its own state
-        .define("WITH_SWDB:BOOL", "0")
         // We don't need docs
         .define("WITH_HTML:BOOL", "0")
         .define("WITH_MAN:BOOL", "0")
         // Don't need bindings
         .define("WITH_BINDINGS:BOOL", "0")
-        .define("WITH_GIR:BOOL", "0")
+        // Needed in Koji at least because timestamps(?)
+        // cause cmake to rerun without our -D flags which
+        // breaks the build.
+        .always_configure(false)
         .build_target("all")
         .build();
     println!(


### PR DESCRIPTION
WITH_SWDB: Removed in https://github.com/rpm-software-management/libdnf/commit/99309fbe04dcbdf6f9f09ceac01549b6cebc1c09
WITH_GIR Removed in https://github.com/rpm-software-management/libdnf/commit/e2f2862bedd0c278ed9781624ddc6861686a4760

Also, most importantly: don't always reconfigure libdnf

This is a questionable default for the cargo `cmake` crate.
Building in Koji is failing I think due to timestamp issues
causing cmake to run twice.
