### PR TITLE
libpriv: Remove unnecessary builder causing memory leak

### DIFF
--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -1282,13 +1282,9 @@ filter_xattrs_cb (OstreeRepo     *repo,
 {
   g_assert (relpath);
 
-  GVariantBuilder builder;
-  g_variant_builder_init (&builder, G_VARIANT_TYPE ("a(ayay)"));
-
   try {
     return filter_xattrs_impl(repo, relpath, file_info, user_data);
   } catch (std::exception& e) {
-      g_variant_builder_clear (&builder);
       /* Unfortunately we have no way to throw from this callback */
       g_printerr ("Failed to read xattrs of '%s': %s\n", relpath, e.what());
       exit (1);


### PR DESCRIPTION
Remove the unnecessary builder causing memory leaks like this one:

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7f60bd2fe3cf in __interceptor_malloc (/lib64/libasan.so.6+0xab3cf)
    #1 0x7f60bca6cbb8 in g_malloc (/lib64/libglib-2.0.so.0+0x5bbb8)
    #2 0x7f60bcaa54f2 in g_variant_type_copy (/lib64/libglib-2.0.so.0+0x944f2)
    #3 0x7f60bcaa3384 in g_variant_builder_init (/lib64/libglib-2.0.so.0+0x92384)
    #4 0x55e5bb3120d3 in filter_xattrs_cb src/libpriv/rpmostree-postprocess.cxx:1493
    #5 0x7f60bc89cb38  (/lib64/libostree-1.so.1+0x49b38)
    #6 0x7f60bc8a5e1a  (/lib64/libostree-1.so.1+0x52e1a)
    #7 0x7f60bc8a622b in ostree_repo_write_dfd_to_mtree (/lib64/libostree-1.so.1+0x5322b)
    #8 0x55e5bb307e6e in write_dfd_thread src/libpriv/rpmostree-postprocess.cxx:1551
    #9 0x7f60bca92401  (/lib64/libglib-2.0.so.0+0x81401)
    #10 0x7f60bc12d3f8 in start_thread (/lib64/libpthread.so.0+0x93f8)
    #11 0x7f60bc05ab52 in __GI___clone (/lib64/libc.so.6+0x101b52)

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>

Thank you for contributing to rpm-ostree.

If you are adding functionality to tree composes, please add
a corresponding test to the compose-test suite. Similarly,
if adding a client-facing feature, consider the vmcheck
suite. Regressions fixes are also great candidates for new
tests.

If you're not sure where or how to add tests, don't hesitate
to ask for help from the maintainers.

Cheers!
