### PR TITLE
rust: Add SPDX-License-Identifier and validate it in ci/codestyle.sh

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 use anyhow::Result;
 
 fn detect_fedora_feature() -> Result<()> {

--- a/ci/codestyle.sh
+++ b/ci/codestyle.sh
@@ -21,3 +21,13 @@ for crate in $(find -iname Cargo.toml); do
     fi
 done
 echo "ok"
+
+ident='SPDX-License-Identifier:'
+echo -n "checking \"$ident\"..."
+git ls-files '*.rs' | while read f; do
+    if ! grep -qF "$ident" $f; then
+        echo "error: File $f: Missing $ident" 1>&2
+        exit 1
+    fi
+done
+echo "ok"

--- a/ci/codestyle.sh
+++ b/ci/codestyle.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tests that validate structure of the source code;
+# can be run without building it.
 set -euo pipefail
 
 echo -n "Checking for tabs..."
@@ -8,6 +10,7 @@ if test -s tabdamage.txt; then
     cat tabdamage.txt
     exit 1
 fi
+rm -v tabdamage.txt
 echo "ok"
 
 echo -n "checking rustfmt..."

--- a/rust/libdnf-sys/build.rs
+++ b/rust/libdnf-sys/build.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 use anyhow::Result;
 
 fn main() -> Result<()> {

--- a/rust/rpmostree-client/src/lib.rs
+++ b/rust/rpmostree-client/src/lib.rs
@@ -1,4 +1,5 @@
 //! APIs for interacting with rpm-ostree client side.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use anyhow::Context;
 use serde_derive::Deserialize;

--- a/rust/rpmostree-client/tests/parse.rs
+++ b/rust/rpmostree-client/tests/parse.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 use anyhow::Result;
 use rpmostree_client;
 

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,5 +1,6 @@
 //! Helpers for the client side binary that will speak DBus
 //! to rpm-ostreed.service.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::cxxrsutil::*;
 use crate::utils;

--- a/rust/src/cliwrap.rs
+++ b/rust/src/cliwrap.rs
@@ -1,24 +1,8 @@
-/*
- * Copyright (C) 2019 Red Hat, Inc.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
- */
-
 //! Implements the `cliwrap` treefile option which intercepts/proxies
 //! other binaries like `/usr/bin/rpm`.
 
+// SPDX-License-Identifier: GPL-2.0-or-later
+// (FIXME: I think I really meant this to be Apache-2.0 OR MIT)
 use anyhow::{anyhow, Result};
 use std::io::prelude::*;
 use std::path;

--- a/rust/src/cliwrap/cliutil.rs
+++ b/rust/src/cliwrap/cliutil.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 use anyhow::Result;
 use nix::sys::statvfs;
 use std::os::unix::process::CommandExt;

--- a/rust/src/cliwrap/dracut.rs
+++ b/rust/src/cliwrap/dracut.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 use anyhow::Result;
 
 use crate::cliwrap::cliutil;

--- a/rust/src/cliwrap/grubby.rs
+++ b/rust/src/cliwrap/grubby.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 use anyhow::Result;
 
 /// Primary entrypoint to running our wrapped `grubby` handling.

--- a/rust/src/cliwrap/rpm.rs
+++ b/rust/src/cliwrap/rpm.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 use anyhow::Result;
 use clap::{App, Arg};
 

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -1,6 +1,7 @@
 //! Code mirroring rpmostree-core.cxx which is the shared "core"
 //! binding of rpm and ostree, used by both client-side layering/overrides
 //! and server side composes.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::cxxrsutil::CxxResult;
 use crate::ffiutil;

--- a/rust/src/countme.rs
+++ b/rust/src/countme.rs
@@ -1,23 +1,6 @@
-/*
- * Copyright (C) 2020 Red Hat, Inc.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
- */
-
 //! Implementation of the "DNF Count Me" system.
-
+// SPDX-License-Identifier: GPL-2.0-or-later
+// (FIXME: Convert to Apache-2.0 OR MIT for consistency?)
 use anyhow::{bail, Context, Result};
 use curl::easy::Easy;
 use os_release::OsRelease;

--- a/rust/src/countme/cookie.rs
+++ b/rust/src/countme/cookie.rs
@@ -1,21 +1,5 @@
-/*
- * Copyright (C) 2020 Red Hat, Inc.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
- */
-
+// SPDX-License-Identifier: GPL-2.0-or-later
+// (FIXME: Convert to Apache-2.0 OR MIT for consistency?)
 use anyhow::{bail, Result};
 use chrono::prelude::*;
 use openat_ext::OpenatDirExt;

--- a/rust/src/countme/repo.rs
+++ b/rust/src/countme/repo.rs
@@ -1,20 +1,5 @@
-/*
- * Copyright (C) 2020 Red Hat, Inc.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
- */
+// SPDX-License-Identifier: GPL-2.0-or-later
+// (FIXME: Convert to Apache-2.0 OR MIT for consistency?)
 
 use anyhow::{Context, Result};
 use std::fs;

--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -7,6 +7,7 @@
 //! the *_sys type (e.g. ostree_sys::OstreeRepo) but the `ostree::Repo` type.
 //! So for now, we define a `FFIGObjectWrapper` trait that helps with this.
 //! In the future though hopefully cxx.rs improves this situation.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use cxx::{type_id, ExternType};
 use glib::translate::ToGlibPtr;

--- a/rust/src/fedora_integration.rs
+++ b/rust/src/fedora_integration.rs
@@ -1,4 +1,5 @@
 //! APIs used to talk to Fedora Infrastructure tooling (Koji, Bodhi).
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::cxxrsutil::CxxResult;
 use anyhow::{Context, Result};

--- a/rust/src/history.rs
+++ b/rust/src/history.rs
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2019 Jonathan Lebon <jonathan@jlebon.com>
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
- */
-
 //! High-level interface to retrieve host rpm-ostree history.
 //!
 //! The basic idea is that at deployment creation time, the upgrader does two
@@ -49,6 +31,8 @@
 //! than scanning the whole journal upfront. This can then be e.g. piped through
 //! a pager, stopped after N entries, etc...
 
+// SPDX-License-Identifier: GPL-2.0-or-later
+// (FIXME: Convert to Apache-2.0 OR MIT for consistency?)
 use crate::cxxrsutil::*;
 use crate::ffi::HistoryEntry;
 use anyhow::{anyhow, Context, Result};

--- a/rust/src/includes.rs
+++ b/rust/src/includes.rs
@@ -7,6 +7,7 @@ strings more efficient).
 NOTICE: The C header definitions are canonical, please update those first
 then synchronize the entries here.
 !*/
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use libdnf_sys::DnfPackage;
 

--- a/rust/src/initramfs.rs
+++ b/rust/src/initramfs.rs
@@ -1,4 +1,5 @@
 //! Generate an "overlay" initramfs image
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::cxxrsutil::*;
 use anyhow::{Context, Result};

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,4 +1,5 @@
 //! The main CLI logic.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use anyhow::Result;
 

--- a/rust/src/nameservice/group.rs
+++ b/rust/src/nameservice/group.rs
@@ -1,4 +1,5 @@
 //! Helpers for [user passwd file](https://man7.org/linux/man-pages/man5/passwd.5.html).
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use anyhow::{anyhow, Context, Result};
 use std::io::{BufRead, Write};

--- a/rust/src/nameservice/mod.rs
+++ b/rust/src/nameservice/mod.rs
@@ -1,5 +1,5 @@
 //! Linux name-service information helpers.
-
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 // TODO(lucab): consider moving this to its own crate.
 
 pub(crate) mod group;

--- a/rust/src/nameservice/passwd.rs
+++ b/rust/src/nameservice/passwd.rs
@@ -1,4 +1,5 @@
 //! Helpers for [user group file](https://man7.org/linux/man-pages/man5/group.5.html).
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use anyhow::{anyhow, Context, Result};
 use std::io::{BufRead, Write};

--- a/rust/src/ostree_utils.rs
+++ b/rust/src/ostree_utils.rs
@@ -1,4 +1,6 @@
 //! Utility helpers or workarounds for incorrectly bound things in ostree-rs
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use glib::translate::*;
 use std::ptr;
 

--- a/rust/src/passwd.rs
+++ b/rust/src/passwd.rs
@@ -1,5 +1,6 @@
 //! APIs for interacting with `/etc/passwd` and `/etc/group`, including
 //! handling the "nss-altfiles" split into `/usr/lib/{passwd,group}`.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::cxxrsutil::{self, FFIGObjectWrapper};
 use crate::ffiutil;


### PR DESCRIPTION
It turns out we accidentally added GPL'd code into the Rust
side, which wasn't intentional on my part and I think it's since
been copied around.

Honestly I think half of the problem is the gigantic
"blah blah blah GNU General blah blah" just makes people's eyes
glaze over.  In contrast the `SPDX-License-Identifier` is short
and obvious.

So let's validate that in CI.

This follows a similar change in ostree:
https://github.com/ostreedev/ostree/pull/1439

If we merge this I'll do the C/C++ side too after that.
