### PR TITLE
core: Two minor API cleanups

### DIFF
--- a/src/app/rpmostree-compose-builtin-rojig.cxx
+++ b/src/app/rpmostree-compose-builtin-rojig.cxx
@@ -278,7 +278,7 @@ rpm_ostree_rojig_compose_new (const char    *treefile_path,
         return FALSE;
     }
 
-  self->corectx = rpmostree_context_new_tree (self->cachedir_dfd, self->repo, cancellable, error);
+  self->corectx = rpmostree_context_new_compose (self->cachedir_dfd, self->repo, cancellable, error);
   if (!self->corectx)
     return FALSE;
 
@@ -333,7 +333,7 @@ impl_rojig_build (RpmOstreeRojigCompose *self,
   g_autoptr(RpmOstreeTreespec) treespec = rpmostree_treespec_new_from_keyfile (tsk, error);
   if (!treespec)
     return FALSE;
-  g_autoptr(RpmOstreeContext) corectx = rpmostree_context_new_tree (self->cachedir_dfd, self->repo, cancellable, error);
+  g_autoptr(RpmOstreeContext) corectx = rpmostree_context_new_compose (self->cachedir_dfd, self->repo, cancellable, error);
   if (!corectx)
     return FALSE;
   DnfContext *dnfctx = rpmostree_context_get_dnf (corectx);

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -699,9 +699,9 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
   }
   self->treefile_path = g_file_new_for_path (treefile_pathstr);
   self->treefile_rs = rpmostreecxx::treefile_new(gs_file_get_path_cached (self->treefile_path), arch, self->workdir_dfd);
-  self->corectx = rpmostree_context_new_tree (self->cachedir_dfd, self->build_repo,
-                                              **self->treefile_rs,
-                                              cancellable, error);
+  self->corectx = rpmostree_context_new_compose (self->cachedir_dfd, self->build_repo,
+                                                 **self->treefile_rs,
+                                                 cancellable, error);
   if (!self->corectx)
     return FALSE;
   /* In the legacy compose path, we don't want to use any of the core's selinux stuff,
@@ -1530,9 +1530,8 @@ rpmostree_compose_builtin_extensions (int             argc,
   // want RPMs, so having them already imported isn't useful to us (and anyway,
   // for OS extensions by definition they're not expected to be cached since
   // they're not in the base tree)
-
   g_autoptr(RpmOstreeContext) ctx =
-      rpmostree_context_new_tree (cachedir_dfd, repo, *treefile, cancellable, error);
+      rpmostree_context_new_compose (cachedir_dfd, repo, *treefile, cancellable, error);
   if (!ctx)
       return FALSE;
 

--- a/src/app/rpmostree-ex-builtin-rojig2commit.cxx
+++ b/src/app/rpmostree-ex-builtin-rojig2commit.cxx
@@ -87,7 +87,7 @@ rpm_ostree_rojig2commit_context_new (RpmOstreeRojig2CommitContext **out_context,
                        "tmp/rpmostree-rojig-XXXXXX", 0700, &self->tmpd, error))
     return FALSE;
 
-  self->ctx = rpmostree_context_new_tree (self->tmpd.fd, self->repo, cancellable, error);
+  self->ctx = rpmostree_context_new_compose (self->tmpd.fd, self->repo, cancellable, error);
   if (!self->ctx)
     return FALSE;
 

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -503,7 +503,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
          * rojig == ostree pull.
          */
         g_autoptr(RpmOstreeContext) ctx =
-          rpmostree_context_new_system (self->repo, cancellable, error);
+          rpmostree_context_new_client (self->repo, cancellable, error);
         if (!ctx)
           return FALSE;
 
@@ -971,7 +971,7 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self,
   if (!checkout_base_tree (self, cancellable, error))
     return FALSE;
 
