### PR TITLE
core: Remove cancellable/error from context creation APIs

### DIFF
--- a/src/app/rpmostree-compose-builtin-rojig.cxx
+++ b/src/app/rpmostree-compose-builtin-rojig.cxx
@@ -278,9 +278,7 @@ rpm_ostree_rojig_compose_new (const char    *treefile_path,
         return FALSE;
     }
 
-  self->corectx = rpmostree_context_new_compose (self->cachedir_dfd, self->repo, cancellable, error);
-  if (!self->corectx)
-    return FALSE;
+  self->corectx = rpmostree_context_new_compose (self->cachedir_dfd, self->repo);
 
   const char *arch = dnf_context_get_base_arch (rpmostree_context_get_dnf (self->corectx));
   self->treefile_rs = rpmostreecxx::treefile_new (treefile_path, arch, self->workdir_dfd);
@@ -333,9 +331,7 @@ impl_rojig_build (RpmOstreeRojigCompose *self,
   g_autoptr(RpmOstreeTreespec) treespec = rpmostree_treespec_new_from_keyfile (tsk, error);
   if (!treespec)
     return FALSE;
-  g_autoptr(RpmOstreeContext) corectx = rpmostree_context_new_compose (self->cachedir_dfd, self->repo, cancellable, error);
-  if (!corectx)
-    return FALSE;
+  g_autoptr(RpmOstreeContext) corectx = rpmostree_context_new_compose (self->cachedir_dfd, self->repo);
   DnfContext *dnfctx = rpmostree_context_get_dnf (corectx);
   if (!glnx_shutil_mkdir_p_at (self->workdir_dfd, "rojig-repos", 0755, cancellable, error))
     return FALSE;

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -700,10 +700,7 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
   self->treefile_path = g_file_new_for_path (treefile_pathstr);
   self->treefile_rs = rpmostreecxx::treefile_new(gs_file_get_path_cached (self->treefile_path), arch, self->workdir_dfd);
   self->corectx = rpmostree_context_new_compose (self->cachedir_dfd, self->build_repo,
-                                                 **self->treefile_rs,
-                                                 cancellable, error);
-  if (!self->corectx)
-    return FALSE;
+                                                 **self->treefile_rs);
   /* In the legacy compose path, we don't want to use any of the core's selinux stuff,
    * e.g. importing, relabeling, etc... so just disable it. We do still set the policy
    * to the final one right before commit as usual. */
