### PR TITLE
app/deploy: Add --skip-branch-check

### DIFF
--- a/src/app/rpmostree-builtin-deploy.cxx
+++ b/src/app/rpmostree-builtin-deploy.cxx
@@ -37,6 +37,7 @@ static gboolean opt_lock_finalization;
 static gboolean opt_disallow_downgrade;
 static gboolean opt_unchanged_exit_77;
 static gboolean opt_bypass_driver;
+static gboolean opt_skip_branch_check;
 
 static GOptionEntry option_entries[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
@@ -48,6 +49,7 @@ static GOptionEntry option_entries[] = {
   { "preview", 0, 0, G_OPTION_ARG_NONE, &opt_preview, "Just preview package differences", NULL },
   { "cache-only", 'C', 0, G_OPTION_ARG_NONE, &opt_cache_only, "Do not download latest ostree and RPM data", NULL },
   { "download-only", 0, 0, G_OPTION_ARG_NONE, &opt_download_only, "Just download latest ostree and RPM data, don't deploy", NULL },
+  { "skip-branch-check", 0, 0, G_OPTION_ARG_NONE, &opt_skip_branch_check, "Do not check if commit belongs on the same branch", NULL },
   { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization, "Prevent automatic deployment finalization on shutdown", NULL },
   { "disallow-downgrade", 0, 0, G_OPTION_ARG_NONE, &opt_disallow_downgrade, "Forbid deployment of chronologically older trees", NULL },
   { "unchanged-exit-77", 0, 0, G_OPTION_ARG_NONE, &opt_unchanged_exit_77, "If no new deployment made, exit 77", NULL },
@@ -132,6 +134,7 @@ rpmostree_builtin_deploy (int            argc,
       g_variant_dict_insert (&dict, "allow-downgrade", "b", !opt_disallow_downgrade);
       g_variant_dict_insert (&dict, "cache-only", "b", opt_cache_only);
       g_variant_dict_insert (&dict, "download-only", "b", opt_download_only);
+      g_variant_dict_insert (&dict, "skip-branch-check", "b", opt_skip_branch_check);
       g_variant_dict_insert (&dict, "lock-finalization", "b", opt_lock_finalization);
       g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
       if (opt_register_driver)

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -314,6 +314,9 @@
          "skip-purge" (type 'b')
             Do not purge the old refspec. Only valid if "set-refspec" is
             specified.
+         "skip-branch-check" (type 'b')
+            When deploying by commit hash (using "set-revision"), do not
+            check if commit belongs on the same branch.
          "no-pull-base" (type 'b')
             Do not pull a base layer from the remote. Not valid if
             either "set-refspec" or "set-revision" is specified.

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -290,6 +290,17 @@ assert_file_has_content status.txt "failed to finalize previous deployment"
 assert_file_has_content status.txt "error: opendir"
 echo "ok previous staged failure in status"
 
+# check that --skip-branch-check indeeds skips branch checking
+csum=$(vm_cmd ostree commit -b otherbranch --tree=ref=vmcheck)
+if vm_rpmostree deploy $csum 2>err.txt; then
+    assert_not_reached "Deployed to commit on different branch"
+fi
+assert_file_has_content err.txt "Checksum .* not found in .*"
+vm_rpmostree cleanup -p
+vm_rpmostree deploy $csum --skip-branch-check
+vm_rpmostree cleanup -p
+echo "ok deploy --skip-branch-check"
+
 # Test `deploy --register-driver` option
 # Create and start a transient test-driver.service unit to register our fake driver
 vm_cmd systemd-run --unit=test-driver.service --wait -q \


### PR DESCRIPTION
In Fedora CoreOS, updates are driven by Zincati and we thus completely
trust the information it gives us. The branch validation rpm-ostree does
is thus not necessary. It's also harmful in the case where the node is
extremely out of date because it may not be able to GPG verify the
commit at the tip of the branch (because the GPG key isn't yet in the
tree).

See: https://github.com/coreos/fedora-coreos-tracker/issues/749