### PR TITLE
libdnf-sys: Drop C API, replace with cxx.rs bridge and move ror_lockfile_read to cxx.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ce42b8998a383572e0a802d859b1f00c79b7b7474e62fff88ee5c2845d9c13"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "console"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +267,21 @@ dependencies = [
  "cxxbridge-flags",
  "cxxbridge-macro",
  "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69c0ba9a6c36216f1cd3cb6aedc605ca22feb9fc64d9a1b76099a9e368fa553d"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
 ]
 
 [[package]]
@@ -640,7 +665,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cmake",
- "libc",
+ "cxx",
+ "cxx-build",
  "system-deps 2.0.3",
 ]
 
@@ -1247,6 +1273,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e114536316b51a5aa7a0e59fc49661fd263c5507dd08bd28de052e57626ce69"
+
+[[package]]
 name = "serde"
 version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,6 +1491,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,6 +1645,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/rust/libdnf-sys/Cargo.toml
+++ b/rust/libdnf-sys/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 links = "dnf"
 
 [dependencies]
-libc = "0.2"
+cxx = "1.0.30"
 
 [lib]
 name = "libdnf_sys"
@@ -16,6 +16,7 @@ path = "lib.rs"
 cmake = "0.1.45"
 system-deps = "2.0"
 anyhow = "1.0"
+cxx-build = "1.0.30"
 
 # This currently needs to duplicate the libraries from libdnf
 [package.metadata.system-deps]
@@ -30,3 +31,4 @@ libcurl = "7"
 sqlite3 = "3"
 modulemd = { name = "modulemd-2.0", version = "2" }
 jsonc = { name = "json-c", version = "0" }
+glib = { name = "glib-2.0", version = "2" }

--- a/rust/libdnf-sys/cxx/libdnf.cxx
+++ b/rust/libdnf-sys/cxx/libdnf.cxx
@@ -1,0 +1,44 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "libdnf.hxx"
+
+namespace dnfcxx {
+  // XXX: use macro to dedupe
+  rust::String dnf_package_get_nevra(DnfPackage &pkg) {
+    return rust::String(::dnf_package_get_nevra(&pkg));
+  }
+  rust::String dnf_package_get_name(DnfPackage &pkg) {
+    return rust::String(::dnf_package_get_name(&pkg));
+  }
+  rust::String dnf_package_get_evr(DnfPackage &pkg) {
+    return rust::String(::dnf_package_get_evr(&pkg));
+  }
+  rust::String dnf_package_get_arch(DnfPackage &pkg) {
+    return rust::String(::dnf_package_get_arch(&pkg));
+  }
+
+  rust::String dnf_repo_get_id(DnfRepo &repo) {
+    return rust::String(::dnf_repo_get_id(&repo));
+  }
+  guint64 dnf_repo_get_timestamp_generated(DnfRepo &repo) {
+    return ::dnf_repo_get_timestamp_generated(&repo);
+  }
+}

--- a/rust/libdnf-sys/cxx/libdnf.hxx
+++ b/rust/libdnf-sys/cxx/libdnf.hxx
@@ -1,0 +1,37 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <libdnf/libdnf.h>
+
+#include "rust/cxx.h"
+
+namespace dnfcxx {
+  typedef ::DnfPackage DnfPackage;
+  rust::String dnf_package_get_nevra(DnfPackage &pkg);
+  rust::String dnf_package_get_name(DnfPackage &pkg);
+  rust::String dnf_package_get_evr(DnfPackage &pkg);
+  rust::String dnf_package_get_arch(DnfPackage &pkg);
+
+  typedef ::DnfRepo DnfRepo;
+  rust::String dnf_repo_get_id(DnfRepo &repo);
+  guint64 dnf_repo_get_timestamp_generated(DnfRepo &repo);
+}

