### PR TITLE
Fix ambigous compose postprocess man entry

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1242,7 +1242,7 @@ rpmostree_compose_builtin_postprocess (int             argc,
                                        GCancellable   *cancellable,
                                        GError        **error)
 {
-  g_autoptr(GOptionContext) context = g_option_context_new ("postprocess ROOTFS [TREEFILE]");
+  g_autoptr(GOptionContext) context = g_option_context_new ("ROOTFS [TREEFILE]");
   if (!rpmostree_option_context_parse (context,
                                        postprocess_option_entries,
                                        &argc, &argv,


### PR DESCRIPTION
[As suggested by](https://github.com/coreos/rpm-ostree/pull/2693#discussion_r600839336) @jlebon in #2693 I've updated the man-page entry with the provided diff.