### PR TITLE
tree-wide: Include GLib headers before libdnf

### DIFF
--- a/src/libpriv/rpmostree-refsack.h
+++ b/src/libpriv/rpmostree-refsack.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <gio/gio.h>
 #include <libdnf/libdnf.h>
 #include "libglnx.h"
 

--- a/src/libpriv/rpmostree-refts.h
+++ b/src/libpriv/rpmostree-refts.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <gio/gio.h>
 #include <libdnf/libdnf.h>
 #include "libglnx.h"
 


### PR DESCRIPTION
Alternative fix to https://github.com/rpm-software-management/libdnf/pull/1139
aka https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1935

This way libdnf's `extern "C"` over the glib headers doesn't apply
because we already processed that header.
