### PR TITLE
Two CI cleanups

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -50,8 +50,7 @@ parallel insttests: {
         """)
       }
       stage("Install Deps") {
-        // really, we just need test deps, but meh...
-        shwrap("ci/installdeps.sh")
+        shwrap("ci/install-test-deps.sh")
       }
       stage("Kola") {
         // TODO upstream this into coreos-ci-lib
@@ -86,7 +85,7 @@ compose: {
         unstash 'rpms'
         stage("Install Deps") {
           shwrap("""
-            ci/installdeps.sh  # really, we just need test deps, but meh...
+            ci/install-test-deps.sh
             dnf install -y *.rpm  # install our built rpm-ostree
           """)
         }

--- a/Makefile.am
+++ b/Makefile.am
@@ -110,7 +110,7 @@ DIST_HOOKS += use-git-not-dist-hook
 GITIGNOREFILES += target/
 
 # From coreos-assembler
-GITIGNOREFILES += "fastbuild*.qcow2" _kola_temp/
+GITIGNOREFILES += .cosa/ "fastbuild*.qcow2" _kola_temp/
 
 include libglnx/Makefile-libglnx.am.inc
 noinst_LTLIBRARIES += libglnx.la

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -6,7 +6,6 @@ set -xeuo pipefail
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
 
-${dn}/install-extra-builddeps.sh
 ${dn}/installdeps.sh
 # make it clear what rustc version we're compiling with (this is grepped in CI)
 rustc --version

--- a/ci/ci-commitmessage-submodules.sh
+++ b/ci/ci-commitmessage-submodules.sh
@@ -30,7 +30,6 @@ cleanup_tmp() {
 trap cleanup_tmp EXIT
 
 if ! [ -x /usr/bin/git ]; then
-  pkg_upgrade
   pkg_install git
 fi
 

--- a/ci/clang-analyzer.sh
+++ b/ci/clang-analyzer.sh
@@ -5,7 +5,6 @@ set -xeuo pipefail
 
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
-${dn}/install-extra-builddeps.sh
 ${dn}/installdeps.sh
 env NOCONFIGURE=1 ./autogen.sh
 scan-build ./configure --prefix=/usr --libdir=/usr/lib64 --sysconfdir=/etc

--- a/ci/coreosci-rpmbuild.sh
+++ b/ci/coreosci-rpmbuild.sh
@@ -8,7 +8,6 @@ dn=$(dirname $0)
 git fetch origin --tags
 git submodule update --init --recursive
 ci/installdeps.sh
-ci/install-extra-builddeps.sh
 # Our primary CI build goes via RPM rather than direct to binaries
 # to better test that path, including our vendored spec file, etc.
 # The RPM build expects pre-generated bindings, so do that now.

--- a/ci/install-extra-builddeps.sh
+++ b/ci/install-extra-builddeps.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 CXX_VER=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name == "cxx").version')
-cargo install cxxbridge-cmd --version "${CXX_VER}"
+time cargo install cxxbridge-cmd --version "${CXX_VER}"
 
 CBINDGEN_VER=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name == "cbindgen").version')
-cargo install cbindgen --version "${CBINDGEN_VER}"
+time cargo install cbindgen --version "${CBINDGEN_VER}"

--- a/ci/install-extra-builddeps.sh
+++ b/ci/install-extra-builddeps.sh
@@ -1,13 +1,1 @@
 #!/usr/bin/env bash
-# cxx.rs (cxxbridge) isn't packaged in Fedora today.  Both it and cbindgen generate
-# source code, which we vendor along with our dependent crates into release
-# tarballs.  Note in the future it's likely we stop using cbindgen entirely in
-# favor of cxx.rs.
-
-set -euo pipefail
-
-CXX_VER=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name == "cxx").version')
-time cargo install cxxbridge-cmd --version "${CXX_VER}"
-
-CBINDGEN_VER=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name == "cbindgen").version')
-time cargo install cbindgen --version "${CBINDGEN_VER}"

--- a/ci/install-test-deps.sh
+++ b/ci/install-test-deps.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -euo pipefail
-
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
-
-ci/installdeps.sh
-ci/build.sh
+deps=$(grep -v '^#' "${dn}"/testdeps.txt)
+pkg_install ${deps}

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -12,7 +12,7 @@ fi
 
 # we have the canonical spec file handy so just builddep from that
 # XXX: use --allowerasing as a temporary hack to ease the migration to libmodulemd2
-dnf builddep --spec -y packaging/rpm-ostree.spec.in --allowerasing
+time dnf builddep --spec -y packaging/rpm-ostree.spec.in --allowerasing
 # Mostly dependencies for tests; TODO move these into the spec file
 # and also put them in the cosa buildroot (or another container)
 pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq python3-pyyaml \

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -10,17 +10,11 @@ if [ -n "${SKIP_INSTALLDEPS:-}" ] || test $(id -u) != 0; then
     exit 0
 fi
 
-# Add the continuous tag for latest build tools and mark as required.
-version_id=$(. /etc/os-release && echo $VERSION_ID)
-echo -e "[f${version_id}-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f${version_id}-coreos-continuous/latest/\$basearch/\ngpgcheck=0\nskip_if_unavailable=False\n" > /etc/yum.repos.d/coreos.repo
-
-pkg_upgrade
-# install base builddeps like @buildsys-build
-pkg_install_builddeps
 # we have the canonical spec file handy so just builddep from that
 # XXX: use --allowerasing as a temporary hack to ease the migration to libmodulemd2
 dnf builddep --spec -y packaging/rpm-ostree.spec.in --allowerasing
-# Mostly dependencies for tests
+# Mostly dependencies for tests; TODO move these into the spec file
+# and also put them in the cosa buildroot (or another container)
 pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq python3-pyyaml \
     libubsan libasan libtsan elfutils fuse sudo python3-gobject-base \
     selinux-policy-devel selinux-policy-targeted python3-createrepo_c \

--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -10,35 +10,33 @@ export PATH="$HOME/.cargo/bin:$PATH"
 
 pkg_upgrade() {
     echo "Running dnf -y distro-sync... $(date)"
-    dnf -y distro-sync
+    time dnf -y distro-sync
     echo "Done dnf -y distro-sync! $(date)"
 }
 
 make() {
-    /usr/bin/make -j ${MAKE_JOBS:-$(getconf _NPROCESSORS_ONLN)} "$@"
+    time /usr/bin/make -j ${MAKE_JOBS:-$(getconf _NPROCESSORS_ONLN)} "$@"
 }
 
 build() {
     env NOCONFIGURE=1 ./autogen.sh
-    ./configure --prefix=/usr --libdir=/usr/lib64 --sysconfdir=/etc "$@"
-    make V=1
+    time ./configure --prefix=/usr --libdir=/usr/lib64 --sysconfdir=/etc "$@"
+    time make V=1
 }
 
 pkg_install() {
     echo "Running dnf -y install... $(date)"
-    dnf -y install "$@"
+    time dnf -y install "$@"
     echo "Done running dnf -y install! $(date)"
 }
 
 pkg_builddep() {
-    echo "Running builddep... $(date)"
     # This is sadly the only case where it's a different command
     if test -x /usr/bin/dnf; then
-        dnf builddep -y "$@"
+        time dnf builddep -y "$@"
     else
-        yum-builddep -y "$@"
+        time yum-builddep -y "$@"
     fi
-    echo "Done running builddep! $(date)"
 }
 
 pkg_install_builddeps() {
@@ -50,6 +48,6 @@ pkg_install_builddeps() {
     if [ $# -ne 0 ]; then
       pkg_builddep "$@"
       pkg_install "$@"
-      rpm -e "$@"
+      time rpm -e "$@"
     fi
 }

--- a/ci/testdeps.txt
+++ b/ci/testdeps.txt
@@ -1,0 +1,8 @@
+# Dependencies for our test suites, i.e. ./tests/compose and
+# ./tests/vmcheck.
+createrepo_c 
+/usr/bin/jq 
+python3-pyyaml
+libubsan libasan libtsan elfutils fuse sudo python3-gobject-base
+selinux-policy-devel selinux-policy-targeted python3-createrepo_c
+rsync python3-rpm parallel distribution-gpg-keys

--- a/configure.ac
+++ b/configure.ac
@@ -98,7 +98,7 @@ AS_IF([test -z "$cargo"], [AC_MSG_ERROR([cargo is required for --enable-rust])])
 AC_PATH_PROG([rustc], [rustc])
 AS_IF([test -z "$rustc"], [AC_MSG_ERROR([rustc is required for --enable-rust])])
 
-dnl See comment in install-extra-builddeps.sh
+dnl See comment in installdeps.sh
 AM_CONDITIONAL(BUILDOPT_PREBUILT_BINDINGS, [test -f rpmostree-rust-prebuilt.h])
 
 AC_MSG_CHECKING(whether to build in debug mode)

--- a/packaging/make-git-snapshot.sh
+++ b/packaging/make-git-snapshot.sh
@@ -60,7 +60,7 @@ open(checksum_file, "w").write(json.dumps(j))' $crate_subdir
  tar --transform="s,^,${PKG_VER}/," -rf ${TARFILE_TMP} * .cargo/
  )
 
-# And finally, vendor generated code.  See install-extra-builddeps.sh
+# And finally, vendor generated code.  See installdeps.sh
 # and Makefile-rpm-ostree.am for more.
 (cd ${srcdir}
  cp rpmostree-rust{,-prebuilt}.h

--- a/tests/vmcheck/test-layering-non-root-caps.sh
+++ b/tests/vmcheck/test-layering-non-root-caps.sh
@@ -115,7 +115,7 @@ check_fcap() {
     fi
     return
   fi
-  # Replace '+' with '='; a libcap change https://bodhi.fedoraproject.org/updates/FEDORA-2021-eeff266a64
+  # Replace '+' with '='; a libcap change https://bodhi.fedoraproject.org/updates/FEDORA-2021-570cc05441
   # changed the output, and the new variant seems more correct
   # because it's matching what we specified above.  But we need
   # to handle the previous case too for backcompat for a bit.


### PR DESCRIPTION
ci: Drop: distro-sync, continuous repo

Doing the distro-sync costs ~3 minutes per execution, and it
happens multiple times.  Let's just ensure our images are up
to date instead.

Also drop the continuous repo (for now) - we added this
to test bleeding edge ostree, but I think we need to reintroduce
"git master" builds as whole separate CI flow (layered container)
instead.

---

ci: Add `time` prefixing before most commands

We don't have timestamps set up right now, and including
timing information is easy and useful to debug CI speed.

---

