### PR TITLE
Support xattr translation

### DIFF
--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -1225,7 +1225,8 @@ filter_xattrs_impl (OstreeRepo     *repo,
   /* If you have a use case for something else, file an issue */
   static const char *accepted_xattrs[] =
     { "security.capability", /* https://lwn.net/Articles/211883/ */
-      "user.pax.flags" /* https://github.com/projectatomic/rpm-ostree/issues/412 */
+      "user.pax.flags", /* https://github.com/projectatomic/rpm-ostree/issues/412 */
+      "user.ima" /* will be replaced with security.ima */
     };
   g_autoptr(GVariant) existing_xattrs = NULL;
   g_autoptr(GVariantIter) viter = NULL;
@@ -1266,7 +1267,13 @@ filter_xattrs_impl (OstreeRepo     *repo,
           const char *validkey = accepted_xattrs[i];
           const char *attrkey = g_variant_get_bytestring (key);
           if (g_str_equal (validkey, attrkey))
-            g_variant_builder_add (&builder, "(@ay@ay)", key, value);
+            {
+              if (g_str_equal (validkey, "user.ima"))
+                  g_variant_builder_add (&builder, "(@ay@ay)",
+                                         g_variant_new_bytestring ("security.ima"), value);
+              else
+                  g_variant_builder_add (&builder, "(@ay@ay)", key, value);
+            }
         }
     }
 


### PR DESCRIPTION
This adds support for a treefile "xattr-translation" dictionary, and
will then translate extended attributes when they are committed into the
ostree commit.

This can be used for example to translate "user.ima" (which is a common
attribute used by for example ima-evm-utils) to "security.ima", which
would require root permissions to write to during compose. Add the
following to a treefile to achieve this:

```
xattr-translation:
  user.ima: security.ima
```

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>