### PR TITLE
lockfile: Allow locking by source RPM EVR

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -309,6 +309,7 @@ pub mod ffi {
         ) -> Result<()>;
 
         fn get_locked_packages(&self) -> Result<Vec<LockedPackage>>;
+        fn get_locked_src_packages(&self) -> Result<Vec<LockedPackage>>;
     }
 
     // rpmutils.rs


### PR DESCRIPTION
Right now if we want to lock e.g. systemd, we need to specify every
subpackage of systemd that we use. This is a lot of duplication because
in the majority of cases, what we really mean is "lock at this build of
systemd".

Since RPMs bake in the source RPM they were built from, we can use this
to lock packages more succinctly. See the testcase and #2676 for
examples of how this looks.

Closes: https://github.com/coreos/rpm-ostree/issues/2676