### PR TITLE
Move some small daemon layering lookup into Rust

### DIFF
--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -4,7 +4,7 @@
 
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::cxxrsutil::*;
+use crate::{cxxrsutil::*, variant_utils};
 use std::pin::Pin;
 
 /// Get a currently unique (for this host) identifier for the
@@ -73,4 +73,55 @@ pub(crate) fn deployment_populate_variant(
     dict.insert("unlocked", &unlocked.to_string());
 
     Ok(())
+}
+
+/// Load basic layering metadata about a deployment commit.
+pub(crate) fn deployment_layeredmeta_from_commit(
+    mut deployment: Pin<&mut crate::FFIOstreeDeployment>,
+    mut commit: Pin<&mut crate::FFIGVariant>,
+) -> CxxResult<crate::ffi::DeploymentLayeredMeta> {
+    let deployment = deployment.gobj_wrap();
+    let commit = &commit.gobj_wrap();
+    let metadata = &variant_utils::variant_tuple_get(commit, 0).expect("commit metadata");
+    let dict = &glib::VariantDict::new(Some(metadata));
+
+    // More recent versions have an explicit clientlayer attribute (which
+    // realistically will always be TRUE). For older versions, we just
+    // rely on the treespec being present. */
+    let is_layered = variant_utils::variant_dict_lookup_bool(dict, "rpmostree.clientlayer")
+        .unwrap_or_else(|| dict.contains("rpmostree.spec"));
+    if !is_layered {
+        Ok(crate::ffi::DeploymentLayeredMeta {
+            is_layered,
+            base_commit: deployment.get_csum().unwrap().into(),
+            clientlayer_version: 0,
+        })
+    } else {
+        let base_commit = ostree::commit_get_parent(commit)
+            .expect("commit parent")
+            .into();
+        let clientlayer_version = dict
+            .lookup_value("rpmostree.clientlayer_version", Some(&*variant_utils::TY_U))
+            .map(|u| u.get().unwrap())
+            .unwrap_or_default();
+        Ok(crate::ffi::DeploymentLayeredMeta {
+            is_layered,
+            base_commit,
+            clientlayer_version,
+        })
+    }
+}
+
+/// Load basic layering metadata about a deployment
+pub(crate) fn deployment_layeredmeta_load(
+    mut repo: Pin<&mut crate::FFIOstreeRepo>,
+    mut deployment: Pin<&mut crate::FFIOstreeDeployment>,
+) -> CxxResult<crate::ffi::DeploymentLayeredMeta> {
+    let repo = repo.gobj_wrap();
+    let deployment = deployment.gobj_wrap();
+    let commit = &repo.load_variant(
+        ostree::ObjectType::Commit,
+        deployment.get_csum().unwrap().as_str(),
+    )?;
+    deployment_layeredmeta_from_commit(deployment.gobj_rewrap(), commit.gobj_rewrap())
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -90,6 +90,15 @@ pub mod ffi {
         fn compose_postprocess_final(rootfs_dfd: i32) -> Result<()>;
     }
 
+    // A grab-bag of metadata from the deployment's ostree commit
+    // around layering/derivation
+    #[derive(Default)]
+    struct DeploymentLayeredMeta {
+        is_layered: bool,
+        base_commit: String,
+        clientlayer_version: u32,
+    }
+
     // daemon.rs
     extern "Rust" {
         fn deployment_generate_id(deployment: Pin<&mut OstreeDeployment>) -> String;
@@ -98,6 +107,14 @@ pub mod ffi {
             mut deployment: Pin<&mut OstreeDeployment>,
             mut dict: Pin<&mut GVariantDict>,
         ) -> Result<()>;
+        fn deployment_layeredmeta_from_commit(
+            mut deployment: Pin<&mut OstreeDeployment>,
+            mut commit: Pin<&mut GVariant>,
+        ) -> Result<DeploymentLayeredMeta>;
+        fn deployment_layeredmeta_load(
+            mut repo: Pin<&mut OstreeRepo>,
+            mut deployment: Pin<&mut OstreeDeployment>,
+        ) -> Result<DeploymentLayeredMeta>;
     }
 
     // initramfs.rs

--- a/rust/src/variant_utils.rs
+++ b/rust/src/variant_utils.rs
@@ -12,6 +12,9 @@ lazy_static::lazy_static! {
     pub(crate) static ref TY_B: &'static glib::VariantTy = {
         glib::VariantTy::new("b").unwrap()
     };
+    pub(crate) static ref TY_U: &'static glib::VariantTy = {
+        glib::VariantTy::new("u").unwrap()
+    };
 }
 
 pub(crate) fn new_variant_tuple<'a>(

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -2583,12 +2583,8 @@ finalize_deployment_transaction_execute (RpmostreedTransaction *transaction,
   if (!g_str_equal (ostree_deployment_get_osname (default_deployment), self->osname))
     return glnx_throw (error, "Staged deployment is not for osname '%s'", self->osname);
 
-  gboolean is_layered = FALSE;
-  g_autofree char *base_checksum = NULL;
-  if (!rpmostree_deployment_get_layered_info (repo, default_deployment, &is_layered, NULL,
-                                              &base_checksum, NULL, NULL, NULL, error))
-    return FALSE;
-  const char *checksum = base_checksum ?: ostree_deployment_get_csum (default_deployment);
+  auto layeredmeta = rpmostreecxx::deployment_layeredmeta_load(*repo, *default_deployment);
+  const char *checksum = layeredmeta.base_commit.c_str();
 
   auto expected_checksum =
     (char*)vardict_lookup_ptr (self->options, "checksum", "&s");


### PR DESCRIPTION
Prep for more oxidation work.  One notable improvement here is that about half
of the callers of the mega function `rpmostree_deployment_get_layered_info`
only wanted the base information, not the layered package lists
for example - so we were passing 4 `NULL`s to ignore those.

This Rust API returns a simple shared struct instead for those
cases.  I also changed things so that `base_commit` is always
set, avoiding the callers needing to do that.
