### PR TITLE
build-sys: Statically link binary against shlib code

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -63,6 +63,7 @@ librpmostreeinternals_la_SOURCES = \
 	src/app/rpmostree-builtin-compose.cxx \
 	$(librpmostreed_sources) \
 	$(librpmostreepriv_sources) \
+	$(librpmostree_1_la_SOURCES) \
 	$(NULL)
 
 if BUILDOPT_ROJIG
@@ -80,9 +81,10 @@ rpmostree_common_cflags = -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
 	-DG_LOG_DOMAIN=\"rpm-ostreed\" \
 	-DLIBDIR=\"$(libdir)\" -DPKGLIBDIR=\"$(pkglibdir)\" \
 	-I $(top_srcdir)/libdnf \
+	-D_RPMOSTREE_EXTERN= \
 	$(PKGDEP_LIBRPMOSTREE_CFLAGS) $(PKGDEP_RPMOSTREE_CFLAGS)
 rpmostree_bin_common_cflags = $(rpmostree_common_cflags)
-rpmostree_common_libs = libglnx.la librpmostree-1.la librpmostreecxxrs.la
+rpmostree_common_libs = libglnx.la librpmostreecxxrs.la
 
 rpmostree_bin_common_libs = librpmostreeinternals.la $(rpmostree_common_libs)
 librpmostreeinternals_la_CFLAGS = $(AM_CFLAGS) $(rpmostree_common_cflags)

--- a/build.rs
+++ b/build.rs
@@ -31,7 +31,6 @@ fn main() -> Result<()> {
     // https://github.com/rust-lang/rust/issues/47714
     println!("cargo:rustc-link-lib=dl");
     println!("cargo:rustc-link-lib=m");
-    println!("cargo:rustc-link-lib=rpmostree-1");
     system_deps::Config::new().probe()?;
     detect_fedora_feature()?;
     Ok(())


### PR DESCRIPTION
Having our binary depend on the shared library, which in
turn depends on the binary (at runtime) is messy.
Instead, statically compile the shlib code into our binary.
This duplicates the text a bit, but it's not a lot of code.

The goal is to more easily in the future to e.g. move the
shared library out into a separate git repository entirely
that runs on a separate lifecycle - that would still build
using Automake for example while the main git repository
switches to purely cargo.

Another motivation is avoiding linker issues I had with other
patches due to this semi-cyclical dependency.
