### PR TITLE
 apply-live: Rework to use refs to store state

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -197,6 +197,7 @@ pub mod ffi {
             sysroot: Pin<&mut OstreeSysroot>,
             deployment: Pin<&mut OstreeDeployment>,
         ) -> Result<bool>;
+        fn applylive_sync_ref(sysroot: Pin<&mut OstreeSysroot>) -> Result<()>;
         // FIXME/cxx make this Option<&str>
         fn transaction_apply_live(sysroot: Pin<&mut OstreeSysroot>, target: &str) -> Result<()>;
         fn applylive_client_finish() -> Result<()>;

--- a/rust/src/ostree_utils.rs
+++ b/rust/src/ostree_utils.rs
@@ -1,8 +1,32 @@
 //! Utility helpers or workarounds for incorrectly bound things in ostree-rs
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use glib;
 use glib::translate::*;
 use std::ptr;
+
+pub(crate) fn repo_resolve_ref_optional(
+    repo: &ostree::Repo,
+    refspec: &str,
+) -> Result<Option<glib::GString>, glib::Error> {
+    unsafe {
+        let mut out_rev = ptr::null_mut();
+        let mut error = ptr::null_mut();
+        let refspec = refspec.to_glib_none();
+        let _ = ostree_sys::ostree_repo_resolve_rev(
+            repo.to_glib_none().0,
+            refspec.0,
+            true.to_glib(),
+            &mut out_rev,
+            &mut error,
+        );
+        if error.is_null() {
+            Ok(from_glib_full(out_rev))
+        } else {
+            Err(from_glib_full(error))
+        }
+    }
+}
 
 pub(crate) fn sysroot_query_deployments_for(
     sysroot: &ostree::Sysroot,
@@ -18,5 +42,21 @@ pub(crate) fn sysroot_query_deployments_for(
             &mut out_rollback,
         );
         (from_glib_full(out_pending), from_glib_full(out_rollback))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use anyhow::Result;
+
+    #[test]
+    fn optional_ref() -> Result<()> {
+        let cancellable = gio::NONE_CANCELLABLE;
+        let td = tempfile::tempdir()?;
+        let r = ostree::Repo::new_for_path(td.path());
+        r.create(ostree::RepoMode::Archive, cancellable)?;
+        assert!(repo_resolve_ref_optional(&r, "someref")?.is_none());
+        Ok(())
     }
 }

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -5,7 +5,8 @@ set -xeuo pipefail
 cd $(mktemp -d)
 
 # make sure that package-related entries are always present,
-# even when they're empty
+# even when they're empty.
+# Validate there's no live state by default.
 rpm-ostree status --json > status.json
 assert_jq status.json \
   '.deployments[0]["packages"]' \
@@ -13,6 +14,8 @@ assert_jq status.json \
   '.deployments[0]["requested-local-packages"]' \
   '.deployments[0]["base-removals"]' \
   '.deployments[0]["requested-base-removals"]' \
+  '.deployments[0]["live-inprogress"]|not' \
+  '.deployments[0]["live-replaced"]|not' \
   '.deployments[0]["layered-commit-meta"]|not'
 rm status.json
 rpm-ostree testutils validate-parse-status

--- a/tests/vmcheck/test-layering-local.sh
+++ b/tests/vmcheck/test-layering-local.sh
@@ -29,13 +29,20 @@ vm_assert_layered_pkg foo absent
 vm_cmd ostree refs $(vm_get_deployment_info 0 checksum) --create vmcheck_tmp/without_foo
 vm_build_rpm foo version 1.2 release 3
 vm_rpmostree install /var/tmp/vmcheck/yumrepo/packages/x86_64/foo-1.2-3.x86_64.rpm
+vm_assert_status_jq '.deployments[0]["packages"]|length == 0' \
+  '.deployments[0]["requested-packages"]|length == 0' \
+  '.deployments[0]["requested-local-packages"]|length == 1' \
+  '.deployments[0]["live-inprogress"]|not' \
+  '.deployments[0]["live-replaced"]|not'
 echo "ok install foo locally"
 
 vm_reboot
 
-vm_assert_status_jq '.deployments[0]["packages"]|length == 0'
-vm_assert_status_jq '.deployments[0]["requested-packages"]|length == 0'
-vm_assert_status_jq '.deployments[0]["requested-local-packages"]|length == 1'
+vm_assert_status_jq '.deployments[0]["packages"]|length == 0' \
+  '.deployments[0]["requested-packages"]|length == 0' \
+  '.deployments[0]["requested-local-packages"]|length == 1' \
+  '.deployments[0]["live-inprogress"]|not' \
+  '.deployments[0]["live-replaced"]|not'
 vm_has_local_packages foo-1.2-3.x86_64
 vm_assert_layered_pkg foo-1.2-3.x86_64 present
 echo "ok pkg foo added locally"


### PR DESCRIPTION

Came out of discussion in #2581
around some racy code for checking for the live commit object.

The reliability of apply-live depends on the
underlying commits not being garbage collected.  Our diff logic
is in terms of ostree commits, not the physical filesystem (this
allows us to make various optimizations too).

Ultimately I think we should drive some of the live-apply
logic into libostree itself; we can more easily have an atomic
state file instead of the two split refs.

(Or perhaps what we should add to ostree is like a refs.d model
 where a single atomic file can refer to multiple commits)

For now though let's rework the code here to write refs.  We
retain the file in `/run` as just a "stamp file" that signals
that a deployment has had `apply-live` run.