### PR TITLE
Add derivation fields to treefile, map origin → treefile

### DIFF
--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -97,7 +97,7 @@ macro_rules! cxxrs_bind {
 cxxrs_bind!(Ostree, ostree, ostree_sys, [Sysroot, Repo, Deployment]);
 cxxrs_bind!(G, glib, gobject_sys, [Object]);
 cxxrs_bind!(G, gio, gio_sys, [Cancellable, DBusConnection]);
-cxxrs_bind!(G, glib, glib_sys, [Variant, VariantDict]);
+cxxrs_bind!(G, glib, glib_sys, [KeyFile, Variant, VariantDict]);
 
 // An error type helper; separate from the GObject bridging
 mod err {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -40,6 +40,7 @@ pub mod ffi {
         type GDBusConnection = crate::FFIGDBusConnection;
         type GVariant = crate::FFIGVariant;
         type GVariantDict = crate::FFIGVariantDict;
+        type GKeyFile = crate::FFIGKeyFile;
 
         #[namespace = "dnfcxx"]
         type DnfPackage = libdnf_sys::DnfPackage;
@@ -270,6 +271,11 @@ pub mod ffi {
         type Treefile;
 
         fn treefile_new(filename: &str, basearch: &str, workdir: i32) -> Result<Box<Treefile>>;
+        fn treefile_new_compose(
+            filename: &str,
+            basearch: &str,
+            workdir: i32,
+        ) -> Result<Box<Treefile>>;
 
         fn get_workdir(&self) -> i32;
         fn get_passwd_fd(&mut self) -> i32;
@@ -425,6 +431,12 @@ pub mod ffi {
         fn get_locked_src_packages(&self) -> Result<Vec<LockedPackage>>;
     }
 
+    // origin.rs
+    extern "Rust" {
+        fn origin_to_treefile(kf: Pin<&mut GKeyFile>) -> Result<Box<Treefile>>;
+        fn origin_validate_roundtrip(mut kf: Pin<&mut GKeyFile>) -> Result<()>;
+    }
+
     // rpmutils.rs
     extern "Rust" {
         fn cache_branch_to_nevra(nevra: &str) -> String;
@@ -555,10 +567,8 @@ pub(crate) use self::lockfile::*;
 mod live;
 pub(crate) use self::live::*;
 mod nameservice;
-// An origin parser in Rust but only built when testing until
-// we're ready to try porting the C++ code.
-#[cfg(test)]
 mod origin;
+pub(crate) use self::origin::*;
 mod passwd;
 use passwd::*;
 mod console_progress;

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -224,7 +224,17 @@ fn kf_diff(kf: &glib::KeyFile, newkf: &glib::KeyFile) -> Result<()> {
 fn origin_validate_roundtrip_inner(kf: &glib::KeyFile) -> Result<()> {
     let tf = origin_to_treefile_inner(&kf)?;
     let newkf = treefile_to_origin_inner(&tf)?;
-    kf_diff(&kf, &newkf)
+    // Compare the two origin keyfiles.  This is the core check.
+    kf_diff(&kf, &newkf)?;
+    // And finally, triple-check things by round-tripping the origin
+    // back to a treefile and asserting it's identical.
+    // At the moment, we don't accept user-supplied treefiles as input
+    // to this code.  For now we fatally error if somehow they differed.
+    // But in the future this check should be part of validating treefile
+    // options that don't make sense on the client side.
+    let newtf = origin_to_treefile_inner(&newkf)?;
+    assert_eq!(tf.parsed, newtf.parsed);
+    Ok(())
 }
 
 /// Convert an origin keyfile to a treefile config.

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -894,7 +894,7 @@ fn split_whitespace_unless_quoted(element: &str) -> Result<impl Iterator<Item = 
     Ok(ret.into_iter())
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 pub(crate) enum BootLocation {
     #[serde(rename = "new")]
     New,
@@ -908,7 +908,7 @@ impl Default for BootLocation {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(tag = "type")]
 pub(crate) enum CheckGroups {
     #[serde(rename = "none")]
@@ -921,17 +921,17 @@ pub(crate) enum CheckGroups {
     Data(CheckGroupsData),
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub(crate) struct CheckFile {
     filename: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub(crate) struct CheckGroupsData {
     pub(crate) entries: BTreeMap<String, u32>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(tag = "type")]
 pub(crate) enum CheckPasswd {
     #[serde(rename = "none")]
@@ -944,12 +944,12 @@ pub(crate) enum CheckPasswd {
     Data(CheckPasswdData),
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub(crate) struct CheckPasswdData {
     pub(crate) entries: BTreeMap<String, CheckPasswdDataEntries>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(untagged)]
 pub(crate) enum CheckPasswdDataEntries {
     IdValue(u32),
@@ -987,7 +987,7 @@ impl From<(u32, u32)> for CheckPasswdDataEntries {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub(crate) struct Rojig {
     pub(crate) name: String,
     pub(crate) summary: String,
@@ -995,7 +995,7 @@ pub(crate) struct Rojig {
     pub(crate) description: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(untagged)]
 pub(crate) enum Include {
     Single(String),
@@ -1015,7 +1015,7 @@ pub(crate) enum RpmdbBackend {
 // Because of how we handle includes, *everything* here has to be
 // Option<T>.  The defaults live in the code (e.g. machineid-compat defaults
 // to `true`).
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
 pub(crate) struct TreeComposeConfig {
     // Compose controls
     #[serde(rename = "ref")]
@@ -1169,13 +1169,13 @@ pub(crate) struct TreeComposeConfig {
     pub(crate) extra: HashMap<String, serde_json::Value>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
 pub(crate) struct RepoPackage {
     pub(crate) repo: String,
     pub(crate) packages: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
 pub(crate) struct LegacyTreeComposeConfigFields {
     #[serde(skip_serializing)]
     pub(crate) gpg_key: Option<String>,
@@ -1187,7 +1187,7 @@ pub(crate) struct LegacyTreeComposeConfigFields {
     pub(crate) automatic_version_prefix: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct DeriveCustom {
     pub(crate) url: String,
@@ -1195,7 +1195,7 @@ pub(crate) struct DeriveCustom {
     pub(crate) description: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct DeriveInitramfs {
     pub(crate) regenerate: bool,
@@ -1208,7 +1208,7 @@ pub(crate) struct DeriveInitramfs {
 /// These fields are only useful when deriving from a prior ostree commit;
 /// at the moment we only use them when translating an origin file
 /// to a treefile for client side assembly.
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct DeriveConfigFields {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -696,7 +696,7 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
       arch = dnf_context_get_base_arch (ctx);
   }
   self->treefile_path = g_file_new_for_path (treefile_pathstr);
-  self->treefile_rs = rpmostreecxx::treefile_new(gs_file_get_path_cached (self->treefile_path), arch, self->workdir_dfd);
+  self->treefile_rs = rpmostreecxx::treefile_new_compose(gs_file_get_path_cached (self->treefile_path), arch, self->workdir_dfd);
   self->corectx = rpmostree_context_new_compose (self->cachedir_dfd, self->build_repo,
                                                  **self->treefile_rs);
   /* In the legacy compose path, we don't want to use any of the core's selinux stuff,
@@ -1289,7 +1289,7 @@ rpmostree_compose_builtin_postprocess (int             argc,
     {
       if (!glnx_mkdtempat (AT_FDCWD, "/var/tmp/rpm-ostree.XXXXXX", 0700, &workdir_tmp, error))
         return FALSE;
-      auto treefile_rs = rpmostreecxx::treefile_new(treefile_path, "", workdir_tmp.fd);
+      auto treefile_rs = rpmostreecxx::treefile_new_compose(treefile_path, "", workdir_tmp.fd);
       auto serialized = treefile_rs->get_json_string();
       treefile_parser = json_parser_new ();
       if (!json_parser_load_from_data (treefile_parser, serialized.c_str(), -1, error))
@@ -1461,7 +1461,7 @@ rpmostree_compose_builtin_extensions (int             argc,
   const char *extensions_path = argv[2];
 
   g_autofree char *basearch = rpm_ostree_get_basearch ();
-  auto treefile = rpmostreecxx::treefile_new (treefile_path, basearch, -1);
+  auto treefile = rpmostreecxx::treefile_new_compose(treefile_path, basearch, -1);
 
   /* We don't want the core to handle repo packages from the treefile. Normally,
    * if repo packages worked like other knobs and went via the treespec, this

--- a/src/libpriv/rpmostree-cxxrs-prelude.h
+++ b/src/libpriv/rpmostree-cxxrs-prelude.h
@@ -33,6 +33,7 @@ namespace rpmostreecxx {
     typedef ::GDBusConnection GDBusConnection;
     typedef ::GVariant GVariant;
     typedef ::GVariantDict GVariantDict;
+    typedef ::GKeyFile GKeyFile;
 }
 
 // XXX: really should just include! libdnf.hxx in the bridge

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -722,7 +722,6 @@ rpmostree_origin_remove_packages (RpmOstreeOrigin  *origin,
     update_keyfile_pkgs_from_cache (origin, "packages", "requested-local",
                                     origin->cached_local_packages, TRUE);
 
-  sync_baserefspec (origin);
   *out_changed = changed || local_changed;
   return TRUE;
 }

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -21,6 +21,7 @@
 #include "config.h"
 
 #include "string.h"
+#include <systemd/sd-journal.h>
 
 #include "libglnx.h"
 #include "rpmostree-origin.h"
@@ -155,6 +156,14 @@ rpmostree_origin_parse_keyfile (GKeyFile         *origin,
 
   ret->cached_initramfs_args =
     g_key_file_get_string_list (ret->kf, "rpmostree", "initramfs-args", NULL, NULL);
+
+  try {
+    rpmostreecxx::origin_validate_roundtrip(*ret->kf);
+  } catch (std::exception& e) {
+    // We don't make this fatal right now until we're confident we're handling
+    // absolutely everything.
+    sd_journal_print (LOG_WARNING, "%s", e.what());
+  }
 
   return util::move_nullify (ret);
 }

--- a/tests/compose/test-basic-unified.sh
+++ b/tests/compose/test-basic-unified.sh
@@ -37,6 +37,17 @@ jq -r .ref < treefile.json > ref.txt
 # Test substitution of ${basearch}
 assert_file_has_content_literal ref.txt "${treeref}"
 
+treefile_pyedit "tf['from'] = 'somebaseref'"
+rpm-ostree compose tree --print-only "${treefile}" > treefile.json
+if runcompose --dry-run &>err.txt; then
+  fatal "ran a compose with derivation"
+fi
+assert_file_has_content_literal err.txt 'Cannot currently use derivation field'
+rm -f err.txt
+treefile_pyedit "del tf['from']"
+echo "ok cannot use derivation for composes yet"
+
+
 treefile_pyedit "tf['add-commit-metadata']['foobar'] = 'bazboo'"
 treefile_pyedit "tf['add-commit-metadata']['overrideme'] = 'old var'"
 


### PR DESCRIPTION


The goal here is to move away from "origin" files and
centralize on "treefile" YAML as our standard declarative
representation.

To do this, add the key "derivation" fields to the treefile,
but error out if they're actually used on the compose side for now.

Eventually of course...there's nothing stopping us from supporting
`from:` on the compose side too.  But one step at a time.

---

