### PR TITLE
rust: Support context attribute on CxxResult, use it more

### DIFF
--- a/rust/src/countme/repo.rs
+++ b/rust/src/countme/repo.rs
@@ -2,6 +2,7 @@
 // (FIXME: Convert to Apache-2.0 OR MIT for consistency?)
 
 use anyhow::{Context, Result};
+use fn_error_context::context;
 use std::fs;
 use std::path::PathBuf;
 
@@ -49,8 +50,9 @@ pub fn all() -> Result<Vec<Repo>> {
 }
 
 /// Read repository configuration from a file
+#[context("Parsing repo file {:?}", path)]
 fn parse_repo_file(path: &PathBuf) -> Result<Vec<Repo>> {
-    let i = Ini::load_from_file(path).with_context(|| "Could not parse as INI".to_string())?;
+    let i = Ini::load_from_file(path)?;
     let mut repos = Vec::new();
     for (sec, prop) in i.iter() {
         let mut repo = match sec {

--- a/rust/src/history.rs
+++ b/rust/src/history.rs
@@ -178,7 +178,7 @@ fn history_get_oldest_deployment_msg_timestamp() -> Result<Option<u64>> {
 /// that correspond to deployments older than that one. Essentially, this binds pruning to
 /// journal pruning.
 #[context("Failed to prune history")]
-fn history_prune_inner() -> Result<()> {
+pub(crate) fn history_prune() -> CxxResult<()> {
     if !Path::new(RPMOSTREE_HISTORY_DIR).exists() {
         return Ok(());
     }
@@ -210,10 +210,6 @@ fn history_prune_inner() -> Result<()> {
     }
 
     Ok(())
-}
-
-pub(crate) fn history_prune() -> CxxResult<()> {
-    Ok(history_prune_inner()?)
 }
 
 pub(crate) fn history_ctx_new() -> CxxResult<Box<HistoryCtx>> {

--- a/rust/src/testutils.rs
+++ b/rust/src/testutils.rs
@@ -11,6 +11,7 @@
 
 use crate::{cxxrsutil::*, variant_utils};
 use anyhow::{Context, Result};
+use fn_error_context::context;
 use glib::ToVariant;
 use openat_ext::{FileExt, OpenatDirExt};
 use rand::Rng;
@@ -144,6 +145,7 @@ pub(crate) fn mutate_executables_to(
 // The ostree version may later use this one.
 /// Given an ostree ref, use the running root filesystem as a source, update
 /// `percentage` percent of binary (ELF) files
+#[context("Generating synthetic ostree update")]
 fn update_os_tree(opts: &SyntheticUpgradeOpts) -> Result<()> {
     // A new mount namespace should have been created for us
     let r = Command::new("mount")


### PR DESCRIPTION
Addresses review comment from
https://github.com/coreos/rpm-ostree/pull/2649#discussion_r591784574
and extends it in a few more random places I found that were
using `with_context()`.
