### PR TITLE
postprocess: Move more code into Rust

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -133,17 +133,10 @@ pub mod ffi {
     // composepost.rs
     extern "Rust" {
         fn composepost_nsswitch_altfiles(rootfs_dfd: i32) -> Result<()>;
-        fn compose_postprocess_targets(rootfs_dfd: i32, treefile: &mut Treefile) -> Result<()>;
-        fn compose_postprocess_mutate_os_release(
-            rootfs_dfd: i32,
-            treefile: &mut Treefile,
-            next_version: &str,
-        ) -> Result<()>;
-        fn compose_postprocess_remove_files(rootfs_dfd: i32, treefile: &mut Treefile)
-            -> Result<()>;
         fn compose_postprocess(
             rootfs_dfd: i32,
             treefile: &mut Treefile,
+            next_version: &str,
             unified_core: bool,
         ) -> Result<()>;
         fn compose_postprocess_final(rootfs_dfd: i32) -> Result<()>;
@@ -260,7 +253,6 @@ pub mod ffi {
         fn get_rpmdb(&self) -> String;
         fn get_files_remove_regex(&self, package: &str) -> Vec<String>;
         fn print_deprecation_warnings(&self);
-        fn write_compose_json(&self, rootfs_dfd: i32) -> Result<()>;
         fn sanitycheck_externals(&self) -> Result<()>;
         fn get_checksum(&self, repo: Pin<&mut OstreeRepo>) -> Result<String>;
         fn get_ostree_ref(&self) -> String;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -746,8 +746,7 @@ for x in *; do mv ${{x}} %{{buildroot}}%{{_prefix}}/lib/ostree-jigdo/%{{name}}; 
     }
 
     /// Write the serialized treefile into /usr/share on the target filesystem.
-    pub(crate) fn write_compose_json(&self, rootfs_dfd: i32) -> CxxResult<()> {
-        let rootfs_dfd = crate::ffiutil::ffi_view_openat_dir(rootfs_dfd);
+    pub(crate) fn write_compose_json(&self, rootfs_dfd: &openat::Dir) -> Result<()> {
         let target = Path::new(COMPOSE_JSON_PATH);
         rootfs_dfd.ensure_dir_all(target.parent().unwrap(), 0o755)?;
         rootfs_dfd.write_file_contents(target, 0o644, self.serialized.as_bytes())?;
@@ -1626,7 +1625,7 @@ arch-include:
         {
             let workdir = tempfile::tempdir()?;
             let tf = new_test_treefile(workdir.path(), VALID_PRELUDE, None).unwrap();
-            tf.write_compose_json(rootdir.as_raw_fd())?;
+            tf.write_compose_json(rootdir)?;
         }
         let mut src = std::io::BufReader::new(rootdir.open_file(COMPOSE_JSON_PATH)?);
         let cfg = treefile_parse_stream(utils::InputFormat::JSON, &mut src, None)?;

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -954,10 +954,7 @@ impl_install_tree (RpmOstreeTreeComposeContext *self,
     return FALSE;
 
   /* Start postprocessing */
-  if (!rpmostree_treefile_postprocessing (self->rootfs_dfd, **self->treefile_rs, self->treefile,
-                                          next_version.length() > 0 ? next_version.c_str() : NULL, self->unified_core_and_fuse,
-                                          cancellable, error))
-    return glnx_prefix_error (error, "Postprocessing");
+  rpmostreecxx::compose_postprocess(self->rootfs_dfd, **self->treefile_rs, next_version, self->unified_core_and_fuse);
 
   /* Until here, we targeted "rootfs.tmp" in the working directory. Most
    * user-configured postprocessing has run. Now, we need to perform required

--- a/src/app/rpmostree-composeutil.cxx
+++ b/src/app/rpmostree-composeutil.cxx
@@ -103,7 +103,7 @@ rpmostree_composeutil_legacy_prep_dev (int         rootfs_dfd,
         continue;
 
       if (mknodat (dest_fd, nodename, stbuf.st_mode, stbuf.st_rdev) != 0)
-        return glnx_throw_errno_prefix (error, "mknodat");
+        return glnx_throw_errno_prefix (error, "mknodat(%s)", nodename);
       if (fchmodat (dest_fd, nodename, stbuf.st_mode, 0) != 0)
         return glnx_throw_errno_prefix (error, "fchmodat");
     }

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -1132,43 +1132,6 @@ rpmostree_rootfs_postprocess_common (int           rootfs_fd,
   return TRUE;
 }
 
-/* Move etc -> usr/etc in the rootfs, and run through treefile
- * postprocessing.
- */
-gboolean
-rpmostree_treefile_postprocessing (int            rootfs_fd,
-                                   rpmostreecxx::Treefile &treefile_rs,
-                                   JsonObject    *treefile,
-                                   const char    *next_version,
-                                   gboolean       unified_core_mode,
-                                   GCancellable  *cancellable,
-                                   GError       **error)
-{
-  g_assert (treefile);
-
-  treefile_rs.write_compose_json(rootfs_fd);
-
-  if (!rename_if_exists (rootfs_fd, "etc", rootfs_fd, "usr/etc", error))
-    return FALSE;
-
-  rpmostreecxx::compose_postprocess_targets(rootfs_fd, treefile_rs);
-
-  /* Put /etc back for backwards compatibility */
-  if (!rename_if_exists (rootfs_fd, "usr/etc", rootfs_fd, "etc", error))
-    return FALSE;
-
-  rpmostreecxx::compose_postprocess_remove_files(rootfs_fd, treefile_rs);
-  rpmostreecxx::compose_postprocess_mutate_os_release(rootfs_fd, treefile_rs, next_version ?: "");
-
-  /* Undo etc move again */
-  if (!rename_if_exists (rootfs_fd, "etc", rootfs_fd, "usr/etc", error))
-    return FALSE;
-
-  rpmostreecxx::compose_postprocess(rootfs_fd, treefile_rs, (bool)unified_core_mode);
-
-  return TRUE;
-}
-
 /**
  * rpmostree_prepare_rootfs_for_commit:
  *

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -26,16 +26,6 @@
 
 G_BEGIN_DECLS
 
-
-gboolean
-rpmostree_treefile_postprocessing (int            rootfs_fd,
-                                   rpmostreecxx::Treefile &treefile_rs,
-                                   JsonObject    *treefile,
-                                   const char    *next_version,
-                                   gboolean       unified_core_mode,
-                                   GCancellable  *cancellable,
-                                   GError       **error);
-
 gboolean
 rpmostree_rootfs_symlink_emptydir_at (int rootfs_fd,
                                       const char *dest,


### PR DESCRIPTION
Previously we carefully ported functionality bit by bit here.
Now take the last step and move it all in to Rust.

A reason I didn't do this in one go before is around the
incredibly twisted handling of the `/etc` vs `/usr/etc`.

I think longer term we should aim to basically have all
of our code keep it as `/etc` up until the very end.  For
now we just do a rename dance around some of the add/remove
files code.
