### PR TITLE
ci: Add Prow e2e testing

### DIFF
--- a/ci/prow/Dockerfile
+++ b/ci/prow/Dockerfile
@@ -1,5 +1,12 @@
-FROM registry.svc.ci.openshift.org/coreos/cosa-buildroot:latest
+FROM registry.svc.ci.openshift.org/coreos/cosa-buildroot:latest as builder
 WORKDIR /src
 COPY . .
-USER root
-RUN env SKIP_INSTALLDEPS=1 ./ci/build-check.sh
+RUN ./ci/build.sh && make install DESTDIR=/cosa/component-install
+# Uncomment this to fake a build to test the code below
+# RUN mkdir -p /cosa/component-install/usr/bin && echo foo > /cosa/component-install/usr/bin/foo
+
+FROM registry.svc.ci.openshift.org/coreos/coreos-assembler:latest
+WORKDIR /srv
+# Install our built binaries as overrides for the target build
+COPY --from=builder /cosa/component-install /srv/overrides/rootfs/
+COPY --from=builder /src/ci/prow/fcos-e2e.sh /usr/bin/fcos-e2e

--- a/ci/prow/fcos-e2e.sh
+++ b/ci/prow/fcos-e2e.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# Prow jobs don't support adding emptydir today
+export COSA_SKIP_OVERLAY=1
+gitdir=$(pwd)
+cd $(mktemp -d)
+cosa init --force https://github.com/coreos/fedora-coreos-config/
+cosa fetch
+cosa build
+cosa kola run 'ext.*'


### PR DESCRIPTION
Our "CoreOS CI Jenkins" flow is great, but the reliability/debuggabilty
of the system isn't the best.  This is an experient to *add* another e2e CI
flow that can be run in Prow too.

I'd like to at least have a basic e2e (compose tree, run client tests)
flow that can operate in Prow so that if CoreOS CI Jenkins is down or
flaky, we at least have some confidence in our commits.

Longer term I think we can figure out how to better share CI flows
across these:
https://github.com/coreos/fedora-coreos-tracker/issues/263#issuecomment-772903759
