### PR TITLE
More ostree sys

### DIFF
--- a/rust/ostree-host/Cargo.toml
+++ b/rust/ostree-host/Cargo.toml
@@ -3,6 +3,7 @@ name = "ostree-host"
 version = "0.1.0"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
 #rust = "1.48"
 
 [dependencies]

--- a/rust/ostree-host/Cargo.toml
+++ b/rust/ostree-host/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ostree-host"
 version = "0.1.0"
-authors = ["Colin Walters <walters@verbum.org>", "Jonathan Lebon <jonathan@jlebon.com>"]
+authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2018"
 #rust = "1.48"
 

--- a/rust/ostree-host/LICENSE-APACHE
+++ b/rust/ostree-host/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/rust/ostree-host/LICENSE-MIT
+++ b/rust/ostree-host/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/rust/ostree-host/README.md
+++ b/rust/ostree-host/README.md
@@ -1,0 +1,31 @@
+# Extended OSTree APIs for host systems
+
+The OSTree project upstream will continue to be written
+in C for the near future.  The goal of this project
+is to contain new Rust APIs that extend the "ostree-based host system"
+case. In other words, some new OSTree functionality may be Rust only.
+
+At this time, this project only contains:
+
+ - Extension traits for `ostree::Repo` and `ostree::Sysroot` that
+   have a few methods prefixed with `x_` that fix incorrect bindings.
+ - An extension trait for `ostree::Sysroot` that adds small new
+   API.
+
+In the future though, more complex functionality may live here
+such as the model for `apply-live` changes.
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any
+additional terms or conditions.

--- a/rust/ostree-host/src/binding_fixes.rs
+++ b/rust/ostree-host/src/binding_fixes.rs
@@ -6,7 +6,7 @@
 use glib::translate::*;
 use std::ptr;
 
-/// Extension functions which fix incorectly bound APIs
+/// Extension functions which fix incorrectly bound APIs.
 pub trait RepoBindingExt {
     fn x_resolve_ref_optional(&self, refspec: &str) -> Result<Option<glib::GString>, glib::Error>;
 }

--- a/rust/ostree-host/src/lib.rs
+++ b/rust/ostree-host/src/lib.rs
@@ -5,7 +5,14 @@
 #![deny(unused_must_use)]
 
 mod binding_fixes;
+pub use binding_fixes::*;
+mod sysroot_ext;
+pub use sysroot_ext::*;
 
+/// This prelude currently just adds extension traits to various OSTree objects,
+/// and like all preludes is intended to be quite "safe" to import and will avoid
+/// likely naming clashes.
 pub mod prelude {
     pub use super::binding_fixes::*;
+    pub use super::sysroot_ext::*;
 }

--- a/rust/ostree-host/src/sysroot_ext.rs
+++ b/rust/ostree-host/src/sysroot_ext.rs
@@ -1,0 +1,17 @@
+//! Extension traits that add new APIs.
+
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// Extension APIs for `ostree::Sysroot`
+pub trait SysrootExt {
+    /// Require a booted deployment; reimplements https://github.com/ostreedev/ostree/pull/2301
+    fn require_booted_deployment(&self) -> Result<ostree::Deployment, glib::Error>;
+}
+
+impl SysrootExt for ostree::Sysroot {
+    fn require_booted_deployment(&self) -> Result<ostree::Deployment, glib::Error> {
+        self.get_booted_deployment().ok_or_else(|| {
+            glib::Error::new(gio::IOErrorEnum::Failed, "Not booted into an OSTree system")
+        })
+    }
+}

--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -333,12 +333,6 @@ fn rerun_tmpfiles() -> Result<()> {
     })
 }
 
-fn get_required_booted_deployment(sysroot: &ostree::Sysroot) -> Result<ostree::Deployment> {
-    sysroot
-        .get_booted_deployment()
-        .ok_or_else(|| anyhow!("Not booted into an OSTree system"))
-}
-
 /// Implementation of `rpm-ostree ex apply-live`.
 pub(crate) fn transaction_apply_live(
     mut sysroot: Pin<&mut crate::ffi::OstreeSysroot>,
@@ -351,7 +345,7 @@ pub(crate) fn transaction_apply_live(
     let allow_replacement = variant_dict_lookup_bool(options, OPT_REPLACE).unwrap_or_default();
     let repo = &sysroot.repo().expect("repo");
 
-    let booted = get_required_booted_deployment(sysroot)?;
+    let booted = sysroot.require_booted_deployment()?;
     let osname = booted.get_osname().expect("osname");
     let booted_commit = booted.get_csum().expect("csum");
     let booted_commit = booted_commit.as_str();


### PR DESCRIPTION
rust/ostree-host: Add SysrootExt trait

This currently just adds a reimplementation of a new API that's
already in C upstream, but the plan is to add more Rust-only APIs in
the future here.

---

rust/ostree-host: Add README.md and license files

In preparation for splitting to a new repo.

---

