### PR TITLE
Add support for modules

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -79,6 +79,15 @@ It supports the following parameters:
    * `packages`: Array of strings, required: List of packages to install.
    * `repo`: String, required: Name of the repo from which to fetch packages.
 
+ * `modules`: Object, optional: Describes RPM modules to enable or install. Two
+   keys are supported:
+   * `enable`: Array of strings, required: Set of RPM module specs to enable
+     (the same formats as dnf are supported, e.g. `NAME[:STREAM]`).
+     One can then cherry-pick specific packages from the enabled modules via
+     `packages`.
+   * `install`: Array of strings, required: Set of RPM module specs to install
+     (the same formats as dnf are supported, e.g. `NAME[:STREAM][/PROFILE]`).
+
  * `ostree-layers`: Array of strings, optional: After all packages are unpacked,
     check out these OSTree refs, which must already be in the destination repository.
     Any conflicts with packages will be an error.

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -81,6 +81,16 @@ fn deployment_populate_variant_origin(
 
     // Package mappings.  Note these are inserted unconditionally, even if empty.
     vdict_insert_optvec(&dict, "requested-packages", tf.packages.as_ref());
+    vdict_insert_optvec(
+        &dict,
+        "requested-modules",
+        tf.modules.as_ref().map(|m| m.install.as_ref()).flatten(),
+    );
+    vdict_insert_optvec(
+        &dict,
+        "modules-enabled",
+        tf.modules.as_ref().map(|m| m.enable.as_ref()).flatten(),
+    );
     vdict_insert_optmap(
         &dict,
         "requested-local-packages",

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -332,6 +332,8 @@ pub mod ffi {
         fn get_packages_local(&self) -> Vec<String>;
         fn get_packages_override_replace_local(&self) -> Vec<String>;
         fn get_packages_override_remove(&self) -> Vec<String>;
+        fn get_modules_enable(&self) -> Vec<String>;
+        fn get_modules_install(&self) -> Vec<String>;
         fn get_exclude_packages(&self) -> Vec<String>;
         fn get_install_langs(&self) -> Vec<String>;
         fn format_install_langs_macro(&self) -> String;
@@ -618,6 +620,7 @@ mod lockfile;
 pub(crate) use self::lockfile::*;
 mod live;
 pub(crate) use self::live::*;
+pub mod modularity;
 mod nameservice;
 mod origin;
 pub(crate) use self::origin::*;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -46,6 +46,7 @@ fn inner_main() -> Result<i32> {
         Some("countme") => rpmostree_rust::countme::entrypoint(&args).map(|_| 0),
         Some("cliwrap") => rpmostree_rust::cliwrap::entrypoint(&args).map(|_| 0),
         Some("ex-container") => rpmostree_rust::container::entrypoint(&args).map(|_| 0),
+        Some("module") => rpmostree_rust::modularity::entrypoint(&args).map(|_| 0),
         _ => {
             // Otherwise fall through to C++ main().
             Ok(rpmostree_rust::ffi::rpmostree_main(&args)?)

--- a/rust/src/modularity.rs
+++ b/rust/src/modularity.rs
@@ -1,0 +1,130 @@
+//! Implementation of the client-side of "rpm-ostree module".
+
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use anyhow::{anyhow, bail, Result};
+use gio::DBusProxyExt;
+use ostree_ext::variant_utils;
+use structopt::StructOpt;
+
+use crate::utils::print_treepkg_diff;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "rpm-ostree module", no_version)]
+#[structopt(rename_all = "kebab-case")]
+enum Opt {
+    /// Enable a module
+    Enable(InstallOpts),
+    /// Disable a module
+    Disable(InstallOpts),
+    /// Install a module
+    Install(InstallOpts),
+    /// Uninstall a module
+    Uninstall(InstallOpts),
+}
+
+#[derive(Debug, StructOpt)]
+struct InstallOpts {
+    #[structopt(parse(from_str))]
+    modules: Vec<String>,
+    #[structopt(long)]
+    reboot: bool,
+    #[structopt(long)]
+    lock_finalization: bool,
+    #[structopt(long)]
+    dry_run: bool,
+    #[structopt(long)]
+    experimental: bool,
+}
+
+const OPT_KEY_ENABLE_MODULES: &str = "enable-modules";
+const OPT_KEY_DISABLE_MODULES: &str = "disable-modules";
+const OPT_KEY_INSTALL_MODULES: &str = "install-modules";
+const OPT_KEY_UNINSTALL_MODULES: &str = "uninstall-modules";
+
+pub fn entrypoint(args: &[&str]) -> Result<()> {
+    match Opt::from_iter(args.iter().skip(1)) {
+        Opt::Enable(ref opts) => enable(opts),
+        Opt::Disable(ref opts) => disable(opts),
+        Opt::Install(ref opts) => install(opts),
+        Opt::Uninstall(ref opts) => uninstall(opts),
+    }
+}
+
+// XXX: Should split out a lot of the below into a more generic Rust wrapper around
+// UpdateDeployment() like we have on the C side.
+
+fn get_modifiers_variant(key: &str, modules: &[String]) -> Result<glib::Variant> {
+    let r = glib::VariantDict::new(None);
+    r.insert_value(key, &crate::variant_utils::new_variant_strv(modules));
+    Ok(r.end())
+}
+
+fn get_options_variant(opts: &InstallOpts) -> Result<glib::Variant> {
+    let r = glib::VariantDict::new(None);
+    r.insert("no-pull-base", &true);
+    r.insert("reboot", &opts.reboot);
+    r.insert("lock-finalization", &opts.lock_finalization);
+    r.insert("dry-run", &opts.dry_run);
+    Ok(r.end())
+}
+
+fn enable(opts: &InstallOpts) -> Result<()> {
+    modules_impl(OPT_KEY_ENABLE_MODULES, opts)
+}
+
+fn disable(opts: &InstallOpts) -> Result<()> {
+    modules_impl(OPT_KEY_DISABLE_MODULES, opts)
+}
+
+fn install(opts: &InstallOpts) -> Result<()> {
+    modules_impl(OPT_KEY_INSTALL_MODULES, opts)
+}
+
+fn uninstall(opts: &InstallOpts) -> Result<()> {
+    modules_impl(OPT_KEY_UNINSTALL_MODULES, opts)
+}
+
+fn modules_impl(key: &str, opts: &InstallOpts) -> Result<()> {
+    if !opts.experimental {
+        bail!("Modularity support is experimental and subject to change. Use --experimental.");
+    }
+
+    if opts.modules.is_empty() {
+        bail!("At least one module must be specified");
+    }
+
+    let client = &mut crate::client::ClientConnection::new()?;
+    let previous_deployment = client
+        .get_os_proxy()
+        .get_cached_property("DefaultDeployment")
+        .ok_or_else(|| anyhow!("Failed to find default-deployment property"))?;
+    let modifiers = get_modifiers_variant(key, &opts.modules)?;
+    let options = get_options_variant(opts)?;
+    let params = variant_utils::new_variant_tuple(&[modifiers, options]);
+    let reply = &client.get_os_proxy().call_sync(
+        "UpdateDeployment",
+        Some(&params),
+        gio::DBusCallFlags::NONE,
+        -1,
+        gio::NONE_CANCELLABLE,
+    )?;
+    let reply_child = crate::variant_utils::variant_tuple_get(reply, 0)
+        .ok_or_else(|| anyhow!("Invalid reply"))?;
+    let txn_address = reply_child
+        .get_str()
+        .ok_or_else(|| anyhow!("Expected string transaction address"))?;
+    client.transaction_connect_progress_sync(txn_address)?;
+    if opts.dry_run {
+        println!("Exiting because of '--dry-run' option");
+    } else if !opts.reboot {
+        let new_deployment = client
+            .get_os_proxy()
+            .get_cached_property("DefaultDeployment")
+            .ok_or_else(|| anyhow!("Failed to find default-deployment property"))?;
+        if previous_deployment != new_deployment {
+            print_treepkg_diff("/");
+        }
+    }
+    Ok(())
+}

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -19,6 +19,7 @@ use std::result::Result as StdResult;
 const ORIGIN: &str = "origin";
 const RPMOSTREE: &str = "rpmostree";
 const PACKAGES: &str = "packages";
+const MODULES: &str = "modules";
 const OVERRIDES: &str = "overrides";
 
 /// The set of keys that we parse as BTreeMap and need to ignore ordering changes.
@@ -43,6 +44,14 @@ pub(crate) fn origin_to_treefile_inner(kf: &KeyFile) -> Result<Box<Treefile>> {
     cfg.derive.base_refspec = Some(refspec_str);
     cfg.packages = parse_stringlist(&kf, PACKAGES, "requested")?;
     cfg.derive.packages_local = parse_localpkglist(&kf, PACKAGES, "requested-local")?;
+    let modules_enable = parse_stringlist(&kf, MODULES, "enable")?;
+    let modules_install = parse_stringlist(&kf, MODULES, "install")?;
+    if modules_enable.is_some() || modules_install.is_some() {
+        cfg.modules = Some(crate::treefile::ModulesConfig {
+            enable: modules_enable,
+            install: modules_install,
+        });
+    }
     cfg.derive.override_remove = parse_stringlist(&kf, OVERRIDES, "remove")?;
     cfg.derive.override_replace_local = parse_localpkglist(&kf, OVERRIDES, "replace-local")?;
 
@@ -142,6 +151,16 @@ fn treefile_to_origin_inner(tf: &Treefile) -> Result<glib::KeyFile> {
     }
     if let Some(pkgs) = tf.derive.override_replace_local.as_ref() {
         set_sha256_nevra_pkgs(&kf, OVERRIDES, "replace-local", pkgs)
+    }
+    if let Some(ref modcfg) = tf.modules {
+        if let Some(modules) = modcfg.enable.as_deref() {
+            let modules = modules.iter().map(|s| s.as_str());
+            kf_set_string_list(&kf, MODULES, "enable", modules)
+        }
+        if let Some(modules) = modcfg.install.as_deref() {
+            let modules = modules.iter().map(|s| s.as_str());
+            kf_set_string_list(&kf, MODULES, "install", modules)
+        }
     }
 
     // Initramfs bits
@@ -332,6 +351,10 @@ pub(crate) mod test {
     requested=libvirt;fish;
     requested-local=4ed748ba060fce4571e7ef19f3f5ed6209f67dbac8327af0d38ea70b96d2f723:foo-1.2-3.x86_64;
 
+    [modules]
+    enable=foo:2.0;bar:rolling;
+    install=baz:next/development;
+
     [overrides]
     remove=docker;
     replace-local=0c7072500af2758e7dc7d7700fed82c3c5f4da7453b4d416e79f75384eee96b0:rpm-ostree-devel-2021.1-2.fc33.x86_64;648ab3ff4d4b708ea180269297de5fa3e972f4481d47b7879c6329272e474d68:rpm-ostree-2021.1-2.fc33.x86_64;8b29b78d0ade6ec3aedb8e3846f036f6f28afe64635d83cb6a034f1004607678:rpm-ostree-libs-2021.1-2.fc33.x86_64;
@@ -392,6 +415,13 @@ pub(crate) mod test {
         assert_eq!(
             tf.parsed.derive.override_commit.unwrap(),
             "41af286dc0b172ed2f1ca934fd2278de4a1192302ffa07087cea2682e7d372e3"
+        );
+        assert_eq!(
+            tf.parsed.modules,
+            Some(crate::treefile::ModulesConfig {
+                enable: Some(vec!["foo:2.0".into(), "bar:rolling".into()]),
+                install: Some(vec!["baz:next/development".into()]),
+            })
         );
         Ok(())
     }

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -223,7 +223,7 @@ pub fn maybe_shell_quote(input: &str) -> String {
 
 pub(crate) fn shellsafe_quote(input: Cow<str>) -> Cow<str> {
     lazy_static! {
-        static ref SHELLSAFE: Regex = Regex::new("^[[:alnum:]-._/=]+$").unwrap();
+        static ref SHELLSAFE: Regex = Regex::new("^[[:alnum:]-._/=:]+$").unwrap();
     }
 
     if SHELLSAFE.is_match(&input) {

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -539,3 +539,14 @@ pub(crate) fn calculate_advisories_diff(
     let r = variant_utils::new_variant_array(&GV_ADVISORY_TYPE, new_advisories.as_slice());
     Ok(r.to_glib_full() as *mut _)
 }
+
+pub(crate) fn print_treepkg_diff(sysroot: &str) {
+    unsafe {
+        crate::ffi::print_treepkg_diff_from_sysroot_path(
+            sysroot,
+            crate::ffi::RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE,
+            0,
+            std::ptr::null_mut(),
+        );
+    }
+}

--- a/rust/src/variant_utils.rs
+++ b/rust/src/variant_utils.rs
@@ -4,6 +4,7 @@
 use std::borrow::Cow;
 
 use glib::translate::*;
+use glib::ToVariant;
 
 // These constants should really be in gtk-rs
 lazy_static::lazy_static! {
@@ -38,6 +39,11 @@ pub(crate) fn new_variant_array(ty: &glib::VariantTy, children: &[glib::Variant]
         glib_sys::g_variant_ref_sink(r);
         from_glib_full(r)
     }
+}
+
+pub(crate) fn new_variant_strv(strv: &[impl AsRef<str>]) -> glib::Variant {
+    let v: Vec<glib::Variant> = strv.iter().map(|s| s.as_ref().to_variant()).collect();
+    new_variant_array(&TY_S, &v)
 }
 
 pub(crate) fn is_container(v: &glib::Variant) -> bool {

--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -103,10 +103,8 @@ static RpmOstreeCommand commands[] = {
   /* Rust-implemented commands; they're here so that they show up in `rpm-ostree
    * --help` alongside the other commands, but the command itself is fully
    *  handled Rust side. */
-  /*
-  { "my-rust-command", static_cast<RpmOstreeBuiltinFlags>(0),
-    "Cool thing my command does", NULL },
-  */
+  { "module", static_cast<RpmOstreeBuiltinFlags>(0),
+    "Commands to install/uninstall modules", NULL },
   /* Legacy aliases */
   { "pkg-add", static_cast<RpmOstreeBuiltinFlags>(RPM_OSTREE_BUILTIN_FLAG_HIDDEN),
     NULL, rpmostree_builtin_install },

--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -561,7 +561,10 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
   const gchar *origin_refspec;
   RpmOstreeRefspecType refspectype = RPMOSTREE_REFSPEC_TYPE_OSTREE;
   g_autofree const gchar **origin_packages = NULL;
+  g_autofree const gchar **origin_modules = NULL;
+  g_autofree const gchar **origin_modules_enabled = NULL;
   g_autofree const gchar **origin_requested_packages = NULL;
+  g_autofree const gchar **origin_requested_modules = NULL;
   g_autofree const gchar **origin_requested_local_packages = NULL;
   g_autoptr(GVariant) origin_base_removals = NULL;
   g_autofree const gchar **origin_requested_base_removals = NULL;
@@ -572,8 +575,14 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
     {
       origin_packages =
         lookup_array_and_canonicalize (dict, "packages");
+      origin_modules =
+        lookup_array_and_canonicalize (dict, "modules");
+      origin_modules_enabled =
+        lookup_array_and_canonicalize (dict, "modules-enabled");
       origin_requested_packages =
         lookup_array_and_canonicalize (dict, "requested-packages");
+      origin_requested_modules =
+        lookup_array_and_canonicalize (dict, "requested-modules");
       origin_requested_local_packages =
         lookup_array_and_canonicalize (dict, "requested-local-packages");
       origin_base_removals =
@@ -935,10 +944,21 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
     /* requested-packages - packages = inactive (i.e. dormant requests) */
     print_packages ("InactiveRequests", max_key_len,
                     origin_requested_packages, origin_packages);
+  if (origin_requested_modules && opt_verbose)
+    /* requested-modules - modules = inactive (i.e. dormant requests) */
+    /* note the core doesn't support inactive modules yet, but could in the future */
+    print_packages ("InactiveModuleRequests", max_key_len,
+                    origin_requested_modules, origin_modules);
 
   if (origin_packages)
     print_packages ("LayeredPackages", max_key_len,
                     origin_packages, NULL);
+  if (origin_modules)
+    print_packages ("LayeredModules", max_key_len,
+                    origin_modules, NULL);
+  if (origin_modules_enabled)
+    print_packages ("EnabledModules", max_key_len,
+                    origin_modules_enabled, NULL);
 
   if (origin_requested_local_packages)
     print_packages ("LocalPackages", max_key_len,

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -827,6 +827,12 @@ impl_install_tree (RpmOstreeTreeComposeContext *self,
         return glnx_throw_errno_prefix (error, "fchdir");
     }
 
+  /* We don't support installing modules in non-unified mode, because it relies
+   * on the core writing metadata to the commit metadata (obviously this could
+   * be supported, but meh...) */
+  if (!opt_unified_core && json_object_has_member (self->treefile, "modules"))
+    return glnx_throw (error, "Composing with modules requires --unified-core");
+
   /* Read the previous commit. Note we don't actually *need* the full commit; really, only
    * if one uses `check-passwd: { "type": "previous" }`. There are a few other optimizations
    * too, e.g. using the previous SELinux policy in unified core. Also, we might need the

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -298,6 +298,8 @@
          "install-packages" (type 'as')
          "uninstall-packages" (type 'as')
          "install-local-packages" (type 'ah')
+         "install-modules" (type 'as')
+         "uninstall-modules" (type 'as')
          "override-remove-packages" (type 'as')
          "override-reset-packages" (type 'as')
          "override-replace-packages" (type 'as')

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -796,7 +796,6 @@ finalize_overlays (RpmOstreeSysrootUpgrader *self,
   /* request (owned by origin) --> providing nevra */
   g_autoptr(GHashTable) inactive_requests =
     g_hash_table_new_full (g_str_hash, g_str_equal, NULL, g_free);
-  g_autoptr(GPtrArray) ret_missing_pkgs = g_ptr_array_new_with_free_func (g_free);
 
   /* Add the local pkgs as if they were installed: since they're unconditionally
    * layered, we treat them as part of the base wrt regular requested pkgs. E.g.
@@ -846,8 +845,8 @@ finalize_overlays (RpmOstreeSysrootUpgrader *self,
 
       if (matches->len == 0)
         {
-          /* no matches, so we'll need to layer it */
-          g_ptr_array_add (ret_missing_pkgs, g_strdup (pattern));
+          /* no matches, so we'll need to layer it (i.e. not remove it from the
+           * computed origin) */
           continue;
         }
 

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -248,10 +248,11 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
   gboolean is_layered = FALSE;
   g_autofree char *base_checksum = NULL;
   g_auto(GStrv) layered_pkgs = NULL;
+  g_auto(GStrv) layered_modules = NULL;
   g_autoptr(GVariant) removed_base_pkgs = NULL;
   g_autoptr(GVariant) replaced_base_pkgs = NULL;
   if (!rpmostree_deployment_get_layered_info (repo, deployment, &is_layered, NULL,
-                                              &base_checksum, &layered_pkgs,
+                                              &base_checksum, &layered_pkgs, &layered_modules,
                                               &removed_base_pkgs, &replaced_base_pkgs,
                                               error))
     return NULL;
@@ -340,6 +341,7 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
     }
 
   g_variant_dict_insert (dict, "packages", "^as", layered_pkgs);
+  g_variant_dict_insert (dict, "modules", "^as", layered_modules);
   g_variant_dict_insert_value (dict, "base-removals", removed_base_pkgs);
   g_variant_dict_insert_value (dict, "base-local-replacements", replaced_base_pkgs);
 

--- a/src/daemon/rpmostreed-os.cxx
+++ b/src/daemon/rpmostreed-os.cxx
@@ -172,6 +172,14 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
         vardict_lookup_strv (&modifiers_dict, "install-packages");
       g_autofree char **uninstall_pkgs =
         vardict_lookup_strv (&modifiers_dict, "uninstall-packages");
+      g_autofree char **enable_modules =
+        vardict_lookup_strv (&modifiers_dict, "enable-modules");
+      g_autofree char **disable_modules =
+        vardict_lookup_strv (&modifiers_dict, "disable-modules");
+      g_autofree char **install_modules =
+        vardict_lookup_strv (&modifiers_dict, "install-modules");
+      g_autofree char **uninstall_modules =
+        vardict_lookup_strv (&modifiers_dict, "uninstall-modules");
       g_autofree const char *const *override_replace_pkgs =
         vardict_lookup_strv (&modifiers_dict, "override-replace-packages");
       g_autofree const char *const *override_remove_pkgs =
@@ -201,7 +209,10 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
       else if (!no_pull_base)
         g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.upgrade");
 
-      if (install_pkgs != NULL || uninstall_pkgs != NULL || no_layering)
+      if (install_pkgs != NULL || uninstall_pkgs != NULL ||
+          enable_modules != NULL || disable_modules != NULL ||
+          install_modules != NULL || uninstall_modules != NULL ||
+          no_layering)
         g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.install-uninstall-packages");
 
       if (install_local_pkgs != NULL && g_variant_n_children (install_local_pkgs) > 0)

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -992,15 +992,13 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
   dnf_sack_set_module_excludes (dnf_context_get_sack (self->dnfctx), NULL);
   /* And also mark all repos as hotfix repos so that we can indiscriminately cherry-pick
    * from modular repos and non-modular repos alike. */
-  g_autoptr(GPtrArray) repos =
-    rpmostree_get_enabled_rpmmd_repos (self->dnfctx, DNF_REPO_ENABLED_PACKAGES);
-  for (guint i = 0; i < repos->len; i++)
-    dnf_repo_set_module_hotfixes (static_cast<DnfRepo*>(repos->pdata[i]), TRUE);
+  for (guint i = 0; i < rpmmd_repos->len; i++)
+    dnf_repo_set_module_hotfixes (static_cast<DnfRepo*>(rpmmd_repos->pdata[i]), TRUE);
 
   // Print repo information
-  for (guint i = 0; i < repos->len; i++)
+  for (guint i = 0; i < rpmmd_repos->len; i++)
     {
-      auto repo = static_cast<DnfRepo*>(repos->pdata[i]);
+      auto repo = static_cast<DnfRepo*>(rpmmd_repos->pdata[i]);
       gboolean updated = g_hash_table_contains (updated_repos, repo);
       guint64 ts = dnf_repo_get_timestamp_generated (repo);
       g_autofree char *repo_ts_str = rpmostree_timestamp_str_from_unix_utc (ts);

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -81,6 +81,12 @@ GHashTable *
 rpmostree_origin_get_packages (RpmOstreeOrigin *origin);
 
 GHashTable *
+rpmostree_origin_get_modules_enable (RpmOstreeOrigin *origin);
+
+GHashTable *
+rpmostree_origin_get_modules_install (RpmOstreeOrigin *origin);
+
+GHashTable *
 rpmostree_origin_get_local_packages (RpmOstreeOrigin *origin);
 
 GHashTable *
@@ -180,6 +186,20 @@ gboolean
 rpmostree_origin_remove_all_packages (RpmOstreeOrigin  *origin,
                                       gboolean         *out_changed,
                                       GError          **error);
+
+gboolean
+rpmostree_origin_add_modules (RpmOstreeOrigin  *origin,
+                              char           **modules,
+                              gboolean         enable_only,
+                              gboolean        *out_changed,
+                              GError         **error);
+
+gboolean
+rpmostree_origin_remove_modules (RpmOstreeOrigin  *origin,
+                                 char           **modules,
+                                 gboolean         enable_only,
+                                 gboolean        *out_changed,
+                                 GError         **error);
 
 typedef enum {
   /* RPMOSTREE_ORIGIN_OVERRIDE_REPLACE, */

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -245,6 +245,7 @@ rpmostree_deployment_get_layered_info (OstreeRepo        *repo,
                                        guint             *out_layer_version,
                                        char             **out_base_layer,
                                        char            ***out_layered_pkgs,
+                                       char            ***out_layered_modules,
                                        GVariant         **out_removed_base_pkgs,
                                        GVariant         **out_replaced_base_pkgs,
                                        GError           **error);
@@ -337,5 +338,8 @@ rpmostree_variant_be_to_native (GVariant **v);
 
 void
 rpmostree_variant_native_to_be (GVariant **v);
+
+char**
+rpmostree_cxx_string_vec_to_strv (rust::Vec<rust::String> &v);
 
 G_END_DECLS

--- a/tests/kolainst/Makefile
+++ b/tests/kolainst/Makefile
@@ -18,4 +18,5 @@ install: all
 	rsync -prlv rpm-repos/ $(KOLA_TESTDIR)/destructive/data/rpm-repos/
 
 localinstall: all
+	rm -rf ../kola
 	make install KOLA_TESTDIR=../kola

--- a/tests/kolainst/destructive/layering-modules
+++ b/tests/kolainst/destructive/layering-modules
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+
+. ${KOLA_EXT_DATA}/libtest.sh
+cd $(mktemp -d)
+
+set -x
+
+rm -rf /etc/yum.repos.d/*
+cat > /etc/yum.repos.d/vmcheck.repo << EOF
+[test-repo]
+name=test-repo
+baseurl=file:///${KOLA_EXT_DATA}/rpm-repos/0
+gpgcheck=0
+EOF
+
+if rpm-ostree install foomodular 2>err.txt; then
+  assert_not_reached "successfully installed a modular pkg?"
+fi
+assert_file_has_content_literal err.txt "Packages not found: foomodular"
+echo "ok can't install modular pkg by default"
+
+if rpm-ostree module install foomodular --experimental 2>err.txt; then
+  assert_not_reached "successfully installed a module with multiple streams without a default stream"
+fi
+assert_file_has_content err.txt "Cannot enable more streams .* at the same time"
+echo "ok can't install module with multiple streams"
+
+if rpm-ostree module enable foomodular --experimental 2>err.txt; then
+  assert_not_reached "successfully enabled a module with multiple streams without a default stream"
+fi
+assert_file_has_content err.txt "Cannot enable more streams .* at the same time"
+echo "ok can't enable module with multiple streams"
+
+rpm-ostree module enable foomodular:no-profile --experimental
+rpm-ostree install foomodular
+rpm-ostree status > output.txt
+assert_file_has_content_literal output.txt "EnabledModules: foomodular:no-profile"
+assert_file_has_content_literal output.txt "LayeredPackages: foomodular"
+rpm-ostree cleanup -p
+echo "ok enable module"
+
+if rpm-ostree module install foomodular:no-default-profile --experimental 2>err.txt; then
+  assert_not_reached "successfully installed a module without default profile?"
+fi
+assert_file_has_content_literal err.txt "No default profile found"
+echo "ok can't install module without default profile"
+
+rpm-ostree module install foomodular:no-default-profile/myprof --experimental
+rpm-ostree status > output.txt
+assert_file_has_content_literal output.txt "LayeredModules: foomodular:no-default-profile/myprof"
+rpm-ostree cleanup -p
+echo "ok install module without default profile"
+
+rpm-ostree module install foomodular:with-default-profile --experimental
+rpm-ostree status > output.txt
+assert_file_has_content_literal output.txt "LayeredModules: foomodular:with-default-profile"
+rpm-ostree cleanup -p
+echo "ok install module with default profile"

--- a/tests/kolainst/kolainst-build.sh
+++ b/tests/kolainst/kolainst-build.sh
@@ -56,6 +56,23 @@ build_rpm testdaemon \
 # Will be useful for testing cancellation
 build_rpm testpkg-post-infinite-loop \
              post "echo entering testpkg-post-infinite-loop 1>&2; while true; do sleep 1h; done"
+# Test module
+build_rpm foomodular
+build_module foomodular \
+  stream no-profile \
+  rpm foomodular-0:1.0-1.x86_64
+build_module foomodular \
+  stream no-default-profile \
+  profile myprof:foomodular \
+  profile myotherprof:foomodular \
+  rpm foomodular-0:1.0-1.x86_64
+build_module foomodular \
+  stream with-default-profile \
+  profile default:foomodular \
+  profile myotherprof:foomodular \
+  rpm foomodular-0:1.0-1.x86_64
+build_module_defaults foomodular \
+  defprofile with-default-profile:default
 
 mv ${test_tmpdir}/yumrepo/* ${test_tmpdir}/rpm-repos/${repover}
 


### PR DESCRIPTION
Add support for composing with modules and for package layering modules
on the client-side.

This doesn't support modules in `rpm-ostree compose extensions` yet,
which is relevant for RHCOS. We can look at adding that in a follow-up.