-  self->ctx = rpmostree_context_new_system (self->repo, cancellable, error);
+  self->ctx = rpmostree_context_new_client (self->repo, cancellable, error);
   if (!self->ctx)
     return FALSE;
 

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -757,7 +757,7 @@ get_sack_for_booted (OstreeSysroot    *sysroot,
   GLNX_AUTO_PREFIX_ERROR ("Loading sack", error);
 
   g_autoptr(RpmOstreeContext) ctx =
-    rpmostree_context_new_system (repo, cancellable, error);
+    rpmostree_context_new_client (repo, cancellable, error);
 
   g_autofree char *source_root =
     rpmostree_get_deployment_root (sysroot, booted_deployment);
@@ -2316,7 +2316,7 @@ refresh_md_transaction_execute (RpmostreedTransaction *transaction,
     rpmostree_get_deployment_root (sysroot, origin_merge_deployment);
 
   OstreeRepo *repo = ostree_sysroot_repo (sysroot);
-  g_autoptr(RpmOstreeContext) ctx = rpmostree_context_new_system (repo, cancellable, error);
+  g_autoptr(RpmOstreeContext) ctx = rpmostree_context_new_client (repo, cancellable, error);
 
   /* We could bypass rpmostree_context_setup() here and call dnf_context_setup() ourselves
    * since we're not actually going to perform any installation. Though it does provide us
@@ -2442,7 +2442,7 @@ modify_yum_repo_transaction_execute (RpmostreedTransaction *transaction,
     ostree_sysroot_get_merge_deployment (sysroot, self->osname);
 
   OstreeRepo *ot_repo = ostree_sysroot_repo (sysroot);
-  g_autoptr(RpmOstreeContext) ctx = rpmostree_context_new_system (ot_repo, cancellable, error);
+  g_autoptr(RpmOstreeContext) ctx = rpmostree_context_new_client (ot_repo, cancellable, error);
 
   /* We could bypass rpmostree_context_setup() here and call dnf_context_setup() ourselves
    * since we're not actually going to perform any installation. Though it does provide us

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -358,8 +358,11 @@ set_rpm_macro_define (const char *key, const char *value)
   free (rpmExpand (buf, NULL));
 }
 
+/* Create a context intended for use "client side", e.g. for package layering
+ * operations.
+ */
 RpmOstreeContext *
-rpmostree_context_new_system (OstreeRepo   *repo,
+rpmostree_context_new_client (OstreeRepo   *repo,
                               GCancellable *cancellable,
                               GError      **error)
 {
@@ -415,7 +418,8 @@ rpmostree_context_new_tree (int               userroot_dfd,
                             GCancellable     *cancellable,
                             GError          **error)
 {
-  g_autoptr(RpmOstreeContext) ret = rpmostree_context_new_system (repo, cancellable, error);
+  /* Inherit the client baseline, but flip it back to be a "compose" context */
+  g_autoptr(RpmOstreeContext) ret = rpmostree_context_new_client (repo, cancellable, error);
   if (!ret)
     return NULL;
   ret->is_system = FALSE;

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -412,11 +412,11 @@ rpmostree_context_new_client (OstreeRepo   *repo,
  * is assumed to be for unprivileged containers/buildroots.
  */
 RpmOstreeContext *
-rpmostree_context_new_tree (int               userroot_dfd,
-                            OstreeRepo       *repo,
-                            rpmostreecxx::Treefile &treefile_rs,
-                            GCancellable     *cancellable,
-                            GError          **error)
+rpmostree_context_new_compose (int               userroot_dfd,
+                               OstreeRepo       *repo,
+                               rpmostreecxx::Treefile &treefile_rs,
+                               GCancellable     *cancellable,
+                               GError          **error)
 {
   /* Inherit the client baseline, but flip it back to be a "compose" context */
   g_autoptr(RpmOstreeContext) ret = rpmostree_context_new_client (repo, cancellable, error);

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -86,11 +86,11 @@ RpmOstreeContext *rpmostree_context_new_client (OstreeRepo   *repo,
                                                 GCancellable *cancellable,
                                                 GError      **error);
 
-RpmOstreeContext *rpmostree_context_new_tree (int basedir_dfd,
-                                              OstreeRepo  *repo,
-                                              rpmostreecxx::Treefile &treefile_rs,
-                                              GCancellable *cancellable,
-                                              GError **error);
+RpmOstreeContext *rpmostree_context_new_compose (int basedir_dfd,
+                                                 OstreeRepo  *repo,
+                                                 rpmostreecxx::Treefile &treefile_rs,
+                                                 GCancellable *cancellable,
+                                                 GError **error);
 
 void rpmostree_context_set_pkgcache_only (RpmOstreeContext *self,
                                           gboolean          pkgcache_only);

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -82,7 +82,7 @@ char* rpmostree_refspec_to_string (RpmOstreeRefspecType  reftype,
 char* rpmostree_refspec_canonicalize (const char           *orig_refspec,
                                       GError              **error);
 
-RpmOstreeContext *rpmostree_context_new_system (OstreeRepo   *repo,
+RpmOstreeContext *rpmostree_context_new_client (OstreeRepo   *repo,
                                                 GCancellable *cancellable,
                                                 GError      **error);
 


### PR DESCRIPTION
core: Rename context_new_system() to context_new_client()

Makes the intention clearer.

---

core: Rename context_new_tree() to context_new_compose()

Makes the intention clearer.

---

