### PR TITLE
Two bwrap /etc fixes

### DIFF
--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -475,7 +475,11 @@ pub(crate) fn bubblewrap_run_sync(
 /// Validate that bubblewrap works at all.  This will flush out any incorrect
 /// setups such being inside an outer container that disallows `CLONE_NEWUSER` etc.
 pub(crate) fn bubblewrap_selftest() -> CxxResult<()> {
-    let fd = openat::Dir::open("/")?;
-    let _ = bubblewrap_run_sync(fd.as_raw_fd(), &vec!["true".to_string()], false, true)?;
+    let fd = &openat::Dir::open("/")?;
+    let mut bwrap = Bubblewrap::new_with_mutability(fd, BubblewrapMutability::Immutable)?;
+    bwrap.append_child_argv(&["true"]);
+    let cancellable = &gio::Cancellable::new();
+    let cancellable = Some(cancellable);
+    bwrap.run_inner(cancellable)?;
     Ok(())
 }

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -19,11 +19,12 @@ pub struct TempEtcGuard {
     renamed_etc: bool,
 }
 
+/// Detect if we have /usr/etc and no /etc, and rename if so.
 pub(crate) fn prepare_tempetc_guard(rootfs: i32) -> CxxResult<Box<TempEtcGuard>> {
     let rootfs = ffi_view_openat_dir(rootfs);
-    let has_usretc = rootfs.exists("usr/etc")?;
+    let has_etc = rootfs.exists("etc")?;
     let mut renamed_etc = false;
-    if has_usretc {
+    if !has_etc && rootfs.exists("usr/etc")? {
         // In general now, we place contents in /etc when running scripts
         rootfs.local_rename("usr/etc", "etc")?;
         // But leave a compat symlink, as we used to bind mount, so scripts


### PR DESCRIPTION
bwrap: Fix selftest to be truly immutable

We should never have any effect on the host system, so let's
use the more direct APIs which allow us to use the immutable
flag, don't mount `/var` etc.

Crucially this also avoids us running through the tempetc
guard which would try to rename `usr/etc` which can trigger
on an ostree based host.

Closes: https://github.com/coreos/rpm-ostree/issues/2771

---

core: Fix tempetc guard to be no-op if /etc exists

This is further hardening to prevent a situation like
https://github.com/coreos/rpm-ostree/issues/2771
where we would crash on an ostree-based host that has both
`/etc` and `/usr/etc` as physical directories.

That shouldn't happen after the bwrap fix, but we might
as well be more correct here.

---

