### PR TITLE
daemon: Always write `staged` JSON field

### DIFF
--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -61,8 +61,8 @@ pub(crate) fn deployment_populate_variant(
     }
 
     /* Staging status */
+    dict.insert("staged", &deployment.is_staged());
     if deployment.is_staged() {
-        dict.insert("staged", &true);
         if std::path::Path::new("/run/ostree/staged-deployment-locked").exists() {
             dict.insert("finalization-locked", &true);
         }

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -16,7 +16,8 @@ assert_jq status.json \
   '.deployments[0]["requested-base-removals"]' \
   '.deployments[0]["live-inprogress"]|not' \
   '.deployments[0]["live-replaced"]|not' \
-  '.deployments[0]["layered-commit-meta"]|not'
+  '.deployments[0]["layered-commit-meta"]|not' \
+  '.deployments[0]["staged"]|not'
 rm status.json
 rpm-ostree testutils validate-parse-status
 echo "ok empty pkg arrays, and commit meta correct in status json"


### PR DESCRIPTION
It's an important property, and it's more self-documenting if we
always emit the value rather than only when it's `true`.
