### PR TITLE
Docs/compose server

### DIFF
--- a/docs/compose-server.md
+++ b/docs/compose-server.md
@@ -85,6 +85,44 @@ Once we have that commit, let's export it:
 You can tell client systems to rebase to it by combining `ostree remote add`,
 and `rpm-ostree rebase` on the client side.
 
+## Granular tree compose with `install|postprocess|commit`
+
+In order to get even more control we split `rpm-ostree compose tree` into
+`rpm-ostree compose install`, followed by `rpm-ostree compose postprocess`
+and finally `rpm-ostree compose commit`.
+
+Similar to `rpm-ostree compose tree` we'll use a "treefile". We'll also specify a target directory
+serving as our work-in-progress rootfs:
+
+```
+# rpm-ostree compose install --unified-core --cachedir=cache --repo=/srv/repo /path/to/manifest.yaml /var/sysroot
+```
+
+This will download RPMs from the referenced repos and execute any specified post-process scripts.
+
+We now can alter anything found under `/var/sysroot/rootfs`.
+
+Next we can run more postprocessing:
+
+```
+# rpm-ostree compose postprocess postprocess /var/sysroot/rootfs /path/to/manifest.yaml
+```
+
+When we are finished with our manual changes we can now create the commit:
+
+```
+# rpm-ostree compose tree --repo=/srv/repo /path/to/manifest.yaml /var/sysroot
+```
+
+Once we have that commit, let's export it:
+
+```
+# ostree --repo=repo pull-local build-repo exampleos/8/x86_64/stable
+```
+
+You can tell client systems to rebase to it by combining `ostree remote add`,
+and `rpm-ostree rebase` on the client side.
+
 ## Generating OSTree commits in a container
 
 `rpm-ostree compose tree` runs well in an unprivileged (or "run as root")

--- a/docs/compose-server.md
+++ b/docs/compose-server.md
@@ -8,6 +8,21 @@ nav_order: 4
 1. TOC
 {:toc}
 
+## Managing RPM based OSTree commits
+
+With `rpm-ostree compose` you get a tool to compose your own ostree commits based on a
+[treefile](https://coreos.github.io/rpm-ostree/treefile/) configuration, a couple of RPMs,
+some post-processing and possibly some custom modifications directly in the resulting tree.
+
+The tool allows to either build a tree commit in one go with a single command: `rpm-ostree compose tree`.
+Or to split that process up into smaller chunks with the usage of `rpm-ostree compose install`,
+followed by `rpm-ostree compose postprocess` and finally `rpm-ostree compose commit`. While
+the former approach is pretty complete and allows most use-cases the latter is useful if you need
+some more customization on the resulting filesystem. More customization than the sandboxed
+post-process functionality of the treefile allows.
+
+In most scenarios you'll want to consider using a more "high level" tool, than `rpm-ostree compose`.
+
 ## Using higher level build tooling
 
 Originally `rpm-ostree compose tree` was intended to be a "high level" tool,

--- a/docs/compose-server.md
+++ b/docs/compose-server.md
@@ -33,16 +33,6 @@ of the OSTree manual:
  - [buildsystem-and-repos](https://ostreedev.github.io/ostree/buildsystem-and-repos/)
  - [repository-management](https://ostreedev.github.io/ostree/repository-management/)
 
-## Generating OSTree commits in a container
-
-`rpm-ostree compose tree` runs well in an unprivileged (or "run as root")
-podman container.  You can also use other container tools, they are just less
-frequently tested.
-
-You can also directly install `rpm-ostree` on a traditional `yum/rpm` based
-virtual (or physical) machine - it won't affect your host.  However, containers
-are encouraged.
-
 ## Choosing a base config
 
 Currently, rpm-ostree is fairly coupled to the Fedora project.  We are open to supporting
@@ -79,6 +69,16 @@ Once we have that commit, let's export it:
 
 You can tell client systems to rebase to it by combining `ostree remote add`,
 and `rpm-ostree rebase` on the client side.
+
+## Generating OSTree commits in a container
+
+`rpm-ostree compose tree` runs well in an unprivileged (or "run as root")
+podman container.  You can also use other container tools, they are just less
+frequently tested.
+
+You can also directly install `rpm-ostree` on a traditional `yum/rpm` based
+virtual (or physical) machine - it won't affect your host.  However, containers
+are encouraged.
 
 ## More information
 

--- a/docs/compose-server.md
+++ b/docs/compose-server.md
@@ -70,7 +70,7 @@ If you're doing this multiple times, it's strongly recommended to create a cache
 directory:
 
 ```
-# rpm-ostree compose tree --unified-core --cachedir=cache --repo=/srv/repo /path/to/manifest.yaml
+# rpm-ostree compose tree --unified-core --cachedir=cache --repo=./build-repo /path/to/manifest.yaml
 ```
 
 This will download RPMs from the referenced repos, and commit the result to the
@@ -79,7 +79,7 @@ OSTree repository, using the ref named by `ref`.
 Once we have that commit, let's export it:
 
 ```
-# ostree --repo=repo pull-local build-repo exampleos/8/x86_64/stable
+# ostree --repo=/srv/deploy-repo pull-local ./build-repo exampleos/8/x86_64/stable
 ```
 
 You can tell client systems to rebase to it by combining `ostree remote add`,
@@ -95,29 +95,29 @@ Similar to `rpm-ostree compose tree` we'll use a "treefile". We'll also specify 
 serving as our work-in-progress rootfs:
 
 ```
-# rpm-ostree compose install --unified-core --cachedir=cache --repo=/srv/repo /path/to/manifest.yaml /var/sysroot
+# rpm-ostree compose install --unified-core --cachedir=cache --repo=./build-repo /path/to/manifest.yaml ./sysroot
 ```
 
 This will download RPMs from the referenced repos and execute any specified post-process scripts.
 
-We now can alter anything found under `/var/sysroot/rootfs`.
+We now can alter anything found under `./sysroot/rootfs`.
 
 Next we can run more postprocessing:
 
 ```
-# rpm-ostree compose postprocess postprocess /var/sysroot/rootfs /path/to/manifest.yaml
+# rpm-ostree compose postprocess ./sysroot/rootfs /path/to/manifest.yaml
 ```
 
 When we are finished with our manual changes we can now create the commit:
 
 ```
-# rpm-ostree compose tree --repo=/srv/repo /path/to/manifest.yaml /var/sysroot
+# rpm-ostree compose commit --repo=./build-repo /path/to/manifest.yaml ./sysroot/rootfs
 ```
 
 Once we have that commit, let's export it:
 
 ```
-# ostree --repo=repo pull-local build-repo exampleos/8/x86_64/stable
+# ostree --repo=/srv/deploy-repo pull-local ./build-repo exampleos/8/x86_64/stable
 ```
 
 You can tell client systems to rebase to it by combining `ostree remote add`,


### PR DESCRIPTION
I've reworked some of the online documentation on docs/compose-server motivated from #2675.

Changes are:

* Moved the container related section to the bottom since it is not as important as other parts of that document
* Introduced a small introduction section touching some of the mentioned topics, giving a smoother entrance to the topic
* Introduced a section on how to split up the tree compose by usage of the other available commands
