### PR TITLE
Add a helper API to detect running in systemd

### DIFF
--- a/rust/src/isolation.rs
+++ b/rust/src/isolation.rs
@@ -26,7 +26,7 @@ pub(crate) struct UnitConfig<'a> {
 /// isolation like `ProtectHome=true`.
 #[context("Running systemd worker")]
 pub(crate) fn run_systemd_worker_sync(cfg: &UnitConfig) -> Result<()> {
-    if !systemd::daemon::booted()? {
+    if !crate::utils::running_in_systemd() {
         return Err(anyhow!("Not running under systemd"));
     }
     let mut cmd = Command::new("systemd-run");

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -226,6 +226,7 @@ pub mod ffi {
         fn varsubstitute(s: &str, vars: &Vec<StringMapping>) -> Result<String>;
         fn get_features() -> Vec<String>;
         fn sealed_memfd(description: &str, content: &[u8]) -> Result<i32>;
+        fn running_in_systemd() -> bool;
     }
 
     #[derive(Default)]

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -194,6 +194,20 @@ fn varsubst(instr: &str, vars: &HashMap<String, String>) -> Result<String> {
     Ok(s)
 }
 
+lazy_static::lazy_static! {
+    static ref RUNNING_IN_SYSTEMD: bool = {
+        // See https://www.freedesktop.org/software/systemd/man/systemd.exec.html#%24INVOCATION_ID
+        std::env::var_os("INVOCATION_ID").filter(|s| !s.is_empty()).is_some()
+    };
+}
+
+/// Checks if the current process is (apparently at least)
+/// running under systemd.  We use this in various places
+/// to e.g. log to the journal instead of printing to stdout.
+pub(crate) fn running_in_systemd() -> bool {
+    *RUNNING_IN_SYSTEMD
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -411,7 +411,7 @@ rpmostree_run_script_in_bwrap_container (int rootfs_fd,
        * via `ex container`, and in these cases we want to output to stdout, which
        * is where other output will go.
        */
-      if (rpmostree_stdout_is_journal ())
+      if (rpmostreecxx::running_in_systemd())
         {
           stdout_fd = sd_journal_stream_fd (id, LOG_INFO, 0);
           if (stdout_fd < 0)
@@ -460,7 +460,7 @@ rpmostree_run_script_in_bwrap_container (int rootfs_fd,
     {
       dump_buffered_output_noerr (pkg_script, &buffered_output);
       /* If errors go to the journal, help the user/admin find them there */
-      if (error && rpmostree_stdout_is_journal ())
+      if (error && rpmostreecxx::running_in_systemd())
         {
           g_assert (*error);
           g_autofree char *errmsg = (*error)->message;

--- a/src/libpriv/rpmostree-util.cxx
+++ b/src/libpriv/rpmostree-util.cxx
@@ -762,34 +762,6 @@ rpmostree_commit_content_checksum (GVariant *commit)
   return g_strdup (g_checksum_get_string (hasher));
 }
 
-/* Implementation taken from https://git.gnome.org/browse/libgsystem/tree/src/gsystem-log.c */
-gboolean
-rpmostree_stdout_is_journal (void)
-{
-  static gsize initialized;
-  static gboolean stdout_is_socket;
-
-  if (g_once_init_enter (&initialized))
-    {
-      guint64 pid = (guint64) getpid ();
-      g_autofree char *fdpath = g_strdup_printf ("/proc/%" G_GUINT64_FORMAT "/fd/1", pid);
-      char buf[1024];
-      ssize_t bytes_read;
-
-      if ((bytes_read = readlink (fdpath, buf, sizeof(buf) - 1)) != -1)
-        {
-          buf[bytes_read] = '\0';
-          stdout_is_socket = g_str_has_prefix (buf, "socket:");
-        }
-      else
-        stdout_is_socket = FALSE;
-
-      g_once_init_leave (&initialized, TRUE);
-    }
-
-  return stdout_is_socket;
-}
-
 char*
 rpmostree_generate_diff_summary (guint upgraded,
                                  guint downgraded,

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -168,8 +168,6 @@ gs_file_get_path_cached (GFile *file)
   return rpmostree_file_get_path_cached (file);
 }
 
-gboolean rpmostree_stdout_is_journal (void);
-
 char*
 rpmostree_generate_diff_summary (guint upgraded,
                                  guint downgraded,


### PR DESCRIPTION
Use it instead of detecting the journal; we *could* do that
by checking the `JOURNAL_STREAM` variable:
https://www.freedesktop.org/software/systemd/man/systemd.exec.html#%24JOURNAL_STREAM

But, really none of our code cares about this today;
anyone running `rpm-ostree compose tree` under e.g.
`systemd-run` can keep both pieces.
