### PR TITLE
ci: Use buildpod for composes and skip installing in cosa

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -37,14 +37,12 @@ parallel insttests: {
         // run this stage first without installing deps, so we match exactly the cosa pkgset
         // (+ our built rpm-ostree)
         shwrap("""
-          dnf install -y *.rpm
+          # XXX: cosa is currently on f33 still, so skip installing
+          #dnf install -y *.rpm
           coreos-assembler init --force https://github.com/coreos/fedora-coreos-config
           # include our built rpm-ostree in the image
           mkdir -p overrides/rpm
           mv *.rpm overrides/rpm
-          # for now, we cherry-pick newer libsolv to test that it correctly detects our rpmdb
-          # https://github.com/coreos/rpm-ostree/issues/2548
-          (cd overrides/rpm && curl -LO https://kojipkgs.fedoraproject.org//packages/libsolv/0.7.17/1.fc33/x86_64/libsolv-0.7.17-1.fc33.x86_64.rpm)
           coreos-assembler fetch
           coreos-assembler build
            ${env.WORKSPACE}/ci/composepost-checks.sh
@@ -77,7 +75,7 @@ parallel insttests: {
 compose: {
     def jobs = 5
     def mem = (jobs * 2048) + 512
-    cosaPod(runAsUser: 0, memory: "${mem}Mi", cpu: "${jobs}") {
+    buildPod(runAsUser: 0, memory: "${mem}Mi", cpu: "${jobs}") {
         checkout scm
         unstash 'rpms'
         stage("Install Deps") {


### PR DESCRIPTION
A major part of the buildroot CI change was to decouple the FCOS
buildroot from cosa's. We're breaking that here by trying to install our
newly built rpm-ostree RPMs into cosa. So let's drop that.

Obviously it'd be good to get that coverage, though we should be covered
by our own compose tests. Maybe long-term we should just rebuild for
*both* cosa and the FCOS buildroot if they differ. (This will be
especially relevant if we ever want to add e.g. upstream CI testing for
the `next-devel` or `rawhide` streams.)

Similarly for the compose tests, we should use the buildPod, which is
the same userspace in which we built rpm-ostree.