### PR TITLE
tests: Stop running test-lib-introspection.sh

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -21,7 +21,6 @@ endif
 GITIGNOREFILES += ssh-config vmcheck-logs/ test-compose-logs/ .cosa/
 
 uninstalled_test_scripts = \
-	tests/check/test-lib-introspection.sh \
 	$(NULL)
 
 uninstalled_test_extra_programs = \

--- a/tests/check/test-lib-introspection.sh
+++ b/tests/check/test-lib-introspection.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 #
+# NOTE: This is presently disabled by default because
+# we don't want to drag pygobject3 into our build container
+# and anyways the shared library should be considered deprecated.
+#
 # Copyright (C) 2014 Colin Walters <walters@verbum.org>
 #
 # This library is free software; you can redistribute it and/or


### PR DESCRIPTION
Even more fallout of the buildroot change to stop deriving from
cosa.  The new buildroot doesn't have `pygobject3`.

We could convert this to an installed test but...blah.
Not worth it.
