### PR TITLE
Various postprocess oxidation patches

### DIFF
--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -135,6 +135,12 @@ mod err {
         }
     }
 
+    impl From<cxx::Exception> for CxxError {
+        fn from(v: cxx::Exception) -> Self {
+            Self(format!("{:#}", v))
+        }
+    }
+
     impl From<IoError> for CxxError {
         fn from(v: IoError) -> Self {
             Self(format!("{}", v))

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -191,6 +191,7 @@ pub mod ffi {
         fn get_rpmdb(&self) -> String;
         fn get_files_remove_regex(&self, package: &str) -> Vec<String>;
         fn print_deprecation_warnings(&self);
+        fn write_compose_json(&self, rootfs_dfd: i32) -> Result<()>;
         fn sanitycheck_externals(&self) -> Result<()>;
         fn get_checksum(&self, repo: Pin<&mut OstreeRepo>) -> Result<String>;
         fn get_ostree_ref(&self) -> String;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -177,7 +177,6 @@ pub mod ffi {
         fn treefile_new(filename: &str, basearch: &str, workdir: i32) -> Result<Box<Treefile>>;
 
         fn get_workdir(&self) -> i32;
-        fn get_postprocess_script_fd(&mut self) -> i32;
         fn get_passwd_fd(&mut self) -> i32;
         fn get_group_fd(&mut self) -> i32;
         fn get_json_string(&self) -> String;
@@ -192,6 +191,7 @@ pub mod ffi {
         fn get_rpmdb(&self) -> String;
         fn get_files_remove_regex(&self, package: &str) -> Vec<String>;
         fn print_deprecation_warnings(&self);
+        fn sanitycheck_externals(&self) -> Result<()>;
         fn get_checksum(&self, repo: Pin<&mut OstreeRepo>) -> Result<String>;
         fn get_ostree_ref(&self) -> String;
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -93,6 +93,7 @@ pub mod ffi {
             treefile: &mut Treefile,
             unified_core: bool,
         ) -> Result<()>;
+        fn compose_postprocess_add_files(rootfs_dfd: i32, treefile: &mut Treefile) -> Result<()>;
         fn compose_postprocess_final(rootfs_dfd: i32) -> Result<()>;
     }
 
@@ -177,7 +178,6 @@ pub mod ffi {
 
         fn get_workdir(&self) -> i32;
         fn get_postprocess_script_fd(&mut self) -> i32;
-        fn get_add_file_fd(&mut self, filename: &str) -> i32;
         fn get_passwd_fd(&mut self) -> i32;
         fn get_group_fd(&mut self) -> i32;
         fn get_json_string(&self) -> String;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -88,6 +88,11 @@ pub mod ffi {
     // composepost.rs
     extern "Rust" {
         fn composepost_nsswitch_altfiles(rootfs_dfd: i32) -> Result<()>;
+        fn compose_postprocess_scripts(
+            rootfs_dfd: i32,
+            treefile: &mut Treefile,
+            unified_core: bool,
+        ) -> Result<()>;
         fn compose_postprocess_final(rootfs_dfd: i32) -> Result<()>;
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -317,6 +317,16 @@ pub mod ffi {
     }
 
     unsafe extern "C++" {
+        include!("rpmostree-bwrap.h");
+        fn bwrap_run_mutable(
+            rootfs_dfd: i32,
+            binpath: &str,
+            child_argv: &Vec<String>,
+            unified_core_mode: bool,
+        ) -> Result<()>;
+    }
+
+    unsafe extern "C++" {
         include!("rpmostree-clientlib.h");
         fn client_require_root() -> Result<()>;
         type ClientConnection;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -708,6 +708,16 @@ for x in *; do mv ${{x}} %{{buildroot}}%{{_prefix}}/lib/ostree-jigdo/%{{name}}; 
                 return Err(anyhow!("postprocess-script must be executable"));
             }
         }
+
+        let parsed = &self.parsed;
+        let machineid_compat = parsed.machineid_compat.unwrap_or(true);
+        let n_units = parsed.units.as_ref().map(|v| v.len()).unwrap_or_default();
+        if !machineid_compat && n_units > 0 {
+            return Err(anyhow!(
+                "'units' directive is incompatible with machineid-compat = false"
+            ));
+        }
+
         Ok(())
     }
 }

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1027,7 +1027,7 @@ pub(crate) struct TreeComposeConfig {
     postprocess_script: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     // This one is inline, and supports multiple (hence is useful for inheritance)
-    postprocess: Option<Vec<String>>,
+    pub(crate) postprocess: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "add-files")]
     add_files: Option<Vec<(String, String)>>,

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -25,6 +25,7 @@ use c_utf8::CUtf8Buf;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, HashMap};
+use std::fs::File;
 use std::io::prelude::*;
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -472,13 +473,12 @@ impl Treefile {
             .map_or(-1, raw_seeked_fd)
     }
 
-    pub(crate) fn get_add_file_fd(&mut self, filename: &str) -> i32 {
-        raw_seeked_fd(
-            self.externals
-                .add_files
-                .get_mut(filename)
-                .expect("add-file"),
-        )
+    /// Access the opened file object for the injected file
+    pub(crate) fn get_add_file(&mut self, filename: &str) -> &mut File {
+        self.externals
+            .add_files
+            .get_mut(filename)
+            .expect("add-file")
     }
 
     /// Returns the "ref" entry in treefile, or the empty string if unset.
@@ -1030,7 +1030,7 @@ pub(crate) struct TreeComposeConfig {
     pub(crate) postprocess: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "add-files")]
-    add_files: Option<Vec<(String, String)>>,
+    pub(crate) add_files: Option<Vec<(String, String)>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "remove-files")]
     remove_files: Option<Vec<String>>,

