### PR TITLE
daemon: Move a bit more deployment-variant code to Rust

### DIFF
--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -1,4 +1,6 @@
 //! Rust portion of rpmostreed-deployment-utils.cxx
+//! The code here is mainly involved in converting on-disk state (i.e. ostree commits/deployments)
+//! into GVariant which will be serialized via DBus.
 
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
@@ -21,6 +23,8 @@ pub(crate) fn deployment_generate_id(
     )
 }
 
+/// Serialize information about the given deployment into the `dict`;
+/// this will be exposed via DBus and is hence public API.
 pub(crate) fn deployment_populate_variant(
     mut sysroot: Pin<&mut crate::FFIOstreeSysroot>,
     mut deployment: Pin<&mut crate::FFIOstreeDeployment>,
@@ -63,6 +67,10 @@ pub(crate) fn deployment_populate_variant(
             dict.insert("finalization-locked", &true);
         }
     }
+
+    dict.insert("pinned", &deployment.is_pinned());
+    let unlocked = deployment.get_unlocked();
+    dict.insert("unlocked", &unlocked.to_string());
 
     Ok(())
 }

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -360,11 +360,6 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
   g_variant_dict_insert_value (dict, "base-removals", removed_base_pkgs);
   g_variant_dict_insert_value (dict, "base-local-replacements", replaced_base_pkgs);
 
-  g_variant_dict_insert (dict, "pinned", "b",
-                         ostree_deployment_is_pinned (deployment));
-  g_variant_dict_insert (dict, "unlocked", "s",
-                         ostree_deployment_unlocked_state_to_string (ostree_deployment_get_unlocked (deployment)));
-
   g_variant_dict_insert (dict, "regenerate-initramfs", "b",
                          rpmostree_origin_get_regenerate_initramfs (origin));
   { const char *const* args = rpmostree_origin_get_initramfs_args (origin);


### PR DESCRIPTION
These are "base ostree" things we can move into the Rust
function.
