### PR TITLE
daemon: Fix serialization of unlocked state

### DIFF
--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -70,7 +70,13 @@ pub(crate) fn deployment_populate_variant(
 
     dict.insert("pinned", &deployment.is_pinned());
     let unlocked = deployment.get_unlocked();
-    dict.insert("unlocked", &unlocked.to_string());
+    // Unwrap safety: This always returns a value
+    dict.insert(
+        "unlocked",
+        &ostree::Deployment::unlocked_state_to_string(unlocked)
+            .unwrap()
+            .as_str(),
+    );
 
     Ok(())
 }

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -69,9 +69,11 @@ else
     echo "Missing ${wrapdir}; cliwrap not enabled"
 fi
 
-# StateRoot is only in --verbose
+# StateRoot is only in --verbose, also verify we're not showing
+# unlocked.
 rpm-ostree status > status.txt
 assert_not_file_has_content status.txt StateRoot:
+assert_not_file_has_content status.txt Unlocked:
 rpm-ostree status -v > status.txt
 assert_file_has_content status.txt StateRoot:
 echo "ok status text"


### PR DESCRIPTION
It turns out there's a naming clash between `to_string()` here in
Rust *and* introspection is incorrectly associating the method
with `ostree::Deployment` because of the naming prefix.
