### PR TITLE
rust: Add module doc headers

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,3 +1,6 @@
+//! Helpers for the client side binary that will speak DBus
+//! to rpm-ostreed.service.
+
 use crate::cxxrsutil::*;
 use crate::utils;
 use std::os::unix::io::IntoRawFd;

--- a/rust/src/cliwrap.rs
+++ b/rust/src/cliwrap.rs
@@ -16,6 +16,9 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+//! Implements the `cliwrap` treefile option which intercepts/proxies
+//! other binaries like `/usr/bin/rpm`.
+
 use anyhow::{anyhow, Result};
 use std::io::prelude::*;
 use std::path;

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -2,7 +2,12 @@
  * Copyright (C) 2018 Red Hat, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
  */
+
+//! Code run server side to "postprocess"
+//! a filesystem tree (usually containing mostly RPMs) in
+//! order to prepare it as an OSTree commit.
 
 use crate::cxxrsutil::CxxResult;
 use anyhow::Result;

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -1,3 +1,7 @@
+//! Code mirroring rpmostree-core.cxx which is the shared "core"
+//! binding of rpm and ostree, used by both client-side layering/overrides
+//! and server side composes.
+
 use crate::cxxrsutil::CxxResult;
 use crate::ffiutil;
 use ffiutil::*;

--- a/rust/src/countme.rs
+++ b/rust/src/countme.rs
@@ -16,6 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+//! Implementation of the "DNF Count Me" system.
+
 use anyhow::{bail, Context, Result};
 use curl::easy::Easy;
 use os_release::OsRelease;

--- a/rust/src/dirdiff.rs
+++ b/rust/src/dirdiff.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
+//! Compute difference between two filesystem trees.
+
 use anyhow::{Context, Result};
 use openat_ext::OpenatDirExt;
 use serde_derive::{Deserialize, Serialize};

--- a/rust/src/fedora_integration.rs
+++ b/rust/src/fedora_integration.rs
@@ -1,3 +1,5 @@
+//! APIs used to talk to Fedora Infrastructure tooling (Koji, Bodhi).
+
 use crate::cxxrsutil::CxxResult;
 use anyhow::{Context, Result};
 use serde_derive::Deserialize;

--- a/rust/src/journal.rs
+++ b/rust/src/journal.rs
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
+//! Helper functions for interacting with the systemd journal and specific
+//! services like ostree-finalize-staged.
+
 use anyhow::{bail, Result};
 use systemd::id128::Id128;
 use systemd::journal;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,5 +1,6 @@
-//! rpm-ostree is split into a C/C++ portion and a Rust portion, the latter
-//! of which is compiled into a shared library, which is defined here.
+//! rpm-ostree a hybrid Rust and C/C++ application.  This is the
+//! main library used by the executable, which also links to the
+//! C/C++ `librpmostreeinternals.a` static library.
 
 /*
  * Copyright (C) 2018 Red Hat, Inc.

--- a/rust/src/lockfile.rs
+++ b/rust/src/lockfile.rs
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
+//! Manage lockfiles which are a model to pin specific package
+//! versions via JSON files (usually stored in git).
+
 /* Copied and adapted from: treefile.rs
  */
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,3 +1,5 @@
+//! The main CLI logic.
+
 use anyhow::Result;
 
 fn inner_main(args: &Vec<&str>) -> Result<()> {

--- a/rust/src/ostree_diff.rs
+++ b/rust/src/ostree_diff.rs
@@ -1,3 +1,5 @@
+//! Compute the difference between two OSTree commits.
+
 /*
  * Copyright (C) 2020 Red Hat, Inc.
  *

--- a/rust/src/passwd.rs
+++ b/rust/src/passwd.rs
@@ -1,3 +1,6 @@
+//! APIs for interacting with `/etc/passwd` and `/etc/group`, including
+//! handling the "nss-altfiles" split into `/usr/lib/{passwd,group}`.
+
 use crate::cxxrsutil::{self, FFIGObjectWrapper};
 use crate::ffiutil;
 use crate::nameservice;

--- a/rust/src/rpmutils.rs
+++ b/rust/src/rpmutils.rs
@@ -1,3 +1,5 @@
+//! Helpers for RPM.
+
 /*
  * Copyright (C) 2018 Red Hat, Inc.
  *

--- a/rust/src/scripts.rs
+++ b/rust/src/scripts.rs
@@ -1,3 +1,6 @@
+//! Code corresponding to rpmostree-scripts.cxx which deals with
+//! RPM scripts, and is in process of being converted to Rust.
+
 /*
  * Copyright (C) 2020 Red Hat, Inc.
  *

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -4,9 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-/* Copied and adapted from:
- * https://github.com/cgwalters/coreos-assembler
- * */
+//! Code for handling the "treefile" which is a declarative
+//! config file describing how to generate an OSTree commit
+//! from a set of RPMs on the server side.  Today this
+//! code is not used client side; a separate OSTree "origin"
+//! file is used for that.  See also
+//! [this issue](https://github.com/coreos/rpm-ostree/issues/2326).
+
+/*
+ * HACKING: In order to add a entry to the treefile, be sure to:
+ * - Update docs/treefile.md
+ * - Add it to the struct
+ * - Add a merge entry to `treefile_merge()`
+ * - Add a test case in tests/compose
+ */
 
 use anyhow::{anyhow, bail, Result};
 use c_utf8::CUtf8Buf;

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -1,3 +1,6 @@
+//! The generic catchall "utils" file that every
+//! project has.
+
 /*
  * Copyright (C) 2018 Red Hat, Inc.
  *


### PR DESCRIPTION
Specifically motivated by adding some docs in `treefile.rs` around
how to add a field, but I decided to just do a pass and
document everything at least a little.

View with e.g. `cargo doc --document-private-items`.
