### PR TITLE
Add ci/scan-build.sh and fix some warnings

### DIFF
--- a/ci/clang-analyzer.sh
+++ b/ci/clang-analyzer.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/bash
+# Use the clang static analyzer
+
+set -xeuo pipefail
+
+dn=$(dirname $0)
+. ${dn}/libbuild.sh
+env NOCONFIGURE=1 ./autogen.sh
+scan-build ./configure --prefix=/usr --libdir=/usr/lib64 --sysconfdir=/etc
+scan-build ${ARTIFACT_DIR:+-o ${ARTIFACT_DIR}} make

--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -455,13 +455,6 @@ early_main (void)
 static int
 rpmostree_main_inner (const rust::Slice<const rust::Str> args)
 {
-  /* We can leave this function with an error status from both a command
-   * invocation, as well as an option processing failure. Keep an alias to the
-   * two places that hold status codes.
-   */
-  int exit_status = EXIT_SUCCESS;
-  int *exit_statusp = &exit_status;
-
   auto argv0 = std::string(args[0]);
   g_set_prgname (argv0.c_str());
 
@@ -512,7 +505,6 @@ rpmostree_main_inner (const rust::Slice<const rust::Str> args)
     { .command = command,
       .command_line = command_line,
       .exit_code = -1 };
-  exit_statusp = &(invocation.exit_code);
   /* Note this may also throw a C++ exception, which will
    * be caught by a higher level.
    */
@@ -529,12 +521,10 @@ rpmostree_main_inner (const rust::Slice<const rust::Str> args)
   else
     {
       if (invocation.exit_code == -1)
-        invocation.exit_code = EXIT_SUCCESS;
+        return EXIT_SUCCESS;
       else
-        g_assert (invocation.exit_code != EXIT_SUCCESS);
+        return invocation.exit_code;
     }
-
-  return *exit_statusp;
 }
 
 /* Never returns */

--- a/src/app/rpmostree-builtin-rebase.cxx
+++ b/src/app/rpmostree-builtin-rebase.cxx
@@ -130,6 +130,7 @@ rpmostree_builtin_rebase (int             argc,
       else
         new_provided_refspec = opt_branch;
     }
+  (void)new_refspec_owned; /* Pacify static analysis */
 
   const char *remainder = NULL;
   RpmOstreeRefspecType refspectype;

--- a/src/daemon/rpmostreed-daemon.cxx
+++ b/src/daemon/rpmostreed-daemon.cxx
@@ -821,6 +821,7 @@ rpmostreed_daemon_publish (RpmostreedDaemon *self,
 
       if (object == NULL)
         object = owned_object = g_dbus_object_skeleton_new (path);
+      (void)owned_object; /* Pacify static analysis */
 
       g_dbus_object_skeleton_add_interface (object, (GDBusInterfaceSkeleton*)iface);
     }

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -465,6 +465,7 @@ add_all_commit_details_to_vardict (OstreeDeployment *deployment,
         return FALSE;
       refspec = refspec_remainder;
     }
+  (void)refspec_owned; /* Pacify static analysis */
   refspec_is_ostree = refspec_type == RPMOSTREE_REFSPEC_TYPE_OSTREE;
   if (refspec_type == RPMOSTREE_REFSPEC_TYPE_CHECKSUM && !commit)
     checksum = refspec;

--- a/src/daemon/rpmostreed-os.cxx
+++ b/src/daemon/rpmostreed-os.cxx
@@ -793,12 +793,13 @@ os_handle_automatic_update_trigger (RPMOSTreeOS *interface,
     }
 
   /* if output-to-self is not explicitly set, default to TRUE */
-  g_autoptr(GVariant) new_dict = NULL;
+  g_autoptr(GVariant) arg_options_owned = NULL;
   if (!g_variant_dict_contains (&dict, "output-to-self"))
     {
       g_variant_dict_insert (&dict, "output-to-self", "b", TRUE);
-      arg_options = new_dict = g_variant_ref_sink (g_variant_dict_end (&dict));
+      arg_options = arg_options_owned = g_variant_ref_sink (g_variant_dict_end (&dict));
     }
