### PR TITLE
lib/package: Fix rpm version comparison

### DIFF
--- a/src/lib/rpmostree-package.c
+++ b/src/lib/rpmostree-package.c
@@ -133,6 +133,28 @@ rpm_ostree_package_get_arch (RpmOstreePackage *p)
 }
 
 /**
+ * evr_cmp:
+ * @a: String representation of EVR
+ * @b: String representation of EVR
+ *
+ * Compares two string representations of EVR by calling rpmverCmp
+ *
+ * Returns: 1: a is newer than b
+ *          0: a and b are the same version
+ *         -1: b is newer than a
+ */
+static int
+evr_cmp (const char *a, const char *b)
+{
+  rpmver v1 = rpmverParse (a);
+  rpmver v2 = rpmverParse (b);
+  int rc = rpmverCmp (v1, v2);
+  rpmverFree (v1);
+  rpmverFree (v2);
+  return rc;
+}
+
+/**
  * rpm_ostree_package_cmp:
  * @p1: Package
  * @p2: Package
@@ -154,7 +176,7 @@ rpm_ostree_package_cmp (RpmOstreePackage *p1, RpmOstreePackage *p2)
    * when we read it out of the commit metadata and we also sort
    * the diff in_rpm_ostree_diff_package_lists().
    **/
-  ret = rpmvercmp (p1->evr, p2->evr);
+  ret = evr_cmp (p1->evr, p2->evr);
   if (ret)
     return ret;
 
@@ -314,7 +336,7 @@ _rpm_ostree_diff_package_lists (GPtrArray  *a,
           cmp = strcmp (pkg_a->arch, pkg_b->arch);
           if (cmp == 0)
             {
-              cmp = rpmvercmp (pkg_a->evr, pkg_b->evr);
+              cmp = evr_cmp (pkg_a->evr, pkg_b->evr);
               if (cmp == 0)
                 {
                   g_ptr_array_add (common, g_object_ref (pkg_a));

--- a/tests/vmcheck/test-db.sh
+++ b/tests/vmcheck/test-db.sh
@@ -53,7 +53,7 @@ check_not_diff() {
 # make the package name start with zzz so it's last to be processed
 vm_build_rpm zzz-pkg-to-downgrade version 2.0
 vm_build_rpm pkg-to-remove
-vm_build_rpm pkg-to-replace
+vm_build_rpm pkg-to-replace version 15 release 8
 vm_build_rpm pkg-to-replace-archtrans arch noarch
 vm_rpmostree install pkg-to-remove pkg-to-replace pkg-to-replace-archtrans zzz-pkg-to-downgrade
 
@@ -118,11 +118,11 @@ echo "ok setup"
 
 vm_rpmostree override remove pkg-to-remove
 vm_build_rpm zzz-pkg-to-downgrade version 1.0
-vm_build_rpm pkg-to-replace version 2.0
+vm_build_rpm pkg-to-replace version 15.4 release 4
 vm_build_rpm pkg-to-replace-archtrans version 2.0
 vm_rpmostree override replace \
   $YUMREPO/zzz-pkg-to-downgrade-1.0-1.x86_64.rpm \
-  $YUMREPO/pkg-to-replace-2.0-1.x86_64.rpm \
+  $YUMREPO/pkg-to-replace-15.4-4.x86_64.rpm \
   $YUMREPO/pkg-to-replace-archtrans-2.0-1.x86_64.rpm
 vm_build_rpm pkg-to-overlay build 'echo same > pkg-to-overlay'
 # some multilib handling tests (override default /bin script to skip conflicts)
@@ -134,7 +134,7 @@ check_diff $booted_csum $pending_layered_csum \
   +pkg-to-overlay-1.0-1.x86_64 \
   +pkg-to-overlay-1.0-1.i686 \
   +glibc-1.0-1.i686 \
-  +pkg-to-replace-2.0 \
+  +pkg-to-replace-15.4-4 \
   +zzz-pkg-to-downgrade-1.0 \
   +pkg-to-replace-archtrans-2.0
 # check that regular glibc is *not* in the list of modified/dropped packages
@@ -152,8 +152,8 @@ check_diff $pending_csum $pending_layered_csum \
   -pkg-to-remove \
   !zzz-pkg-to-downgrade-2.0 \
   =zzz-pkg-to-downgrade-1.0 \
-  !pkg-to-replace-1.0 \
-  =pkg-to-replace-2.0 \
+  !pkg-to-replace-15-8 \
+  =pkg-to-replace-15.4-4 \
   !pkg-to-replace-archtrans-1.0 \
   =pkg-to-replace-archtrans-2.0
 # also do a human diff check
@@ -162,6 +162,7 @@ assert_file_has_content diff.txt 'Upgraded'
 assert_file_has_content diff.txt 'Downgraded'
 assert_file_has_content diff.txt 'Removed'
 assert_file_has_content diff.txt 'Added'
+grep -A1 '^Upgraded:' diff.txt | grep 'pkg-to-replace 15-8 -> 15.4-4'
 grep -A1 '^Downgraded:' diff.txt | grep zzz-pkg-to-downgrade
 echo "ok db diff"
 
@@ -181,8 +182,8 @@ check_diff $pending_csum $pending_layered_csum \
   +pkg-to-overlay-1.0-1.i686 \
   +glibc-1.0-1.i686 \
   -pkg-to-remove \
-  !pkg-to-replace-1.0 \
-  =pkg-to-replace-2.0 \
+  !pkg-to-replace-15-8 \
+  =pkg-to-replace-15.4-4 \
   !pkg-to-replace-archtrans-1.0 \
   =pkg-to-replace-archtrans-2.0
 echo "ok db from pkglist.metadata"
@@ -191,12 +192,12 @@ echo "ok db from pkglist.metadata"
 vm_rpmostree db list $pending_layered_csum > out.txt
 assert_not_file_has_content out.txt \
   pkg-to-remove \
-  pkg-to-replace-1.0 \
+  pkg-to-replace-15-8 \
   pkg-to-replace-archtrans-1.0
 assert_file_has_content out.txt \
   pkg-to-overlay-1.0-1.x86_64 \
   pkg-to-overlay-1.0-1.i686 \
   glibc-1.0-1.i686 \
-  pkg-to-replace-2.0 \
+  pkg-to-replace-15.4-4 \
   pkg-to-replace-archtrans-2.0
 echo "ok list from pkglist.metadata"


### PR DESCRIPTION
`rpmvercmp()` doesn't properly compare full EVR. It needs to
be given the Version and Release separately in order to do
a comparison. For example `rpmVersionCompare()` first calls
`rpmvercmp()` to compare the Version and then checks the Release
in a second call to `rpmvercmp()`.

https://github.com/rpm-software-management/rpm/blob/35739c2a2298e61caacb45157706bf342ffcd20e/lib/headerutil.c#L434-L440

Let's just use `rpmverCmp()` instead, which can do the full
EVR comparison.

Fixes: https://github.com/coreos/rpm-ostree/issues/2668
