### PR TITLE
Bake advisory information into commit metadata

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -272,6 +272,11 @@ pub mod ffi {
         fn get_features() -> Vec<String>;
         fn sealed_memfd(description: &str, content: &[u8]) -> Result<i32>;
         fn running_in_systemd() -> bool;
+        fn calculate_advisories_diff(
+            repo: Pin<&mut OstreeRepo>,
+            checksum_from: &str,
+            checksum_to: &str,
+        ) -> Result<*mut GVariant>;
     }
 
     #[derive(Default)]

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -220,6 +220,7 @@ filter_commit_meta (GVariant *commit_meta)
   g_variant_dict_init (&dict, commit_meta);
   /* for now we just blacklist, but we may want to whitelist in the future */
   g_variant_dict_remove (&dict, "rpmostree.rpmdb.pkglist");
+  g_variant_dict_remove (&dict, "rpmostree.advisories");
   return g_variant_dict_end (&dict);
 }
 

--- a/tests/compose/test-basic-unified.sh
+++ b/tests/compose/test-basic-unified.sh
@@ -100,6 +100,10 @@ echo "ok --no-parent"
 rpm-ostree db list --repo="${repo}" "${treeref}" --advisories > db-list-adv.txt
 assert_not_file_has_content_literal db-list-adv.txt TEST-SEC-LOW
 assert_file_has_content_literal db-list-adv.txt TEST-SEC-CRIT
+rpm-ostree db diff --repo="${repo}" "${origrev}" "${newrev}" --advisories > db-diff-adv.txt
+assert_not_file_has_content_literal db-diff-adv.txt TEST-SEC-LOW
+assert_file_has_content_literal db-diff-adv.txt TEST-SEC-CRIT
+echo "ok db diff --advisories"
 
 build_rpm dodo-base
 build_rpm dodo requires dodo-base


### PR DESCRIPTION
There are a lot of use cases for this, notably:
- This allows us to display advisories without fetching updateinfo
  metadata in the pure OSTree case.
- It allows pipelines to fetch and display this information to
  sanity-check builds (and then into user-facing release notes).
- It makes it much easier to fix the "intermediate CVEs" issue described
  in https://github.com/coreos/rpm-ostree/issues/1696#issuecomment-443861107.

This patch just adds the advisory information to the commit metadata.
There's follow-up work to make the client-side of rpm-ostree use this
data. Also, for pipelines, we leave it to higher level tools like cosa
to calculate the "advisory diff" like it does for the package diff for
example.

Closes: #1696