### PR TITLE
compose/extensions: Handle no --base-rev

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -186,6 +186,7 @@ pub mod ffi {
         fn get_files_remove_regex(&self, package: &str) -> Vec<String>;
         fn print_deprecation_warnings(&self);
         fn get_checksum(&self, repo: Pin<&mut OstreeRepo>) -> Result<String>;
+        fn get_ostree_ref(&self) -> String;
     }
 
     // utils.rs

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -481,6 +481,11 @@ impl Treefile {
         )
     }
 
+    /// Returns the "ref" entry in treefile, or the empty string if unset.
+    pub(crate) fn get_ostree_ref(&self) -> String {
+        self.parsed.treeref.clone().unwrap_or_default()
+    }
+
     pub(crate) fn get_passwd_fd(&mut self) -> i32 {
         self.externals.passwd.as_mut().map_or(-1, raw_seeked_fd)
     }

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1468,6 +1468,14 @@ rpmostree_compose_builtin_extensions (int             argc,
   if (!repo)
     return FALSE;
 
+  if (!opt_extensions_base_rev)
+    {
+      auto treeref = treefile->get_ostree_ref();
+      if (treeref.length() == 0)
+        return glnx_throw (error, "--base-rev not specified and treefile doesn't have a ref");
+      opt_extensions_base_rev = g_strdup(treeref.c_str());
+    }
+
   /* this is a similar construction to what's in rpm_ostree_compose_context_new() */
   g_auto(GLnxTmpDir) cachedir_tmp = { 0, };
   glnx_autofd int cachedir_dfd = -1;

--- a/tests/compose/test-basic-unified.sh
+++ b/tests/compose/test-basic-unified.sh
@@ -137,7 +137,7 @@ echo "ok extensions"
 
 rm extensions-changed
 runasroot rpm-ostree compose extensions --repo=${repo} \
-  --cachedir=${test_tmpdir}/cache --base-rev ${treeref} \
+  --cachedir=${test_tmpdir}/cache \
   --output-dir extensions ${treefile} extensions.yaml \
   --touch-if-changed extensions-changed
 if test -f extensions-changed; then


### PR DESCRIPTION
In this case, let's default to the tip of the tree ref.

Closes: #2633