### PR TITLE
More apply-live cleanups and oxidation

### DIFF
--- a/Makefile-libpriv.am
+++ b/Makefile-libpriv.am
@@ -42,6 +42,7 @@ librpmostreepriv_sources = \
 	src/libpriv/rpmostree-refsack.cxx \
 	src/libpriv/rpmostree-rpm-util.cxx \
 	src/libpriv/rpmostree-rpm-util.h \
+	src/libpriv/rpmostree-diff.cxx \
 	src/libpriv/rpmostree-importer.cxx \
 	src/libpriv/rpmostree-importer.h \
 	src/libpriv/rpmostree-unpacker-core.cxx \

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -32,7 +32,7 @@ librpmostreeinternals_la_SOURCES = \
 	src/app/rpmostree-builtin-cliwrap.cxx \
 	src/app/rpmostree-builtin-initramfs.cxx \
 	src/app/rpmostree-builtin-initramfs-etc.cxx \
-	src/app/rpmostree-builtin-livefs.cxx \
+	src/app/rpmostree-builtin-applylive.cxx \
 	src/app/rpmostree-builtin-usroverlay.cxx \
 	src/app/rpmostree-builtin-override.cxx \
 	src/app/rpmostree-builtin-refresh-md.cxx \

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -261,6 +261,15 @@ pub mod ffi {
     }
 
     unsafe extern "C++" {
+        include!("rpmostree-diff.hpp");
+        type RPMDiff;
+        fn n_removed(&self) -> i32;
+        fn n_added(&self) -> i32;
+        fn n_modified(&self) -> i32;
+            dest: &CxxString,
+    }
+
+    unsafe extern "C++" {
         include!("rpmostree-output.h");
         type Progress;
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -194,6 +194,7 @@ pub mod ffi {
         ) -> Result<bool>;
         // FIXME/cxx make this Option<&str>
         fn transaction_apply_live(sysroot: Pin<&mut OstreeSysroot>, target: &str) -> Result<()>;
+        fn applylive_client_finish() -> Result<()>;
     }
 
     // passwd.rs
@@ -266,7 +267,13 @@ pub mod ffi {
         fn n_removed(&self) -> i32;
         fn n_added(&self) -> i32;
         fn n_modified(&self) -> i32;
+        fn rpmdb_diff(
+            repo: Pin<&mut OstreeRepo>,
+            src: &CxxString,
             dest: &CxxString,
+        ) -> Result<UniquePtr<RPMDiff>>;
+
+        fn print(&self);
     }
 
     unsafe extern "C++" {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -275,6 +275,8 @@ pub mod ffi {
 
         fn progress_begin_task(msg: &str) -> UniquePtr<Progress>;
         fn end(self: Pin<&mut Progress>, msg: &str);
+
+        fn output_message(msg: &str);
     }
 
     // rpmostree-rpm-util.h

--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -496,16 +496,6 @@ pub(crate) fn applylive_client_finish() -> CxxResult<()> {
     let live_state = get_live_state(booted)?
         .ok_or_else(|| anyhow!("Failed to find expected apply-live state"))?;
 
-    // It might happen that the live target commit was GC'd somehow; we're not writing
-    // an explicit ref for it.  In that case skip the diff.
-    if !repo.has_object(
-        ostree::ObjectType::Commit,
-        live_state.commit.as_str(),
-        cancellable,
-    )? {
-        return Ok(());
-    }
-
     let pkgdiff = {
         cxx::let_cxx_string!(from = booted_commit);
         cxx::let_cxx_string!(to = live_state.commit.as_str());

--- a/src/app/rpmostree-builtin-applylive.cxx
+++ b/src/app/rpmostree-builtin-applylive.cxx
@@ -67,11 +67,11 @@ get_args_variant (GError **error)
 }
 
 gboolean
-rpmostree_ex_builtin_livefs (int             argc,
-                             char          **argv,
-                             RpmOstreeCommandInvocation *invocation,
-                             GCancellable   *cancellable,
-                             GError        **error)
+rpmostree_ex_builtin_apply_live (int             argc,
+                                 char          **argv,
+                                 RpmOstreeCommandInvocation *invocation,
+                                 GCancellable   *cancellable,
+                                 GError        **error)
 {
   _cleanup_peer_ GPid peer_pid = 0;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;

--- a/src/app/rpmostree-builtin-ex.cxx
+++ b/src/app/rpmostree-builtin-ex.cxx
@@ -25,10 +25,10 @@
 static RpmOstreeCommand ex_subcommands[] = {
   { "livefs", (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT | RPM_OSTREE_BUILTIN_FLAG_HIDDEN),
     "Apply pending deployment changes to booted deployment",
-    rpmostree_ex_builtin_livefs },
+    rpmostree_ex_builtin_apply_live },
   { "apply-live", (RpmOstreeBuiltinFlags)RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT,
     "Apply pending deployment changes to booted deployment",
-    rpmostree_ex_builtin_livefs },
+    rpmostree_ex_builtin_apply_live },
 #ifdef BUILDOPT_ROJIG
   { "commit2rojig", (RpmOstreeBuiltinFlags)RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
     "Convert an OSTree commit into an rpm-ostree rojig", rpmostree_ex_builtin_commit2rojig },

--- a/src/app/rpmostree-ex-builtins.h
+++ b/src/app/rpmostree-ex-builtins.h
@@ -31,7 +31,7 @@ G_BEGIN_DECLS
                                                                    GCancellable *cancellable, GError **error)
 
 BUILTINPROTO(unpack);
-BUILTINPROTO(livefs);
+BUILTINPROTO(apply_live);
 #ifdef BUILDOPT_ROJIG
 BUILTINPROTO(commit2rojig);
 BUILTINPROTO(rojig2commit);

--- a/src/daemon/rpmostreed-os-experimental.cxx
+++ b/src/daemon/rpmostreed-os-experimental.cxx
@@ -140,11 +140,11 @@ osexperimental_handle_live_fs (RPMOSTreeOSExperimental *interface,
                                       &local_error))
     goto out;
 
