### PR TITLE
lockfile: Allow `metadata` field in locked packages

### DIFF
--- a/rust/src/lockfile.rs
+++ b/rust/src/lockfile.rs
@@ -118,12 +118,13 @@ struct LockfileConfigMetadata {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 struct LockfileRepoMetadata {
     generated: DateTime<Utc>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 enum LockedPackage {
     Evr {
         evr: String,


### PR DESCRIPTION
This field will allow humans to shove additional structured metadata
into lockfiles which could then be used by higher-level tools.

See: coreos/fedora-coreos-config#965