### PR TITLE
client: Remove peer_pid value from option parsing

### DIFF
--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -202,7 +202,6 @@ rpmostree_option_context_parse (GOptionContext *context,
                                 const char *const* *out_install_pkgs,
                                 const char *const* *out_uninstall_pkgs,
                                 RPMOSTreeSysroot **out_sysroot_proxy,
-                                GPid *out_peer_pid,
                                 GBusType *out_bus_type,
                                 GError **error)
 {
@@ -285,7 +284,6 @@ rpmostree_option_context_parse (GOptionContext *context,
                                    opt_force_peer,
                                    cancellable,
                                    out_sysroot_proxy,
-                                   out_peer_pid,
                                    out_bus_type,
                                    error))
         return FALSE;
@@ -373,7 +371,7 @@ rpmostree_handle_subcommand (int argc, char **argv,
                                              &argc, &argv,
                                              invocation,
                                              cancellable,
-                                             NULL, NULL, NULL, NULL, NULL, NULL);
+                                             NULL, NULL, NULL, NULL, NULL);
       if (subcommand_name == NULL)
         {
           g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
@@ -488,7 +486,7 @@ rpmostree_main_inner (const rust::Slice<const rust::Str> args)
       /* This will not return for some options (e.g. --version). */
       (void) rpmostree_option_context_parse (context, NULL, &argc, &argv,
                                              NULL, NULL, NULL, NULL, NULL,
-                                             NULL, NULL, NULL);
+                                             NULL, NULL);
       g_autofree char *help = g_option_context_get_help (context, FALSE, NULL);
       g_printerr ("%s", help);
       if (command_name == NULL)

