### PR TITLE
ci/clang-analyzer: Install deps

### DIFF
--- a/ci/clang-analyzer.sh
+++ b/ci/clang-analyzer.sh
@@ -5,6 +5,8 @@ set -xeuo pipefail
 
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
+${dn}/install-extra-builddeps.sh
+${dn}/installdeps.sh
 env NOCONFIGURE=1 ./autogen.sh
 scan-build ./configure --prefix=/usr --libdir=/usr/lib64 --sysconfdir=/etc
 scan-build ${ARTIFACT_DIR:+-o ${ARTIFACT_DIR}} make


### PR DESCRIPTION
This flow was missing from here which broke in CI.
