### PR TITLE
libpriv/passwd: move UID/GID checker to Rust

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -225,6 +225,8 @@ pub mod ffi {
             previous_checksum: &str,
             unified_core: bool,
         ) -> Result<()>;
+        fn dir_contains_uid(dirfd: i32, id: u32) -> Result<bool>;
+        fn dir_contains_gid(dirfd: i32, id: u32) -> Result<bool>;
 
         type PasswdDB;
         fn lookup_user(self: &PasswdDB, uid: u32) -> Result<String>;


### PR DESCRIPTION
This ports to Rust the logic for checking whether a directory tree
contains content owned by a given UID/GID.
