### PR TITLE
daemon: Move some "deployment variant" generation to Rust

### DIFF
--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -100,12 +100,19 @@ bind_ostree_obj!(Deployment);
 // try to instead create a bind_gio_obj!() macro or so.
 #[repr(transparent)]
 pub struct FFIGCancellable(gio_sys::GCancellable);
-
 unsafe impl ExternType for FFIGCancellable {
     type Id = type_id!(rpmostreecxx::GCancellable);
     type Kind = cxx::kind::Trivial;
 }
 impl_wrap!(FFIGCancellable, gio::Cancellable, gio_sys::GCancellable);
+
+#[repr(transparent)]
+pub struct FFIGVariantDict(glib_sys::GVariantDict);
+unsafe impl ExternType for FFIGVariantDict {
+    type Id = type_id!(rpmostreecxx::GVariantDict);
+    type Kind = cxx::kind::Trivial;
+}
+impl_wrap!(FFIGVariantDict, glib::VariantDict, glib_sys::GVariantDict);
 
 // An error type helper; separate from the GObject bridging
 mod err {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -37,6 +37,7 @@ pub mod ffi {
         type OstreeRepo = crate::FFIOstreeRepo;
         type OstreeDeployment = crate::FFIOstreeDeployment;
         type GCancellable = crate::FFIGCancellable;
+        type GVariantDict = crate::FFIGVariantDict;
     }
 
     /// Currently cxx-rs doesn't support mappings; like probably most projects,
@@ -80,6 +81,11 @@ pub mod ffi {
     // daemon.rs
     extern "Rust" {
         fn deployment_generate_id(deployment: Pin<&mut OstreeDeployment>) -> String;
+        fn deployment_populate_variant(
+            mut sysroot: Pin<&mut OstreeSysroot>,
+            mut deployment: Pin<&mut OstreeDeployment>,
+            mut dict: Pin<&mut GVariantDict>,
+        ) -> Result<()>;
     }
 
     // initramfs.rs

--- a/src/libpriv/rpmostree-cxxrs-prelude.h
+++ b/src/libpriv/rpmostree-cxxrs-prelude.h
@@ -29,4 +29,5 @@ namespace rpmostreecxx {
     typedef ::OstreeRepo OstreeRepo;
     typedef ::OstreeDeployment OstreeDeployment;
     typedef ::GCancellable GCancellable;
+    typedef ::GVariantDict GVariantDict;
 }


### PR DESCRIPTION
More prep for https://github.com/coreos/rpm-ostree/pull/2388

This was actually also my first time really trying out the
latest gtk-rs `glib::Variant` API, which is one of the major
things we need to use to progress oxidation more.
