### PR TITLE
rust: add missing SPDX-License-Identifier tag

### DIFF
--- a/ci/codestyle.sh
+++ b/ci/codestyle.sh
@@ -3,17 +3,17 @@
 # can be run without building it.
 set -euo pipefail
 
-echo -n "Checking for tabs..."
+echo -n "checking for tabs... "
 (git grep -E '^	+' -- '*.[ch]' || true) > tabdamage.txt
 if test -s tabdamage.txt; then
     echo "Error: tabs in .[ch] files:"
     cat tabdamage.txt
     exit 1
 fi
-rm -v tabdamage.txt
+rm tabdamage.txt
 echo "ok"
 
-echo -n "checking rustfmt..."
+echo -n "checking rustfmt... "
 for crate in $(find -iname Cargo.toml); do
     if ! cargo fmt --manifest-path ${crate} -- --check; then
         echo "cargo fmt failed; run: cd $(dirname ${crate}) && cargo fmt" 1>&2
@@ -23,7 +23,7 @@ done
 echo "ok"
 
 ident='SPDX-License-Identifier:'
-echo -n "checking \"$ident\"..."
+echo -n "checking \"$ident\"... "
 git ls-files '*.rs' | while read f; do
     if ! grep -qF "$ident" $f; then
         echo "error: File $f: Missing $ident" 1>&2

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -1,5 +1,7 @@
 //! Rust portion of rpmostreed-deployment-utils.cxx
 
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use crate::cxxrsutil::*;
 use std::pin::Pin;
 


### PR DESCRIPTION
This adds a missing `SPDX-License-Identifier` tag, fixing CI.