### PR TITLE
passwd: Make default perms 0644

### DIFF
--- a/tests/compose/libbasic-test.sh
+++ b/tests/compose/libbasic-test.sh
@@ -19,6 +19,9 @@ validate_passwd() {
 validate_passwd passwd
 validate_passwd group
 
+ostree --repo=${repo} ls ${treeref} /usr/etc/passwd > passwd.txt
+assert_file_has_content_literal passwd.txt '00644 '
+
 ostree --repo=${repo} cat ${treeref} /usr/etc/default/useradd > useradd.txt
 assert_file_has_content_literal useradd.txt HOME=/var/home
 


### PR DESCRIPTION
This matches the default from the RPM, and we don't want
the file to be writable if an admin adds a user to the `root`
group.  (Which IMO is just a bad idea, but
for historical reasons OpenShift suggests this for
images
https://docs.openshift.com/container-platform/4.7/openshift_images/create-images.html#images-create-guide-openshift_create-images
for example)
