### PR TITLE
More client api

### DIFF
--- a/rust/rpmostree-client/src/lib.rs
+++ b/rust/rpmostree-client/src/lib.rs
@@ -76,6 +76,25 @@ impl Deployment {
             .as_deref()
             .unwrap_or(self.checksum.as_str())
     }
+
+    /// Find a given metadata key in the base commit, which must hold a non-empty string.
+    pub fn find_base_commitmeta_string<'a>(&'a self, k: &str) -> Result<&'a str> {
+        let v = self.base_commit_meta.get(k);
+        if let Some(v) = v {
+            match v {
+                serde_json::Value::String(v) => {
+                    if v.is_empty() {
+                        Err(format!("Invalid empty {} metadata key", k).into())
+                    } else {
+                        Ok(v)
+                    }
+                }
+                _ => Err(format!("Invalid non-string {} metadata key", k).into()),
+            }
+        } else {
+            Err(format!("No {} metadata key", k).into())
+        }
+    }
 }
 
 fn cli_cmd(c: &CliClient) -> Command {

--- a/rust/rpmostree-client/src/lib.rs
+++ b/rust/rpmostree-client/src/lib.rs
@@ -56,6 +56,19 @@ pub struct Deployment {
     pub version: Option<String>,
 }
 
+impl Status {
+    /// Find the booted deployment, if any.
+    pub fn find_booted(&self) -> Option<&Deployment> {
+        self.deployments.iter().find(|d| d.booted)
+    }
+
+    /// Find the booted deployment.
+    pub fn require_booted(&self) -> Result<&Deployment> {
+        self.find_booted()
+            .ok_or_else(|| format!("No booted deployment").into())
+    }
+}
+
 fn cli_cmd(c: &CliClient) -> Command {
     let mut cmd = Command::new("rpm-ostree");
     cmd.env("RPMOSTREE_CLIENT_ID", c.agent_id.as_str());

--- a/rust/rpmostree-client/src/lib.rs
+++ b/rust/rpmostree-client/src/lib.rs
@@ -69,6 +69,15 @@ impl Status {
     }
 }
 
+impl Deployment {
+    /// Find the base OSTree commit
+    pub fn get_base_commit(&self) -> &str {
+        self.base_checksum
+            .as_deref()
+            .unwrap_or(self.checksum.as_str())
+    }
+}
+
 fn cli_cmd(c: &CliClient) -> Command {
     let mut cmd = Command::new("rpm-ostree");
     cmd.env("RPMOSTREE_CLIENT_ID", c.agent_id.as_str());

--- a/rust/rpmostree-client/tests/parse.rs
+++ b/rust/rpmostree-client/tests/parse.rs
@@ -9,5 +9,9 @@ fn parse_workstation() -> Result<()> {
     assert_eq!(state.deployments.len(), 2);
     let booted = state.require_booted().unwrap();
     assert_eq!(booted.version.as_ref().unwrap().as_str(), "33.21");
+    assert_eq!(
+        booted.get_base_commit(),
+        "229387d3c0bb8ad698228ca5702eca72aed8b298a7c800be1dc72bab160a9f7f"
+    );
     Ok(())
 }

--- a/rust/rpmostree-client/tests/parse.rs
+++ b/rust/rpmostree-client/tests/parse.rs
@@ -13,5 +13,12 @@ fn parse_workstation() -> Result<()> {
         booted.get_base_commit(),
         "229387d3c0bb8ad698228ca5702eca72aed8b298a7c800be1dc72bab160a9f7f"
     );
+    assert!(booted.find_base_commitmeta_string("foo").is_err());
+    assert_eq!(
+        booted
+            .find_base_commitmeta_string("coreos-assembler.config-gitrev")
+            .unwrap(),
+        "80966f951c766846da070b4c168b9170c61513e2"
+    );
     Ok(())
 }

--- a/rust/rpmostree-client/tests/parse.rs
+++ b/rust/rpmostree-client/tests/parse.rs
@@ -7,7 +7,7 @@ fn parse_workstation() -> Result<()> {
     let data = include_str!("fixtures/workstation-status.json");
     let state: &rpmostree_client::Status = &serde_json::from_str(data)?;
     assert_eq!(state.deployments.len(), 2);
-    let booted = &state.deployments[0];
+    let booted = state.require_booted().unwrap();
     assert_eq!(booted.version.as_ref().unwrap().as_str(), "33.21");
     Ok(())
 }

--- a/rust/src/testutils.rs
+++ b/rust/src/testutils.rs
@@ -224,7 +224,8 @@ fn update_os_tree(opts: &SyntheticUpgradeOpts) -> Result<()> {
 // query_status_deny_unknown_fields() which will force us
 // to update the client bindings when adding new fields.
 fn validate_parse_status() -> Result<()> {
-    let s = rpmostree_client::query_status().map_err(anyhow::Error::msg)?;
+    let c = rpmostree_client::CliClient::new("tests");
+    let s = rpmostree_client::query_status(&c).map_err(anyhow::Error::msg)?;
     assert_ne!(s.deployments.len(), 0);
     Ok(())
 }


### PR DESCRIPTION
rust/client: Add a CliClient with agent ID, require for status

In prep for adding more methods, require the caller to identify
themselves.

For now this is `CliClient` - one could imagine in the future
we actually do direct DBus, but there's a whole other world
of stuff there.

---

rust/client: Add methods to find/require booted deployment

This is a common need.

---

rust/client: Add Deployment/get_base_commit() API

Zincati wants this.

---

client: Add API to fetch base commit metadata

Also desired by Zincati.

---

