### PR TITLE
Fixes for Count Me support

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -82,9 +82,6 @@ endif
 $(systemdunit_service_files): Makefile
 	$(SED_SUBST) $(daemon_asan_options) $@.in > $@
 
-systemdsysusers_DATA = $(srcdir)/src/daemon/rpm-ostree.conf
-systemdsysusersdir   = $(prefix)/lib/sysusers.d
-
 # We keep this stub script around to have SELinux labeling work,
 # plus some backwards compatibility.
 libexec_SCRIPTS = rpm-ostreed
@@ -114,7 +111,6 @@ EXTRA_DIST += \
 	$(service_in_files) \
 	$(systemdunit_service_in_files) \
 	$(systemdunit_timer_files) \
-	$(systemdsysusers_conf_files) \
 	$(NULL)
 
 CLEANFILES += \

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -149,6 +149,7 @@ BUILT_SOURCES += $(binding_generated_sources)
 install-rpmostree-hook:
 	install -d -m 0755 $(DESTDIR)$(bindir)
 	install -m 0755 -t $(DESTDIR)$(bindir) rpm-ostree
+	install -m 0755 rpm-ostree $(DESTDIR)$(libexecdir)/rpm-ostree-unpriv
 INSTALL_EXEC_HOOKS += install-rpmostree-hook
 
 # Wraps `cargo test`.  This is always a debug non-release build;

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -175,7 +175,6 @@ $PYTHON autofiles.py > files \
   '%{_datadir}/dbus-1/system.d/*' \
   '%{_sysconfdir}/rpm-ostreed.conf' \
   '%{_prefix}/lib/systemd/system/*' \
-  '%{_prefix}/lib/sysusers.d*' \
   '%{_libexecdir}/rpm-ostree*' \
   '%{_datadir}/polkit-1/actions/*.policy' \
   '%{_datadir}/dbus-1/system-services' \

--- a/src/daemon/rpm-ostree-countme.service.in
+++ b/src/daemon/rpm-ostree-countme.service.in
@@ -9,4 +9,4 @@ User=rpm-ostree
 DynamicUser=yes
 StateDirectory=rpm-ostree-countme
 StateDirectoryMode=750
-ExecStart=@bindir@/rpm-ostree countme
+ExecStart=@libexecdir@/rpm-ostree-unpriv countme

--- a/src/daemon/rpm-ostree-countme.timer
+++ b/src/daemon/rpm-ostree-countme.timer
@@ -6,8 +6,9 @@ ConditionPathExists=/run/ostree-booted
 [Timer]
 # Trigger weekly with a random delay
 OnCalendar=weekly UTC
-AccuracySec=1u
+AccuracySec=1s
 RandomizedDelaySec=1w
+OnBootSec=5m
 Persistent=yes
 
 [Install]

--- a/src/daemon/rpm-ostree.conf
+++ b/src/daemon/rpm-ostree.conf
@@ -1,1 +1,0 @@
-u rpm-ostree - "Unprivileged rpm-ostree user"


### PR DESCRIPTION
Remove rpm-ostree sysusers config

---

countme: Refuse to run as root

We do not need root privileges and should only be started via the system
service unit so avoid mistake by verifying that on startup.

---

rpm-ostree-countme.timer: Fix AccuracySec and add OnBootSec

  * Use OnBootSec=5m to give a chance for the timer to trigger on the
    first week the system is booted up.
  * Use '1s' for AccuracySec as this is accurate enough for this use
    case.

---

Install a temporary copy of rpm-ostree for unprivileged use

Install a copy of rpm-ostree as rpm-ostree-unpriv to get a `bin_t`
labeled binary as a temporary workaround for:
https://bugzilla.redhat.com/show_bug.cgi?id=1937404

Also modify the rpm-ostree count me service to use that binary.