### PR TITLE
composepost: move rpmdb linking logic to Rust

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -154,6 +154,10 @@ pub mod ffi {
             rootfs_dfd: i32,
             cancellable: Pin<&mut GCancellable>,
         ) -> Result<()>;
+        fn prepare_rpmdb_base_location(
+            rootfs_dfd: i32,
+            cancellable: Pin<&mut GCancellable>,
+        ) -> Result<()>;
     }
 
     // A grab-bag of metadata from the deployment's ostree commit


### PR DESCRIPTION
This ports the rpmdb hardlinking logic which serves to maintain
a coherent single source of truth across tools.