--- a/src/app/rpmostree-builtin-applylive.cxx
+++ b/src/app/rpmostree-builtin-applylive.cxx
@@ -73,7 +73,6 @@ rpmostree_ex_builtin_apply_live (int             argc,
                                  GCancellable   *cancellable,
                                  GError        **error)
 {
-  _cleanup_peer_ GPid peer_pid = 0;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   g_autoptr(GOptionContext) context = g_option_context_new ("");
   if (!rpmostree_option_context_parse (context,
@@ -83,7 +82,6 @@ rpmostree_ex_builtin_apply_live (int             argc,
                                        cancellable,
                                        NULL, NULL,
                                        &sysroot_proxy,
-                                       &peer_pid,
                                        NULL,
                                        error))
     return FALSE;

--- a/src/app/rpmostree-builtin-cancel.cxx
+++ b/src/app/rpmostree-builtin-cancel.cxx
@@ -65,7 +65,6 @@ rpmostree_builtin_cancel (int             argc,
 {
   g_autoptr(GOptionContext) context = g_option_context_new ("");
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
-  _cleanup_peer_ GPid peer_pid = 0;
 
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
@@ -74,7 +73,6 @@ rpmostree_builtin_cancel (int             argc,
                                        cancellable,
                                        NULL, NULL,
                                        &sysroot_proxy,
-                                       &peer_pid,
                                        NULL,
                                        error))
     return FALSE;

--- a/src/app/rpmostree-builtin-cleanup.cxx
+++ b/src/app/rpmostree-builtin-cleanup.cxx
@@ -57,7 +57,6 @@ rpmostree_builtin_cleanup (int             argc,
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   g_autofree char *transaction_address = NULL;
-  _cleanup_peer_ GPid peer_pid = 0;
 
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
@@ -66,7 +65,6 @@ rpmostree_builtin_cleanup (int             argc,
                                        cancellable,
                                        NULL, NULL,
                                        &sysroot_proxy,
-                                       &peer_pid,
                                        NULL,
                                        error))
     return FALSE;

--- a/src/app/rpmostree-builtin-db.cxx
+++ b/src/app/rpmostree-builtin-db.cxx
@@ -61,7 +61,7 @@ rpmostree_db_option_context_parse (GOptionContext *context,
                                        argc, argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-deploy.cxx
+++ b/src/app/rpmostree-builtin-deploy.cxx
@@ -69,7 +69,6 @@ rpmostree_builtin_deploy (int            argc,
   g_autofree char *transaction_address = NULL;
   const char * const packages[] = { NULL };
   const char *revision;
-  _cleanup_peer_ GPid peer_pid = 0;
   const char *const *install_pkgs = NULL;
   const char *const *uninstall_pkgs = NULL;
 
@@ -84,7 +83,6 @@ rpmostree_builtin_deploy (int            argc,
                                        &install_pkgs,
                                        &uninstall_pkgs,
                                        &sysroot_proxy,
-                                       &peer_pid,
                                        &bus_type,
                                        error))
     return FALSE;

--- a/src/app/rpmostree-builtin-finalize-deployment.cxx
+++ b/src/app/rpmostree-builtin-finalize-deployment.cxx
@@ -45,11 +45,10 @@ rpmostree_builtin_finalize_deployment (int             argc,
 {
   g_autoptr(GOptionContext) context = g_option_context_new ("CHECKSUM");
 
-  _cleanup_peer_ GPid peer_pid = 0;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   if (!rpmostree_option_context_parse (context, option_entries, &argc, &argv,
                                        invocation, cancellable, NULL, NULL,
-                                       &sysroot_proxy, &peer_pid, NULL, error))
+                                       &sysroot_proxy, NULL, error))
     return FALSE;
 
   const char *checksum = NULL;

--- a/src/app/rpmostree-builtin-initramfs-etc.cxx
+++ b/src/app/rpmostree-builtin-initramfs-etc.cxx
@@ -60,7 +60,6 @@ rpmostree_ex_builtin_initramfs_etc (int             argc,
 {
   g_autoptr(GOptionContext) context = g_option_context_new ("");
 
-  _cleanup_peer_ GPid peer_pid = 0;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
@@ -69,7 +68,6 @@ rpmostree_ex_builtin_initramfs_etc (int             argc,
                                        cancellable,
                                        NULL, NULL,
                                        &sysroot_proxy,
-                                       &peer_pid,
                                        NULL,
                                        error))
     return FALSE;

--- a/src/app/rpmostree-builtin-initramfs.cxx
+++ b/src/app/rpmostree-builtin-initramfs.cxx
@@ -55,7 +55,6 @@ rpmostree_builtin_initramfs (int             argc,
 {
   g_autoptr(GOptionContext) context = g_option_context_new ("");
 
-  _cleanup_peer_ GPid peer_pid = 0;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
@@ -64,7 +63,6 @@ rpmostree_builtin_initramfs (int             argc,
                                        cancellable,
                                        NULL, NULL,
                                        &sysroot_proxy,
-                                       &peer_pid,
                                        NULL,
                                        error))
     return FALSE;

--- a/src/app/rpmostree-builtin-kargs.cxx
+++ b/src/app/rpmostree-builtin-kargs.cxx
@@ -165,7 +165,6 @@ rpmostree_builtin_kargs (int            argc,
                          GCancellable  *cancellable,
                          GError       **error)
 {
-  _cleanup_peer_ GPid peer_pid = 0;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   g_autoptr(GOptionContext) context = g_option_context_new ("");
   gboolean display_kernel_args = FALSE;
@@ -176,7 +175,6 @@ rpmostree_builtin_kargs (int            argc,
                                        cancellable,
                                        NULL, NULL,
                                        &sysroot_proxy,
-                                       &peer_pid,
                                        NULL,
                                        error))
     return FALSE;

--- a/src/app/rpmostree-builtin-rebase.cxx
+++ b/src/app/rpmostree-builtin-rebase.cxx
@@ -80,7 +80,6 @@ rpmostree_builtin_rebase (int             argc,
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   g_autofree char *transaction_address = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
-  _cleanup_peer_ GPid peer_pid = 0;
   const char *const *install_pkgs = NULL;
   const char *const *uninstall_pkgs = NULL;
 
@@ -93,7 +92,7 @@ rpmostree_builtin_rebase (int             argc,
                                        &install_pkgs,
                                        &uninstall_pkgs,
                                        &sysroot_proxy,
-                                       &peer_pid, &bus_type,
+                                       &bus_type,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-refresh-md.cxx
+++ b/src/app/rpmostree-builtin-refresh-md.cxx
@@ -57,7 +57,6 @@ rpmostree_builtin_refresh_md (int             argc,
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   g_autofree char *transaction_address = NULL;
-  _cleanup_peer_ GPid peer_pid = 0;
 
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
@@ -66,7 +65,6 @@ rpmostree_builtin_refresh_md (int             argc,
                                        cancellable,
                                        NULL, NULL,
                                        &sysroot_proxy,
-                                       &peer_pid,
                                        NULL,
                                        error))
     return FALSE;

--- a/src/app/rpmostree-builtin-reload.cxx
+++ b/src/app/rpmostree-builtin-reload.cxx
@@ -42,7 +42,6 @@ rpmostree_builtin_reload (int             argc,
 {
   g_autoptr(GOptionContext) context = g_option_context_new ("");
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
-  _cleanup_peer_ GPid peer_pid = 0;
 
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
@@ -51,7 +50,6 @@ rpmostree_builtin_reload (int             argc,
                                        cancellable,
                                        NULL, NULL,
                                        &sysroot_proxy,
-                                       &peer_pid,
                                        NULL,
                                        error))
     return FALSE;

--- a/src/app/rpmostree-builtin-reset.cxx
+++ b/src/app/rpmostree-builtin-reset.cxx
@@ -57,7 +57,6 @@ rpmostree_builtin_reset (int             argc,
   g_autoptr(GOptionContext) context = g_option_context_new ("");
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   g_autofree char *transaction_address = NULL;
-  _cleanup_peer_ GPid peer_pid = 0;
   const char *const *install_pkgs = NULL;
   const char *const *uninstall_pkgs = NULL;
 
@@ -69,7 +68,6 @@ rpmostree_builtin_reset (int             argc,
                                        &install_pkgs,
                                        &uninstall_pkgs,
                                        &sysroot_proxy,
-                                       &peer_pid,
                                        NULL,
                                        error))
     return FALSE;

--- a/src/app/rpmostree-builtin-rollback.cxx
+++ b/src/app/rpmostree-builtin-rollback.cxx
@@ -58,7 +58,6 @@ rpmostree_builtin_rollback (int             argc,
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   g_autofree char *transaction_address = NULL;
-  _cleanup_peer_ GPid peer_pid = 0;
 
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
@@ -67,7 +66,6 @@ rpmostree_builtin_rollback (int             argc,
                                        cancellable,
                                        NULL, NULL,
                                        &sysroot_proxy,
-                                       &peer_pid,
                                        NULL,
                                        error))
     return FALSE;

--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -1125,7 +1125,6 @@ rpmostree_builtin_status (int             argc,
   g_autoptr(GOptionContext) context = g_option_context_new ("");
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
-  _cleanup_peer_ GPid peer_pid = 0;
 
   GBusType bus_type;
   if (!rpmostree_option_context_parse (context,
@@ -1135,7 +1134,7 @@ rpmostree_builtin_status (int             argc,
                                        cancellable,
                                        NULL, NULL,
                                        &sysroot_proxy,
-                                       &peer_pid, &bus_type,
+                                       &bus_type,
                                        error))
     return FALSE;
 
@@ -1397,7 +1396,7 @@ rpmostree_ex_builtin_history (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-upgrade.cxx
+++ b/src/app/rpmostree-builtin-upgrade.cxx
@@ -74,7 +74,6 @@ rpmostree_builtin_upgrade (int             argc,
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   g_autofree char *transaction_address = NULL;
-  _cleanup_peer_ GPid peer_pid = 0;
   const char *const *install_pkgs = NULL;
   const char *const *uninstall_pkgs = NULL;
 
@@ -87,7 +86,7 @@ rpmostree_builtin_upgrade (int             argc,
                                        &install_pkgs,
                                        &uninstall_pkgs,
                                        &sysroot_proxy,
-                                       &peer_pid, &bus_type,
+                                       &bus_type,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-usroverlay.cxx
+++ b/src/app/rpmostree-builtin-usroverlay.cxx
@@ -42,7 +42,6 @@ rpmostree_builtin_usroverlay (int             argc,
 {
   g_autoptr(GOptionContext) context = g_option_context_new ("");
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
-  _cleanup_peer_ GPid peer_pid = 0;
 
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
@@ -51,7 +50,6 @@ rpmostree_builtin_usroverlay (int             argc,
                                        cancellable,
                                        NULL, NULL,
                                        &sysroot_proxy,
-                                       &peer_pid,
                                        NULL,
                                        error))
     return FALSE;

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -71,7 +71,6 @@ rpmostree_option_context_parse (GOptionContext *context,
                                 const char *const* *out_install_pkgs,
                                 const char *const* *out_uninstall_pkgs,
                                 RPMOSTreeSysroot **out_sysroot_proxy,
-                                GPid *out_peer_pid,
                                 GBusType *out_bus_type,
                                 GError **error);
 

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1198,7 +1198,7 @@ rpmostree_compose_builtin_install (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 
@@ -1265,7 +1265,7 @@ rpmostree_compose_builtin_postprocess (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 
@@ -1328,7 +1328,7 @@ rpmostree_compose_builtin_commit (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 
@@ -1374,7 +1374,7 @@ rpmostree_compose_builtin_tree (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 
@@ -1438,7 +1438,7 @@ rpmostree_compose_builtin_extensions (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-dbus-helpers.h
+++ b/src/app/rpmostree-dbus-helpers.h
@@ -33,17 +33,11 @@ G_BEGIN_DECLS
 
 #define BUS_NAME "org.projectatomic.rpmostree1"
 
-#define _cleanup_peer_ __attribute__((cleanup(rpmostree_cleanup_peer)))
-
-void
-rpmostree_cleanup_peer                       (GPid *peer_pid);
-
 gboolean
 rpmostree_load_sysroot                       (gchar *sysroot,
                                               gboolean force_peer,
                                               GCancellable *cancellable,
                                               RPMOSTreeSysroot **out_sysroot_proxy,
-                                              GPid *out_peer_pid,
                                               GBusType *out_bus_type,
                                               GError **error);
 

--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -141,7 +141,6 @@ rpmostree_override_builtin_replace (int argc, char **argv,
 {
   GOptionContext *context;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
-  _cleanup_peer_ GPid peer_pid = 0;
 
   context = g_option_context_new ("PACKAGE [PACKAGE...]");
 
@@ -155,7 +154,7 @@ rpmostree_override_builtin_replace (int argc, char **argv,
                                        &install_pkgs,
                                        &uninstall_pkgs,
                                        &sysroot_proxy,
-                                       &peer_pid, NULL,
+                                       NULL,
                                        error))
     return FALSE;
 
@@ -184,7 +183,6 @@ rpmostree_override_builtin_remove (int argc, char **argv,
 {
   GOptionContext *context;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
-  _cleanup_peer_ GPid peer_pid = 0;
 
   context = g_option_context_new ("PACKAGE [PACKAGE...]");
 
@@ -198,7 +196,7 @@ rpmostree_override_builtin_remove (int argc, char **argv,
                                        &install_pkgs,
                                        &uninstall_pkgs,
                                        &sysroot_proxy,
-                                       &peer_pid, NULL,
+                                       NULL,
                                        error))
     return FALSE;
 
@@ -227,7 +225,6 @@ rpmostree_override_builtin_reset (int argc, char **argv,
 {
   GOptionContext *context;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
-  _cleanup_peer_ GPid peer_pid = 0;
 
   context = g_option_context_new ("PACKAGE [PACKAGE...]");
 
@@ -241,7 +238,7 @@ rpmostree_override_builtin_reset (int argc, char **argv,
                                        &install_pkgs,
                                        &uninstall_pkgs,
                                        &sysroot_proxy,
-                                       &peer_pid, NULL,
+                                       NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -155,7 +155,6 @@ rpmostree_builtin_install (int            argc,
 {
   GOptionContext *context;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
-  _cleanup_peer_ GPid peer_pid = 0;
 
   context = g_option_context_new ("PACKAGE [PACKAGE...]");
 
@@ -168,7 +167,7 @@ rpmostree_builtin_install (int            argc,
                                        cancellable,
                                        NULL, NULL,
                                        &sysroot_proxy,
-                                       &peer_pid, NULL,
+                                       NULL,
                                        error))
     return FALSE;
 
@@ -198,7 +197,6 @@ rpmostree_builtin_uninstall (int            argc,
 {
   GOptionContext *context;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
-  _cleanup_peer_ GPid peer_pid = 0;
 
   context = g_option_context_new ("PACKAGE [PACKAGE...]");
 
@@ -211,7 +209,7 @@ rpmostree_builtin_uninstall (int            argc,
                                        cancellable,
                                        NULL, NULL,
                                        &sysroot_proxy,
-                                       &peer_pid, NULL,
+                                       NULL,
                                        error))
     return FALSE;
 


### PR DESCRIPTION
Instead of passing the pid back up the stack and using a cleanup
function on it to invoke `kill()`, use `PR_SET_PDEATHSIG` which
has the kernel take care of this for us.

(In practice we don't actually use this peer functionality anymore
 because all of the client/daemon code kind of requires being run under systemd
 on a real system now)

This shrinks the API surface and is much less repetitive in
the codebase.

Prep for moving more of the CLI code to Rust.
