### PR TITLE
daemon: Make actually initiating reboot asynchronous

### DIFF
--- a/src/daemon/rpmostreed-daemon.h
+++ b/src/daemon/rpmostreed-daemon.h
@@ -53,6 +53,8 @@ char *             rpmostreed_daemon_client_get_agent_id (RpmostreedDaemon *self
 char *             rpmostreed_daemon_client_get_sd_unit (RpmostreedDaemon *self,
                                                          const char *client);
 void               rpmostreed_daemon_exit_now       (RpmostreedDaemon *self);
+void               rpmostreed_daemon_reboot         (RpmostreedDaemon *self);
+gboolean           rpmostreed_daemon_is_rebooting   (RpmostreedDaemon *self);
 void               rpmostreed_daemon_run_until_idle_exit (RpmostreedDaemon *self);
 void               rpmostreed_daemon_publish        (RpmostreedDaemon *self,
                                                      const gchar *path,

--- a/src/daemon/rpmostreed-sysroot.cxx
+++ b/src/daemon/rpmostreed-sysroot.cxx
@@ -818,6 +818,8 @@ rpmostreed_sysroot_prep_for_txn (RpmostreedSysroot     *self,
                                  RpmostreedTransaction **out_compat_txn,
                                  GError               **error)
 {
+  if (rpmostreed_daemon_is_rebooting (rpmostreed_daemon_get()))
+    return glnx_throw (error, "Reboot initiated, cannot start new transaction");
   if (self->transaction)
     {
       if (rpmostreed_transaction_is_compatible (self->transaction, invocation))

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -542,7 +542,7 @@ rollback_transaction_execute (RpmostreedTransaction *transaction,
     }
 
   if (self->reboot)
-    rpmostreed_reboot (cancellable, error);
+    rpmostreed_daemon_reboot (rpmostreed_daemon_get ());
 
   return TRUE;
 }
@@ -1511,7 +1511,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
         }
 
       if (deploy_has_bool_option (self, "reboot"))
-        rpmostreed_reboot (cancellable, error);
+        rpmostreed_daemon_reboot (rpmostreed_daemon_get ());
     }
   else
     {
@@ -1913,7 +1913,7 @@ initramfs_etc_transaction_execute (RpmostreedTransaction *transaction,
     return FALSE;
 
   if (vardict_lookup_bool (self->options, "reboot", FALSE))
-    rpmostreed_reboot (cancellable, error);
+    rpmostreed_daemon_reboot (rpmostreed_daemon_get ());
 
   return TRUE;
 }
@@ -2051,7 +2051,7 @@ initramfs_state_transaction_execute (RpmostreedTransaction *transaction,
     return FALSE;
 
   if (vardict_lookup_bool (self->options, "reboot", FALSE))
-    rpmostreed_reboot (cancellable, error);
+    rpmostreed_daemon_reboot (rpmostreed_daemon_get ());
 
   return TRUE;
 }
@@ -2610,7 +2610,7 @@ finalize_deployment_transaction_execute (RpmostreedTransaction *transaction,
   (void) rpmostree_syscore_bump_mtime (sysroot, NULL);
 
   sd_journal_print (LOG_INFO, "Finalized deployment; rebooting into %s", checksum);
-  rpmostreed_reboot (cancellable, error);
+  rpmostreed_daemon_reboot (rpmostreed_daemon_get ());
   return TRUE;
 }
 
@@ -2787,7 +2787,7 @@ kernel_arg_transaction_execute (RpmostreedTransaction *transaction,
     return FALSE;
 
   if (vardict_lookup_bool (self->options, "reboot", FALSE))
-    rpmostreed_reboot (cancellable, error);
+    rpmostreed_daemon_reboot (rpmostreed_daemon_get ());
 
   return TRUE;
 }

--- a/src/daemon/rpmostreed-utils.cxx
+++ b/src/daemon/rpmostreed-utils.cxx
@@ -211,14 +211,6 @@ rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
   return TRUE;
 }
 
-void
-rpmostreed_reboot (GCancellable *cancellable, GError **error)
-{
-  const char *child_argv[] = { "systemctl", "reboot", NULL };
-  (void) g_spawn_sync (NULL, (char**)child_argv, NULL, (GSpawnFlags)(G_SPAWN_CHILD_INHERITS_STDIN | G_SPAWN_SEARCH_PATH),
-                       NULL, NULL, NULL, NULL, NULL, NULL);
-}
-
 /**
  * rpmostreed_repo_pull_ancestry:
  * @repo: Repo

--- a/src/daemon/rpmostreed-utils.h
+++ b/src/daemon/rpmostreed-utils.h
@@ -36,8 +36,6 @@ gboolean   rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
                                              const gchar *base_refspec,
                                              gchar **out_refspec,
                                              GError **error);
-void
-rpmostreed_reboot (GCancellable *cancellable, GError **error);
 
 /* XXX These pull-ancestry and lookup-version functions should eventually
  *     be integrated into libostree, but it's still a bit premature to do


### PR DESCRIPTION
Alternative to https://github.com/coreos/rpm-ostree/pull/2845
which moved the `reboot` invocation into the client (which I think
still makes sense in some cases).

Previously we were starting the reboot before we're returned
a success reply to the client, so it could see the daemon killed
by `SIGTERM` and hence emit a spurious error.

(Really in this case any 3 of the calling process, the client
 binary or the daemon could be killed in any order, so it's messy
 but this just closes one race)

For cleanliness we reject starting any new transactions after the daemon has
started a reboot.

Closes: https://github.com/coreos/rpm-ostree/issues/1348
