### PR TITLE
core: Don't load host rpmdb when doing composes

### DIFF
--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -1033,6 +1033,9 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
   /* https://github.com/rpm-software-management/libdnf/pull/416
    * https://github.com/projectatomic/rpm-ostree/issues/1127
    */
+  // In composes, don't load the host (container) rpmdb
+  if (!self->is_system)
+    flags = static_cast<DnfContextSetupSackFlags>(static_cast<int>(flags) | DNF_CONTEXT_SETUP_SACK_FLAG_SKIP_RPMDB);
   if (flags & DNF_CONTEXT_SETUP_SACK_FLAG_SKIP_FILELISTS)
     dnf_context_set_enable_filelists (self->dnfctx, FALSE);
 


### PR DESCRIPTION
I was trying to do an RHCOS build using a custom rpm-ostree build
in a f34 container without having used `--enable-sqlite-rpmdb-default`.

This immediately failed trying to load the host rpmdb.
Now, in practice we don't care about this problem, and it doesn't
solve https://github.com/openshift/os/issues/552 because
the f34 rpm still can't write bdb and so just dies later.

But, I think this is the right thing to do - we shouldn't pollute
the sack with the host (container) rpmdb in the `compose tree`
case.
