### PR TITLE
packaging/spec: require rpm >= 4.16.0

### DIFF
--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -52,7 +52,7 @@ BuildRequires: /usr/bin/g-ir-scanner
 BuildRequires: pkgconfig(ostree-1) >= 2020.7
 BuildRequires: pkgconfig(polkit-gobject-1)
 BuildRequires: pkgconfig(json-glib-1.0)
-BuildRequires: pkgconfig(rpm)
+BuildRequires: pkgconfig(rpm) >= 4.16.0
 BuildRequires: pkgconfig(libarchive)
 BuildRequires: pkgconfig(libsystemd)
 BuildRequires: libcap-devel


### PR DESCRIPTION
This adds a minimum required version on rpm-devel >= 4.16.0.
rpm-ostree uses the new comparison APIs from 'rpmver.h', which
did not exist on previous versions.

Refs:
 * https://github.com/coreos/rpm-ostree/pull/2503
 * https://github.com/rpm-software-management/rpm/pull/1221
 * http://rpm.org/wiki/Releases/4.16.0