### PR TITLE
core: Split off a method to set the treespec

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -255,6 +255,11 @@ pub mod ffi {
         fn get_ostree_override_layers(&self) -> Vec<String>;
         fn get_all_ostree_layers(&self) -> Vec<String>;
         fn get_repos(&self) -> Vec<String>;
+        fn get_packages(&self) -> Vec<String>;
+        fn get_exclude_packages(&self) -> Vec<String>;
+        fn get_install_langs(&self) -> Vec<String>;
+        fn format_install_langs_macro(&self) -> String;
+        fn get_lockfile_repos(&self) -> Vec<String>;
         fn get_ref(&self) -> &str;
         fn get_rojig_spec_path(&self) -> String;
         fn get_rojig_name(&self) -> String;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -537,8 +537,34 @@ impl Treefile {
             .collect()
     }
 
+    pub(crate) fn get_packages(&self) -> Vec<String> {
+        self.parsed.packages.clone().unwrap_or_default()
+    }
+
+    pub(crate) fn get_exclude_packages(&self) -> Vec<String> {
+        self.parsed.exclude_packages.clone().unwrap_or_default()
+    }
+
+    pub(crate) fn get_install_langs(&self) -> Vec<String> {
+        self.parsed.install_langs.clone().unwrap_or_default()
+    }
+
+    /// If install_langs is set, generate a value suitable for the RPM macro `_install_langs`;
+    /// otherwise return the empty string.
+    pub(crate) fn format_install_langs_macro(&self) -> String {
+        if let Some(langs) = self.parsed.install_langs.as_ref() {
+            langs.join(":")
+        } else {
+            "".to_string()
+        }
+    }
+
     pub(crate) fn get_repos(&self) -> Vec<String> {
         self.parsed.repos.clone().unwrap_or_default()
+    }
+
+    pub(crate) fn get_lockfile_repos(&self) -> Vec<String> {
+        self.parsed.lockfile_repos.clone().unwrap_or_default()
     }
 
     pub(crate) fn get_ref(&self) -> &str {

--- a/src/app/rpmostree-compose-builtin-rojig.cxx
+++ b/src/app/rpmostree-compose-builtin-rojig.cxx
@@ -139,8 +139,10 @@ install_packages (RpmOstreeRojigCompose  *self,
   else
     dnf_context_set_cache_age (dnfctx, G_MAXUINT);
 
+  rpmostree_context_set_treespec (self->corectx, self->treespec);
+
   { g_autofree char *tmprootfs_abspath = glnx_fdrel_abspath (self->rootfs_dfd, ".");
-    if (!rpmostree_context_setup (self->corectx, tmprootfs_abspath, NULL, self->treespec,
+    if (!rpmostree_context_setup (self->corectx, tmprootfs_abspath, NULL,
                                   cancellable, error))
       return FALSE;
   }
@@ -349,7 +351,8 @@ impl_rojig_build (RpmOstreeRojigCompose *self,
 
   g_autofree char *reposdir_abspath = glnx_fdrel_abspath (self->workdir_dfd, "rojig-repos");
   dnf_context_set_repo_dir (dnfctx, reposdir_abspath);
-  if (!rpmostree_context_setup (corectx, NULL, NULL, treespec, cancellable, error))
+  rpmostree_context_set_treespec (corectx, treespec);
+  if (!rpmostree_context_setup (corectx, NULL, NULL, cancellable, error))
     return FALSE;
   if (!rpmostree_context_prepare_rojig (corectx, TRUE, cancellable, error))
     return FALSE;

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -310,8 +310,9 @@ install_packages (RpmOstreeTreeComposeContext  *self,
                                      opt_cache_only ? RPMOSTREE_CONTEXT_DNF_CACHE_FOREVER :
                                      RPMOSTREE_CONTEXT_DNF_CACHE_NEVER);
 
+  rpmostree_context_set_treespec (self->corectx, self->treespec);
   { g_autofree char *tmprootfs_abspath = glnx_fdrel_abspath (rootfs_dfd, ".");
-    if (!rpmostree_context_setup (self->corectx, tmprootfs_abspath, NULL, self->treespec,
+    if (!rpmostree_context_setup (self->corectx, tmprootfs_abspath, NULL,
                                   cancellable, error))
       return FALSE;
   }
@@ -1567,7 +1568,8 @@ rpmostree_compose_builtin_extensions (int             argc,
   }
 
   g_autofree char *checkout_path = glnx_fdrel_abspath (cachedir_dfd, TMP_EXTENSIONS_ROOTFS);
-  if (!rpmostree_context_setup (ctx, checkout_path, checkout_path, spec, cancellable, error))
+  rpmostree_context_set_treespec (ctx, spec);
+  if (!rpmostree_context_setup (ctx, checkout_path, checkout_path, cancellable, error))
     return FALSE;
 
 #undef TMP_EXTENSIONS_ROOTFS

--- a/src/app/rpmostree-ex-builtin-rojig2commit.cxx
+++ b/src/app/rpmostree-ex-builtin-rojig2commit.cxx
@@ -120,7 +120,8 @@ impl_rojig2commit (RpmOstreeRojig2CommitContext *self,
     return FALSE;
 
   /* We're also "pure" rojig - this adds assertions that we don't depsolve for example */
-  if (!rpmostree_context_setup (self->ctx, NULL, NULL, treespec, cancellable, error))
+  rpmostree_context_set_treespec (self->ctx, treespec);
+  if (!rpmostree_context_setup (self->ctx, NULL, NULL, cancellable, error))
     return FALSE;
   if (!rpmostree_context_prepare_rojig (self->ctx, FALSE, cancellable, error))
     return FALSE;

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -510,7 +510,8 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
          * really need a way for users to configure a different releasever when
          * e.g. rebasing across majors.
          */
-        if (!rpmostree_context_setup (ctx, NULL, "/", treespec, cancellable, error))
+        rpmostree_context_set_treespec (ctx, treespec);
+        if (!rpmostree_context_setup (ctx, NULL, "/", cancellable, error))
           return FALSE;
         /* We're also "pure" rojig - this adds assertions that we don't depsolve for example */
         if (!rpmostree_context_prepare_rojig (ctx, FALSE, cancellable, error))
@@ -985,7 +986,8 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self,
   if (treespec == NULL)
     return FALSE;
 
-  if (!rpmostree_context_setup (self->ctx, tmprootfs_abspath, tmprootfs_abspath, treespec,
+  rpmostree_context_set_treespec (self->ctx, treespec);
+  if (!rpmostree_context_setup (self->ctx, tmprootfs_abspath, tmprootfs_abspath,
                                 cancellable, error))
     return FALSE;
 

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -760,7 +760,7 @@ get_sack_for_booted (OstreeSysroot    *sysroot,
 
   g_autofree char *source_root =
     rpmostree_get_deployment_root (sysroot, booted_deployment);
-  if (!rpmostree_context_setup (ctx, NULL, source_root, NULL, cancellable, error))
+  if (!rpmostree_context_setup (ctx, NULL, source_root, cancellable, error))
     return FALSE;
 
   DnfContext *dnfctx = rpmostree_context_get_dnf (ctx);
@@ -2320,7 +2320,7 @@ refresh_md_transaction_execute (RpmostreedTransaction *transaction,
   /* We could bypass rpmostree_context_setup() here and call dnf_context_setup() ourselves
    * since we're not actually going to perform any installation. Though it does provide us
    * with the right semantics for install/source_root. */
-  if (!rpmostree_context_setup (ctx, NULL, origin_deployment_root, NULL, cancellable, error))
+  if (!rpmostree_context_setup (ctx, NULL, origin_deployment_root, cancellable, error))
     return FALSE;
 
   if (force)
@@ -2446,7 +2446,7 @@ modify_yum_repo_transaction_execute (RpmostreedTransaction *transaction,
   /* We could bypass rpmostree_context_setup() here and call dnf_context_setup() ourselves
    * since we're not actually going to perform any installation. Though it does provide us
    * with the right semantics for install/source_root. */
-  if (!rpmostree_context_setup (ctx, NULL, NULL, NULL, cancellable, error))
+  if (!rpmostree_context_setup (ctx, NULL, NULL, cancellable, error))
     return FALSE;
 
   /* point libdnf to our repos dir */

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -110,10 +110,11 @@ GVariant *rpmostree_context_get_rpmmd_repo_commit_metadata (RpmOstreeContext  *s
 
 GVariant *rpmostree_treespec_to_variant (RpmOstreeTreespec *spec);
 
+void rpmostree_context_set_treespec (RpmOstreeContext *self, RpmOstreeTreespec *treespec);
+
 gboolean rpmostree_context_setup (RpmOstreeContext     *self,
                                   const char    *install_root,
                                   const char    *source_root,
-                                  RpmOstreeTreespec *treespec,
                                   GCancellable  *cancellable,
                                   GError       **error);
 


### PR DESCRIPTION
Since in the future we'll operate on a treefile, move the callers
still using treespecs to an explicit API.  This is also clearer
because about half the callers were passing `NULL` for this anyways.
