### PR TITLE
Add and use the `camino` library for UTF-8 paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "c_utf8",
+ "camino",
  "chrono",
  "clap",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ rpm = "4"
 [dependencies]
 anyhow = "1.0.40"
 c_utf8 = "0.1.0"
+camino = "1.0.4"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = "2.33.3"
 curl = "0.4.36"


### PR DESCRIPTION
ostree hard requires UTF-8 paths (and really we should
never have any non-UTF-8 paths in the OS in general).  The
camino library has types that are both `Path` and `&str` and
has a convenient `try_into()` too to avoid us duplicating
the error handling.