### PR TITLE
rust/passwd: Fix handling of `previous` mode

### DIFF
--- a/rust/src/passwd.rs
+++ b/rust/src/passwd.rs
@@ -256,12 +256,13 @@ pub fn passwd_compose_prep_repo(
 ) -> Result<()> {
     let rootfs = ffiutil::ffi_view_openat_dir(rootfs_dfd);
     let repo = ffi_repo.gobj_wrap();
-    passwd_compose_prep_impl(
-        &rootfs,
-        treefile,
-        Some((&repo, previous_checksum)),
-        unified_core,
-    )
+    // C side uses "" for None
+    let repo_previous_rev = if previous_checksum == "" {
+        None
+    } else {
+        Some((&repo, previous_checksum))
+    };
+    passwd_compose_prep_impl(&rootfs, treefile, repo_previous_rev, unified_core)
 }
 
 fn passwd_compose_prep_impl(


### PR DESCRIPTION
We need to handle the case where no previous commit exists. This is
expressed from the C side by passing the empty string.

We're currently not testing this, though... AFAIK no distro uses this
right now anyway and hopefully we simplify a lot of this when we move to
systemd-sysusers!

Fixes: #2580
Fixes: #2769