-  transaction = rpmostreed_transaction_new_livefs (invocation,
-                                                   ot_sysroot,
-                                                   arg_options,
-                                                   cancellable,
-                                                   &local_error);
+  transaction = rpmostreed_transaction_new_apply_live (invocation,
+                                                       ot_sysroot,
+                                                       arg_options,
+                                                       cancellable,
+                                                       &local_error);
   if (transaction == NULL)
     goto out;
 

--- a/src/daemon/rpmostreed-transaction-applylive.cxx
+++ b/src/daemon/rpmostreed-transaction-applylive.cxx
@@ -107,11 +107,11 @@ livefs_transaction_init (LiveFsTransaction *self)
 }
 
 RpmostreedTransaction *
-rpmostreed_transaction_new_livefs (GDBusMethodInvocation *invocation,
-                                   OstreeSysroot         *sysroot,
-                                   GVariant              *options,
-                                   GCancellable          *cancellable,
-                                   GError               **error)
+rpmostreed_transaction_new_apply_live (GDBusMethodInvocation *invocation,
+                                       OstreeSysroot         *sysroot,
+                                       GVariant              *options,
+                                       GCancellable          *cancellable,
+                                       GError               **error)
 {
   g_assert (G_IS_DBUS_METHOD_INVOCATION (invocation));
   g_assert (OSTREE_IS_SYSROOT (sysroot));

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -117,12 +117,12 @@ rpmostreed_transaction_new_cleanup       (GDBusMethodInvocation *invocation,
                                           GError               **error);
 
 RpmostreedTransaction *
-rpmostreed_transaction_new_livefs (GDBusMethodInvocation *invocation,
-                                   OstreeSysroot         *sysroot,
-                                   GVariant              *options,
-                                   GCancellable          *cancellable,
-                                   GError               **error);
-
+rpmostreed_transaction_new_apply_live (GDBusMethodInvocation *invocation,
+                                       OstreeSysroot         *sysroot,
+                                       GVariant              *options,
+                                       GCancellable          *cancellable,
+                                       GError               **error);
+    
 typedef enum {
   RPMOSTREE_TRANSACTION_REFRESH_MD_FLAG_FORCE = (1 << 0),
 } RpmOstreeTransactionRefreshMdFlags;

--- a/src/libpriv/rpmostree-diff.cxx
+++ b/src/libpriv/rpmostree-diff.cxx
@@ -1,0 +1,61 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include <memory>
+
+#include "rpmostree-diff.hpp"
+#include "rpmostree-db.h"
+#include "rpmostree-util.h"
+
+namespace rpmostreecxx {
+
+RPMDiff::RPMDiff(GPtrArray *removed, GPtrArray *added, GPtrArray *modified_old, GPtrArray *modified_new) {
+  removed_ = g_ptr_array_ref(removed);
+  added_ = g_ptr_array_ref(added);
+  modified_old_ = g_ptr_array_ref(modified_old);
+  modified_new_ = g_ptr_array_ref(modified_new);
+}
+
+RPMDiff::~RPMDiff() {
+  g_ptr_array_unref(removed_);
+  g_ptr_array_unref(added_);
+  g_ptr_array_unref(modified_old_);
+  g_ptr_array_unref(modified_new_);
+}
+
+std::unique_ptr<RPMDiff>
+rpmdb_diff(OstreeRepo &repo, const std::string &from, const std::string &to) {
+  g_autoptr(GPtrArray) removed = NULL;
+  g_autoptr(GPtrArray) added = NULL;
+  g_autoptr(GPtrArray) modified_old = NULL;
+  g_autoptr(GPtrArray) modified_new = NULL;
+  g_autoptr(GError) local_error = NULL;
+  if (!rpm_ostree_db_diff(&repo, from.c_str(), to.c_str(),
+                          &removed, &added, &modified_old, &modified_new,
+                          NULL, &local_error))
+    util::throw_gerror(local_error);
+  return std::make_unique<RPMDiff>(removed, added, modified_old, modified_new);
+}
+
+void
+RPMDiff::print() const
+{
+  rpmostree_diff_print_formatted (RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, NULL, 0,
+                                  removed_, added_, modified_old_, modified_new_);
+}
+
+} /* namespace */

--- a/src/libpriv/rpmostree-diff.hpp
+++ b/src/libpriv/rpmostree-diff.hpp
@@ -1,0 +1,57 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <string>
+#include <exception>
+#include <sstream>
+#include <memory>
+
+#include <ostree.h>
+
+#include "rust/cxx.h"
+
+namespace rpmostreecxx {
+
+class RPMDiff final {
+public:
+    int n_removed() const {
+        return removed_->len;
+    }
+    int n_added() const {
+        return added_->len;
+    }
+    int n_modified() const {
+        return modified_old_->len + modified_new_->len;
+    }
+    ~RPMDiff();
+    RPMDiff(GPtrArray *removed, GPtrArray *added, GPtrArray *modified_old, GPtrArray *modified_new);
+
+    // TODO(cgwalters) enhance this with options
+    void print() const;
+
+private:
+    GPtrArray *removed_;
+    GPtrArray *added_;
+    GPtrArray *modified_old_;
+    GPtrArray *modified_new_;
+};
+
+std::unique_ptr<RPMDiff> rpmdb_diff(OstreeRepo &repo, const std::string &src, const std::string &dest);
+
+} /* namespace */

--- a/src/libpriv/rpmostree-output.cxx
+++ b/src/libpriv/rpmostree-output.cxx
@@ -124,16 +124,6 @@ progress_begin_task(const rust::Str msg) noexcept
   return std::make_unique<Progress>(ProgressType::TASK);
 }
 
