### PR TITLE
Minor deployment status oxidation

### DIFF
--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -1,0 +1,20 @@
+//! Rust portion of rpmostreed-deployment-utils.cxx
+
+use crate::cxxrsutil::*;
+use std::pin::Pin;
+
+/// Get a currently unique (for this host) identifier for the
+/// deployment; TODO - adding the deployment timestamp would make it
+/// persistently unique, needs API in libostree.
+pub(crate) fn deployment_generate_id(
+    mut deployment: Pin<&mut crate::FFIOstreeDeployment>,
+) -> String {
+    let deployment = deployment.gobj_wrap();
+    // unwrap safety: These can't actually return NULL
+    format!(
+        "{}-{}.{}",
+        deployment.get_osname().unwrap(),
+        deployment.get_csum().unwrap(),
+        deployment.get_deployserial()
+    )
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -76,6 +76,11 @@ pub mod ffi {
         fn compose_postprocess_final(rootfs_dfd: i32) -> Result<()>;
     }
 
+    // daemon.rs
+    extern "Rust" {
+        fn deployment_generate_id(deployment: Pin<&mut OstreeDeployment>) -> String;
+    }
+
     // initramfs.rs
     extern "Rust" {
         fn get_dracut_random_cpio() -> &'static [u8];
@@ -284,7 +289,9 @@ pub mod countme;
 pub(crate) use composepost::*;
 mod core;
 use crate::core::*;
+mod daemon;
 mod dirdiff;
+pub(crate) use daemon::*;
 mod extensions;
 pub(crate) use extensions::*;
 #[cfg(feature = "fedora-integration")]

--- a/src/daemon/rpmostreed-os.cxx
+++ b/src/daemon/rpmostreed-os.cxx
@@ -1782,7 +1782,8 @@ rpmostreed_os_load_internals (RpmostreedOS *self, GError **error)
                                                     booted_id, ot_repo, TRUE, error));
       if (!booted_variant)
         return FALSE;
-      booted_id = rpmostreed_deployment_generate_id (booted_deployment);
+      auto bootedid_v = rpmostreecxx::deployment_generate_id(*booted_deployment);
+      booted_id = g_strdup(bootedid_v.c_str());
     }
   else
     booted_variant = g_variant_ref_sink (rpmostreed_deployment_generate_blank_variant ());

--- a/src/daemon/rpmostreed-sysroot.cxx
+++ b/src/daemon/rpmostreed-sysroot.cxx
@@ -28,6 +28,7 @@
 #include "rpmostreed-deployment-utils.h"
 #include "rpmostreed-errors.h"
 #include "rpmostreed-transaction.h"
+#include "rpmostree-cxxrs.h"
 
 #include "rpmostree-output.h"
 
@@ -273,7 +274,8 @@ sysroot_populate_deployments_unlocked (RpmostreedSysroot *self,
       const gchar *os = ostree_deployment_get_osname (booted);
       g_autofree gchar *path = rpmostreed_generate_object_path (BASE_DBUS_PATH, os, NULL);
       rpmostree_sysroot_set_booted (RPMOSTREE_SYSROOT (self), path);
-      booted_id = rpmostreed_deployment_generate_id (booted);
+      auto bootedid_v = rpmostreecxx::deployment_generate_id(*booted);
+      booted_id = g_strdup(bootedid_v.c_str());
     }
   else
     {


### PR DESCRIPTION
daemon: Refactor deployment variant generation code

Changes to this ad-hoc `a{sv}` code have been scattered
around over time.  Move the "core" bits to the top of
the function, then have the more complex stuff that depends
on the origin (and refspec/layering status) later.

Prep for further cleanups.

---

Add daemon.rs with one helper function, use it from C++

Trying to port to use origin Rust code, I think actually
it gets simpler if we move more to Rust to start.

---

