### PR TITLE
Patches to drain treespec -> treefile

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -258,6 +258,7 @@ pub mod ffi {
         fn get_documentation(&self) -> bool;
         fn get_recommends(&self) -> bool;
         fn get_selinux(&self) -> bool;
+        fn get_releasever(&self) -> &str;
         fn get_rpmdb(&self) -> String;
         fn get_files_remove_regex(&self, package: &str) -> Vec<String>;
         fn print_deprecation_warnings(&self);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -256,6 +256,8 @@ pub mod ffi {
         fn get_cliwrap(&self) -> bool;
         fn get_readonly_executables(&self) -> bool;
         fn get_documentation(&self) -> bool;
+        fn get_recommends(&self) -> bool;
+        fn get_selinux(&self) -> bool;
         fn get_rpmdb(&self) -> String;
         fn get_files_remove_regex(&self, package: &str) -> Vec<String>;
         fn print_deprecation_warnings(&self);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -255,6 +255,7 @@ pub mod ffi {
         fn get_rojig_name(&self) -> String;
         fn get_cliwrap(&self) -> bool;
         fn get_readonly_executables(&self) -> bool;
+        fn get_documentation(&self) -> bool;
         fn get_rpmdb(&self) -> String;
         fn get_files_remove_regex(&self, package: &str) -> Vec<String>;
         fn print_deprecation_warnings(&self);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -251,6 +251,7 @@ pub mod ffi {
         fn get_ostree_override_layers(&self) -> Vec<String>;
         fn get_all_ostree_layers(&self) -> Vec<String>;
         fn get_repos(&self) -> Vec<String>;
+        fn get_ref(&self) -> &str;
         fn get_rojig_spec_path(&self) -> String;
         fn get_rojig_name(&self) -> String;
         fn get_cliwrap(&self) -> bool;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -541,6 +541,10 @@ impl Treefile {
         self.parsed.repos.clone().unwrap_or_default()
     }
 
+    pub(crate) fn get_ref(&self) -> &str {
+        self.parsed.treeref.as_deref().unwrap_or_default()
+    }
+
     pub(crate) fn get_rojig_spec_path(&self) -> String {
         self.rojig_spec.clone().unwrap_or_default()
     }

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -561,6 +561,14 @@ impl Treefile {
         self.parsed.documentation.unwrap_or(true)
     }
 
+    pub(crate) fn get_recommends(&self) -> bool {
+        self.parsed.recommends.unwrap_or(true)
+    }
+
+    pub(crate) fn get_selinux(&self) -> bool {
+        self.parsed.selinux.unwrap_or(true)
+    }
+
     pub(crate) fn get_rpmdb(&self) -> String {
         let s: &str = match self.parsed.rpmdb.as_ref().unwrap_or(&DEFAULT_RPMDB_BACKEND) {
             RpmdbBackend::BDB => "bdb",

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -569,6 +569,10 @@ impl Treefile {
         self.parsed.selinux.unwrap_or(true)
     }
 
+    pub(crate) fn get_releasever(&self) -> &str {
+        self.parsed.releasever.as_deref().unwrap_or_default()
+    }
+
     pub(crate) fn get_rpmdb(&self) -> String {
         let s: &str = match self.parsed.rpmdb.as_ref().unwrap_or(&DEFAULT_RPMDB_BACKEND) {
             RpmdbBackend::BDB => "bdb",

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -557,6 +557,10 @@ impl Treefile {
         self.parsed.readonly_executables.unwrap_or(false)
     }
 
+    pub(crate) fn get_documentation(&self) -> bool {
+        self.parsed.documentation.unwrap_or(true)
+    }
+
     pub(crate) fn get_rpmdb(&self) -> String {
         let s: &str = match self.parsed.rpmdb.as_ref().unwrap_or(&DEFAULT_RPMDB_BACKEND) {
             RpmdbBackend::BDB => "bdb",

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -710,6 +710,8 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
   if (!opt_unified_core)
     rpmostree_context_disable_selinux (self->corectx);
 
+  self->ref = g_strdup (rpmostree_context_get_ref (self->corectx));
+
   if (opt_lockfiles)
     {
       rpmostree_context_set_lockfile (self->corectx, opt_lockfiles, opt_lockfile_strict);
@@ -782,7 +784,6 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
                                                        error);
   if (!self->treespec)
     return FALSE;
-  self->ref = rpmostree_treespec_get_ref (self->treespec);
 
   *out_context = util::move_nullify (self);
   return TRUE;

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -704,6 +704,11 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
                                               cancellable, error);
   if (!self->corectx)
     return FALSE;
+  /* In the legacy compose path, we don't want to use any of the core's selinux stuff,
+   * e.g. importing, relabeling, etc... so just disable it. We do still set the policy
+   * to the final one right before commit as usual. */
+  if (!opt_unified_core)
+    rpmostree_context_disable_selinux (self->corectx);
 
   if (opt_lockfiles)
     {
@@ -774,7 +779,6 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
   self->treespec = rpmostree_composeutil_get_treespec (self->corectx,
                                                        **self->treefile_rs,
                                                        self->treefile,
-                                                       opt_unified_core,
                                                        error);
   if (!self->treespec)
     return FALSE;

--- a/src/app/rpmostree-composeutil.cxx
+++ b/src/app/rpmostree-composeutil.cxx
@@ -175,7 +175,6 @@ rpmostree_composeutil_get_treespec (RpmOstreeContext  *ctx,
                                     GError     **error)
 {
   GLNX_AUTO_PREFIX_ERROR ("Parsing treefile", error);
-  auto varsubsts = rpmostree_dnfcontext_get_varsubsts (rpmostree_context_get_dnf (ctx));
   g_autoptr(GKeyFile) treespec = g_key_file_new ();
 
   if (!treespec_bind_array (treedata, treespec, "packages", NULL, TRUE, error))
@@ -194,15 +193,6 @@ rpmostree_composeutil_get_treespec (RpmOstreeContext  *ctx,
 
   if (!treespec_bind_array (treedata, treespec, "install-langs", "instlangs", FALSE, error))
     return NULL;
-
-  const char *input_ref = NULL;
-  if (!_rpmostree_jsonutil_object_get_optional_string_member (treedata, "ref", &input_ref, error))
-    return NULL;
-  if (input_ref)
-    {
-      auto ref = rpmostreecxx::varsubstitute (input_ref, *varsubsts);
-      g_key_file_set_string (treespec, "tree", "ref", ref.c_str());
-    }
 
   return rpmostree_treespec_new_from_keyfile (treespec, error);
 }

--- a/src/app/rpmostree-composeutil.cxx
+++ b/src/app/rpmostree-composeutil.cxx
@@ -166,26 +166,6 @@ treespec_bind_array (JsonObject *treedata,
   return set_keyfile_string_array_from_json (ts, "tree", dest_name ?: src_name, a, error);
 }
 
-/* Given a boolean value in JSON, add it to treespec
- * if it's not the default.
- */
-static gboolean
-treespec_bind_bool (JsonObject *treedata,
-                    GKeyFile   *ts,
-                    const char *name,
-                    gboolean    default_value,
-                    GError    **error)
-{
-  gboolean v = default_value;
-  if (!_rpmostree_jsonutil_object_get_optional_boolean_member (treedata, name, &v, error))
-    return FALSE;
-
-  if (v != default_value)
-    g_key_file_set_boolean (ts, "tree", name, v);
-
-  return TRUE;
-}
-
 /* Convert a treefile into a "treespec" understood by the core.
  */
 RpmOstreeTreespec *

--- a/src/app/rpmostree-composeutil.cxx
+++ b/src/app/rpmostree-composeutil.cxx
@@ -213,8 +213,6 @@ rpmostree_composeutil_get_treespec (RpmOstreeContext  *ctx,
       !json_object_has_member (treedata, "lockfile-repos"))
     return (RpmOstreeTreespec*)glnx_null_throw (error, "Treefile has neither \"repos\" nor \"lockfile-repos\" members");
 
-  if (!treespec_bind_bool (treedata, treespec, "documentation", TRUE, error))
-    return NULL;
   if (!treespec_bind_bool (treedata, treespec, "recommends", TRUE, error))
     return NULL;
   if (!treespec_bind_array (treedata, treespec, "install-langs", "instlangs", FALSE, error))

--- a/src/app/rpmostree-composeutil.cxx
+++ b/src/app/rpmostree-composeutil.cxx
@@ -194,13 +194,6 @@ rpmostree_composeutil_get_treespec (RpmOstreeContext  *ctx,
 
   if (!treespec_bind_array (treedata, treespec, "install-langs", "instlangs", FALSE, error))
     return NULL;
-  { const char *releasever;
-    if (!_rpmostree_jsonutil_object_get_optional_string_member (treedata, "releasever",
-                                                                &releasever, error))
-      return NULL;
-    if (releasever)
-      g_key_file_set_string (treespec, "tree", "releasever", releasever);
-  }
 
   const char *input_ref = NULL;
   if (!_rpmostree_jsonutil_object_get_optional_string_member (treedata, "ref", &input_ref, error))

--- a/src/app/rpmostree-composeutil.cxx
+++ b/src/app/rpmostree-composeutil.cxx
@@ -199,9 +199,6 @@ rpmostree_composeutil_get_treespec (RpmOstreeContext  *ctx,
   auto varsubsts = rpmostree_dnfcontext_get_varsubsts (rpmostree_context_get_dnf (ctx));
   g_autoptr(GKeyFile) treespec = g_key_file_new ();
 
-  // TODO: Rework things so we always use this data going forward
-  rpmostree_context_set_treefile (ctx, &treefile_rs);
-
   if (!treespec_bind_array (treedata, treespec, "packages", NULL, TRUE, error))
     return NULL;
   if (!treespec_bind_array (treedata, treespec, "exclude-packages", NULL, FALSE, error))

--- a/src/app/rpmostree-composeutil.h
+++ b/src/app/rpmostree-composeutil.h
@@ -43,7 +43,6 @@ RpmOstreeTreespec *
 rpmostree_composeutil_get_treespec (RpmOstreeContext  *ctx,
                                     rpmostreecxx::Treefile &treefile_rs,
                                     JsonObject  *treedata,
-                                    gboolean     bind_selinux,
                                     GError     **error);
 gboolean
 rpmostree_composeutil_read_json_metadata (JsonNode    *root,

--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -39,6 +39,7 @@ struct _RpmOstreeContext {
   rpmostreecxx::Treefile *treefile_rs; /* For composes for now */
   gboolean empty;
   gboolean disable_selinux;
+  char *ref;
 
   /* rojig-mode data */
   const char *rojig_spec; /* The rojig spec like: repoid:package */

--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -38,6 +38,7 @@ struct _RpmOstreeContext {
   RpmOstreeTreespec *spec;
   rpmostreecxx::Treefile *treefile_rs; /* For composes for now */
   gboolean empty;
+  gboolean disable_selinux;
 
   /* rojig-mode data */
   const char *rojig_spec; /* The rojig spec like: repoid:package */

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -442,6 +442,7 @@ rpmostree_context_new_system (OstreeRepo   *repo,
 RpmOstreeContext *
 rpmostree_context_new_tree (int               userroot_dfd,
                             OstreeRepo       *repo,
+                            rpmostreecxx::Treefile &treefile_rs,
                             GCancellable     *cancellable,
                             GError          **error)
 {
@@ -449,6 +450,7 @@ rpmostree_context_new_tree (int               userroot_dfd,
   if (!ret)
     return NULL;
   ret->is_system = FALSE;
+  ret->treefile_rs = &treefile_rs;
 
   { g_autofree char *reposdir = glnx_fdrel_abspath (userroot_dfd, "rpmmd.repos.d");
     dnf_context_set_repo_dir (ret->dnfctx, reposdir);
@@ -520,17 +522,6 @@ rpmostree_context_configure_from_deployment (RpmOstreeContext *self,
   /* point the core to the passwd & group of the merge deployment */
   g_assert (!self->passwd_dir);
   self->passwd_dir = g_build_filename (cfg_deployment_root, "etc", NULL);
-}
-
-
-/* By default, we use a "treespec" however, reflecting everything from
- * treefile -> treespec is annoying.  Long term we want to unify those.  This
- * is a temporary escape hatch.
- */
-void
-rpmostree_context_set_treefile (RpmOstreeContext *self, rpmostreecxx::Treefile *treefile_rs)
-{
-  self->treefile_rs = treefile_rs;
 }
 
 /* Use this if no packages will be installed, and we just want a "dummy" run.

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -217,20 +217,6 @@ add_canonicalized_string_array (GVariantBuilder *builder,
                          g_variant_new_strv ((const char*const*)sorted, count));
 }
 
-/* Get a bool from @keyfile, adding it to @builder */
-static void
-tf_bind_boolean (GKeyFile *keyfile,
-                 GVariantBuilder *builder,
-                 const char *name,
-                 gboolean default_value)
-{
-  gboolean v = default_value;
-  if (g_key_file_has_key (keyfile, "tree", name, NULL))
-    v = g_key_file_get_boolean (keyfile, "tree", name, NULL);
-
-  g_variant_builder_add (builder, "{sv}", name, g_variant_new_boolean (v));
-}
-
 RpmOstreeTreespec *
 rpmostree_treespec_new_from_keyfile (GKeyFile   *keyfile,
                                      GError    **error)

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -128,6 +128,7 @@ rpmostree_context_configure_from_deployment (RpmOstreeContext *self,
                                              OstreeDeployment *cfg_deployment);
 
 void rpmostree_context_set_is_empty (RpmOstreeContext *self);
+void rpmostree_context_disable_selinux (RpmOstreeContext *self);
 
 void rpmostree_context_set_repos (RpmOstreeContext *self,
                                   OstreeRepo       *base_repo,

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -88,6 +88,7 @@ RpmOstreeContext *rpmostree_context_new_system (OstreeRepo   *repo,
 
 RpmOstreeContext *rpmostree_context_new_tree (int basedir_dfd,
                                               OstreeRepo  *repo,
+                                              rpmostreecxx::Treefile &treefile_rs,
                                               GCancellable *cancellable,
                                               GError **error);
 
@@ -125,8 +126,6 @@ void
 rpmostree_context_configure_from_deployment (RpmOstreeContext *self,
                                              OstreeSysroot    *sysroot,
                                              OstreeDeployment *cfg_deployment);
-
-void rpmostree_context_set_treefile (RpmOstreeContext *self, rpmostreecxx::Treefile *treefile_rs);
 
 void rpmostree_context_set_is_empty (RpmOstreeContext *self);
 

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -113,7 +113,6 @@ RpmOstreeTreespec *rpmostree_treespec_new (GVariant   *variant);
 GVariant *rpmostree_context_get_rpmmd_repo_commit_metadata (RpmOstreeContext  *self);
 
 GVariant *rpmostree_treespec_to_variant (RpmOstreeTreespec *spec);
-const char *rpmostree_treespec_get_ref (RpmOstreeTreespec *spec);
 
 gboolean rpmostree_context_setup (RpmOstreeContext     *self,
                                   const char    *install_root,
@@ -129,6 +128,7 @@ rpmostree_context_configure_from_deployment (RpmOstreeContext *self,
 
 void rpmostree_context_set_is_empty (RpmOstreeContext *self);
 void rpmostree_context_disable_selinux (RpmOstreeContext *self);
+const char *rpmostree_context_get_ref (RpmOstreeContext *self);
 
 void rpmostree_context_set_repos (RpmOstreeContext *self,
                                   OstreeRepo       *base_repo,


### PR DESCRIPTION
Related to https://github.com/coreos/rpm-ostree/issues/2665

By getting rid of the "treespec" we remove one of our intermediate formats in favor of the treefile.

Depends https://github.com/coreos/rpm-ostree/pull/2737