-// Output a string.  Note that this should not be called when
-// a "task" is active.
-void 
-Progress::message(const rust::Str msg)
-{
-  auto msg_c = std::string(msg);
-  RpmOstreeOutputMessage task = { msg_c.c_str() };
-  active_cb (RPMOSTREE_OUTPUT_MESSAGE, &task, active_cb_opaque);
-}
-
 // When working on a task/percent/nitems, often we want to display a particular
 // item (such as a package).
 void 

--- a/src/libpriv/rpmostree-output.h
+++ b/src/libpriv/rpmostree-output.h
@@ -36,7 +36,6 @@ void output_message (rust::Str msg);
 struct Progress {
 public:
   void set_sub_message(rust::Str msg);
-  void message (rust::Str msg);
   void nitems_update(guint n);
   void percent_update(guint n);
 


### PR DESCRIPTION
Depends https://github.com/coreos/rpm-ostree/pull/2574

---

app: Rename livefs.cxx → apply-live.cxx

Continuing the renaming.

---

daemon: Rename transaction_livefs → transaction_apply_live

Continuing the renaming.

---

Add a C++ rpmdb-diff API wrapping the C one, bind in Rust

I'd like to compute diffs in apply-live to differentiate
between "pure layering" versus modifications/removals.

---

Fix progress API to have "output message" separate from task

A lot of our output is outside of a "task"; the Rust binding
incorrectly made it a method on `Progress`.  This is really
just a `println!()` that is backed by our dispatch system.

---

apply-live: Move client-side finish to Rust

Now that we have an RPM diff+printing binding, we can
move the client side postprocessing for `apply-live`
to Rust.

---

