### PR TITLE
app/override: Hint at `rpm-ostree override reset`

### DIFF
--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -127,6 +127,9 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
             RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0, cancellable, error))
         return FALSE;
 
+      if (override_replace || override_remove)
+        g_print ("Use \"rpm-ostree override reset\" to undo overrides\n");
+
       g_print ("Run \"systemctl reboot\" to start a reboot\n");
     }
 


### PR DESCRIPTION
It's always nice when apps provide useful hints about other commands you
may be interested in.

For instance, if they've done `rpm-ostree override replace/remove`,
let's be helpful and tell users that they can use `rpm-ostree override
reset` to unpin packages.