### PR TITLE
app/{deploy,rebase}: Do not deploy/rebase if updates driver registered

### DIFF
--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -287,8 +287,8 @@ get_update_driver_state (RPMOSTreeSysroot *sysroot_proxy,
     g_dbus_proxy_get_connection (G_DBUS_PROXY (sysroot_proxy));
 
   const char *update_driver_objpath = NULL;
-  if (!get_sd_unit_objpath(connection, update_driver_sd_unit, &update_driver_objpath,
-                           cancellable, error))
+  if (!get_sd_unit_objpath (connection, "LoadUnit", g_variant_new ("(s)", update_driver_sd_unit),
+                            &update_driver_objpath, cancellable, error))
     return FALSE;
 
   /* Look up ActiveState property of update driver's systemd unit. */

--- a/src/app/rpmostree-dbus-helpers.h
+++ b/src/app/rpmostree-dbus-helpers.h
@@ -133,8 +133,9 @@ rpmostree_print_cached_update (GVariant         *cached_update,
 
 gboolean
 get_sd_unit_objpath (GDBusConnection  *connection,
-                     const char       *update_driver_sd_unit,
-                     const char      **update_driver_objpath,
+                     const char       *method_name,
+                     GVariant         *parameters,
+                     const char      **unit_objpath,
                      GCancellable     *cancellable,
                      GError          **error);
 

--- a/src/app/rpmostree-dbus-helpers.h
+++ b/src/app/rpmostree-dbus-helpers.h
@@ -131,4 +131,17 @@ rpmostree_print_cached_update (GVariant         *cached_update,
                                GCancellable     *cancellable,
                                GError          **error);
 
+gboolean
+get_sd_unit_objpath (GDBusConnection  *connection,
+                     const char       *update_driver_sd_unit,
+                     const char      **update_driver_objpath,
+                     GCancellable     *cancellable,
+                     GError          **error);
+
+gboolean
+error_if_driver_registered (GBusType          bus_type,
+                            RPMOSTreeSysroot *sysroot_proxy,
+                            GCancellable     *cancellable,
+                            GError          **error);
+
 G_END_DECLS

--- a/src/app/rpmostree-libbuiltin.cxx
+++ b/src/app/rpmostree-libbuiltin.cxx
@@ -141,29 +141,3 @@ rpmostree_print_timestamp_version (const char  *version_string,
       rpmostree_print_kv ("Version", max_key_len, version_time);
     }
 }
-
-/* Query systemd for update driver's systemd unit's object path. */
-gboolean
-get_sd_unit_objpath (GDBusConnection  *connection,
-                     const char       *update_driver_sd_unit,
-                     const char      **update_driver_objpath,
-                     GCancellable     *cancellable,
-                     GError          **error)
-{
-  g_autoptr(GVariant) update_driver_objpath_tuple = 
-    g_dbus_connection_call_sync (connection, "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
-                                 "org.freedesktop.systemd1.Manager", "LoadUnit",
-                                 g_variant_new ("(s)", update_driver_sd_unit), G_VARIANT_TYPE_TUPLE,
-                                 G_DBUS_CALL_FLAGS_NONE, -1, cancellable, error);
-  if (!update_driver_objpath_tuple)
-    return FALSE;
-  else if (g_variant_n_children (update_driver_objpath_tuple) < 1)
-    return glnx_throw (error, "LoadUnit(%s) returned empty tuple", update_driver_sd_unit);
-
-  g_autoptr(GVariant) update_driver_objpath_val =
-    g_variant_get_child_value (update_driver_objpath_tuple, 0);
-  *update_driver_objpath = g_variant_dup_string (update_driver_objpath_val, NULL);
-  g_assert (*update_driver_objpath);
-
-  return TRUE;
-}

--- a/src/app/rpmostree-libbuiltin.h
+++ b/src/app/rpmostree-libbuiltin.h
@@ -75,11 +75,4 @@ rpmostree_print_timestamp_version (const char  *version_string,
                                    const char  *timestamp_string,
                                    guint        max_key_len);
 
-gboolean
-get_sd_unit_objpath (GDBusConnection  *connection,
-                     const char       *update_driver_sd_unit,
-                     const char      **update_driver_objpath,
-                     GCancellable     *cancellable,
-                     GError          **error);
-
 G_END_DECLS


### PR DESCRIPTION
Follow up to #2566.
Error out if users try to manually do a deploy/rebase if an updates
driver is registered. Provide `--bypass-driver` option to proceed
anyway.