### PR TITLE
treefile: Add new `repo-packages` field for pinning packages to repos

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -73,6 +73,11 @@ It supports the following parameters:
    An example use case for this is for Fedora CoreOS, which will blacklist the `python` and `python3`
    packages to ensure that nothing included in the OS starts depending on it in the future.
 
+ * `repo-packages`: Array of objects, optional: Set of packages to install from
+   specific repos. Each object in the array supports the following keys:
+   * `packages`: Array of strings, required: List of packages to install.
+   * `repo`: String, required: Name of the repo from which to fetch packages.
+
  * `ostree-layers`: Array of strings, optional: After all packages are unpacked,
     check out these OSTree refs, which must already be in the destination repository.
     Any conflicts with packages will be an error.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -276,6 +276,16 @@ pub mod ffi {
         fn sanitycheck_externals(&self) -> Result<()>;
         fn get_checksum(&self, repo: Pin<&mut OstreeRepo>) -> Result<String>;
         fn get_ostree_ref(&self) -> String;
+        fn get_repo_packages(&self) -> &[RepoPackage];
+        fn clear_repo_packages(&mut self);
+    }
+
+    // treefile.rs (split out from above to make &self nice to use)
+    extern "Rust" {
+        type RepoPackage;
+
+        fn get_repo(&self) -> &str;
+        fn get_packages(&self) -> &[String];
     }
 
     // utils.rs

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1468,6 +1468,14 @@ rpmostree_compose_builtin_extensions (int             argc,
   g_autofree char *basearch = rpm_ostree_get_basearch ();
   auto treefile = rpmostreecxx::treefile_new (treefile_path, basearch, -1);
 
+  /* We don't want the core to handle repo packages from the treefile. Normally,
+   * if repo packages worked like other knobs and went via the treespec, this
+   * would naturally be handled because we create our own treespec below. But
+   * we're trying to move away from that. We'll eventually want repo packages on
+   * the client-side too though, which means it won't be a treefile thing
+   * anymore, so we can rejig this then. */
+  treefile->clear_repo_packages();
+
   g_autoptr(OstreeRepo) repo = ostree_repo_open_at (AT_FDCWD, opt_repo, cancellable, error);
   if (!repo)
     return FALSE;

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -2200,6 +2200,35 @@ rpmostree_context_prepare (RpmOstreeContext *self,
   GLNX_HASH_TABLE_FOREACH_V (local_pkgs_to_install, DnfPackage*, pkg)
     hy_goal_install (goal,  pkg);
 
+  /* Now repo-packages; only supported during server composes for now. */
+  if (!self->is_system)
+    {
+      auto repo_pkgs = self->treefile_rs->get_repo_packages();
+      for (auto & repo_pkg : repo_pkgs)
+        {
+          auto repo = std::string(repo_pkg.get_repo());
+          auto pkgs = repo_pkg.get_packages();
+          for (auto & pkg_str : pkgs)
+            {
+              auto pkg = std::string(pkg_str);
+              g_auto(HySubject) subject = hy_subject_create(pkg.c_str());
+              /* this is basically like a slightly customized dnf_context_install() */
+              HyNevra nevra = NULL;
+              hy_autoquery HyQuery query =
+                hy_subject_get_best_solution(subject, sack, NULL, &nevra, FALSE, TRUE, TRUE, TRUE, FALSE);
+              hy_query_filter (query, HY_PKG_REPONAME, HY_EQ, repo.c_str());
+              g_autoptr(DnfPackageSet) pset = hy_query_run_set (query);
+              if (dnf_packageset_count (pset) == 0)
+                return glnx_throw (error, "No matches for '%s' in repo '%s'", pkg.c_str(), repo.c_str());
+
+              g_auto(HySelector) selector = hy_selector_create (sack);
+              hy_selector_pkg_set (selector, pset);
+              if (!hy_goal_install_selector (goal, selector, error))
+                return FALSE;
+            }
+        }
+    }
+
   /* And finally, handle repo packages to install */
   g_autoptr(GPtrArray) missing_pkgs = NULL;
   for (char **it = pkgnames; it && *it; it++)

--- a/tests/compose/test-basic-unified.sh
+++ b/tests/compose/test-basic-unified.sh
@@ -17,7 +17,14 @@ uinfo_cmd add-ref TEST-SEC-LOW 1 http://example.com/vuln1 "CVE-12-34 vuln1"
 
 echo gpgcheck=0 >> yumrepo.repo
 ln "$PWD/yumrepo.repo" config/yumrepo.repo
-treefile_append "packages" '["foobar", "vuln-pkg"]'
+treefile_append "packages" '["vuln-pkg"]'
+
+treefile_pyedit "
+tf['repo-packages'] = [{
+  'repo': 'test-repo',
+  'packages': ['foobar'],
+}]
+"
 
 # Test --print-only.  We also
 # just in this test (for now) use ${basearch} to test substitution.

--- a/tests/compose/test-basic.sh
+++ b/tests/compose/test-basic.sh
@@ -15,7 +15,12 @@ build_rpm foobar-rec
 
 echo gpgcheck=0 >> yumrepo.repo
 ln "$PWD/yumrepo.repo" config/yumrepo.repo
-treefile_append "packages" '["foobar"]'
+treefile_pyedit "
+tf['repo-packages'] = [{
+  'repo': 'test-repo',
+  'packages': ['foobar'],
+}]
+"
 
 treefile_pyedit "tf['add-commit-metadata']['foobar'] = 'bazboo'"
 treefile_pyedit "tf['add-commit-metadata']['overrideme'] = 'old var'"


### PR DESCRIPTION
This addresses the server compose side of
#2584.

One tricky bit is handling overrides across included treefiles (or
really, even within a single treefile): as usual, higher-level treefiles
should override lowel-level ones. Rust makes it pretty nice to handle.

For now this just supports a `repo` field, but one could imagine e.g.
`repos` (which takes an array of repoids instead), or e.g.
`exclude-repos`.

The actual core implementation otherwise is pretty straightforward.

This should help a lot in RHCOS where we currently use many `exclude=`
directives in repo files to get it to do what we want.

This is also kind of a requirement for modularity support because as
soon as rpm-ostree becomes modules-aware, modular filtering logic will
break composes which assume rpm-ostree treats modular and non-modular
packages the same.