### PR TITLE
 Bind output core into Rust, use in apply-live

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -91,13 +91,13 @@ pub mod ffi {
 
     // progress.rs
     extern "Rust" {
-        fn progress_begin_task(msg: &str);
-        fn progress_begin_n_items(msg: &str, n: u64);
-        fn progress_begin_percent(msg: &str);
-        fn progress_set_message(msg: &str);
-        fn progress_set_sub_message(msg: &str);
-        fn progress_update(n: u64);
-        fn progress_end(suffix: &str);
+        fn console_progress_begin_task(msg: &str);
+        fn console_progress_begin_n_items(msg: &str, n: u64);
+        fn console_progress_begin_percent(msg: &str);
+        fn console_progress_set_message(msg: &str);
+        fn console_progress_set_sub_message(msg: &str);
+        fn console_progress_update(n: u64);
+        fn console_progress_end(suffix: &str);
     }
 
     // history.rs

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -226,6 +226,14 @@ pub mod ffi {
         fn main_print_error(msg: &str);
     }
 
+    unsafe extern "C++" {
+        include!("rpmostree-output.h");
+        type Progress;
+
+        fn progress_begin_task(msg: &str) -> UniquePtr<Progress>;
+        fn end(self: Pin<&mut Progress>, msg: &str);
+    }
+
     // rpmostree-rpm-util.h
     unsafe extern "C++" {
         include!("rpmostree-rpm-util.h");

--- a/rust/src/progress.rs
+++ b/rust/src/progress.rs
@@ -192,14 +192,14 @@ pub(crate) fn console_progress_begin_percent(msg: &str) {
 
 pub(crate) fn console_progress_set_message(msg: &str) {
     let mut lock = PROGRESS.lock().unwrap();
-    let state = lock.as_mut().expect("progress to update");
+    let state = lock.as_mut().expect("progress to set message");
     state.set_message(msg);
 }
 
 pub(crate) fn console_progress_set_sub_message(msg: &str) {
     let msg = optional_str(msg);
     let mut lock = PROGRESS.lock().unwrap();
-    let state = lock.as_mut().expect("progress to update");
+    let state = lock.as_mut().expect("progress sub-msg update");
     state.set_sub_message(msg);
 }
 

--- a/rust/src/progress.rs
+++ b/rust/src/progress.rs
@@ -1,3 +1,10 @@
+//! A wrapper around the `indicatif` crate that maintains
+//! stateful drawing to a TTY console.  Note that much
+//! of rpm-ostree needs to work as both a DBus daemon
+//! under systemd, and a direct process in a podman/Kube
+//! container.  So there's a wrapping/indirection layer
+//! which currently lives in C++ in rpmostree-output.h.
+
 /*
  * Copyright (C) 2018 Red Hat, Inc.
  *
@@ -165,44 +172,44 @@ fn optional_str(s: &str) -> Option<&str> {
     Some(s).filter(|s| !s.is_empty())
 }
 
-pub(crate) fn progress_begin_task(msg: &str) {
+pub(crate) fn console_progress_begin_task(msg: &str) {
     let mut lock = PROGRESS.lock().unwrap();
     assert_empty(&lock);
     *lock = Some(ProgressState::new(msg, ProgressType::Task));
 }
 
-pub(crate) fn progress_begin_n_items(msg: &str, n: u64) {
+pub(crate) fn console_progress_begin_n_items(msg: &str, n: u64) {
     let mut lock = PROGRESS.lock().unwrap();
     assert_empty(&lock);
     *lock = Some(ProgressState::new(msg, ProgressType::NItems(n as u64)));
 }
 
-pub(crate) fn progress_begin_percent(msg: &str) {
+pub(crate) fn console_progress_begin_percent(msg: &str) {
     let mut lock = PROGRESS.lock().unwrap();
     assert_empty(&lock);
     *lock = Some(ProgressState::new(msg, ProgressType::Percent));
 }
 
-pub(crate) fn progress_set_message(msg: &str) {
+pub(crate) fn console_progress_set_message(msg: &str) {
     let mut lock = PROGRESS.lock().unwrap();
     let state = lock.as_mut().expect("progress to update");
     state.set_message(msg);
 }
 
-pub(crate) fn progress_set_sub_message(msg: &str) {
+pub(crate) fn console_progress_set_sub_message(msg: &str) {
     let msg = optional_str(msg);
     let mut lock = PROGRESS.lock().unwrap();
     let state = lock.as_mut().expect("progress to update");
     state.set_sub_message(msg);
 }
 
-pub(crate) fn progress_update(n: u64) {
+pub(crate) fn console_progress_update(n: u64) {
     let lock = PROGRESS.lock().unwrap();
     let state = lock.as_ref().expect("progress to update");
     state.update(n);
 }
 
-pub(crate) fn progress_end(suffix: &str) {
+pub(crate) fn console_progress_end(suffix: &str) {
     let suffix = optional_str(suffix);
     let mut lock = PROGRESS.lock().unwrap();
     let state = lock.take().expect("progress to end");

--- a/src/app/rpmostree-dbus-helpers.cxx
+++ b/src/app/rpmostree-dbus-helpers.cxx
@@ -443,7 +443,7 @@ transaction_progress_end (TransactionProgress *self)
 {
   if (self->progress)
     {
-      rpmostreecxx::progress_end(rust::Str());
+      rpmostreecxx::console_progress_end(rust::Str());
       self->progress = FALSE;
     }
   g_main_loop_quit (self->loop);
@@ -476,7 +476,7 @@ on_transaction_progress (GDBusProxy *proxy,
       const gchar *message = NULL;
       g_variant_get_child (parameters, 0, "&s", &message);
       tp->progress = TRUE;
-      rpmostreecxx::progress_begin_task (message);
+      rpmostreecxx::console_progress_begin_task (message);
     }
   else if (g_strcmp0 (signal_name, "TaskEnd") == 0)
     {
@@ -485,7 +485,7 @@ on_transaction_progress (GDBusProxy *proxy,
       if (tp->progress)
         {
           g_assert (tp->progress);
-          rpmostreecxx::progress_end (message);
+          rpmostreecxx::console_progress_end (message);
           tp->progress = FALSE;
         }
     }
@@ -494,7 +494,7 @@ on_transaction_progress (GDBusProxy *proxy,
       if (tp->progress)
         {
           g_assert (tp->progress);
-          rpmostreecxx::progress_end (rust::Str());
+          rpmostreecxx::console_progress_end (rust::Str());
           tp->progress = FALSE;
         }
     }
@@ -507,9 +507,9 @@ on_transaction_progress (GDBusProxy *proxy,
       if (!tp->progress)
         {
           tp->progress = TRUE;
-          rpmostreecxx::progress_begin_percent (message);
+          rpmostreecxx::console_progress_begin_percent (message);
         }
-      rpmostreecxx::progress_update (percentage);
+      rpmostreecxx::console_progress_update (percentage);
     }
   else if (g_strcmp0 (signal_name, "DownloadProgress") == 0)
     {
@@ -555,10 +555,10 @@ on_transaction_progress (GDBusProxy *proxy,
       if (!tp->progress)
         {
           tp->progress = TRUE;
-          rpmostreecxx::progress_begin_task (line);
+          rpmostreecxx::console_progress_begin_task (line);
         }
       else
-        rpmostreecxx::progress_set_message (line);
+        rpmostreecxx::console_progress_set_message (line);
     }
   else if (g_strcmp0 (signal_name, "Finished") == 0)
     {

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -559,8 +559,8 @@ checkout_base_tree (RpmOstreeSysrootUpgrader *self,
     return TRUE; /* already checked out! */
 
   /* let's give the user some feedback so they don't think we're blocked */
-  g_auto(RpmOstreeProgress) task = { 0, };
-  rpmostree_output_task_begin (&task, "Checking out tree %.7s", self->base_revision);
+  auto msg = g_strdup_printf ("Checking out tree %.7s", self->base_revision);
+  auto task = rpmostreecxx::progress_begin_task(msg);
 
   int repo_dfd = ostree_repo_get_dfd (self->repo); /* borrowed */
   /* Always delete this */
@@ -1168,8 +1168,7 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self,
         g_ptr_array_add (initramfs_args, g_strdup (*it));
       g_ptr_array_add (initramfs_args, NULL);
 
-      g_auto(RpmOstreeProgress) task = { 0, };
-      rpmostree_output_task_begin (&task, "Generating initramfs");
+      auto task = rpmostreecxx::progress_begin_task("Generating initramfs");
 
       g_assert (kernel_state && kernel_path);
 
@@ -1490,8 +1489,7 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
                                             _OSTREE_SYSROOT_RUNSTATE_STAGED_LOCKED);
         }
 
-      g_auto(RpmOstreeProgress) task = { 0, };
-      rpmostree_output_task_begin (&task, "Staging deployment");
+      auto task = rpmostreecxx::progress_begin_task("Staging deployment");
       if (!ostree_sysroot_stage_tree_with_options (self->sysroot, self->osname,
                                                    target_revision, origin,
                                                    self->cfg_merge_deployment,

--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -23,6 +23,7 @@
 #include "libglnx.h"
 #include "rpmostree-rojig-core.h"
 #include "rpmostree-core.h"
+#include "rpmostree-output.h"
 
 G_BEGIN_DECLS
 
@@ -63,6 +64,7 @@ struct _RpmOstreeContext {
   guint n_async_max;
   gboolean async_running;
   GCancellable *async_cancellable;
+  std::unique_ptr<rpmostreecxx::Progress> async_progress;
   GError *async_error;
   GPtrArray *pkgs; /* All packages */
   GPtrArray *pkgs_to_download;

--- a/src/libpriv/rpmostree-output.cxx
+++ b/src/libpriv/rpmostree-output.cxx
@@ -44,29 +44,29 @@ rpmostree_output_default_handler (RpmOstreeOutputType type,
     {
       auto begin = static_cast<RpmOstreeOutputProgressBegin *>(data);
       if (begin->percent)
-        rpmostreecxx::progress_begin_percent (begin->prefix);
+        rpmostreecxx::console_progress_begin_percent (begin->prefix);
       else if (begin->n > 0)
-        rpmostreecxx::progress_begin_n_items (begin->prefix, begin->n);
+        rpmostreecxx::console_progress_begin_n_items (begin->prefix, begin->n);
       else
-        rpmostreecxx::progress_begin_task (begin->prefix);
+        rpmostreecxx::console_progress_begin_task (begin->prefix);
     }
     break;
   case RPMOSTREE_OUTPUT_PROGRESS_UPDATE:
     {
       auto upd = static_cast<RpmOstreeOutputProgressUpdate *>(data);
-      rpmostreecxx::progress_update (upd->c);
+      rpmostreecxx::console_progress_update (upd->c);
     }
     break;
   case RPMOSTREE_OUTPUT_PROGRESS_SUB_MESSAGE:
     {
       auto msg = static_cast<const char *>(data);
-      rpmostreecxx::progress_set_sub_message (rust::Str(msg ?: ""));
+      rpmostreecxx::console_progress_set_sub_message (rust::Str(msg ?: ""));
     }
     break;
   case RPMOSTREE_OUTPUT_PROGRESS_END:
     {
       auto end = static_cast<RpmOstreeOutputProgressEnd *>(data);
-      rpmostreecxx::progress_end (rust::Str(end->msg ?: ""));
+      rpmostreecxx::console_progress_end (rust::Str(end->msg ?: ""));
       break;
     }
   }

--- a/src/libpriv/rpmostree-util.cxx
+++ b/src/libpriv/rpmostree-util.cxx
@@ -673,8 +673,7 @@ rpmostree_migrate_pkgcache_repo (OstreeRepo   *repo,
     {
       if (S_ISDIR (stbuf.st_mode))
         {
-          g_auto(RpmOstreeProgress) task = { 0, };
-          rpmostree_output_task_begin (&task, "Migrating pkgcache");
+          auto task = rpmostreecxx::progress_begin_task("Migrating pkgcache");
 
           g_autoptr(OstreeRepo) pkgcache = ostree_repo_open_at (repo_dfd,
                                                                 RPMOSTREE_OLD_PKGCACHE_DIR,
@@ -686,7 +685,8 @@ rpmostree_migrate_pkgcache_repo (OstreeRepo   *repo,
           if (!do_pkgcache_migration (repo, pkgcache, &n_migrated, cancellable, error))
             return FALSE;
 
-          rpmostree_output_progress_end_msg (&task, "%u done", n_migrated);
+          auto msg = g_strdup_printf("%u done", n_migrated);
+          task->end(msg);
           if (n_migrated > 0)
             sd_journal_print (LOG_INFO, "migrated %u cached package%s to system repo",
                               n_migrated, _NS(n_migrated));

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -70,6 +70,27 @@ throw_gerror (GError *&error)
   error = NULL;
   throw std::runtime_error (s);
 }
+
+// Duplicate a non-empty Rust Str to a NUL-terminated C string.
+// The empty string is converted to a NULL pointer.
+// This method should be viewed as a workaround for the lack
+// of Option<> binding in cxx-rs.
+static inline char *
+ruststr_dup_c_optempty(const rust::Str s) {
+  if (s.length() > 0)
+    return g_strndup(s.data(), s.length());
+  return NULL;
+}
+
+// Return a Rust string pointer from a possibly-NULL C string.
+// The NULL C string is converted to the empty string.
+// This method should be viewed as a workaround for the lack
+// of Option<> binding in cxx-rs.
+static inline rust::Str
+ruststr_or_empty (const char *c_str) {
+  return rust::Str(c_str ?: "");
+}
+
 }
 
 namespace rpmostreecxx {


### PR DESCRIPTION
Originally the Rust apply-live code was exposed from Rust to C
via bindgen.  But when working on that, I hit the problem
that our output infrastructure was C...and the "reverse direction"
binding stuff was just ugly.

This PR again IMO shows the value of the investment in cxx-rs
because we can now seamlessly call back from the Rust side
into a "C++-ish" progress API, which the C++ side is updated
to use.

The level of indirection here is obviously pretty silly
because the main thing on the C++ output side is basically
a function dispatcher, but...I didn't want to try to rework
that into Rust fully yet.  (But, the moment we do this
whole area will get a *lot* cleaner)

Anyways, in the end this makes it easy for the apply-live
code to output progress to the user which was sorely
needed.