### PR TITLE
Oxidize postprocessing `altfiles` addition to `/etc/nsswitch.conf`

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -87,6 +87,7 @@ pub mod ffi {
 
     // composepost.rs
     extern "Rust" {
+        fn composepost_nsswitch_altfiles(rootfs_dfd: i32) -> Result<()>;
         fn compose_postprocess_final(rootfs_dfd: i32) -> Result<()>;
     }
 

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -26,10 +26,6 @@
 
 G_BEGIN_DECLS
 
-/* "public" for unit tests */
-char *
-rpmostree_postprocess_replace_nsswitch (const char *buf,
-                                        GError    **error);
 
 gboolean
 rpmostree_treefile_postprocessing (int            rootfs_fd,


### PR DESCRIPTION
The ugly C code for this turns into shorter Rust with a unit
test, a lot less allocation (notice how we don't malloc `NUL` terminated
strings in so many places).
