### PR TITLE
RELEASE: Add step to update libdnf's deps

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -6,7 +6,9 @@ nav_order: 8
 
 1. Increment the `year_version` and `release_version` macros in `configure.ac`.
 2. Increment the `Version` field in `rpm-ostree.spec.in`.
-3. Submit as a PR and wait until reviewed *and* CI is green.
+3. Verify the libdnf deps in `rpm-ostree.spec.in` are up to date by comparing to
+   the spec of the bundled version (`libdnf/libdnf.spec`).
+4. Submit as a PR and wait until reviewed *and* CI is green.
 5. Once merged, do `git pull $upstream && git reset --hard $upstream/master` on
    your local `master` branch to make sure you're on the right commit.
 6. Draft release notes by seeding a HackMD.io with `git shortlog $last_tag..`

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -58,7 +58,8 @@ BuildRequires: pkgconfig(libsystemd)
 BuildRequires: libcap-devel
 BuildRequires: libattr-devel
 
-# We currently interact directly with librepo
+# We currently interact directly with librepo (libdnf below also pulls it in,
+# but duplicating to be clear)
 BuildRequires: pkgconfig(librepo)
 
 # Needed by curl-rust
@@ -67,6 +68,9 @@ BuildRequires: pkgconfig(libcurl)
 BuildRequires: cmake
 BuildRequires: pkgconfig(expat)
 BuildRequires: pkgconfig(check)
+
+# We use some libsolv types directly too (libdnf below also pulls it in,
+# but duplicating to be clear)
 BuildRequires: pkgconfig(libsolv)
 
 # We need g++ for libdnf
@@ -75,9 +79,13 @@ BuildRequires: gcc-c++
 
 # more libdnf build deps (see libdnf's spec for versions)
 %global swig_version 3.0.12
-%global libmodulemd_version 2.5.0
+%global libmodulemd_version 2.11.2-2
+%global librepo_version 1.13.0
+%global libsolv_version 0.7.17
 BuildRequires:  swig >= %{swig_version}
 BuildRequires:  pkgconfig(modulemd-2.0) >= %{libmodulemd_version}
+BuildRequires:  pkgconfig(librepo) >= %{librepo_version}
+BuildRequires:  libsolv-devel >= %{libsolv_version}
 BuildRequires:  pkgconfig(json-c)
 BuildRequires:  pkgconfig(cppunit)
 BuildRequires:  pkgconfig(sqlite3)
@@ -87,7 +95,10 @@ BuildRequires:  pkgconfig(zck) >= 0.9.11
 %endif
 BuildRequires:  gpgme-devel
 
+# Runtime libdnf deps
 Requires:       libmodulemd%{?_isa} >= %{libmodulemd_version}
+Requires:       libsolv%{?_isa} >= %{libsolv_version}
+Requires:       librepo%{?_isa} >= %{librepo_version}
 
 # For now...see https://github.com/projectatomic/rpm-ostree/pull/637
 # and https://github.com/fedora-infra/fedmsg-atomic-composer/pull/17


### PR DESCRIPTION
In the latest release, we should've bumped librepo's requirement. It
doesn't use symbol versioning, so we don't automatically get this. At
release time at least, we should just peek at the spec we're baking in
and pick up from that.

Clearly the updated deps are in the buildroot if CI is green, so this
should mostly be a matter of bumping to versions which are already
shipped in Fedora.

See: https://github.com/rpm-software-management/libdnf/pull/1128
See: https://github.com/coreos/rpm-ostree/pull/2644
See: https://bugzilla.redhat.com/show_bug.cgi?id=1943773