### PR TITLE
core: Don't allow noent when resolving pkgcache rev

### DIFF
--- a/src/daemon/rpmostree-sysroot-core.cxx
+++ b/src/daemon/rpmostree-sysroot-core.cxx
@@ -123,7 +123,7 @@ add_package_refs_to_set (RpmOstreeRefSack *rsack,
   /* TODO: convert this to an iterator to avoid lots of malloc */
 
   if (pkglist->len == 0)
-    sd_journal_print (LOG_WARNING, "Failed to find any packages in root");
+    return glnx_throw (error, "Failed to find any packages in root");
   else
     {
       for (guint i = 0; i < pkglist->len; i++)
@@ -187,7 +187,7 @@ generate_pkgcache_refs (OstreeSysroot            *sysroot,
             return FALSE;
 
           if (!add_package_refs_to_set (rsack, FALSE, referenced_pkgs, cancellable, error))
-            return FALSE;
+            return glnx_prefix_error (error, "Deployment index=%d", i);
         }
       /* In rojig mode, we need to also reference packages from the base; this
        * is a different refspec format.

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -1042,7 +1042,7 @@ rpmostree_pkgcache_find_pkg_header (OstreeRepo    *pkgcache,
       g_autoptr(GVariant) commit = NULL;
       g_autofree char *actual_sha256 = NULL;
 
-      if (!ostree_repo_resolve_rev (pkgcache, cachebranch->c_str(), TRUE, &commit_csum, error))
+      if (!ostree_repo_resolve_rev (pkgcache, cachebranch->c_str(), FALSE, &commit_csum, error))
         return FALSE;
 
       if (!ostree_repo_load_commit (pkgcache, commit_csum, &commit, NULL, error))

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -2260,7 +2260,7 @@ rpmostree_context_prepare (RpmOstreeContext *self,
                                           DNF_PACKAGE_INFO_UPDATE,
                                           DNF_PACKAGE_INFO_DOWNGRADE, -1);
       if (!sort_packages (self, self->pkgs, cancellable, error))
-        return FALSE;
+        return glnx_prefix_error (error, "Sorting packages");
     }
 
   return TRUE;


### PR DESCRIPTION
If we get here, it's that we expect the pkgcache to be there. So don't
allow ENOENT (we weren't even checking for the ENOENT case here, which
shows that this was the intent).

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1925584