### PR TITLE
cliwrap: Add initial yum/dnf wrapper

### DIFF
--- a/rust/src/cliwrap.rs
+++ b/rust/src/cliwrap.rs
@@ -4,23 +4,27 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use anyhow::{anyhow, Result};
-use std::io::prelude::*;
-use std::path;
-
+use fn_error_context::context;
 use openat_ext::OpenatDirExt;
 use rayon::prelude::*;
+use std::io::prelude::*;
+use std::path::Path;
 mod cliutil;
 mod dracut;
 mod grubby;
 mod rpm;
+mod yumdnf;
 use crate::cxxrsutil::CxxResult;
 use crate::ffiutil::*;
 
 /// Location for the underlying (not wrapped) binaries.
 pub const CLIWRAP_DESTDIR: &str = "usr/libexec/rpm-ostree/wrapped";
 
-/// Our list of binaries that will be wrapped.  Must be a relative path.
+/// Binaries that will be wrapped if they exist.
 static WRAPPED_BINARIES: &[&str] = &["usr/bin/rpm", "usr/bin/dracut", "usr/sbin/grubby"];
+
+/// Binaries we will wrap, or create if they don't exist.
+static MUSTWRAP_BINARIES: &[&str] = &["usr/bin/yum", "usr/bin/dnf"];
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum RunDisposition {
@@ -49,11 +53,47 @@ pub(crate) fn cliwrap_entrypoint(args: Vec<String>) -> CxxResult<()> {
     } else {
         match name {
             "rpm" => Ok(self::rpm::main(&args)?),
+            "yum" | "dnf" => Ok(self::yumdnf::main(&args)?),
             "dracut" => Ok(self::dracut::main(&args)?),
             "grubby" => Ok(self::grubby::main(&args)?),
             _ => Err(anyhow!("Unknown wrapped binary: {}", name).into()),
         }
     }
+}
+
+#[context("Writing wrapper for {:?}", binpath)]
+fn write_one_wrapper(rootfs_dfd: &openat::Dir, binpath: &Path, allow_noent: bool) -> Result<()> {
+    let exists = rootfs_dfd.exists(binpath)?;
+    if !exists && allow_noent {
+        return Ok(());
+    }
+
+    let name = binpath.file_name().unwrap().to_str().unwrap();
+
+    if exists {
+        let destpath = format!("{}/{}", CLIWRAP_DESTDIR, name);
+        rootfs_dfd.local_rename(binpath, destpath.as_str())?;
+        rootfs_dfd.write_file_with(binpath, 0o755, |w| {
+            indoc::writedoc! {w, r#"
+#!/bin/sh
+# Wrapper created by rpm-ostree to override
+# behavior of the underlying binary.  For more
+# information see `man rpm-ostree`.  The real
+# binary is now located at: {}
+exec /usr/bin/rpm-ostree cliwrap $0 "$@"
+"#,  destpath }
+        })?;
+    } else {
+        rootfs_dfd.write_file_with(binpath, 0o755, |w| {
+            indoc::writedoc! {w, r#"
+#!/bin/sh
+# Wrapper created by rpm-ostree to implement this CLI interface.
+# For more information see `man rpm-ostree`.
+exec /usr/bin/rpm-ostree cliwrap $0 "$@"
+"#}
+        })?;
+    }
+    Ok(())
 }
 
 /// Move the real binaries to a subdir, and replace them with
@@ -62,32 +102,12 @@ fn write_wrappers(rootfs_dfd: &openat::Dir) -> Result<()> {
     let destdir = std::path::Path::new(CLIWRAP_DESTDIR);
     rootfs_dfd.ensure_dir(destdir.parent().unwrap(), 0o755)?;
     rootfs_dfd.ensure_dir(destdir, 0o755)?;
-    WRAPPED_BINARIES.par_iter().try_for_each(|&bin| {
-        let binpath = path::Path::new(bin);
 
-        if !rootfs_dfd.exists(binpath)? {
-            return Ok(());
-        }
-
-        let name = binpath.file_name().unwrap().to_str().unwrap();
-        let destpath = format!("{}/{}", CLIWRAP_DESTDIR, name);
-        rootfs_dfd.local_rename(bin, destpath.as_str())?;
-
-        rootfs_dfd.write_file_with(binpath, 0o755, |w| {
-            write!(
-                w,
-                "#!/bin/sh
-# Wrapper created by rpm-ostree to override
-# behavior of the underlying binary.  For more
-# information see `man rpm-ostree`.  The real
-# binary is now located at: {}
-exec /usr/bin/rpm-ostree cliwrap $0 \"$@\"
-",
-                binpath.to_str().unwrap()
-            )
-        })?;
-        Ok(())
-    })
+    WRAPPED_BINARIES
+        .par_iter()
+        .map(|p| (Path::new(p), true))
+        .chain(MUSTWRAP_BINARIES.par_iter().map(|p| (Path::new(p), false)))
+        .try_for_each(|(binpath, allow_noent)| write_one_wrapper(rootfs_dfd, binpath, allow_noent))
 }
 
 pub(crate) fn cliwrap_write_wrappers(rootfs_dfd: i32) -> CxxResult<()> {
@@ -97,4 +117,46 @@ pub(crate) fn cliwrap_write_wrappers(rootfs_dfd: i32) -> CxxResult<()> {
 pub(crate) fn cliwrap_destdir() -> String {
     // We return an owned string because it's used by C so we want c_str()
     CLIWRAP_DESTDIR.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Context;
+
+    fn file_contains(
+        d: &openat::Dir,
+        p: impl AsRef<Path>,
+        expected_contents: impl AsRef<str>,
+    ) -> Result<bool> {
+        let p = p.as_ref();
+        let expected_contents = expected_contents.as_ref();
+        let found_contents = d
+            .read_to_string(p)
+            .with_context(|| format!("Reading {:?}", p))?;
+        Ok(found_contents.contains(expected_contents))
+    }
+
+    #[test]
+    fn test_write_wrappers() -> Result<()> {
+        let td = tempfile::tempdir()?;
+        let td = &openat::Dir::open(td.path())?;
+        for &d in &["usr/bin", "usr/libexec"] {
+            td.ensure_dir_all(d, 0o755)?;
+        }
+        td.write_file_contents("usr/bin/rpm", 0o755, "this is rpm")?;
+        write_wrappers(td)?;
+        assert!(file_contains(
+            td,
+            "usr/bin/rpm",
+            "binary is now located at: usr/libexec/rpm-ostree/wrapped/rpm"
+        )?);
+        assert!(!td.exists("usr/sbin/grubby")?);
+        assert!(file_contains(
+            td,
+            "usr/bin/yum",
+            "to implement this CLI interface"
+        )?);
+        Ok(())
+    }
 }

--- a/rust/src/cliwrap/yumdnf.rs
+++ b/rust/src/cliwrap/yumdnf.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use anyhow::{anyhow, Result};
+use indoc::formatdoc;
+use indoc::indoc;
+use std::os::unix::process::CommandExt;
+use std::path::Path;
+use std::process::Command;
+use structopt::StructOpt;
+
+/// Emitted at the first line.
+const IMAGEBASED: &str = "Note: This system is image (rpm-ostree) based.";
+
+/// Emitted for unhandled options.
+const UNHANDLED: &str = indoc::indoc! {r#"
+rpm-ostree: Unknown arguments passed to yum/dnf compatibility wrapper.
+
+Please see `yum --help` for currently accepted commands via this
+wrapper, and `rpm-ostree --help` for more information about.the rpm-ostree
+project.
+"#};
+
+const OTHER_OPTIONS: &[(&str, &str)] = &[
+    (
+        "toolbox",
+        "For command-line development and debugging tools in a privileged container",
+    ),
+    ("podman", "General purpose containers"),
+    ("docker", "General purpose containers"),
+    ("flatpak", "Desktop (GUI) applications"),
+];
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "yumdnf-rpmostree",
+    about = "Compatibility wrapper implementing subset of yum/dnf CLI"
+)]
+#[structopt(rename_all = "kebab-case")]
+/// Main options struct
+enum Opt {
+    /// Start an upgrade of the operating system
+    Upgrade,
+    /// Start an upgrade of the operating system
+    Update,
+    /// Display information about system state
+    Status,
+    /// Perform a search of packages.
+    Search {
+        /// Search terms
+        terms: Vec<String>,
+    },
+    /// Will return an error suggesting other approaches.
+    Install {
+        /// Set of packages to install
+        packages: Vec<String>,
+    },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RunDisposition {
+    HelpOrVersionDisplayed,
+    ExecRpmOstree(Vec<String>),
+    UseSomethingElse,
+    NotImplementedYet(&'static str),
+    Unhandled,
+}
+
+fn disposition(argv: &[&str]) -> Result<RunDisposition> {
+    let opt = match Opt::from_iter_safe(std::iter::once(&"yum").chain(argv.iter())) {
+        Ok(v) => v,
+        Err(e)
+            if e.kind == clap::ErrorKind::VersionDisplayed
+                || e.kind == clap::ErrorKind::HelpDisplayed =>
+        {
+            return Ok(RunDisposition::HelpOrVersionDisplayed)
+        }
+        Err(_) => {
+            return Ok(RunDisposition::Unhandled);
+        }
+    };
+
+    let disp = match opt {
+        Opt::Upgrade | Opt::Update => RunDisposition::ExecRpmOstree(vec!["upgrade".into()]),
+        Opt::Status => RunDisposition::ExecRpmOstree(vec!["status".into()]),
+        Opt::Install { packages: _ } => {
+            // TODO analyze packages to find e.g. `gcc` (not ok, use `toolbox`) versus `libvirt` (ok)
+            RunDisposition::UseSomethingElse
+        }
+        Opt::Search { .. } => RunDisposition::NotImplementedYet(indoc! { r##"
+            Package search is not yet implemented.
+            For now, it's recommended to use e.g. `toolbox` and `dnf search` inside there.
+            "##}),
+    };
+
+    Ok(disp)
+}
+
+/// Primary entrypoint to running our wrapped `yum`/`dnf` handling.
+pub(crate) fn main(argv: &[&str]) -> Result<()> {
+    match disposition(argv)? {
+        RunDisposition::HelpOrVersionDisplayed => Ok(()),
+        RunDisposition::ExecRpmOstree(args) => {
+            eprintln!("{}", IMAGEBASED);
+            Err(Command::new("rpm-ostree").args(args).exec().into())
+        }
+        RunDisposition::UseSomethingElse => {
+            eprintln!("{}", IMAGEBASED);
+            let mut valid_options = String::new();
+            for (cmd, text) in OTHER_OPTIONS {
+                if Path::new(&format!("/usr/bin/{}", cmd)).exists() {
+                    valid_options.push_str(&format!(" - `{}`: {}\n", cmd, text));
+                }
+            }
+            let msg = formatdoc! {r#"{}
+            Before installing packages to the host root filesystem, consider other options:
+            {}
+             - `rpm-ostree install`: Install RPM packages layered on the host root filesystem.
+            Consider these "operating system extensions". 
+            Add `--apply-live` to immediately start using the layered packages.
+            "#, IMAGEBASED, valid_options.as_str()};
+            Err(anyhow!("{}", msg))
+        }
+        RunDisposition::Unhandled => Err(anyhow!("{}", UNHANDLED)),
+        RunDisposition::NotImplementedYet(msg) => Err(anyhow!("{}\n{}", IMAGEBASED, msg)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_yumdnf() -> Result<()> {
+        assert!(matches!(
+            disposition(&["--version"])?,
+            RunDisposition::HelpOrVersionDisplayed
+        ));
+        assert!(matches!(
+            disposition(&["--help"])?,
+            RunDisposition::HelpOrVersionDisplayed
+        ));
+        assert!(matches!(
+            disposition(&["unknown", "--other"])?,
+            RunDisposition::Unhandled
+        ));
+        assert!(matches!(
+            disposition(&["upgrade"])?,
+            RunDisposition::ExecRpmOstree(_)
+        ));
+        assert!(matches!(
+            disposition(&["install", "foo"])?,
+            RunDisposition::UseSomethingElse
+        ));
+        assert!(matches!(
+            disposition(&["install", "foo", "bar"])?,
+            RunDisposition::UseSomethingElse
+        ));
+        assert!(matches!(
+            disposition(&["search", "foo", "bar"])?,
+            RunDisposition::NotImplementedYet(_)
+        ));
+        Ok(())
+    }
+}

--- a/tests/kolainst/destructive/cliwrap
+++ b/tests/kolainst/destructive/cliwrap
@@ -50,10 +50,16 @@ if dracut --blah 2>out.txt; then
 fi
 assert_file_has_content out.txt 'This system is rpm-ostree based'
 rm -f out.txt
-echo "ok cliwrap"
+echo "ok cliwrap rpm + dracut"
+
+if yum install tmux 2>err.txt; then
+    fatal "yum install worked"
+fi
+assert_file_has_content err.txt "operating system extensions"
+echo "ok cliwrap yum install"
 
 rpm-ostree deploy --ex-cliwrap=false
-rpm-ostree ex apply-live
+rpm-ostree ex apply-live --allow-replacement
 rpm --version
 rpm -qa >/dev/null
 rpm --verify bash >out.txt || true


### PR DESCRIPTION
I've come to the conclusion that we need to be friendlier
to people who are transitioning from existing `yum/dnf`
systems.  Just saying `yum: command not found` is harsh.

And moreover, there are some things that IMO *should* work.
Let's take as an example: https://tailscale.com/download/linux/fedora
This is exactly an operating system extension; it doesn't
make sense in `toolbox` or `flatpak`.  (It *could* be containerized
but...let's leave that aside)

So following that, this provides a useful bit of information for
the `dnf install tailscale` part that will point people instead to
`dnf install-osextension tailscale`.  I think the basics of `dnf config-manager` should be
implemented here too.

Obviously, there's a *lot* more that could be done (and changed) here.  This
is just an initial starting point for discussion.  It's not
enabled by default.

The goal is to have people be able to run `rpm-ostree deploy --ex-cliwrap=true`
and try it out.
