### PR TITLE
rust: Port some bits to new ostree_ext::variant_utils

### DIFF
--- a/rust/src/builtins/apply_live.rs
+++ b/rust/src/builtins/apply_live.rs
@@ -1,10 +1,11 @@
 //!
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+use crate::cxxrsutil::*;
 use crate::live;
-use crate::{cxxrsutil::*, variant_utils};
 use anyhow::{anyhow, Result};
 use gio::DBusProxyExt;
+use ostree_ext::variant_utils;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -53,7 +54,7 @@ pub(crate) fn applylive_entrypoint(args: &Vec<String>) -> Result<()> {
 
     let args = get_args_variant(sysroot, opts)?;
 
-    let params = crate::variant_utils::new_variant_tuple(&[args]);
+    let params = variant_utils::new_variant_tuple(&[args]);
     let reply = &client.get_os_ex_proxy().call_sync(
         "LiveFs",
         Some(&params),
@@ -62,7 +63,7 @@ pub(crate) fn applylive_entrypoint(args: &Vec<String>) -> Result<()> {
         gio::NONE_CANCELLABLE,
     )?;
     let reply_child =
-        variant_utils::variant_tuple_get(reply, 0).ok_or_else(|| anyhow!("Invalid reply"))?;
+        variant_utils::variant_get_child_value(reply, 0).ok_or_else(|| anyhow!("Invalid reply"))?;
     let txn_address = reply_child
         .get_str()
         .ok_or_else(|| anyhow!("Expected string transaction address"))?;

--- a/rust/src/testutils.rs
+++ b/rust/src/testutils.rs
@@ -9,11 +9,12 @@
 //! This backs the hidden `rpm-ostree testutils` CLI.  Subject
 //! to change.
 
-use crate::{cxxrsutil::*, variant_utils};
+use crate::cxxrsutil::*;
 use anyhow::{Context, Result};
 use fn_error_context::context;
 use glib::ToVariant;
 use openat_ext::{FileExt, OpenatDirExt};
+use ostree_ext::variant_utils;
 use rand::Rng;
 use std::fs;
 use std::fs::File;
@@ -239,7 +240,7 @@ fn test_moo() -> Result<()> {
     let mut bus_conn = client_conn.pin_mut().get_connection();
     let bus_conn = bus_conn.gobj_wrap();
 
-    let params = crate::variant_utils::new_variant_tuple(&[true.to_variant()]);
+    let params = variant_utils::new_variant_tuple(&[true.to_variant()]);
     let reply = &bus_conn.call_sync(
         Some("org.projectatomic.rpmostree1"),
         "/org/projectatomic/rpmostree1/fedora_coreos",
@@ -251,7 +252,7 @@ fn test_moo() -> Result<()> {
         -1,
         gio::NONE_CANCELLABLE,
     )?;
-    let reply = variant_utils::variant_tuple_get(reply, 0).unwrap();
+    let reply = variant_utils::variant_get_child_value(reply, 0).unwrap();
     // Unwrap safety: We validated the (s) above.
     let reply = reply.get_str().unwrap();
     let cow = "🐄\n";

--- a/rust/src/variant_utils.rs
+++ b/rust/src/variant_utils.rs
@@ -18,17 +18,6 @@ lazy_static::lazy_static! {
     };
 }
 
-pub(crate) fn new_variant_tuple<'a>(
-    items: impl IntoIterator<Item = &'a glib::Variant>,
-) -> glib::Variant {
-    let v: Vec<_> = items.into_iter().map(|v| v.to_glib_none().0).collect();
-    unsafe {
-        let r = glib_sys::g_variant_new_tuple(v.as_ptr(), v.len());
-        glib_sys::g_variant_ref_sink(r);
-        from_glib_full(r)
-    }
-}
-
 pub(crate) fn variant_tuple_get(v: &glib::Variant, n: usize) -> Option<glib::Variant> {
     let v = v.to_glib_none();
     let l = unsafe { glib_sys::g_variant_n_children(v.0) };
@@ -81,22 +70,5 @@ pub(crate) fn byteswap_be_to_native(v: &glib::Variant) -> Cow<glib::Variant> {
             let r = glib_sys::g_variant_byteswap(v.to_glib_none().0);
             Cow::Owned(from_glib_full(r))
         }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use anyhow::Result;
-    use glib::ToVariant;
-
-    #[test]
-    fn tuple() -> Result<()> {
-        let t = &new_variant_tuple(&["hello".to_variant(), "world".to_variant()]);
-        assert_eq!(variant_tuple_get(t, 0).unwrap().get_str().unwrap(), "hello");
-        assert_eq!(variant_tuple_get(t, 1).unwrap().get_str().unwrap(), "world");
-        assert!(variant_tuple_get(t, 2).is_none());
-        assert!(variant_tuple_get(t, 42).is_none());
-        Ok(())
     }
 }


### PR DESCRIPTION
Trying to deduplicate this stuff there.