+  (void) arg_options_owned; /* Pacify static analysis */
 
   return os_merge_or_start_deployment_txn (
       interface,

--- a/src/lib/rpmostree.c
+++ b/src/lib/rpmostree.c
@@ -55,7 +55,7 @@ _rpmostree_shlib_ipc_send (const char *variant_type, char **args, const char *wd
   g_autoptr(GSocket) my_sock = g_socket_new_from_fd (my_sock_fd, error);
   if (!my_sock)
     return NULL;
-  my_sock_fd = -1; /* Ownership was transferred */
+  my_sock_fd = -1; (void) my_sock_fd; /* Ownership was transferred */
   g_autoptr(GPtrArray) full_args = g_ptr_array_new ();
   g_ptr_array_add (full_args, "rpm-ostree");
   g_ptr_array_add (full_args, "shlib-backend");

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -3716,7 +3716,7 @@ apply_rpmfi_overrides (RpmOstreeContext *self,
   if (!get_package_metainfo (self, path, NULL, &fi, error))
     return FALSE;
 
-  while ((i = rpmfiNext (fi)) >= 0)
+  while (rpmfiNext (fi) >= 0)
     {
       const char *fn = rpmfiFN (fi);
       const char *user = rpmfiFUser (fi) ?: "root";

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -3077,6 +3077,7 @@ get_rpmdb_pkg_header (rpmts rpmdb_ts,
   g_auto(rpmts) rpmdb_ts_owned = NULL;
   if (!rpmdb_ts) /* allow callers to pass NULL */
     rpmdb_ts = rpmdb_ts_owned = rpmtsCreate ();
+  (void)rpmdb_ts_owned; /* Pacify static analysis */
 
   unsigned int dbid = dnf_package_get_rpmdbid (pkg);
   g_assert (dbid > 0);
@@ -3189,6 +3190,7 @@ delete_package_from_root (RpmOstreeContext *self,
           if (fn_owned)
             fn = fn_owned;
         }
+      (void)fn_owned; /* Pacify static analysis */
 
       /* for now, we only remove files from /usr */
       if (!g_str_has_prefix (fn, "usr/"))

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -778,7 +778,7 @@ rpmostree_context_setup (RpmOstreeContext    *self,
       /* Makes sure we only disable all repos once. This is more for future proofing against
        * refactors for now since we don't support `lockfile-repos` on the client-side and on
        * the server-side we always require `repos` anyway. */
-      gboolean disabled_all_repos = FALSE;
+      bool disabled_all_repos = false;
 
       /* NB: missing "repos" --> let libdnf figure it out for itself (we're likely doing a
        * client-side compose where we want to use /etc/yum.repos.d/) */
@@ -788,7 +788,7 @@ rpmostree_context_setup (RpmOstreeContext    *self,
           if (!disabled_all_repos)
             {
               disable_all_repos (self);
-              disabled_all_repos = TRUE;
+              disabled_all_repos = true;
             }
           if (!enable_repos (self, (const char *const*)enabled_repos, error))
             return FALSE;
@@ -802,10 +802,7 @@ rpmostree_context_setup (RpmOstreeContext    *self,
           if (g_variant_dict_lookup (self->spec->dict, "lockfile-repos", "^a&s", &enabled_lockfile_repos))
             {
               if (!disabled_all_repos)
-                {
-                  disable_all_repos (self);
-                  disabled_all_repos = TRUE;
-                }
+                disable_all_repos (self);
               if (!enable_repos (self, (const char *const*)enabled_lockfile_repos, error))
                 return FALSE;
             }

--- a/src/libpriv/rpmostree-importer.cxx
+++ b/src/libpriv/rpmostree-importer.cxx
@@ -169,7 +169,7 @@ rpmostree_importer_read_metainfo (int fd,
       goto out;
     }
 
-  if ((r = rpmReadPackageFile (ts, rpmfd, abspath, &ret_header)) != RPMRC_OK)
+  if (rpmReadPackageFile (ts, rpmfd, abspath, &ret_header) != RPMRC_OK)
     {
       g_set_error (error,
                    G_IO_ERROR,

--- a/src/libpriv/rpmostree-passwd-util.cxx
+++ b/src/libpriv/rpmostree-passwd-util.cxx
@@ -727,7 +727,7 @@ open_file_stream_write_at (int dfd,
   if (!ret)
     return (FILE*)glnx_null_throw_errno_prefix (error, "fdopen");
   /* fdopen() steals ownership of fd */
-  fd = -1;
+  fd = -1; (void)fd;
   return ret;
 }
 

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -1286,10 +1286,9 @@ rpmostree_rootfs_postprocess_common (int           rootfs_fd,
   if (!rename_if_exists (rootfs_fd, "etc", rootfs_fd, "usr/etc", error))
     return FALSE;
 
-  gboolean have_rpmdb;
   if (!glnx_fstatat_allow_noent (rootfs_fd, RPMOSTREE_RPMDB_LOCATION, NULL, AT_SYMLINK_NOFOLLOW, error))
     return FALSE;
-  have_rpmdb = (errno == 0);
+  const bool have_rpmdb = (errno == 0);
   if (!have_rpmdb)
     {
       /* Try looking in var/lib/rpm */
@@ -1302,7 +1301,6 @@ rpmostree_rootfs_postprocess_common (int           rootfs_fd,
             return FALSE;
           if (symlinkat ("../../" RPMOSTREE_RPMDB_LOCATION, rootfs_fd, "var/lib/rpm") < 0)
             return glnx_throw_errno_prefix (error, "symlinkat(%s)", "var/lib/rpm");
-          have_rpmdb = TRUE;
         }
     }
 

--- a/src/libpriv/rpmostree-rpm-util.cxx
+++ b/src/libpriv/rpmostree-rpm-util.cxx
@@ -309,7 +309,7 @@ rpmhdrs_new (RpmOstreeRefTs *refts, const GPtrArray *patterns)
       h1 = headerLink (h1);
       g_ptr_array_add (hs, h1);
     }
-  iter = rpmdbFreeIterator (iter);
+  iter = rpmdbFreeIterator (iter); (void) iter;
 
   g_ptr_array_sort (hs, header_cmp_p);
 

--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -558,6 +558,7 @@ impl_run_rpm_script (const KnownRpmScriptKind *rpmscript,
   g_assert (script);
   if (expand)
     script = script_owned = rpmExpand (script, NULL);
+  (void)script_owned; /* Pacify static analysis */
 
   /* http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html#S2-RPM-INSIDE-ERASE-TIME-SCRIPTS */
   const char *script_arg = NULL;
@@ -855,6 +856,7 @@ rpmostree_transfiletriggers_run_sync (Header        hdr,
         continue;
       if (flags & RPMSCRIPT_FLAG_EXPAND)
         script = script_owned = rpmExpand (script, NULL);
+      (void)script_owned; /* Pacify static analysis */
 
       g_autoptr(GPtrArray) patterns = g_ptr_array_new_with_free_func (g_free);
 

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -54,7 +54,7 @@ template<typename T>
 // pattern of adding a "prefix" to the string.  When used multiple times it's
 // a bit like a human-friendly stack trace subset.
 template<typename T>
-  inline void rethrow_prefixed (std::exception& e, T prefix)
+  [[ noreturn ]] inline void rethrow_prefixed (std::exception& e, T prefix)
   {
     std::ostringstream msg;
     msg << prefix << ": " << e.what();
@@ -62,7 +62,7 @@ template<typename T>
   }
 
 // Convert a GError into a C++ exception.  Takes ownership of the error.
-static inline void 
+[[ noreturn ]] static inline void
 throw_gerror (GError *&error)
 {
   auto s = std::string (error->message);


### PR DESCRIPTION
ci: Add clang-analyzer.sh

There are really no excuses for any C/C++ project not to use
both ASAN+UBSAN and static analysis in CI.

---

tree-wide: Fix some spurious "Dead assignment" from clang-analyzer

This fixes some spurious warnings from clang-analyzer (aka `scan-build`) around
"Dead assignment".  Unfortunately the analyzer doesn't understand
the side effects of `__attribute__((cleanup))` here.

More info on the `(void)` pattern: https://clang-analyzer.llvm.org/faq.html#dead_store

---

tree-wide: Fix some "Dead assignment" from clang-analyzer

The `have_rpmdb` one was a leftover looks like.  In the `disabled_all_repos`
case it was clearly there for symmetry, but eh; it seems somewhat
unlikely that we add a *3rd* case there.  Also while we're
here change it to C++ `bool` so tools like analyzers know it really
is a boolean.

---

util: Annotate our "throw" wrappers as `[[ noreturn ]]`

This way the compiler and `clang-analyzer` understand and won't
issue an error if we are missing a `return` after an unconditional
`throw_gerror()`.

---

libmain: Refactor to fix analyzer warning

Previously this function was in `goto out` style
and so we had this awkward "track return value in pointer"
thing.  But `clang-analyzer` correctly points out that
we don't need this anymore because we never read the value
initially stored.

----

tree-wide: Pacify some clang-analyzer "Dead nested assignment"

It doesn't understand the "$x_owned" pattern (which is really
much like Rust's `std::borrow::Cow`).

---

tree-wide: Squash some clang-analyzer found unused variables

We weren't using the return values, so just drop them.

