### PR TITLE
tree-wide: Remove (almost) all remaining rojig bits

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -137,7 +137,6 @@ echo "
     $PACKAGE $VERSION
 
     introspection:                           $found_introspection
-    rojig:                                   ${enable_rojig:-no}
     ASAN + UBSAN:                            ${enable_sanitizers:-no}
     gtk-doc:                                 $enable_gtk_doc
     rust:                                    $rust_debug_release

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -276,8 +276,6 @@ pub mod ffi {
         fn format_install_langs_macro(&self) -> String;
         fn get_lockfile_repos(&self) -> Vec<String>;
         fn get_ref(&self) -> &str;
-        fn get_rojig_spec_path(&self) -> String;
-        fn get_rojig_name(&self) -> String;
         fn get_cliwrap(&self) -> bool;
         fn get_readonly_executables(&self) -> bool;
         fn get_documentation(&self) -> bool;

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -15,7 +15,6 @@ use std::result::Result as StdResult;
 
 use std::collections::{BTreeMap, BTreeSet};
 
-const ROJIG_PREFIX: &str = "rojig://";
 const ORIGIN: &str = "origin";
 const OVERRIDE_COMMIT: &str = "override-commit";
 
@@ -23,7 +22,6 @@ const OVERRIDE_COMMIT: &str = "override-commit";
 pub(crate) enum RefspecType {
     Checksum,
     Ostree,
-    Rojig,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -224,11 +222,7 @@ impl Origin {
     }
 
     pub(crate) fn get_prefixed_refspec(&self) -> String {
-        let val = self.cache.refspec.value.as_str();
-        match self.cache.refspec.kind {
-            RefspecType::Rojig => format!("{}{}", ROJIG_PREFIX, val),
-            _ => val.to_string(),
-        }
+        self.cache.refspec.value.as_str().to_string()
     }
 
     pub(crate) fn get_custom_url(&self) -> Result<String> {

--- a/src/app/rpmostree-builtin-rebase.cxx
+++ b/src/app/rpmostree-builtin-rebase.cxx
@@ -142,10 +142,8 @@ rpmostree_builtin_rebase (int             argc,
   RpmOstreeRefspecType refspectype;
   if (!rpmostree_refspec_classify (new_provided_refspec, &refspectype, &remainder, error))
     return FALSE;
-  if (!opt_experimental && refspectype == RPMOSTREE_REFSPEC_TYPE_ROJIG)
-    return glnx_throw (error, "rojig:// refspec requires --experimental");
 
-  /* catch "ostree://" or "rojig://"; we'd error out much later in the daemon otherwise */
+  /* catch "ostree://"; we'd error out much later in the daemon otherwise */
   if (strlen (remainder) == 0)
     return glnx_throw (error, "Refspec is empty");
 

--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -652,8 +652,6 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
             g_print ("%s", canonrefspec);
           }
           break;
-        case RPMOSTREE_REFSPEC_TYPE_ROJIG:
-          g_assert_not_reached ();
         }
     }
   else

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -147,7 +147,6 @@ typedef struct {
   OstreeRepo *pkgcache_repo; /* unified mode: pkgcache repo where we import pkgs */
   OstreeRepoDevInoCache *devino_cache;
   const char *ref;
-  char *rojig_spec;
   char *previous_checksum;
 
   std::optional<rust::Box<rpmostreecxx::Treefile>> treefile_rs;
@@ -295,8 +294,7 @@ install_packages (RpmOstreeTreeComposeContext  *self,
   }
 
   /* By default, retain packages in addition to metadata with --cachedir, unless
-   * we're doing unified core, in which case the pkgcache repo is the cache.  But
-   * the rojigSet build still requires the original RPMs too.
+   * we're doing unified core, in which case the pkgcache repo is the cache.
    */
   if (opt_cachedir && !opt_unified_core)
     dnf_context_set_keep_cache (dnfctx, TRUE);
@@ -448,9 +446,7 @@ install_packages (RpmOstreeTreeComposeContext  *self,
         return FALSE;
 
       /* Now reload the policy from the tmproot, and relabel the pkgcache - this
-       * is the same thing done in rpmostree_context_commit(). But here we want
-       * to ensure our pkgcache labels are accurate, since that will
-       * be important for the ostree-rojig work.
+       * is the same thing done in rpmostree_context_commit().
        */
       g_autoptr(OstreeSePolicy) sepolicy = ostree_sepolicy_new_at (rootfs_dfd, cancellable, error);
       if (sepolicy == NULL)

--- a/src/daemon/rpmostree-sysroot-core.cxx
+++ b/src/daemon/rpmostree-sysroot-core.cxx
@@ -128,8 +128,7 @@ add_package_refs_to_set (RpmOstreeRefSack *rsack,
       for (guint i = 0; i < pkglist->len; i++)
         {
           auto pkg = static_cast<DnfPackage *>(pkglist->pdata[i]);
-          g_autofree char *pkgref =
-            is_rojig ? rpmostree_get_rojig_branch_pkg (pkg) : rpmostree_get_cache_branch_pkg (pkg);
+          g_autofree char *pkgref = rpmostree_get_cache_branch_pkg (pkg);
           g_hash_table_add (referenced_pkgs, util::move_nullify (pkgref));
         }
     }

--- a/src/daemon/rpmostree-sysroot-core.cxx
+++ b/src/daemon/rpmostree-sysroot-core.cxx
@@ -156,7 +156,6 @@ generate_pkgcache_refs (OstreeSysroot            *sysroot,
   for (guint i = 0; i < deployments->len; i++)
     {
       auto deployment = static_cast<OstreeDeployment *>(deployments->pdata[i]);
-      const char *current_checksum = ostree_deployment_get_csum (deployment);
 
       g_autofree char *base_commit = NULL;
       if (!rpmostree_deployment_get_base_layer (repo, deployment, &base_commit, error))
@@ -187,20 +186,6 @@ generate_pkgcache_refs (OstreeSysroot            *sysroot,
 
           if (!add_package_refs_to_set (rsack, FALSE, referenced_pkgs, cancellable, error))
             return glnx_prefix_error (error, "Deployment index=%d", i);
-        }
-      /* In rojig mode, we need to also reference packages from the base; this
-       * is a different refspec format.
-       */
-      if (rpmostree_origin_is_rojig (origin))
-        {
-          const char *actual_base_commit = base_commit ?: current_checksum;
-          g_autoptr(RpmOstreeRefSack) base_rsack =
-            rpmostree_get_base_refsack_for_commit (repo, actual_base_commit, cancellable, error);
-          if (base_rsack == NULL)
-            return FALSE;
-
-          if (!add_package_refs_to_set (base_rsack, TRUE, referenced_pkgs, cancellable, error))
-            return FALSE;
         }
 
       /* also add any inactive local replacements */

--- a/src/daemon/rpmostree-sysroot-core.cxx
+++ b/src/daemon/rpmostree-sysroot-core.cxx
@@ -109,7 +109,6 @@ generate_baselayer_refs (OstreeSysroot            *sysroot,
  */
 static gboolean
 add_package_refs_to_set (RpmOstreeRefSack *rsack,
-                         gboolean          is_rojig,
                          GHashTable *referenced_pkgs,
                          GCancellable *cancellable,
                          GError **error)
@@ -183,7 +182,7 @@ generate_pkgcache_refs (OstreeSysroot            *sysroot,
           if (rsack == NULL)
             return FALSE;
 
-          if (!add_package_refs_to_set (rsack, FALSE, referenced_pkgs, cancellable, error))
+          if (!add_package_refs_to_set (rsack, referenced_pkgs, cancellable, error))
             return glnx_prefix_error (error, "Deployment index=%d", i);
         }
 
@@ -203,20 +202,6 @@ generate_pkgcache_refs (OstreeSysroot            *sysroot,
                                   OSTREE_REPO_LIST_REFS_EXT_NONE, cancellable, error))
     return FALSE;
   GLNX_HASH_TABLE_FOREACH (pkg_refs, const char*, ref)
-    {
-      if (g_hash_table_contains (referenced_pkgs, ref))
-        continue;
-
-      ostree_repo_transaction_set_ref (repo, NULL, ref, NULL);
-      n_freed++;
-    }
-
-  /* Loop over rojig refs */
-  g_autoptr(GHashTable) rojig_refs = NULL;
-  if (!ostree_repo_list_refs_ext (repo, "rpmostree/rojig", &rojig_refs,
-                                  OSTREE_REPO_LIST_REFS_EXT_NONE, cancellable, error))
-    return FALSE;
-  GLNX_HASH_TABLE_FOREACH (rojig_refs, const char*, ref)
     {
       if (g_hash_table_contains (referenced_pkgs, ref))
         continue;

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -947,16 +947,6 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self,
                                 cancellable, error))
     return FALSE;
 
-  if (rpmostree_origin_is_rojig (self->origin))
-    {
-      /* We don't want to re-check the metadata, we already did that for the
-       * base. In the future we should try to re-use the DnfContext.
-       */
-      g_autoptr(DnfState) hifstate = dnf_state_new ();
-      if (!dnf_context_setup_sack (rpmostree_context_get_dnf (self->ctx), hifstate, error))
-        return FALSE;
-    }
-
   const gboolean have_packages = (self->overlay_packages->len > 0 ||
                                   g_hash_table_size (local_pkgs) > 0 ||
                                   self->override_remove_packages->len > 0 ||

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -52,7 +52,7 @@
  * The #RpmOstreeSysrootUpgrader class models a `baserefspec` OSTree branch
  * in an origin file, along with a set of layered RPM packages.
  *
- * It also supports the plain-ostree "refspec" model, as well as rojig://.
+ * It also supports the plain-ostree "refspec" model.
  */
 typedef struct {
   GObjectClass parent_class;
@@ -480,10 +480,6 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
           }
       }
       break;
-    case RPMOSTREE_REFSPEC_TYPE_ROJIG:
-      {
-        return glnx_throw (error, "rojig is not supported in this build of rpm-ostree");
-      }
     }
 
   gboolean changed = !g_str_equal (new_base_rev, self->base_revision);

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -338,10 +338,7 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
       }
       break;
     case RPMOSTREE_REFSPEC_TYPE_ROJIG:
-      {
-        g_variant_dict_insert (dict, "rojig-description", "@a{sv}",
-                               rpmostree_origin_get_rojig_description (origin));
-      }
+      g_assert_not_reached ();
       break;
     }
 

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -337,9 +337,6 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
           }
       }
       break;
