### PR TITLE
Release 2021.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2021])
-m4_define([release_version], [4])
+m4_define([release_version], [5])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2021.4
+Version: 2021.5
 Release: 1%{?dist}
 License: LGPLv2+
 URL: https://github.com/coreos/rpm-ostree


### PR DESCRIPTION
# rpm-ostree v2021.5

This is mostly a bugfix release, with a few new user-facing features.

### Client

Kernel arguments can now be updated in an idempotent fashion, via the new `kargs` flags `--append-if-missing` and `--delete-if-present`.

It is now possible to skip on-branch checks when deploying a specific revision by commit hash. This will be used by Zincati in Fedora CoreOS.

The Count Me feature from DNF is now fully disabled by default in all repo queries and will only be triggered by the corresponding `rpm-ostree-countme.timer` and `rpm-ostree-countme.service` units. See https://coreos.github.io/rpm-ostree/countme/ for details.

### Compose

Among notable changes, the post-processing logic now understands the IMA extended attribute `user.ima`. When such xattr is found, it is automatically translated to `security.ima` in the final OSTree content.

The treefile got a new `repo-packages` field. It can be used to pin a set of packages to a specific repository.

The legacy `unified-core` logic proceeds on its path to deprecation, with an increased artificial delay to encourage remaining consumers to migrate away. 

### Internals

Several cleanups of internal treefile handling were completed with the goal of having the client side use treefiles as well.

Special thanks to our first-time contributors Rafael G. Ruiz and Stefan Berger!

---

```
Benjamin Gilbert (1):
      docs: fix "Edit this page on GitHub" links

Colin Walters (25):
      compose: Pass treefile directly in rpmostree_context_new_tree()
      Read treefile directly for `documentation` flag
      Read treefile directly for `selinux` and `recommends` flags
      compose: Remove unused helper functions
      Read treefile directly for `releasever`
      Move `ref` parsing into core
      build-sys: Drop git.mk, hardcode .gitignore
      core: Rename context_new_system() to context_new_client()
      core: Rename context_new_tree() to context_new_compose()
      build-sys: Avoid re-building + re-linking cxx-rs C++ bits each build
      compose: Move repos/lockfile-repos validation to Rust
      daemon: Always write `staged` JSON field
      core: Remove cancellable/error from context creation APIs
      core: Split off a method to set the treespec
      Expose more from treefile via cxx-rs; adapt _install_langs to use it
      bwrap: Fix selftest to be truly immutable
      core: Fix tempetc guard to be no-op if /etc exists
      Require ostree v2021.2, use ostree-ext crate
      tests/compose: Bump pinned fcos commit
      Fix bwrap usage for mutate-os-release
      Add Rust tracing crate usage
      compose: Bump timeout for non-unified-core to 10s
      Add and use the `camino` library for UTF-8 paths
      composepost: Fix race condition in timestamp checking
      treefile: Minor cleanup of handle_repo_packages_overrides()

Dusty Mabe (1):
      lib/package: Fix rpm version comparison

Jonathan Lebon (35):
      .gitignore: add compose-{cache,logs} dirs
      rust/passwd: Fix handling of `previous` mode
      tests/compose: Change rpmdb test to check for sqlite
      tests/compose: Adapt chrony autovar for newer FCOS
      rust/main: Pass CLI args to command entrypoints
      rust: Drop includes.rs
      libpriv: Bridge print_treepkg_diff_from_sysroot_path()
      rust/treefile: Fix minor comment typo
      core: Add comment about SERVER_BASE commits
      treefile: Add new `repo-packages` field for pinning packages to repos
      tests/vmcheck/misc-2: Update error message to grep for
      treefile: Fix rpmdb backend casing
      app/deploy: Add --skip-branch-check
      lockfile: Add missing serde(deny_unknown_fields)
      lockfile: Allow `metadata` field in locked packages

Kelvin Fan (1):
      app/clientlib: Don't error if update driver "stopped"

Luca BRUNO (12):
      composepost: uniform results and visibility for cxxbridge
      tests/compose: add more autovar testcases
      postprocess: move /var tmpfiles.d translation logic to Rust
      tests/compose: check symlinks injected into the rootfs
      composepost: move rootfs symlinks creation to Rust
      composepost: optimize disk roundtrips
      composepost: expand unit test surface
      composepost: fix fchmod flags for tmpdir (glibc compat)
      composepost: move SELinux workaround logic to Rust
      composepost: move rpmdb linking logic to Rust
      tests/override-kernel: add f34 kernel
      libpriv/importer: move path-checking logic to Rust

Rafael G. Ruiz (3):
      kargs: add CLI switches --append-if-missing and --delete-if-present
      kargs: Add CLI switch --unchanged-exit-77
      kargs: Simplify conditional statements

Stefan Berger (1):
      Support hardcoded user.ima to security.ima translation

Timothée Ravier (3):
      countme: Force disable Count Me logic in DNF
      daemon: Only update idle status every 10 seconds
      countme: Drop SELinux workaround/unpriv copy of rpm-ostree
```