### PR TITLE
ci: Add a Github Action for Rust lints

### DIFF
--- a/.github/workflows/rust-lints.yml
+++ b/.github/workflows/rust-lints.yml
@@ -1,0 +1,27 @@
+---
+name: Rust
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLOR: always
+  ACTIONS_LINTS_TOOLCHAIN: 1.50.0
+
+jobs:
+  linting:
+    name: "cargo fmt"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env['ACTIONS_LINTS_TOOLCHAIN']  }}
+          default: true
+          components: rustfmt
+      - name: cargo fmt (check)
+        run: cargo fmt -- --check -l

--- a/rust/src/ostree_utils.rs
+++ b/rust/src/ostree_utils.rs
@@ -1,7 +1,6 @@
 //! Utility helpers or workarounds for incorrectly bound things in ostree-rs
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use glib;
 use glib::translate::*;
 use std::ptr;
 

--- a/rust/src/variant_utils.rs
+++ b/rust/src/variant_utils.rs
@@ -1,7 +1,6 @@
 //! Helpers for GVariant until we can use a newer glib crate with https://github.com/gtk-rs/glib/pull/651
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use glib;
 use glib::translate::*;
 
 // These constants should really be in gtk-rs


### PR DESCRIPTION



I'd like to move `cargo fmt` checking out of Jenkins; among
other things, GH actions are *much* faster and nicer for this.
This leaves Jenkins to be more heavyweight testing.
