### PR TITLE
Migrate `depmod` helper to core.rs

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -53,6 +53,16 @@ pub(crate) fn get_systemctl_wrapper() -> &'static [u8] {
     include_bytes!("../../src/libpriv/systemctl-wrapper.sh")
 }
 
+/// Run the standard `depmod` utility.
+pub(crate) fn run_depmod(rootfs_dfd: i32, kver: &str, unified_core: bool) -> CxxResult<()> {
+    let args: Vec<_> = vec!["depmod", "-a", kver]
+        .into_iter()
+        .map(|s| s.to_string())
+        .collect();
+    let _ = crate::bwrap::bubblewrap_run_sync(rootfs_dfd, &args, false, unified_core)?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -125,6 +125,8 @@ pub mod ffi {
         fn prepare_tempetc_guard(rootfs: i32) -> Result<Box<TempEtcGuard>>;
         fn undo(self: &TempEtcGuard) -> Result<()>;
 
+        fn run_depmod(rootfs_dfd: i32, kver: &str, unified_core: bool) -> Result<()>;
+
         fn get_systemctl_wrapper() -> &'static [u8];
     }
 

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -1148,8 +1148,7 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self,
   if (rpmostree_context_get_kernel_changed (self->ctx))
     {
       g_assert (kernel_state && kver);
-      if (!rpmostree_postprocess_run_depmod (self->tmprootfs_dfd, kver, TRUE, cancellable, error))
-        return FALSE;
+      rpmostreecxx::run_depmod(self->tmprootfs_dfd, kver, true);
     }
 
   if (kernel_or_initramfs_changed)

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -204,18 +204,6 @@ hardlink_recurse (int                src_dfd,
   return TRUE;
 }
 
-gboolean
-rpmostree_postprocess_run_depmod (int           rootfs_dfd,
-                                  const char   *kver,
-                                  gboolean      unified_core_mode,
-                                  GCancellable *cancellable,
-                                  GError      **error)
-{
-  rust::Vec child_argv = { rust::String("depmod"), rust::String("-a"), rust::String(kver) };
-  rpmostreecxx::bubblewrap_run_sync(rootfs_dfd, child_argv, false, (bool)unified_core_mode);
-  return TRUE;
-}
-
 /* Handle the kernel/initramfs, which can be in at least 2 different places:
  *  - /boot (CentOS, Fedora treecompose before we suppressed kernel.spec's %posttrans)
  *  - /usr/lib/modules (Fedora treecompose without kernel.spec's %posttrans)
@@ -301,9 +289,7 @@ process_kernel_and_initramfs (int            rootfs_dfd,
   /* Ensure depmod (kernel modules index) is up to date; because on Fedora we
    * suppress the kernel %posttrans we need to take care of this.
    */
-  if (!rpmostree_postprocess_run_depmod (rootfs_dfd, kver, unified_core_mode,
-                                         cancellable, error))
-    return FALSE;
+  rpmostreecxx::run_depmod(rootfs_dfd, kver, unified_core_mode);
 
   RpmOstreePostprocessBootLocation boot_location =
     RPMOSTREE_POSTPROCESS_BOOT_LOCATION_NEW;

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -58,13 +58,6 @@ rpmostree_rootfs_postprocess_common (int           rootfs_fd,
                                      GError       **error);
 
 gboolean
-rpmostree_postprocess_run_depmod (int           rootfs_fd,
-                                  const char   *kver,
-                                  gboolean      unified_core_mode,
-                                  GCancellable *cancellable,
-                                  GError      **error);
-
-gboolean
 rpmostree_prepare_rootfs_get_sepolicy (int            dfd,
                                        OstreeSePolicy **out_sepolicy,
                                        GCancellable  *cancellable,


### PR DESCRIPTION
Since it's called from both client and compose side, it should be
in core.  Migrate to Rust too.
