### PR TITLE
clientlib: Strip GDBus remote error before throwing exception

### DIFF
--- a/src/app/rpmostree-clientlib.cxx
+++ b/src/app/rpmostree-clientlib.cxx
@@ -270,7 +270,12 @@ ClientConnection::transaction_connect_progress_sync(const rust::Str address) con
   g_autoptr(GCancellable) cancellable = g_cancellable_new();
   auto address_c = g_strndup(address.data(), address.length());
   if (!impl_transaction_get_response_sync (conn, address_c, cancellable, &local_error))
-    util::throw_gerror(local_error);
+    {
+      // In this case the caller doesn't care about the remote exception; we never
+      // try to match on it.
+      g_dbus_error_strip_remote_error (local_error);
+      util::throw_gerror(local_error);
+    }
 }
 
 } // namespace

--- a/tests/kolainst/destructive/apply-live
+++ b/tests/kolainst/destructive/apply-live
@@ -73,6 +73,8 @@ if rpm-ostree ex apply-live 2>err.txt; then
     fatal "live-removed foo"
 fi
 assert_file_has_content_literal err.txt 'packages would be removed: 1, enable replacement to override'
+# Ensure remote error is stripped
+assert_not_file_has_content_literal err.txt 'GDBus.Error'
 rpm-ostree ex livefs --allow-replacement | tee out.txt
 assert_file_has_content out.txt 'Added:'
 assert_file_has_content out.txt '  bar-1.0'


### PR DESCRIPTION
In general our error handling philosophy is "errors are strings".
Previously (before C++) we were relying on calling this API
to strip out the GDBus remote error message.

In the recent refactoring of clientlib to expose the txn APIs
to Rust via C++, we implicitly lost that because the C++
wrapper API throws an exception.

Add a copy of the remote error stripping here.  Eventually
it will likely make sense for it to *only* be here instead
of also in `main.cxx`, but one thing at a time.
