### PR TITLE
Move reboot handling to client

### DIFF
--- a/src/app/rpmostree-builtin-deploy.cxx
+++ b/src/app/rpmostree-builtin-deploy.cxx
@@ -139,7 +139,6 @@ rpmostree_builtin_deploy (int            argc,
 
       GVariantDict dict;
       g_variant_dict_init (&dict, NULL);
-      g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
       g_variant_dict_insert (&dict, "allow-downgrade", "b", !opt_disallow_downgrade);
       /* If we're not specifying a revision, then don't touch the network */
       if (revision == NULL)
@@ -225,8 +224,12 @@ rpmostree_builtin_deploy (int            argc,
         }
 
       rpmostree_print_package_diffs (result);
+      return TRUE;
     }
-  else if (!opt_reboot)
+
+  if (opt_reboot)
+    return rpmostree_client_reboot (error);
+  else
     {
       if (!rpmostree_has_new_default_deployment (os_proxy, previous_deployment))
         {

--- a/src/app/rpmostree-builtin-finalize-deployment.cxx
+++ b/src/app/rpmostree-builtin-finalize-deployment.cxx
@@ -82,6 +82,7 @@ rpmostree_builtin_finalize_deployment (int             argc,
   g_variant_dict_insert (&dict, "allow-missing-checksum", "b", opt_allow_missing);
   g_variant_dict_insert (&dict, "allow-unlocked", "b", opt_allow_unlocked);
   g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
+  g_variant_dict_insert (&dict, "reboot", "b", FALSE);
   g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
   g_autofree char *transaction_address = NULL;
@@ -98,5 +99,5 @@ rpmostree_builtin_finalize_deployment (int             argc,
                                                 error))
     return FALSE;
 
-  return TRUE;
+  return rpmostree_client_reboot (error);
 }

--- a/src/app/rpmostree-builtin-initramfs-etc.cxx
+++ b/src/app/rpmostree-builtin-initramfs-etc.cxx
@@ -115,7 +115,6 @@ rpmostree_ex_builtin_initramfs_etc (int             argc,
 
   GVariantDict dict;
   g_variant_dict_init (&dict, NULL);
-  g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
   g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
   g_variant_dict_insert (&dict, "lock-finalization", "b", opt_lock_finalization);
   g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
@@ -138,7 +137,9 @@ rpmostree_ex_builtin_initramfs_etc (int             argc,
                                                 error))
     return FALSE;
 
-  if (!opt_reboot)
+  if (opt_reboot)
+    return rpmostree_client_reboot (error);
+  else
     {
       if (!rpmostree_has_new_default_deployment (os_proxy, previous_deployment))
         {

--- a/src/app/rpmostree-builtin-initramfs.cxx
+++ b/src/app/rpmostree-builtin-initramfs.cxx
@@ -134,7 +134,6 @@ rpmostree_builtin_initramfs (int             argc,
 
       GVariantDict dict;
       g_variant_dict_init (&dict, NULL);
-      g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
       g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
       g_variant_dict_insert (&dict, "lock-finalization", "b", opt_lock_finalization);
       g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
@@ -156,6 +155,9 @@ rpmostree_builtin_initramfs (int             argc,
         return FALSE;
 
       g_print ("Initramfs regeneration is now: %s\n", opt_enable ? "enabled" : "disabled");
+
+      if (opt_reboot)
+        return rpmostree_client_reboot (error);
     }
 
   return TRUE;

--- a/src/app/rpmostree-builtin-kargs.cxx
+++ b/src/app/rpmostree-builtin-kargs.cxx
@@ -271,7 +271,6 @@ rpmostree_builtin_kargs (int            argc,
 
   GVariantDict dict;
   g_variant_dict_init (&dict, NULL);
-  g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
   g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
   g_variant_dict_insert (&dict, "lock-finalization", "b", opt_lock_finalization);
   if (opt_kernel_append_if_missing_strings && *opt_kernel_append_if_missing_strings)
@@ -362,6 +361,9 @@ rpmostree_builtin_kargs (int            argc,
     g_print("Kernel arguments updated.\nRun \"systemctl reboot\" to start a reboot\n");
   else if (opt_unchanged_exit_77)
     invocation->exit_code = RPM_OSTREE_EXIT_UNCHANGED;
+
+  if (opt_reboot)
+    return rpmostree_client_reboot (error);
 
   return TRUE;
 }

--- a/src/app/rpmostree-builtin-rebase.cxx
+++ b/src/app/rpmostree-builtin-rebase.cxx
@@ -171,7 +171,6 @@ rpmostree_builtin_rebase (int             argc,
 
   GVariantDict dict;
   g_variant_dict_init (&dict, NULL);
-  g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
   g_variant_dict_insert (&dict, "allow-downgrade", "b", !opt_disallow_downgrade);
   g_variant_dict_insert (&dict, "cache-only", "b", opt_cache_only);
   g_variant_dict_insert (&dict, "download-only", "b", opt_download_only);
@@ -231,7 +230,7 @@ rpmostree_builtin_rebase (int             argc,
     }
 
   return rpmostree_transaction_client_run (invocation, sysroot_proxy, os_proxy,
-                                           options, FALSE,
+                                           options, FALSE, opt_reboot,
                                            transaction_address,
                                            previous_deployment,
                                            cancellable, error);

--- a/src/app/rpmostree-builtin-reset.cxx
+++ b/src/app/rpmostree-builtin-reset.cxx
@@ -94,7 +94,6 @@ rpmostree_builtin_reset (int             argc,
 
   GVariantDict dict;
   g_variant_dict_init (&dict, NULL);
-  g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
   g_variant_dict_insert (&dict, "no-pull-base", "b", TRUE);
   g_variant_dict_insert (&dict, "no-layering", "b", opt_overlays);
   g_variant_dict_insert (&dict, "no-overrides", "b", opt_overrides);
@@ -110,7 +109,7 @@ rpmostree_builtin_reset (int             argc,
     return FALSE;
 
   return rpmostree_transaction_client_run (invocation, sysroot_proxy, os_proxy,
-                                           options, FALSE,
+                                           options, FALSE, opt_reboot,
                                            transaction_address,
                                            previous_deployment,
                                            cancellable, error);

--- a/src/app/rpmostree-builtin-rollback.cxx
+++ b/src/app/rpmostree-builtin-rollback.cxx
@@ -42,7 +42,6 @@ get_args_variant (void)
   GVariantDict dict;
 
   g_variant_dict_init (&dict, NULL);
-  g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
 
   return g_variant_dict_end (&dict);
 }
@@ -78,7 +77,6 @@ rpmostree_builtin_rollback (int             argc,
   /* really, rollback only supports the "reboot" option; all others are ignored */
   GVariantDict dict;
   g_variant_dict_init (&dict, NULL);
-  g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
   g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
   if (!rpmostree_os_call_rollback_sync (os_proxy,
@@ -89,7 +87,7 @@ rpmostree_builtin_rollback (int             argc,
     return FALSE;
 
   return rpmostree_transaction_client_run (invocation, sysroot_proxy, os_proxy,
-                                           options, FALSE,
+                                           options, FALSE, opt_reboot,
                                            transaction_address,
                                            previous_deployment,
                                            cancellable, error);

--- a/src/app/rpmostree-builtin-upgrade.cxx
+++ b/src/app/rpmostree-builtin-upgrade.cxx
@@ -170,7 +170,6 @@ rpmostree_builtin_upgrade (int             argc,
     {
       GVariantDict dict;
       g_variant_dict_init (&dict, NULL);
-      g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
       g_variant_dict_insert (&dict, "allow-downgrade", "b", opt_allow_downgrade);
       g_variant_dict_insert (&dict, "cache-only", "b", opt_cache_only);
       g_variant_dict_insert (&dict, "download-only", "b", opt_download_only);
@@ -233,8 +232,13 @@ rpmostree_builtin_upgrade (int             argc,
                                               cancellable, error))
             return FALSE;
         }
+
+      return TRUE;
     }
-  else if (!opt_reboot)
+
+  if (opt_reboot)
+    return rpmostree_client_reboot (error);
+  else
     {
       if (!rpmostree_has_new_default_deployment (os_proxy, previous_deployment))
         {

--- a/src/app/rpmostree-clientlib.h
+++ b/src/app/rpmostree-clientlib.h
@@ -107,6 +107,7 @@ rpmostree_transaction_client_run             (RpmOstreeCommandInvocation *invoca
                                               RPMOSTreeOS      *os_proxy,
                                               GVariant         *options,
                                               gboolean          exit_unchanged_77,
+                                              gboolean          reboot,
                                               const char *transaction_address,
                                               GVariant         *previous_deployment,
                                               GCancellable *cancellable,
@@ -175,5 +176,8 @@ error_if_driver_registered (GBusType          bus_type,
                             RPMOSTreeSysroot *sysroot_proxy,
                             GCancellable     *cancellable,
                             GError          **error);
+
+gboolean
+rpmostree_client_reboot (GError ** error);
 
 G_END_DECLS

--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -79,7 +79,6 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
 
   GVariantDict dict;
   g_variant_dict_init (&dict, NULL);
-  g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
   g_variant_dict_insert (&dict, "cache-only", "b", cache_only);
   g_variant_dict_insert (&dict, "no-pull-base", "b", TRUE);
   g_variant_dict_insert (&dict, "dry-run", "b", opt_dry_run);
@@ -116,7 +115,11 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
     {
       g_print ("Exiting because of '--dry-run' option\n");
     }
-  else if (!opt_reboot)
+  else if (opt_reboot)
+    {
+      return rpmostree_client_reboot (error);
+    }
+  else
     {
       /* only print diff if a new deployment was laid down (e.g. reset --all may not) */
       if (!rpmostree_has_new_default_deployment (os_proxy, previous_deployment))

--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -92,7 +92,6 @@ pkg_change (RpmOstreeCommandInvocation *invocation,
 
   GVariantDict dict;
   g_variant_dict_init (&dict, NULL);
-  g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
   g_variant_dict_insert (&dict, "cache-only", "b", opt_cache_only);
   g_variant_dict_insert (&dict, "download-only", "b", opt_download_only);
   g_variant_dict_insert (&dict, "no-pull-base", "b", TRUE);
@@ -142,7 +141,7 @@ pkg_change (RpmOstreeCommandInvocation *invocation,
     }
 
   return rpmostree_transaction_client_run (invocation, sysroot_proxy, os_proxy,
-                                           options, opt_unchanged_exit_77,
+                                           options, opt_unchanged_exit_77, opt_reboot,
                                            transaction_address,
                                            previous_deployment,
                                            cancellable, error);

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -373,6 +373,10 @@
             providing a checksum should be a conscious decision.
          "allow-unlocked" (type 'b')
             Don't error out if the staged deployment wasn't locked.
+         "reboot" (type 'b')
+            Have the daemon initiate a reboot.  Defaults to `TRUE`.
+            This option exists for compatibility reasons; it's recommended
+            to set it to `FALSE` and start the reboot in the calling process.
     -->
     <method name="FinalizeDeployment">
       <arg type="a{sv}" name="options" direction="in"/>

--- a/src/daemon/rpmostreed-utils.cxx
+++ b/src/daemon/rpmostreed-utils.cxx
@@ -214,6 +214,7 @@ rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
 void
 rpmostreed_reboot (GCancellable *cancellable, GError **error)
 {
+  sd_journal_print (LOG_INFO, "daemon-initiated reboot is deprecated");
   const char *child_argv[] = { "systemctl", "reboot", NULL };
   (void) g_spawn_sync (NULL, (char**)child_argv, NULL, (GSpawnFlags)(G_SPAWN_CHILD_INHERITS_STDIN | G_SPAWN_SEARCH_PATH),
                        NULL, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Having the daemon start the reboot means that it can be killed
by `SIGTERM` before the client processes the completion, causing
the client to exit with a spurious error.

Instead, have the client start the reboot.  This is cleaner
in numerous ways.  An additional benefit for example is that
if there are systemd reboot inhibitors present, it will be
the client that blocks, not the daemon.
