### PR TITLE
daemon: Fix crash on upgrade with remote:checksum

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -428,8 +428,10 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
         if (!ostree_parse_refspec (refspec, &origin_remote, &origin_ref, error))
           return FALSE;
 
+        const gboolean is_commit = ostree_validate_checksum_string (origin_ref, NULL);
+
         g_assert (self->origin_merge_deployment);
-        if (origin_remote && !synthetic)
+        if (origin_remote && !synthetic && !is_commit)
           {
             g_autoptr(GVariantBuilder) optbuilder = g_variant_builder_new (G_VARIANT_TYPE ("a{sv}"));
             if (dir_to_pull && *dir_to_pull)

--- a/tests/vmcheck/test-pinned-commit.sh
+++ b/tests/vmcheck/test-pinned-commit.sh
@@ -37,4 +37,9 @@ if vm_rpmostree deploy 42 2>err.txt; then
     fatal "deployed version from commit?"
 fi
 assert_file_has_content err.txt 'Cannot look up version while pinned to commit'
+
+# And test https://github.com/coreos/rpm-ostree/issues/2603
+vm_cmd ostree remote add self --set=gpg-verify=false file:///ostree/repo
+vm_rpmostree rebase self:${checksum}
+vm_rpmostree upgrade
 echo "ok cmds"


### PR DESCRIPTION
The refspec code really needs to be cleaned up and oxidized (and
unit tested more).

The intention is that if you're pinned to a commit, we say
"No upgrade available" but we were crashing if one (understandably)
rebased to the combination of `remote:checksum` instead of just `checksum`.

Fix the classifer code to say this is a `CHECKSUM` case, and
fix the upgrader to skip the pull path.

Closes: https://github.com/coreos/rpm-ostree/issues/2603