--- a/src/app/rpmostree-compose-builtin-rojig.cxx
+++ b/src/app/rpmostree-compose-builtin-rojig.cxx
@@ -186,9 +186,7 @@ install_packages (RpmOstreeRojigCompose  *self,
   if (opt_dry_run)
     return TRUE; /* NB: early return */
 
-  if (!rpmostree_composeutil_sanity_checks (self->treefile_rs, self->treefile,
-                                            cancellable, error))
-    return FALSE;
+  self->treefile_rs->sanitycheck_externals();
 
   /* --- Downloading packages --- */
   if (!rpmostree_context_download (self->corectx, cancellable, error))

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -418,10 +418,7 @@ install_packages (RpmOstreeTreeComposeContext  *self,
   if (opt_dry_run)
     return TRUE; /* NB: early return */
 
-  if (!rpmostree_composeutil_sanity_checks (**self->treefile_rs,
-                                            self->treefile,
-                                            cancellable, error))
-    return FALSE;
+  (*self->treefile_rs)->sanitycheck_externals();
 
   /* --- Downloading packages --- */
   if (!rpmostree_context_download (self->corectx, cancellable, error))

--- a/src/app/rpmostree-composeutil.cxx
+++ b/src/app/rpmostree-composeutil.cxx
@@ -122,30 +122,6 @@ rpmostree_composeutil_legacy_prep_dev (int         rootfs_dfd,
   return TRUE;
 }
 
-
-gboolean
-rpmostree_composeutil_sanity_checks (rpmostreecxx::Treefile &tf,
-                                     JsonObject   *treefile,
-                                     GCancellable *cancellable,
-                                     GError      **error)
-{
-  int fd = tf.get_postprocess_script_fd();
-  if (fd != -1)
-    {
-      /* Check that postprocess-script is executable; https://github.com/projectatomic/rpm-ostree/issues/817 */
-      struct stat stbuf;
-      if (!glnx_fstat (fd, &stbuf, error))
-        return glnx_prefix_error (error, "postprocess-script");
-
-      if ((stbuf.st_mode & S_IXUSR) == 0)
-        return glnx_throw (error, "postprocess-script must be executable");
-    }
-
-  /* Insert other sanity checks here */
-
-  return TRUE;
-}
-
 static gboolean
 set_keyfile_string_array_from_json (GKeyFile    *keyfile,
                                     const char  *keyfile_group,

--- a/src/app/rpmostree-composeutil.h
+++ b/src/app/rpmostree-composeutil.h
@@ -39,11 +39,6 @@ gboolean
 rpmostree_composeutil_legacy_prep_dev (int         rootfs_dfd,
                                        GError    **error);
 
-gboolean
-rpmostree_composeutil_sanity_checks (rpmostreecxx::Treefile &tf,
-                                     JsonObject   *treefile,
-                                     GCancellable *cancellable,
-                                     GError      **error);
 RpmOstreeTreespec *
 rpmostree_composeutil_get_treespec (RpmOstreeContext  *ctx,
                                     rpmostreecxx::Treefile &treefile_rs,

--- a/src/libpriv/rpmostree-bwrap.h
+++ b/src/libpriv/rpmostree-bwrap.h
@@ -24,6 +24,16 @@
 
 #include "libglnx.h"
 
+#include "rust/cxx.h"
+
+namespace rpmostreecxx {
+
+void bwrap_run_mutable(int32_t rootfs_dfd, rust::Str binpath,
+                       const rust::Vec<rust::String> &child_argv,
+                       bool unified_core_mode);
+
+}
+
 G_BEGIN_DECLS
 
 typedef enum {

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -1208,6 +1208,8 @@ rpmostree_treefile_postprocessing (int            rootfs_fd,
 {
   g_assert (treefile);
 
+  treefile_rs.write_compose_json(rootfs_fd);
+
   if (!rename_if_exists (rootfs_fd, "etc", rootfs_fd, "usr/etc", error))
     return FALSE;
 
@@ -1256,16 +1258,6 @@ rpmostree_treefile_postprocessing (int            rootfs_fd,
           return glnx_throw_errno_prefix (error, "symlinkat(%s)", unitname);
       }
   }
-
-  if (!glnx_shutil_mkdir_p_at (rootfs_fd, "usr/share/rpm-ostree", 0755, cancellable, error))
-    return FALSE;
-
-  auto json = treefile_rs.get_json_string();
-  if (!glnx_file_replace_contents_at (rootfs_fd, "usr/share/rpm-ostree/treefile.json",
-                                      (guint8*)json.data(), json.length(),
-                                      GLNX_FILE_REPLACE_NODATASYNC,
-                                      cancellable, error))
-    return FALSE;
 
   const char *default_target = NULL;
   if (!_rpmostree_jsonutil_object_get_optional_string_member (treefile, "default-target",

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -1211,11 +1211,6 @@ rpmostree_treefile_postprocessing (int            rootfs_fd,
   if (!rename_if_exists (rootfs_fd, "etc", rootfs_fd, "usr/etc", error))
     return FALSE;
 
-  gboolean machineid_compat = TRUE;
-  if (!_rpmostree_jsonutil_object_get_optional_boolean_member (treefile, "machineid-compat",
-                                                               &machineid_compat, error))
-    return FALSE;
-
   JsonArray *units = NULL;
   if (json_object_has_member (treefile, "units"))
     units = json_object_get_array_member (treefile, "units");
@@ -1225,9 +1220,6 @@ rpmostree_treefile_postprocessing (int            rootfs_fd,
     len = json_array_get_length (units);
   else
     len = 0;
-
-  if (len > 0 && !machineid_compat)
-    return glnx_throw (error, "'units' directive is incompatible with machineid-compat = false");
 
   {
     glnx_autofd int multiuser_wants_dfd = -1;


### PR DESCRIPTION
Move high level bwrap postprocess interface to C++

A future patch will then expose this interface via cxxrs, allowing
us to port more of the postprocess.cxx code to Rust.

---

postprocess: Move script execution to Rust

Continuing oxidation.

---

postprocess: Move add-files handling to Rust

Port add-files handling to Rust.

Note that there's one very magical line of diff here worth calling out:
We dropped an interface from the cxxrs bridge, because both sides
are now Rust!  The treefile code can directly return an `&mut File` reference
instead of needing to pass the raw fd as `i32`.

---

postprocess: Move treefile externals sanitycheck to Rust

This code really makes sense as a method on the treefile.

And when that's done, we no longer need to expose
`get_postprocess_script()` via cxx, so we can return a nicely
Rust native `Option<&mut File>`.

---

Move units/machineid-compat checking to treefile in Rust

More oxidation.

---

Move writing /usr/share/rpm-ostree/treefile.json to Rust

More oxidation.  Also with a quick unit test now.

---