-    case RPMOSTREE_REFSPEC_TYPE_ROJIG:
-      g_assert_not_reached ();
-      break;
     }
 
   if (refspec)
@@ -806,17 +803,6 @@ rpmostreed_update_generate_variant (OstreeDeployment  *booted_deployment,
     const char *refspec_data;
     if (!rpmostree_refspec_classify (refspec, &refspectype, &refspec_data, error))
       return FALSE;
-
-    /* we don't support rojig-based origins yet */
-    switch (refspectype)
-      {
-      case RPMOSTREE_REFSPEC_TYPE_ROJIG:
-        *out_update = NULL;
-        return TRUE; /* NB: early return */
-      case RPMOSTREE_REFSPEC_TYPE_OSTREE:
-      case RPMOSTREE_REFSPEC_TYPE_CHECKSUM:
-        break;
-      }
 
     /* just skip over "ostree://" so we can talk with libostree without thinking about it */
     refspec = refspec_data;

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -212,8 +212,7 @@ apply_revision_override (RpmostreedTransaction    *transaction,
           }
           break;
         case RPMOSTREE_REFSPEC_TYPE_ROJIG:
-          /* This case we'll look up later */
-          rpmostree_origin_set_rojig_version (origin, version);
+          g_assert_not_reached ();
           break;
         case RPMOSTREE_REFSPEC_TYPE_CHECKSUM:
           g_assert_not_reached ();  /* Handled above */

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -68,33 +68,6 @@ change_origin_refspec (GVariantDict    *options,
   const char *current_refspecdata;
   rpmostree_origin_classify_refspec (origin, &current_refspectype, &current_refspecdata);
 
-  /* This function ideally would be split into ostree/rojig handling
-   * and we'd also do "partial" support for rojig so one could do e.g.
-   * `rpm-ostree rebase fedora-atomic-workstation` instead of
-   * `rpm-ostree rebase updates:fedora-atomic-workstation` etc.
-   */
-  switch (refspectype)
-    {
-      case RPMOSTREE_REFSPEC_TYPE_ROJIG:
-        {
-          if (!rpmostree_origin_set_rebase (origin, src_refspec, error))
-            return FALSE;
-
-          if (current_refspectype == RPMOSTREE_REFSPEC_TYPE_ROJIG
-              && strcmp (current_refspecdata, refspecdata) == 0)
-            return glnx_throw (error, "Old and new refs are equal: %s", src_refspec);
-
-          if (out_old_refspec != NULL)
-            *out_old_refspec = g_strdup (current_refspecdata);
-          if (out_new_refspec != NULL)
-            *out_new_refspec = g_strdup (src_refspec);
-          return TRUE;
-        }
-    case RPMOSTREE_REFSPEC_TYPE_OSTREE:
-    case RPMOSTREE_REFSPEC_TYPE_CHECKSUM:
-      break;
-    }
-
   /* Now here we "peel" it since the rest of the code assumes libostree */
   const char *refspec = refspecdata;
 
@@ -211,9 +184,6 @@ apply_revision_override (RpmostreedTransaction    *transaction,
             rpmostree_origin_set_override_commit (origin, checksum, version);
           }
           break;
-        case RPMOSTREE_REFSPEC_TYPE_ROJIG:
-          g_assert_not_reached ();
-          break;
         case RPMOSTREE_REFSPEC_TYPE_CHECKSUM:
           g_assert_not_reached ();  /* Handled above */
         }
@@ -232,11 +202,6 @@ apply_revision_override (RpmostreedTransaction    *transaction,
                                                     checksum, progress, cancellable, error))
                 return FALSE;
             }
