### PR TITLE
Use new `ostree_commit_metadata_for_bootable()` API

### DIFF
--- a/ci/composepost-checks.sh
+++ b/ci/composepost-checks.sh
@@ -26,3 +26,7 @@ ostree --repo="${repo}" ls -R "${ref}" /usr/lib/modules > tmp/modules-lsr.txt
 assert_file_has_content tmp/modules-lsr.txt '/vmlinuz$'
 assert_file_has_content tmp/modules-lsr.txt '/initramfs.img$'
 echo "ok boot location modules"
+
+ostree --repo="${repo}" show --print-metadata-key=ostree.bootable "${ref}" >out.txt
+assert_file_has_content_literal out.txt 'true'
+echo "ok bootable metadata"

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -49,7 +49,7 @@ BuildRequires: gnome-common
 BuildRequires: /usr/bin/g-ir-scanner
 # Core requirements
 # One way to check this: `objdump -p /path/to/rpm-ostree | grep LIBOSTREE` and pick the highest (though that might miss e.g. new struct members)
-BuildRequires: pkgconfig(ostree-1) >= 2020.7
+BuildRequires: pkgconfig(ostree-1) >= 2021.1
 BuildRequires: pkgconfig(polkit-gobject-1)
 BuildRequires: pkgconfig(json-glib-1.0)
 BuildRequires: pkgconfig(rpm) >= 4.16.0

--- a/tests/kolainst/destructive/layering-local
+++ b/tests/kolainst/destructive/layering-local
@@ -55,6 +55,12 @@ rpmostree_assert_status '.deployments[0]["packages"]|length == 0' \
 assert_streq $(rpm -q foo) foo-1.2-3.x86_64
 echo "ok pkg foo added locally"
 
+booted_commit=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
+
+ostree show --print-metadata-key=ostree.bootable ${booted_commit} >out.txt
+assert_file_has_content_literal out.txt 'true'
+echo "ok bootable metadata"
+
 # check we could uninstall the package using either its NEVRA or name
 rpm-ostree uninstall foo-1.2-3.x86_64
 rpmostree_assert_status '.deployments[0]["requested-local-packages"]|length == 0'
@@ -81,7 +87,6 @@ rpmostree_assert_status '.deployments[0]["packages"]|length == 1' \
 echo "ok layer foo back from repos"
 
 # check that trying to install a package already in the base errors out
-booted_commit=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
 ostree refs ${booted_commit} --create vmcheck_tmp/with_foo
 ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo
 rpm-ostree uninstall foo


### PR DESCRIPTION
I planned to use this as part of doing live diffs, e.g. to
notice the kernel changed between commits.

But also, at some point I'd like to add `ostree.architecture`
there to obsolete the cosa-specific `coreos-assembler.basearch`
so that multiple buildsystems and consumers can use that.
(That said, they can also just use `$(arch)` today)
