### PR TITLE
Fix bwrap usage for mutate-os-release

### DIFF
--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -383,7 +383,10 @@ impl Bubblewrap {
     }
 
     /// Execute the container, capturing stdout.
-    fn run_captured(&mut self, cancellable: Option<&gio::Cancellable>) -> Result<glib::Bytes> {
+    pub(crate) fn run_captured(
+        &mut self,
+        cancellable: Option<&gio::Cancellable>,
+    ) -> Result<glib::Bytes> {
         self.launcher.set_flags(gio::SubprocessFlags::STDOUT_PIPE);
         let (child, argv0) = self.spawn()?;
         let (stdout, stderr) = child.communicate(None, cancellable)?;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -64,7 +64,7 @@ pub mod ffi {
     }
 
     #[derive(Debug)]
-    enum BubblewrapMutability {
+    pub(crate) enum BubblewrapMutability {
         Immutable,
         RoFiles,
         MutateFreely,


### PR DESCRIPTION
Followup to https://pagure.io/fedora-infrastructure/issue/9909

In the refactor we were passing `unified_core: true` unconditionally which was wrong,
as that implies using fuse.  Anyways what we really want here is an immutable bwrap
and not `rofiles-fuse` annyways.  So refactor things to use that.

From https://kojipkgs.fedoraproject.org//work/tasks/7579/66867579/runroot.log
```
fuse: device not found, try 'modprobe fuse' first
fuse: device not found, try 'modprobe fuse' first
bwrap: execvp realpath: No such file or directory
fusermount: failed to unmount /tmp/rpmostree-rofiles-fuseAAphRY: Invalid argument
fusermount: failed to unmount /tmp/rpmostree-rofiles-fuseSCLs24: Invalid argument
error: Updating os-release with commit version: Running realpath: bwrap(realpath): Child process killed by signal 1
```