-          break;
-        case RPMOSTREE_REFSPEC_TYPE_ROJIG:
-          /* For now we skip validation here, if there's an error we'll see it later
-           * on.
-           */
           break;
         case RPMOSTREE_REFSPEC_TYPE_CHECKSUM:
           g_assert_not_reached ();  /* Handled above */
@@ -1073,9 +1038,6 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
       if (!rpmostree_refspec_classify (self->refspec, &refspectype, &ref, error))
         return FALSE;
 
-      if (refspectype == RPMOSTREE_REFSPEC_TYPE_ROJIG)
-        return glnx_throw (error, "Local repo remotes not supported for rojig://");
-
       g_autoptr(OstreeRepo) local_repo_remote =
         ostree_repo_open_at (self->local_repo_remote_dfd, ".", cancellable, error);
       if (!local_repo_remote)
@@ -1436,7 +1398,6 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
         return glnx_throw (error, "Refusing to download rpm-md for offline OS '%s'",
                            self->osname);
 
-      /* XXX: in rojig mode we'll want to do this unconditionally */
       g_autoptr(DnfSack) sack = NULL;
       if (g_hash_table_size (rpmostree_origin_get_packages (origin)) > 0)
         {

--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -40,15 +40,6 @@ struct _RpmOstreeContext {
   gboolean disable_selinux;
   char *ref;
 
-  /* rojig-mode data */
-  const char *rojig_spec; /* The rojig spec like: repoid:package */
-  const char *rojig_version; /* Optional */
-  gboolean rojig_pure; /* There is only rojig */
-  gboolean rojig_allow_not_found; /* Don't error if package not found */
-  DnfPackage *rojig_pkg;
-  char *rojig_checksum;
-  char *rojig_inputhash;
-
   gboolean pkgcache_only;
   DnfContext *dnfctx;
   RpmOstreeContextDnfCachePolicy dnf_cache_policy;
@@ -59,9 +50,6 @@ struct _RpmOstreeContext {
   gboolean unprivileged;
   OstreeSePolicy *sepolicy;
   char *passwd_dir;
-  /* Used in async imports, not owned */
-  GVariant *rojig_xattr_table;
-  GHashTable *rojig_pkg_to_xattrs;
 
   guint async_index; /* Offset into array if applicable */
   guint n_async_running;

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -2554,7 +2554,6 @@ start_async_import_one_package (RpmOstreeContext *self, DnfPackage *pkg,
   if (rojig_xattrs)
     {
       g_assert (!self->sepolicy);
-      rpmostree_importer_set_rojig_mode (unpacker, self->rojig_xattr_table, rojig_xattrs);
     }
 
   rpmostree_importer_run_async (unpacker, cancellable, on_async_import_done, self);

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -90,9 +90,6 @@ rpmostree_refspec_to_string (RpmOstreeRefspecType  reftype,
     case RPMOSTREE_REFSPEC_TYPE_CHECKSUM:
       prefix = RPMOSTREE_REFSPEC_OSTREE_PREFIX;
       break;
-    case RPMOSTREE_REFSPEC_TYPE_ROJIG:
-      prefix = RPMOSTREE_REFSPEC_ROJIG_PREFIX;
-      break;
     }
   g_assert (prefix);
   return g_strconcat (prefix, data, NULL);
@@ -2156,23 +2153,6 @@ GPtrArray *
 rpmostree_context_get_packages (RpmOstreeContext *self)
 {
   return g_ptr_array_ref (self->pkgs);
-}
-
-/* Rather than doing a depsolve, directly set which packages
- * are required.  Will be used by rojig.
- */
-gboolean
-rpmostree_context_set_packages (RpmOstreeContext *self,
-                                GPtrArray        *packages,
-                                GCancellable     *cancellable,
-                                GError          **error)
-{
-  g_clear_pointer (&self->pkgs_to_download, (GDestroyNotify)g_ptr_array_unref);
-  g_clear_pointer (&self->pkgs_to_import, (GDestroyNotify)g_ptr_array_unref);
-  self->n_async_pkgs_imported = 0;
-  g_clear_pointer (&self->pkgs_to_relabel, (GDestroyNotify)g_ptr_array_unref);
-  self->n_async_pkgs_relabeled = 0;
-  return sort_packages (self, packages, cancellable, error);
 }
 
 /* Returns a reference to the set of packages that will be imported */

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -162,11 +162,6 @@ gboolean rpmostree_context_download_metadata (RpmOstreeContext  *context,
 gboolean rpmostree_context_prepare (RpmOstreeContext     *self,
                                     GCancellable   *cancellable,
                                     GError        **error);
-/* Like above, but used for "pure rojig" cases */
-gboolean rpmostree_context_prepare_rojig (RpmOstreeContext     *self,
-                                          gboolean              allow_not_found,
-                                          GCancellable         *cancellable,
-                                          GError              **error);
 
 GPtrArray *rpmostree_context_get_packages (RpmOstreeContext *self);
 
@@ -194,30 +189,15 @@ gboolean rpmostree_context_download (RpmOstreeContext *self,
 void rpmostree_set_repos_on_packages (DnfContext *dnfctx,
                                       GPtrArray  *packages);
 
-gboolean rpmostree_context_execute_rojig (RpmOstreeContext     *self,
-                                          gboolean             *out_changed,
-                                          GCancellable         *cancellable,
-                                          GError              **error);
-
 gboolean
 rpmostree_context_consume_package (RpmOstreeContext  *self,
                                    DnfPackage        *package,
                                    int               *out_fd,
                                    GError           **error);
 
-DnfPackage *rpmostree_context_get_rojig_pkg (RpmOstreeContext  *self);
-const char *rpmostree_context_get_rojig_checksum (RpmOstreeContext  *self);
-const char *rpmostree_context_get_rojig_inputhash (RpmOstreeContext  *self);
-
 gboolean rpmostree_context_import (RpmOstreeContext *self,
                                    GCancellable     *cancellable,
                                    GError          **error);
-
-gboolean rpmostree_context_import_rojig (RpmOstreeContext *self,
-                                         GVariant         *xattr_table,
-                                         GHashTable       *pkg_to_xattrs,
-                                         GCancellable     *cancellable,
-                                         GError          **error);
 
 gboolean rpmostree_context_force_relabel (RpmOstreeContext *self,
                                           GCancellable     *cancellable,

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -59,17 +59,13 @@ G_DECLARE_FINAL_TYPE (RpmOstreeContext, rpmostree_context, RPMOSTREE, CONTEXT, G
 #define RPMOSTREE_TYPE_TREESPEC (rpmostree_treespec_get_type ())
 G_DECLARE_FINAL_TYPE (RpmOstreeTreespec, rpmostree_treespec, RPMOSTREE, TREESPEC, GObject)
 
-/* Now in the code we handle "refspec" types of rojig (rpm-ostree jigdo),
- * in addition to ostree.
- */
+
 typedef enum {
   RPMOSTREE_REFSPEC_TYPE_OSTREE,
-  RPMOSTREE_REFSPEC_TYPE_ROJIG,
   RPMOSTREE_REFSPEC_TYPE_CHECKSUM,
 } RpmOstreeRefspecType;
 
 #define RPMOSTREE_REFSPEC_OSTREE_PREFIX "ostree://"
-#define RPMOSTREE_REFSPEC_ROJIG_PREFIX "rojig://"
 
 gboolean rpmostree_refspec_classify (const char *refspec,
                                      RpmOstreeRefspecType *out_type,
@@ -164,12 +160,6 @@ gboolean rpmostree_context_prepare (RpmOstreeContext     *self,
                                     GError        **error);
 
 GPtrArray *rpmostree_context_get_packages (RpmOstreeContext *self);
-
-/* Alternative to _prepare() for non-depsolve cases like rojig */
-gboolean rpmostree_context_set_packages (RpmOstreeContext *self,
-                                         GPtrArray        *packages,
-                                         GCancellable     *cancellable,
-                                         GError          **error);
 
 GPtrArray *rpmostree_context_get_packages_to_import (RpmOstreeContext *self);
 

--- a/src/libpriv/rpmostree-importer.h
+++ b/src/libpriv/rpmostree-importer.h
@@ -58,10 +58,6 @@ rpmostree_importer_new_take_fd (int                     *fd,
                                 OstreeSePolicy          *sepolicy,
                                 GError                 **error);
 
-void rpmostree_importer_set_rojig_mode (RpmOstreeImporter *self,
-                                        GVariant *xattr_table,
-                                        GVariant *xattrs);
-
 gboolean
 rpmostree_importer_read_metainfo (int fd,
                                   Header *out_header,

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -187,23 +187,13 @@ rpmostree_origin_get_refspec (RpmOstreeOrigin *origin)
   return origin->cached_refspec;
 }
 
-/* For rojig:// refspecs, includes the prefix. */
 char *
 rpmostree_origin_get_full_refspec (RpmOstreeOrigin *origin,
                                    RpmOstreeRefspecType *out_refspectype)
 {
   if (out_refspectype)
     *out_refspectype = origin->refspec_type;
-  switch (origin->refspec_type)
-    {
-    case RPMOSTREE_REFSPEC_TYPE_OSTREE:
-    case RPMOSTREE_REFSPEC_TYPE_CHECKSUM:
-      return g_strdup (origin->cached_refspec);
-    case RPMOSTREE_REFSPEC_TYPE_ROJIG:
-      return g_strconcat (RPMOSTREE_REFSPEC_ROJIG_PREFIX, origin->cached_refspec, NULL);
-    }
-  g_assert_not_reached ();
-  return NULL;
+  return g_strdup (origin->cached_refspec);
 }
 
 void
@@ -530,9 +520,6 @@ rpmostree_origin_set_rebase_custom (RpmOstreeOrigin *origin,
           }
       }
       break;
-    case RPMOSTREE_REFSPEC_TYPE_ROJIG:
-      g_assert_not_reached ();
-      break;
     }
 
   return TRUE;
@@ -589,11 +576,6 @@ update_keyfile_pkgs_from_cache (RpmOstreeOrigin *origin,
             g_key_file_remove_key (origin->kf, "origin", "refspec", NULL);
             break;
           }
-        case RPMOSTREE_REFSPEC_TYPE_ROJIG:
-          /* Nothing to switch, since libostree already doesn't know how to
-           * handle rojig.
-           */
-          break;
         }
     }
 }

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -69,14 +69,6 @@ char *
 rpmostree_origin_get_full_refspec (RpmOstreeOrigin *origin,
                                    RpmOstreeRefspecType *out_refspectype);
 
-gboolean rpmostree_origin_is_rojig (RpmOstreeOrigin *origin);
-
-const char *
-rpmostree_origin_get_rojig_version (RpmOstreeOrigin *origin);
-
-GVariant *
-rpmostree_origin_get_rojig_description (RpmOstreeOrigin *origin);
-
 void
 rpmostree_origin_get_custom_description (RpmOstreeOrigin *origin,
                                          char           **custom_type,
@@ -143,13 +135,6 @@ void
 rpmostree_origin_set_override_commit (RpmOstreeOrigin *origin,
                                       const char      *checksum,
                                       const char      *version);
-void
-rpmostree_origin_set_rojig_description (RpmOstreeOrigin *origin,
-                                        DnfPackage      *package);
-
-void
-rpmostree_origin_set_rojig_version (RpmOstreeOrigin *origin,
-                                    const char      *version);
 
 gboolean
 rpmostree_origin_get_cliwrap (RpmOstreeOrigin *origin);

--- a/src/libpriv/rpmostree-rpm-util.cxx
+++ b/src/libpriv/rpmostree-rpm-util.cxx
@@ -1418,15 +1418,6 @@ rpmostree_get_cache_branch_header (Header hdr)
   return rpmostree_get_cache_branch_for_n_evr_a (name, evr, arch);
 }
 
-char *
-rpmostree_get_rojig_branch_header (Header hdr)
-{
-  g_autofree char *name = headerGetAsString (hdr, RPMTAG_NAME);
-  g_autofree char *evr = headerGetAsString (hdr, RPMTAG_EVR);
-  g_autofree char *arch = headerGetAsString (hdr, RPMTAG_ARCH);
-  return get_branch_for_n_evr_a ("rojig", name, evr, arch);
-}
-
 /* Return the ostree cache branch from a libdnf Package */
 char *
 rpmostree_get_cache_branch_pkg (DnfPackage *pkg)
@@ -1434,14 +1425,6 @@ rpmostree_get_cache_branch_pkg (DnfPackage *pkg)
   return rpmostree_get_cache_branch_for_n_evr_a (dnf_package_get_name (pkg),
                                                  dnf_package_get_evr (pkg),
                                                  dnf_package_get_arch (pkg));
-}
-
-char *
-rpmostree_get_rojig_branch_pkg (DnfPackage *pkg)
-{
-  return get_branch_for_n_evr_a ("rojig", dnf_package_get_name (pkg),
-                                 dnf_package_get_evr (pkg),
-                                 dnf_package_get_arch (pkg));
 }
 
 GPtrArray*

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -219,9 +219,7 @@ rpmostree_create_rpmdb_pkglist_variant (int              dfd,
 
 char * rpmostree_get_cache_branch_for_n_evr_a (const char *name, const char *evr, const char *arch);
 char *rpmostree_get_cache_branch_header (Header hdr);
-char *rpmostree_get_rojig_branch_header (Header hdr);
 char *rpmostree_get_cache_branch_pkg (DnfPackage *pkg);
-char *rpmostree_get_rojig_branch_pkg (DnfPackage *pkg);
 
 gboolean
 rpmostree_decompose_nevra (const char  *nevra,


### PR DESCRIPTION
importer: Remove rojig bits

---

core: Remove rojig bits

Nothing uses this code now.

---

daemon/sysroot: Replace some rojig code with g_assert_not_reached()

Prep for removing the APIs entirely.

---

origin: Remove rojig bits

Nothing calls these now.

---

rust/origin: Remove rojig bits

Has never been used.

---

util: Remove rojig cache branch mapping functions

Not used.

---

rust/treefile: Remove rojig spec writing

One thing I realized is we need to keep the `rojig:` bit
in the treefile because we're (ab)using it in coreos-assembler
for image naming.

But we don't need the spec file generation bits, so that can go.

---

tree-wide: Remove (almost) all remaining rojig bits

The only part left that we will need to keep ~forever is
the treefile parsing `rojig:` because it's used by coreos-assembler.
But all we need is to propagate it into the JSON treefile.

---

