### PR TITLE
tree-wide: Fix clang -Wgnu-designator/-Wunused-variable

### DIFF
--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -500,7 +500,6 @@ rpmostree_main_inner (const rust::Slice<const rust::Str> args)
   g_autofree char *prgname = g_strdup_printf ("%s %s", g_get_prgname (), command_name);
   g_set_prgname (prgname);
 
-  gboolean funcres = FALSE;
   RpmOstreeCommandInvocation invocation = 
     { .command = command,
       .command_line = command_line,

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1527,7 +1527,7 @@ rpmostree_compose_builtin_extensions (int             argc,
       RpmOstreePackage *pkg = (RpmOstreePackage*)packages->pdata[i];
       const char *name = rpm_ostree_package_get_name (pkg);
       const char *evr = rpm_ostree_package_get_evr (pkg);
-      packages_mapping->push_back(rpmostreecxx::StringMapping {k: name, v: evr});
+      packages_mapping->push_back(rpmostreecxx::StringMapping{name, evr});
     }
 
   auto extensions = rpmostreecxx::extensions_load (extensions_path, basearch, *packages_mapping);

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -842,7 +842,7 @@ get_driver_g_variant (GVariant **driver_info,
                            &local_error))
     {
       if (!g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
-        g_propagate_error (error, util::move_nullify (local_error)), FALSE;
+        return g_propagate_error (error, util::move_nullify (local_error)), FALSE;
       // Don't propagate error if state file not found; just return early.
       return TRUE;
     }

--- a/src/daemon/rpmostreed-utils.cxx
+++ b/src/daemon/rpmostreed-utils.cxx
@@ -514,7 +514,6 @@ rpmostreed_repo_lookup_cached_version (OstreeRepo    *repo,
 {
   VersionVisitorClosure closure = { version, NULL };
   g_autofree char *checksum = NULL;
-  gboolean ret = FALSE;
 
   g_assert (OSTREE_IS_REPO (repo));
   g_assert (refspec != NULL);

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -627,7 +627,7 @@ std::unique_ptr<rust::Vec<rpmostreecxx::StringMapping>>
 rpmostree_dnfcontext_get_varsubsts (DnfContext *context)
 {
   auto r = std::make_unique<rust::Vec<rpmostreecxx::StringMapping>>();
-  r->push_back(rpmostreecxx::StringMapping {k: "basearch", v: dnf_context_get_base_arch (context) });
+  r->push_back(rpmostreecxx::StringMapping{"basearch", dnf_context_get_base_arch (context) });
   return r;
 }
 
@@ -3708,7 +3708,6 @@ apply_rpmfi_overrides (RpmOstreeContext *self,
   if (getuid () != 0)
     return TRUE;  /* 🔚 Early return */
 
-  int i;
   g_auto(rpmfi) fi = NULL;
   gboolean emitted_nonusr_warning = FALSE;
   g_autofree char *path = get_package_relpath (pkg);

--- a/src/libpriv/rpmostree-importer.cxx
+++ b/src/libpriv/rpmostree-importer.cxx
@@ -140,7 +140,6 @@ rpmostree_importer_read_metainfo (int fd,
   gboolean ret = FALSE;
   g_auto(rpmts) ts = NULL;
   FD_t rpmfd;
-  int r;
   g_auto(Header) ret_header = NULL;
   g_auto(rpmfi) ret_fi = NULL;
   gsize ret_cpio_offset;

--- a/src/libpriv/rpmostree-kernel.cxx
+++ b/src/libpriv/rpmostree-kernel.cxx
@@ -506,7 +506,6 @@ rpmostree_run_dracut (int     rootfs_dfd,
                       GCancellable  *cancellable,
                       GError **error)
 {
-  gboolean ret = FALSE;
   auto destdir = rpmostreecxx::cliwrap_destdir();
   /* Shell wrapper around dracut to write to the O_TMPFILE fd;
    * at some point in the future we should add --fd X instead of -f


### PR DESCRIPTION
tree-wide: Fix clang -Wgnu-designator/-Wunused-variable

clang warns about this:
https://clang.llvm.org/docs/DiagnosticsReference.html#wgnu-designator
Also fix unused variables and hard error on them.

---

transaction: Fix missing return in error case

Hooray for compiler warnings.

---

