### PR TITLE
countme: Persist last timer trigger for Silverblue-like systems

### DIFF
--- a/src/app/rpm-ostree-countme.timer
+++ b/src/app/rpm-ostree-countme.timer
@@ -8,6 +8,7 @@ ConditionPathExists=/run/ostree-booted
 OnCalendar=weekly UTC
 AccuracySec=1u
 RandomizedDelaySec=1w
+Persistent=yes
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
Set `Persistent=yes` in the timer unit to make sure that systems that
are not running 24/7 gets counted when they wake up if they missed the
previous timer run / counting window.

This is mostly for Fedora Silverblue like systems as Fedora CoreOS
systems usually run 24/7.

See https://www.freedesktop.org/software/systemd/man/systemd.timer.html#Persistent=