### PR TITLE
postprocess: Migrate `mutate-os-release` to Rust

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -89,7 +89,11 @@ pub mod ffi {
     extern "Rust" {
         fn composepost_nsswitch_altfiles(rootfs_dfd: i32) -> Result<()>;
         fn compose_postprocess_targets(rootfs_dfd: i32, treefile: &mut Treefile) -> Result<()>;
-        fn mutate_os_release(contents: &str, base_version: &str, next_version: &str) -> String;
+        fn compose_postprocess_mutate_os_release(
+            rootfs_dfd: i32,
+            treefile: &mut Treefile,
+            next_version: &str,
+        ) -> Result<()>;
         fn compose_postprocess_remove_files(rootfs_dfd: i32, treefile: &mut Treefile)
             -> Result<()>;
         fn compose_postprocess(
@@ -365,6 +369,7 @@ pub mod ffi {
             child_argv: &Vec<String>,
             unified_core_mode: bool,
         ) -> Result<()>;
+        fn bwrap_run_captured(rootfs_dfd: i32, child_argv: &Vec<String>) -> Result<Vec<u8>>;
     }
 
     unsafe extern "C++" {

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1062,7 +1062,7 @@ pub(crate) struct TreeComposeConfig {
     automatic_version_suffix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "mutate-os-release")]
-    mutate_os_release: Option<String>,
+    pub(crate) mutate_os_release: Option<String>,
 
     // passwd-related bits
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/libpriv/rpmostree-bwrap.h
+++ b/src/libpriv/rpmostree-bwrap.h
@@ -28,6 +28,10 @@
 
 namespace rpmostreecxx {
 
+rust::Vec<uint8_t> 
+bwrap_run_captured(int32_t rootfs_dfd,
+                   const rust::Vec<rust::String> &child_argv);
+
 void bwrap_run_mutable(int32_t rootfs_dfd, rust::Str binpath,
                        const rust::Vec<rust::String> &child_argv,
                        bool unified_core_mode);


### PR DESCRIPTION
Required binding a bit more of the bwrap bits.
