### PR TITLE
Add gobj_rewrap() API to pass glib-rs objects back to C++

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -249,6 +249,7 @@ pub mod ffi {
             version_suffix: &str,
             last_version: &str,
         ) -> Result<String>;
+        fn testutil_validate_cxxrs_passthrough(repo: Pin<&mut OstreeRepo>) -> i32;
     }
 
     unsafe extern "C++" {

--- a/src/libpriv/rpmostree-util.cxx
+++ b/src/libpriv/rpmostree-util.cxx
@@ -289,6 +289,16 @@ util_next_version (rust::Str auto_version_prefix,
   g_autofree char *v = increment_version (version_suffix, last_version, next_version->str, date_tag_given ? "0" : NULL);
   return rust::String(v);
 }
+
+// A test function to validate that we can pass glib-rs types
+// from Rust back through cxx-rs to C++.
+int
+testutil_validate_cxxrs_passthrough(OstreeRepo &repo) noexcept
+{
+  return ostree_repo_get_dfd(&repo);
+}
+
+
 } /* namespace */
 #undef VERSION_TAG_REGEX
 

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -99,6 +99,9 @@ util_next_version (rust::Str auto_version_prefix,
                    rust::Str version_suffix,
                    rust::Str last_version);
 
+int
+testutil_validate_cxxrs_passthrough(OstreeRepo &repo) noexcept;
+
 }
 
 // Below here is C code


### PR DESCRIPTION
When we started using cxxrs, most of the glib-rs objects like
`OstreeRepo`/`OstreeSysroot` were owned by C++ and passed
down into Rust.  That motivated the addition of the special
bridging infrastructure to re-create a glib-rs wrapper
type from what cxxrs wants (a `Pin<&mut T>`).

But now that we're adding more in Rust, we have the need
to pass these objects back into C++.  In fact this will
hopefully soon because the default case as more of the
binary entrypoint becomes Rust.

Add another trait with a method `gobj_rewrap()` that converts
in the other direction.  This implementation took me a number
of tries before I finally settled on simply using `mem::transmute()`.
There are a *lot* of caveats listed on the docs for that function,
but I think it really is what we want here.  See the link for pending work
on a Rust RFC to enable safe transmutes for some cases, and I believe
that would cover this use case:
https://internals.rust-lang.org/t/pre-rfc-v2-safe-transmute/11431

I've verified this works in a separate patch, but this commit
also adds a simple test case - this goes all the way from:
   Rust glib-rs `ostree::Repo` (holding strong ref)
   -> Rust `Pin<&mut ostree_sys::OstreeRepo>`
   -> (internal cxx-rs C bridge)
   -> C++ `OstreeRepo&` reference
   -> C `OstreeRepo*` pointer
Which is quite the dance if you think about it!