### PR TITLE
tree-wide: Fix C++ range iteration to use references

### DIFF
--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -250,7 +250,7 @@ rpmostree_option_context_parse (GOptionContext *context,
       for (char **iter = features; iter && *iter; iter++)
         g_print ("  - %s\n", *iter);
       auto featuresrs = rpmostreecxx::get_features();
-      for (auto s : featuresrs)
+      for (auto & s : featuresrs)
         {
           g_print ("  - %s\n", s.c_str());
         }
@@ -466,7 +466,7 @@ rpmostree_main_inner (const rust::Slice<const rust::Str> args)
    * us calling free().  The right solution is to replace this with Rust.
    */
   g_autoptr(GPtrArray) argv_p = g_ptr_array_new ();
-  for (auto arg: args) {
+  for (const auto & arg: args) {
     g_ptr_array_add (argv_p, g_strndup (arg.data(), arg.size()));
   }
   char **argv = (char**)argv_p->pdata;

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -708,7 +708,7 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
         lockfiles.push_back(std::string(*it));
       auto mappings = rpmostreecxx::ror_lockfile_read (lockfiles);
       g_autoptr(GHashTable) map = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
-      for (auto mapping : mappings)
+      for (auto & mapping : mappings)
         g_hash_table_insert (map, g_strdup (mapping.k.c_str()), g_strdup (mapping.v.c_str()));
       rpmostree_context_set_vlockmap (self->corectx, map, opt_lockfile_strict);
       g_print ("Loaded lockfiles:\n  %s\n", g_strjoinv ("\n  ", opt_lockfiles));
@@ -1541,7 +1541,7 @@ rpmostree_compose_builtin_extensions (int             argc,
   g_autoptr(RpmOstreeTreespec) spec = NULL;
   { g_autoptr(GPtrArray) gpkgs = g_ptr_array_new_with_free_func (g_free);
     auto pkgs = extensions->get_os_extension_packages();
-    for (auto pkg : pkgs)
+    for (auto & pkg : pkgs)
       g_ptr_array_add (gpkgs, (gpointer*) g_strdup (pkg.c_str()));
     g_autoptr(GPtrArray) grepos = g_ptr_array_new ();
     auto repos = treefile->get_repos();
@@ -1612,7 +1612,7 @@ rpmostree_compose_builtin_extensions (int             argc,
   auto pkgs = extensions->get_development_packages();
   g_autoptr(GPtrArray) devel_pkgs_to_download =
     g_ptr_array_new_with_free_func (g_object_unref);
-  for (auto pkg : pkgs)
+  for (auto & pkg : pkgs)
     {
       g_autoptr(GPtrArray) matches = rpmostree_get_matching_packages (sack, pkg.c_str());
       if (matches->len == 0)

--- a/src/app/rpmostree-dbus-helpers.cxx
+++ b/src/app/rpmostree-dbus-helpers.cxx
@@ -1066,7 +1066,7 @@ rpmostree_sort_pkgs_strv (const char *const* pkgs,
       auto fds = rpmostreecxx::client_handle_fd_argument(pkg, basearch);
       if (fds.size() > 0)
         {
-          for (auto fd: fds)
+          for (const auto & fd: fds)
             {
               auto idx = g_unix_fd_list_append (fd_list, fd, error);
               if (idx < 0)


### PR DESCRIPTION
This is actually a perfect example of the tradeoffs involved
in our team of C/Rust programmers trying to use C++ so we
can use cxx-rs =)

It turns out that "for (auto foo : bar)" is really yet another
one of those C++ sharp edges just waiting to cut.  That
version does a copy of each value; one almost always wants to use
"for (auto & foo : bar)" which like Rust's `.iter()`.

In most of our code we were OK making copies, they were just
a performance hit, but in another place I was relying on the
"side effect" of `.c_str()` but that meant our value got
destroyed.
