### PR TITLE
countme: Drop SELinux workaround/unpriv copy of rpm-ostree

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -148,7 +148,6 @@ BUILT_SOURCES += $(binding_generated_sources)
 install-rpmostree-hook:
 	install -d -m 0755 $(DESTDIR)$(bindir)
 	install -m 0755 -t $(DESTDIR)$(bindir) rpm-ostree
-	install -m 0755 rpm-ostree $(DESTDIR)$(libexecdir)/rpm-ostree-unpriv
 INSTALL_EXEC_HOOKS += install-rpmostree-hook
 
 # Wraps `cargo test`.  This is always a debug non-release build;

--- a/src/daemon/rpm-ostree-countme.service.in
+++ b/src/daemon/rpm-ostree-countme.service.in
@@ -9,4 +9,4 @@ User=rpm-ostree
 DynamicUser=yes
 StateDirectory=rpm-ostree-countme
 StateDirectoryMode=750
-ExecStart=@libexecdir@/rpm-ostree-unpriv countme
+ExecStart=@bindir@/rpm-ostree countme


### PR DESCRIPTION
The SELinux policy change has been merged and released upstream.

This reverts: 5d5ccf01 Install a temporary copy of rpm-ostree for unprivileged use

I need to check if we should keep this for RHEL while the policy gets updated.