### PR TITLE
Cargo.lock: Bump openat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,9 +806,9 @@ checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "openat"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eff876e3964841fd6067ecf1d040e0315879c1a1cce2a0f162828e82f04d1ce"
+checksum = "97cdc0668b258e022a16a9c71a77f69b73e8d32b6f20bb3082b623f6396438b8"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
To pull in https://github.com/tailhook/openat/pull/36
so we can update libc.