### PR TITLE
compose: Fix leak of Rust treefile object

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -165,6 +165,7 @@ rpm_ostree_tree_compose_context_free (RpmOstreeTreeComposeContext *ctx)
   g_clear_object (&ctx->corectx);
   g_clear_object (&ctx->treefile_path);
   g_clear_pointer (&ctx->metadata, g_hash_table_unref);
+  ctx->treefile_rs.~optional();
   /* Only close workdir_dfd if it's not owned by the tmpdir */
   if (!ctx->workdir_tmp.initialized)
     glnx_close_fd (&ctx->workdir_dfd);


### PR DESCRIPTION
I did at one point look at converting this stuff into a C++
object but that led in to a whole rathole around a C++ `GObject<>`
smart pointer like glibmm has.  But that would take over the code
and it's better to just port to Rust.
