### PR TITLE
More postprocess rs 3

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -90,6 +90,8 @@ pub mod ffi {
         fn composepost_nsswitch_altfiles(rootfs_dfd: i32) -> Result<()>;
         fn compose_postprocess_targets(rootfs_dfd: i32, treefile: &mut Treefile) -> Result<()>;
         fn mutate_os_release(contents: &str, base_version: &str, next_version: &str) -> String;
+        fn compose_postprocess_remove_files(rootfs_dfd: i32, treefile: &mut Treefile)
+            -> Result<()>;
         fn compose_postprocess(
             rootfs_dfd: i32,
             treefile: &mut Treefile,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -89,6 +89,7 @@ pub mod ffi {
     extern "Rust" {
         fn composepost_nsswitch_altfiles(rootfs_dfd: i32) -> Result<()>;
         fn compose_postprocess_targets(rootfs_dfd: i32, treefile: &mut Treefile) -> Result<()>;
+        fn mutate_os_release(contents: &str, base_version: &str, next_version: &str) -> String;
         fn compose_postprocess(
             rootfs_dfd: i32,
             treefile: &mut Treefile,

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1081,7 +1081,7 @@ pub(crate) struct TreeComposeConfig {
     pub(crate) add_files: Option<Vec<(String, String)>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "remove-files")]
-    remove_files: Option<Vec<String>>,
+    pub(crate) remove_files: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "remove-from-packages")]
     remove_from_packages: Option<Vec<Vec<String>>>,

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -897,6 +897,7 @@ pub(crate) enum CheckPasswdDataEntries {
 
 impl CheckPasswdDataEntries {
     /// Return IDs for user and group.
+    #[allow(dead_code)]
     pub fn ids(&self) -> (Uid, Gid) {
         let (user, group) = match self {
             CheckPasswdDataEntries::IdValue(v) => (*v, *v),

--- a/tests/compose/test-mutate-os-release.sh
+++ b/tests/compose/test-mutate-os-release.sh
@@ -41,6 +41,7 @@ ostree --repo=${repo} cat ${treeref} \
 assert_file_has_content os-release.prop VERSION_ID=${releasever}
 assert_file_has_content os-release.prop OSTREE_VERSION=\'${releasever}.444\'
 assert_file_has_content os-release.prop 'VERSION="'${releasever}'\.444 (CoreOS'
+assert_file_has_content os-release.prop 'PRETTY_NAME=.*'${releasever}'\.444'
 echo "ok mutate-os-release-cli"
 
 # make sure automatic_version_prefix works


### PR DESCRIPTION
treefile: Add an allow(dead_code)

I assume this will be used soon.

---

compose: Move mutate-os-release string code to Rust

More classic C string manipulation which is much nicer in Rust

---

compose: Move `remove-files` code to Rust

More oxidation.

---

