### PR TITLE
Two rawhide build fixes

### DIFF
--- a/rust/libdnf-sys/cxx/libdnf.hxx
+++ b/rust/libdnf-sys/cxx/libdnf.hxx
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <gio/gio.h>
 #include <libdnf/libdnf.h>
 
 #include "rust/cxx.h"

--- a/src/app/rpmostree-compose-builtin-rojig.cxx
+++ b/src/app/rpmostree-compose-builtin-rojig.cxx
@@ -34,6 +34,7 @@
 #include <sys/vfs.h>
 #include <libglnx.h>
 #include <rpm/rpmmacro.h>
+#include <optional>
 
 #include "rpmostree-compose-builtins.h"
 #include "rpmostree-util.h"

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -35,6 +35,7 @@
 #include <libglnx.h>
 #include <rpm/rpmmacro.h>
 #include <utility>
+#include <optional>
 
 #include "rpmostree-compose-builtins.h"
 #include "rpmostree-util.h"


### PR DESCRIPTION
compose: Add missing #include <optional>

This only fails on newer gcc/libstdc++ apparently in current
Fedora rawhide: https://kojipkgs.fedoraproject.org//work/tasks/4372/62164372/build.log

---

libdnf-sys: Include gio.h before libdnf.h

See https://github.com/coreos/rpm-ostree/pull/2562/commits/b77f710cfb45279262144a02208781c94269ed25

Alternative fix to rpm-software-management/libdnf#1139
aka https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1935

This way libdnf's `extern "C"` over the glib headers doesn't apply
because we already processed that header.

---

