### PR TITLE
countme: Force disable Count Me logic in DNF

### DIFF
--- a/docs/countme.md
+++ b/docs/countme.md
@@ -32,19 +32,4 @@ mask the corresponding unit as a precaution:
 $ systemctl mask --now rpm-ostree-countme.timer
 ```
 
-If you have packages layered on top of the base image from an RPM repository,
-then you will have to make sure that the `countme` option is disabled there
-until we fix [this issue in libdnf][libdnfissue]:
-
-```
-$ sed -i 's/countme=1/countme=0/g' /etc/yum.repos.d/*.repo
-```
-
-Note that once you do that, those repository configuration files will be
-considered as locally modified by ostree which will hence ignore any other
-changes to the defaults that may happen via a future update. You can always
-restore the original configuration or propagate updates from the default
-configuration available in `/usr/etc/yum.repos.d/*.repo`.
-
 [countme]: https://fedoraproject.org/wiki/Changes/DNF_Better_Counting
-[libdnfissue]: https://github.com/rpm-software-management/libdnf/issues/1174

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -424,6 +424,9 @@ rpmostree_context_new_system (OstreeRepo   *repo,
   /* we don't need any plugins */
   dnf_context_set_plugins_dir (self->dnfctx, NULL);
 
+  /* Force disable internal libdnf Count Me logic */
+  dnf_conf_add_setopt("*.countme", DNF_CONF_COMMANDLINE, "false", NULL);
+
   /* Hack until libdnf+librepo know how to better negotaiate zchunk.
    * see also the bits in configure.ac that define HAVE_ZCHUNK
    **/


### PR DESCRIPTION
Make sure that we do not use the internal Count Me logic in DNF in
rpm-ostree as we have our own external implementation that is aware of
the different behavior regarding repo handling.

See also the discussions in:
  - https://github.com/rpm-software-management/libdnf/issues/1174
  - https://github.com/rpm-software-management/libdnf/issues/1068
  - https://github.com/coreos/rpm-ostree/pull/2671