--- a/rust/libdnf-sys/lib.rs
+++ b/rust/libdnf-sys/lib.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use libc;
+use cxx::{type_id, ExternType};
 
 /* This is an experiment in calling libdnf functions from Rust. Really, it'd be more sustainable to
  * generate a "libdnf-sys" from SWIG (though it doesn't look like that's supported yet
@@ -13,15 +13,34 @@ use libc;
 
 // This technique for an uninstantiable/opaque type is used by libgit2-sys at least:
 // https://github.com/rust-lang/git2-rs/blob/master/libgit2-sys/lib.rs#L51
+// XXX: dedupe with macro
 pub enum DnfPackage {}
-pub enum DnfRepo {}
-
-extern "C" {
-    pub fn dnf_package_get_nevra(package: *mut DnfPackage) -> *const libc::c_char;
-    pub fn dnf_package_get_name(package: *mut DnfPackage) -> *const libc::c_char;
-    pub fn dnf_package_get_evr(package: *mut DnfPackage) -> *const libc::c_char;
-    pub fn dnf_package_get_arch(package: *mut DnfPackage) -> *const libc::c_char;
-
-    pub fn dnf_repo_get_id(repo: *mut DnfRepo) -> *const libc::c_char;
-    pub fn dnf_repo_get_timestamp_generated(repo: *mut DnfRepo) -> u64;
+unsafe impl ExternType for DnfPackage {
+    type Id = type_id!(dnfcxx::DnfPackage);
+    type Kind = cxx::kind::Trivial;
 }
+
+pub enum DnfRepo {}
+unsafe impl ExternType for DnfRepo {
+    type Id = type_id!(dnfcxx::DnfRepo);
+    type Kind = cxx::kind::Trivial;
+}
+
+#[cxx::bridge(namespace = "dnfcxx")]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("libdnf.hxx");
+
+        type DnfPackage = crate::DnfPackage;
+        fn dnf_package_get_nevra(pkg: &mut DnfPackage) -> Result<String>;
+        fn dnf_package_get_name(pkg: &mut DnfPackage) -> Result<String>;
+        fn dnf_package_get_evr(pkg: &mut DnfPackage) -> Result<String>;
+        fn dnf_package_get_arch(pkg: &mut DnfPackage) -> Result<String>;
+
+        type DnfRepo = crate::DnfRepo;
+        fn dnf_repo_get_id(repo: &mut DnfRepo) -> Result<String>;
+        fn dnf_repo_get_timestamp_generated(repo: &mut DnfRepo) -> Result<u64>;
+    }
+}
+
+pub use ffi::*;

--- a/rust/src/ffiutil.rs
+++ b/rust/src/ffiutil.rs
@@ -67,24 +67,6 @@ pub(crate) fn ffi_ptr_array_to_vec<T>(a: *mut glib_sys::GPtrArray) -> Vec<*mut T
     v
 }
 
-/// Transform a NULL-terminated array of C strings to an allocated Vec holding unowned references.
-/// This is similar to FromGlibPtrContainer::from_glib_none(), but avoids cloning elements.
-pub(crate) fn ffi_strv_to_os_str_vec<'a>(mut strv: *mut *mut libc::c_char) -> Vec<&'a OsStr> {
-    assert!(!strv.is_null());
-
-    // In theory, we could use std::slice::from_raw_parts instead to make this more 0-cost and
-    // create an &[*mut libc::c_char], but from there there's no clean way to get a &['a OsStr]
-    // short of just transmuting.
-    let mut v = Vec::new();
-    unsafe {
-        while !(*strv).is_null() {
-            v.push(ffi_view_os_str(*strv));
-            strv = strv.offset(1);
-        }
-    }
-    v
-}
-
 // View `fd` as an `openat::Dir` instance.  Lifetime of return value
 // must be less than or equal to that of parameter.
 pub(crate) fn ffi_view_openat_dir(fd: libc::c_int) -> openat::Dir {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -203,6 +203,11 @@ pub mod ffi {
         fn serialize_to_dir(&self, output_dir: &str) -> Result<()>;
     }
 
+    // lockfile.rs
+    extern "Rust" {
+        fn ror_lockfile_read(filenames: &Vec<String>) -> Result<Vec<StringMapping>>;
+    }
+
     // rpmutils.rs
     extern "Rust" {
         fn cache_branch_to_nevra(nevra: &str) -> String;


### PR DESCRIPTION
```
libdnf-sys: Drop C API, replace with cxx.rs bridge

Right now, we're using libdnf APIs from Rust via hand-crafted `extern C`
interfaces, which is extra dangerous because there is no signature
checking that happens at compile-time.

Until either we can automate libdnf bindings or use its C++ API directly
via cxx.rs, let's do some basic wrapping in C++ ourselves and use libdnf
through that API only instead. That gives us a lot more confidence and
makes the libdnf API feel more natural to use in Rust.
```

```
lockfile: Move ror_lockfile_read to cxx.rs

Pretty straightforward. Haven't moved `ror_lockfile_write` yet because
that's trickier to do and I'm still figuring out the most elegant way to
do this within cxx.rs' constraints.
```