### PR TITLE
ci: Drop tests/vmcheck/image.qcow2, use COSA_DIR/.cosa

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -60,11 +60,7 @@ parallel insttests: {
       stage("vmcheck") {
         try {
           timeout(time: 30, unit: 'MINUTES') {
-            shwrap("""
-              fcos=\$(ls builds/latest/*/*.qcow2) # */
-              ln -sf "\$(realpath \${fcos})" tests/vmcheck/image.qcow2
-              JOBS=${nhosts} tests/vmcheck.sh
-            """)
+            shwrap("COSA_DIR=${env.WORKSPACE} JOBS=${nhosts} tests/vmcheck.sh")
           }
         } finally {
           shwrap("""

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -18,7 +18,7 @@ if BUILDOPT_ASAN
 AM_TESTS_ENVIRONMENT += BUILDOPT_ASAN=yes ASAN_OPTIONS=detect_leaks=false
 endif
 
-GITIGNOREFILES += ssh-config ansible-inventory.yml vmcheck-logs/ test-compose-logs/ tests/vmcheck/image.qcow2
+GITIGNOREFILES += ssh-config vmcheck-logs/ test-compose-logs/ .cosa/
 
 uninstalled_test_scripts = \
 	tests/check/test-lib-introspection.sh \
@@ -32,10 +32,8 @@ dbus_run_session_SOURCES = tests/utils/dbus-run-session.c
 
 check-local:
 	@echo "  *** NOTE ***"
-	@echo "  *** NOTE ***"
-	@echo " \"make check\" only runs a subset of rpm-ostree's tests."
-	@echo " Use \"make vmcheck\" to run remaining tests in a VM."
-	@echo "  *** NOTE ***"
+	@echo " \"make check\" only runs unit tests, which have limited coverage currently."
+	@echo " See HACKING.md for more information about VM-based integration testing."
 	@echo "  *** NOTE ***"
 
 .PHONY: vmsync vmoverlay vmcheck testenv

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -60,7 +60,9 @@ rpm-ostree has some tests that use the [coreos-assembler/kola framework](https:/
 
 You will want to [build a custom image](https://coreos.github.io/coreos-assembler/working/#using-overrides), then run `make install` in the `${topsrcdir}/tests/kolainst/` directory, and finally `kola run --qemu-image path/to/custom-rpm-ostree-qemu.qcow2 'ext.rpm-ostree.*'`. See the [kola external tests documentation](https://coreos.github.io/coreos-assembler/kola/external-tests/#using-kola-run-with-externally-defined-tests) for more information and also how to filter tests.
 
-There's also a `vmcheck` test suite. This model always operates on an immutable base image. It takes that image and dynamically launches a separate VM for each test using `kola spawn`. For example, using the [CoreOS Assembler](https://coreos.github.io/coreos-assembler/building-fcos/), you can build a FCOS image that contains the version of rpm-ostree that you would like to test. To run the `vmcheck` test suite on it, symlink the built image to `${topsrcdir}/tests/vmcheck/image.qcow2` and execute `tests/vmcheck.sh`. 
+There's also a `vmcheck` test suite. This model always operates on an immutable base image. It takes that image and dynamically launches a separate VM for each test using `kola spawn`. For example, using the [CoreOS Assembler](https://coreos.github.io/coreos-assembler/building-fcos/), you can build a FCOS image that contains the version of rpm-ostree that you would like to test.
+
+One approach for (somewhat) fast iteration is `cosa build-fast`, then run e.g. `./tests/vmcheck.sh`.
 
 To filter tests, use the `TESTS=` environment variable. For example, to run only `tests/vmcheck/test-misc-2.sh`, you can do:
 

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -46,7 +46,11 @@ vm_kola_spawn() {
 
   exec 4> info.json
   mkdir kola-ssh
-  test_image="${topsrcdir}/tests/vmcheck/image.qcow2"
+  if test -n "${COSA_DIR:-}"; then
+    test_image=$(cd ${COSA_DIR} && cosa meta --image-path qemu)
+  else
+    test_image=$(echo ${topsrcdir}/.cosa/*.qcow2)
+  fi
   if [ ! -e "$test_image" ]; then
     if  [ -L "$test_image" ]; then
       echo "$test_image is an invalid symlink" >&3


### PR DESCRIPTION
Now that `cosa build-fast` writes to `.cosa`, teach our
test suite to pick that up by default.  We don't anymore
support non-CoreOS (i.e. non-Ignition) hosts for our test
suite, so making this more CoreOS specific is fine.

Then use the "standard" COSA_DIR as a way to find the target
cosa dir in the e2e CI.