@@ -1530,10 +1527,7 @@ rpmostree_compose_builtin_extensions (int             argc,
   // want RPMs, so having them already imported isn't useful to us (and anyway,
   // for OS extensions by definition they're not expected to be cached since
   // they're not in the base tree)
-  g_autoptr(RpmOstreeContext) ctx =
-      rpmostree_context_new_compose (cachedir_dfd, repo, *treefile, cancellable, error);
-  if (!ctx)
-      return FALSE;
+  g_autoptr(RpmOstreeContext) ctx = rpmostree_context_new_compose (cachedir_dfd, repo, *treefile);
 
   { int tf_dfd = treefile->get_workdir();
     g_autofree char *abs_tf_path = glnx_fdrel_abspath (tf_dfd, ".");

--- a/src/app/rpmostree-ex-builtin-rojig2commit.cxx
+++ b/src/app/rpmostree-ex-builtin-rojig2commit.cxx
@@ -87,9 +87,7 @@ rpm_ostree_rojig2commit_context_new (RpmOstreeRojig2CommitContext **out_context,
                        "tmp/rpmostree-rojig-XXXXXX", 0700, &self->tmpd, error))
     return FALSE;
 
-  self->ctx = rpmostree_context_new_compose (self->tmpd.fd, self->repo, cancellable, error);
-  if (!self->ctx)
-    return FALSE;
+  self->ctx = rpmostree_context_new_compose (self->tmpd.fd, self->repo);
 
   DnfContext *dnfctx = rpmostree_context_get_dnf (self->ctx);
 

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -503,9 +503,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
          * rojig == ostree pull.
          */
         g_autoptr(RpmOstreeContext) ctx =
-          rpmostree_context_new_client (self->repo, cancellable, error);
-        if (!ctx)
-          return FALSE;
+          rpmostree_context_new_client (self->repo);
 
         /* We use / as a source root mostly so we get $releasever from it so
          * things work out of the box. That said this is kind of wrong and we'll
@@ -971,9 +969,7 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self,
   if (!checkout_base_tree (self, cancellable, error))
     return FALSE;
 
-  self->ctx = rpmostree_context_new_client (self->repo, cancellable, error);
-  if (!self->ctx)
-    return FALSE;
+  self->ctx = rpmostree_context_new_client (self->repo);
 
   g_autofree char *tmprootfs_abspath = glnx_fdrel_abspath (self->tmprootfs_dfd, ".");
 

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -756,8 +756,7 @@ get_sack_for_booted (OstreeSysroot    *sysroot,
 {
   GLNX_AUTO_PREFIX_ERROR ("Loading sack", error);
 
-  g_autoptr(RpmOstreeContext) ctx =
-    rpmostree_context_new_client (repo, cancellable, error);
+  g_autoptr(RpmOstreeContext) ctx = rpmostree_context_new_client (repo);
 
   g_autofree char *source_root =
     rpmostree_get_deployment_root (sysroot, booted_deployment);
@@ -2316,7 +2315,7 @@ refresh_md_transaction_execute (RpmostreedTransaction *transaction,
     rpmostree_get_deployment_root (sysroot, origin_merge_deployment);
 
   OstreeRepo *repo = ostree_sysroot_repo (sysroot);
-  g_autoptr(RpmOstreeContext) ctx = rpmostree_context_new_client (repo, cancellable, error);
+  g_autoptr(RpmOstreeContext) ctx = rpmostree_context_new_client (repo);
 
   /* We could bypass rpmostree_context_setup() here and call dnf_context_setup() ourselves
    * since we're not actually going to perform any installation. Though it does provide us
@@ -2442,7 +2441,7 @@ modify_yum_repo_transaction_execute (RpmostreedTransaction *transaction,
     ostree_sysroot_get_merge_deployment (sysroot, self->osname);
 
   OstreeRepo *ot_repo = ostree_sysroot_repo (sysroot);
-  g_autoptr(RpmOstreeContext) ctx = rpmostree_context_new_client (ot_repo, cancellable, error);
+  g_autoptr(RpmOstreeContext) ctx = rpmostree_context_new_client (ot_repo);
 
   /* We could bypass rpmostree_context_setup() here and call dnf_context_setup() ourselves
    * since we're not actually going to perform any installation. Though it does provide us

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -362,9 +362,7 @@ set_rpm_macro_define (const char *key, const char *value)
  * operations.
  */
 RpmOstreeContext *
-rpmostree_context_new_client (OstreeRepo   *repo,
-                              GCancellable *cancellable,
-                              GError      **error)
+rpmostree_context_new_client (OstreeRepo   *repo)
 {
   g_assert (repo != NULL);
 
@@ -417,14 +415,10 @@ rpmostree_context_new_client (OstreeRepo   *repo,
 RpmOstreeContext *
 rpmostree_context_new_compose (int               userroot_dfd,
                                OstreeRepo       *repo,
-                               rpmostreecxx::Treefile &treefile_rs,
-                               GCancellable     *cancellable,
-                               GError          **error)
+                               rpmostreecxx::Treefile &treefile_rs)
 {
   /* Inherit the client baseline, but flip it back to be a "compose" context */
-  g_autoptr(RpmOstreeContext) ret = rpmostree_context_new_client (repo, cancellable, error);
-  if (!ret)
-    return NULL;
+  auto ret = rpmostree_context_new_client (repo);
   ret->is_system = FALSE;
   ret->treefile_rs = &treefile_rs;
 

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -82,15 +82,11 @@ char* rpmostree_refspec_to_string (RpmOstreeRefspecType  reftype,
 char* rpmostree_refspec_canonicalize (const char           *orig_refspec,
                                       GError              **error);
 
-RpmOstreeContext *rpmostree_context_new_client (OstreeRepo   *repo,
-                                                GCancellable *cancellable,
-                                                GError      **error);
+RpmOstreeContext *rpmostree_context_new_client (OstreeRepo   *repo);
 
 RpmOstreeContext *rpmostree_context_new_compose (int basedir_dfd,
                                                  OstreeRepo  *repo,
-                                                 rpmostreecxx::Treefile &treefile_rs,
-                                                 GCancellable *cancellable,
-                                                 GError **error);
+                                                 rpmostreecxx::Treefile &treefile_rs);
 
 void rpmostree_context_set_pkgcache_only (RpmOstreeContext *self,
                                           gboolean          pkgcache_only);


### PR DESCRIPTION
A further cleanup, I noticed these functions never throw an
error, and we weren't consistently checking for one anyways.
