### PR TITLE
lockfile: Allow specifying EVR rather than EVRA

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -261,8 +261,8 @@ pub mod ffi {
 
     // lockfile.rs
     extern "Rust" {
-        fn ror_lockfile_read(filenames: &Vec<String>) -> Result<Vec<StringMapping>>;
-        fn ror_lockfile_write(
+        fn lockfile_read(filenames: &Vec<String>) -> Result<Vec<StringMapping>>;
+        fn lockfile_write(
             filename: &str,
             packages: Pin<&mut CxxGObjectArray>,
             rpmmd_repos: Pin<&mut CxxGObjectArray>,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -259,14 +259,25 @@ pub mod ffi {
         fn serialize_to_dir(&self, output_dir: &str) -> Result<()>;
     }
 
+    struct LockedPackage {
+        name: String,
+        evr: String,
+        arch: String,
+        digest: String,
+    }
+
     // lockfile.rs
     extern "Rust" {
-        fn lockfile_read(filenames: &Vec<String>) -> Result<Vec<StringMapping>>;
+        type LockfileConfig;
+
+        fn lockfile_read(filenames: &Vec<String>) -> Result<Box<LockfileConfig>>;
         fn lockfile_write(
             filename: &str,
             packages: Pin<&mut CxxGObjectArray>,
             rpmmd_repos: Pin<&mut CxxGObjectArray>,
         ) -> Result<()>;
+
+        fn get_locked_packages(&self) -> Result<Vec<LockedPackage>>;
     }
 
     // rpmutils.rs

--- a/rust/src/lockfile.rs
+++ b/rust/src/lockfile.rs
@@ -242,7 +242,7 @@ use crate::cxxrsutil::CxxResult;
 use crate::ffi::*;
 use libdnf_sys::*;
 
-pub(crate) fn ror_lockfile_read(filenames: &Vec<String>) -> CxxResult<Vec<StringMapping>> {
+pub(crate) fn lockfile_read(filenames: &Vec<String>) -> CxxResult<Vec<StringMapping>> {
     Ok(lockfile_parse_multiple(&filenames)?
         .packages
         .into_iter()
@@ -253,7 +253,7 @@ pub(crate) fn ror_lockfile_read(filenames: &Vec<String>) -> CxxResult<Vec<String
         .collect())
 }
 
-pub(crate) fn ror_lockfile_write(
+pub(crate) fn lockfile_write(
     filename: &str,
     mut packages: Pin<&mut crate::ffi::CxxGObjectArray>,
     mut rpmmd_repos: Pin<&mut crate::ffi::CxxGObjectArray>,

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -383,7 +383,7 @@ install_packages (RpmOstreeTreeComposeContext  *self,
                                            DNF_REPO_ENABLED_PACKAGES);
       auto pkgs_v = rpmostreecxx::CxxGObjectArray(pkgs);
       auto repos_v = rpmostreecxx::CxxGObjectArray(rpmmd_repos);
-      rpmostreecxx::ror_lockfile_write(opt_write_lockfile_to, pkgs_v, repos_v);
+      rpmostreecxx::lockfile_write(opt_write_lockfile_to, pkgs_v, repos_v);
     }
 
   /* FIXME - just do a depsolve here before we compute download requirements */
@@ -707,7 +707,7 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
       rust::Vec<rust::String> lockfiles;
       for (char **it = opt_lockfiles; it && *it; it++)
         lockfiles.push_back(std::string(*it));
-      auto mappings = rpmostreecxx::ror_lockfile_read (lockfiles);
+      auto mappings = rpmostreecxx::lockfile_read (lockfiles);
       g_autoptr(GHashTable) map = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
       for (auto & mapping : mappings)
         g_hash_table_insert (map, g_strdup (mapping.k.c_str()), g_strdup (mapping.v.c_str()));

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -704,14 +704,7 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
 
   if (opt_lockfiles)
     {
-      rust::Vec<rust::String> lockfiles;
-      for (char **it = opt_lockfiles; it && *it; it++)
-        lockfiles.push_back(std::string(*it));
-      auto mappings = rpmostreecxx::lockfile_read (lockfiles);
-      g_autoptr(GHashTable) map = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
-      for (auto & mapping : mappings)
-        g_hash_table_insert (map, g_strdup (mapping.k.c_str()), g_strdup (mapping.v.c_str()));
-      rpmostree_context_set_vlockmap (self->corectx, map, opt_lockfile_strict);
+      rpmostree_context_set_lockfile (self->corectx, opt_lockfiles, opt_lockfile_strict);
       g_print ("Loaded lockfiles:\n  %s\n", g_strjoinv ("\n  ", opt_lockfiles));
     }
 

--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "libglnx.h"
 #include "rpmostree-rojig-core.h"
 #include "rpmostree-core.h"
@@ -77,8 +79,8 @@ struct _RpmOstreeContext {
   GHashTable *pkgs_to_remove;  /* pkgname --> gv_nevra */
   GHashTable *pkgs_to_replace; /* new gv_nevra --> old gv_nevra */
 
-  GHashTable *vlockmap; /* nevra --> repochecksum */
-  gboolean vlockmap_strict;
+  std::optional<rust::Box<rpmostreecxx::LockfileConfig>> lockfile;
+  gboolean lockfile_strict;
 
   GLnxTmpDir tmpdir;
 

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -1922,7 +1922,7 @@ find_locked_packages (RpmOstreeContext *self,
     {
       g_assert (chksum);
       hy_autoquery HyQuery query = hy_query_create (sack);
-      hy_query_filter (query, HY_PKG_NEVRA_STRICT, HY_EQ, nevra);
+      hy_query_filter (query, HY_PKG_NEVRA, HY_GLOB, nevra);
       g_autoptr(GPtrArray) matches = hy_query_run (query);
 
       gboolean at_least_one = FALSE;

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -182,8 +182,8 @@ gboolean rpmostree_context_set_packages (RpmOstreeContext *self,
 GPtrArray *rpmostree_context_get_packages_to_import (RpmOstreeContext *self);
 
 void
-rpmostree_context_set_vlockmap (RpmOstreeContext *self,
-                                GHashTable       *map,
+rpmostree_context_set_lockfile (RpmOstreeContext *self,
+                                char            **lockfiles,
                                 gboolean          strict);
 
 gboolean rpmostree_download_packages (GPtrArray      *packages,

--- a/tests/compose/test-lockfile.sh
+++ b/tests/compose/test-lockfile.sh
@@ -9,25 +9,28 @@ dn=$(cd "$(dirname "$0")" && pwd)
 treefile_append "repos" '["test-repo"]'
 build_rpm test-pkg-common
 build_rpm test-pkg requires test-pkg-common
-build_rpm another-test-pkg
+build_rpm another-test-pkg-a
+build_rpm another-test-pkg-b
 
 # The test suite writes to pwd, but we need repos together with the manifests
 # Also we need to disable gpgcheck
 echo gpgcheck=0 >> yumrepo.repo
 ln "$PWD/yumrepo.repo" config/yumrepo.repo
-treefile_append "packages" '["test-pkg", "another-test-pkg"]'
+treefile_append "packages" '["test-pkg", "another-test-pkg-a", "another-test-pkg-b"]'
 
 runcompose --ex-write-lockfile-to="$PWD/versions.lock"
 rpm-ostree --repo=${repo} db list ${treeref} > test-pkg-list.txt
 assert_file_has_content test-pkg-list.txt 'test-pkg-1.0-1.x86_64'
-assert_file_has_content test-pkg-list.txt 'another-test-pkg-1.0-1.x86_64'
+assert_file_has_content test-pkg-list.txt 'another-test-pkg-a-1.0-1.x86_64'
+assert_file_has_content test-pkg-list.txt 'another-test-pkg-b-1.0-1.x86_64'
 echo "ok compose"
 
 assert_has_file "versions.lock"
 assert_jq "versions.lock" \
   '.packages["test-pkg"].evra = "1.0-1.x86_64"' \
   '.packages["test-pkg-common"].evra = "1.0-1.x86_64"' \
-  '.packages["another-test-pkg"].evra = "1.0-1.x86_64"' \
+  '.packages["another-test-pkg-a"].evra = "1.0-1.x86_64"' \
+  '.packages["another-test-pkg-b"].evra = "1.0-1.x86_64"' \
   '.metadata.rpmmd_repos|length > 0' \
   '.metadata.generated'
 echo "ok lockfile created"
@@ -35,21 +38,27 @@ echo "ok lockfile created"
 # Read lockfile back (should be a no-op)
 build_rpm test-pkg-common version 2.0
 build_rpm test-pkg version 2.0 requires test-pkg-common
-build_rpm another-test-pkg version 2.0
+build_rpm another-test-pkg-a version 2.0
+build_rpm another-test-pkg-b version 2.0
 runcompose --ex-lockfile="$PWD/versions.lock" |& tee out.txt
 
 rpm-ostree --repo=${repo} db list ${treeref} > test-pkg-list.txt
 assert_file_has_content out.txt 'test-pkg-1.0-1.x86_64'
 assert_file_has_content out.txt 'test-pkg-common-1.0-1.x86_64'
-assert_file_has_content out.txt 'another-test-pkg-1.0-1.x86_64'
+assert_file_has_content out.txt 'another-test-pkg-a-1.0-1.x86_64'
+assert_file_has_content out.txt 'another-test-pkg-b-1.0-1.x86_64'
 echo "ok lockfile read"
 
 # now add an override and check that not specifying a digest is allowed
+# we test both evra and evr locking
 cat > override.lock <<EOF
 {
   "packages": {
-    "another-test-pkg": {
+    "another-test-pkg-a": {
       "evra": "2.0-1.x86_64"
+    },
+    "another-test-pkg-b": {
+      "evr": "2.0-1"
     }
   }
 }
@@ -62,15 +71,17 @@ runcompose \
   --dry-run "${treefile}" |& tee out.txt
 assert_file_has_content out.txt 'test-pkg-1.0-1.x86_64'
 assert_file_has_content out.txt 'test-pkg-common-1.0-1.x86_64'
-assert_file_has_content out.txt 'another-test-pkg-2.0-1.x86_64'
+assert_file_has_content out.txt 'another-test-pkg-a-2.0-1.x86_64'
+assert_file_has_content out.txt 'another-test-pkg-b-2.0-1.x86_64'
 assert_jq versions.lock.new \
   '.packages["test-pkg"].evra = "1.0-1.x86_64"' \
   '.packages["test-pkg-common"].evra = "1.0-1.x86_64"' \
-  '.packages["another-test-pkg"].evra = "2.0-1.x86_64"'
+  '.packages["another-test-pkg-a"].evra = "2.0-1.x86_64"' \
+  '.packages["another-test-pkg-b"].evra = "2.0-1.x86_64"'
 echo "ok override"
 
 # sanity-check that we can remove packages in relaxed mode
-treefile_remove "packages" '"another-test-pkg"'
+treefile_remove "packages" '"another-test-pkg-a"'
 runcompose \
   --ex-lockfile="$PWD/versions.lock" \
   --ex-lockfile="$PWD/override.lock" \
@@ -78,7 +89,7 @@ runcompose \
   --dry-run "${treefile}" |& tee out.txt
 assert_file_has_content out.txt 'test-pkg-1.0-1.x86_64'
 assert_file_has_content out.txt 'test-pkg-common-1.0-1.x86_64'
-assert_not_file_has_content out.txt 'another-test-pkg'
+assert_not_file_has_content out.txt 'another-test-pkg-a'
 echo "ok relaxed mode can remove pkg"
 
 # test strict mode


### PR DESCRIPTION
In FCOS, we use "override" lockfiles to pin packages to certain
versions. Right now, we have separate overrides for each base arch we
(eventually want to) support. But that makes maintaining the overrides
cumbersome because of all the duplication.

Let's allow lockfiles to specify only the `evr` of a package, which is
just as good for FCOS, and means that we'll only have to maintain a
single override file for all the architectures.