### PR TITLE
Use rpm-oxide to pre-validate RPMs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,6 +1034,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "openpgp-parser"
+version = "0.2.2"
+source = "git+https://github.com/QubesOS/qubes-rpm-oxide?tag=v0.2.2#859ee5228358ede5e9365767a0551268dad82e98"
+
+[[package]]
 name = "openssl"
 version = "0.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1509,6 +1514,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpm-crypto"
+version = "0.2.2"
+source = "git+https://github.com/QubesOS/qubes-rpm-oxide?tag=v0.2.2#859ee5228358ede5e9365767a0551268dad82e98"
+dependencies = [
+ "openpgp-parser",
+]
+
+[[package]]
+name = "rpm-parser"
+version = "0.2.2"
+source = "git+https://github.com/QubesOS/qubes-rpm-oxide?tag=v0.2.2#859ee5228358ede5e9365767a0551268dad82e98"
+dependencies = [
+ "openpgp-parser",
+ "rpm-crypto",
+]
+
+[[package]]
 name = "rpmostree-client"
 version = "0.1.0"
 dependencies = [
@@ -1548,6 +1570,7 @@ dependencies = [
  "nix",
  "openat",
  "openat-ext",
+ "openpgp-parser",
  "os-release",
  "ostree",
  "ostree-ext",
@@ -1556,6 +1579,8 @@ dependencies = [
  "phf",
  "rand 0.8.3",
  "rayon",
+ "rpm-crypto",
+ "rpm-parser",
  "rpmostree-client",
  "rust-ini",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ phf = { version = "0.8", features = ["macros"] }
 rand = "0.8.3"
 rayon = "1.5.1"
 rpmostree-client = { path = "rust/rpmostree-client", version = "0.1.0" }
+rpm-parser = { git = "https://github.com/QubesOS/qubes-rpm-oxide", tag = "v0.2.2" }
+rpm-crypto = { git = "https://github.com/QubesOS/qubes-rpm-oxide", tag = "v0.2.2" }
+openpgp-parser = { git = "https://github.com/QubesOS/qubes-rpm-oxide", tag = "v0.2.2" }
 rust-ini = "0.17.0"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_derive = "1.0.118"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -421,6 +421,11 @@ pub mod ffi {
         fn cache_branch_to_nevra(nevra: &str) -> String;
     }
 
+    // rpmverify.rs
+    extern "Rust" {
+        fn rpm_gpgcheck_and_payload_validate(path: &str) -> Result<()>;
+    }
+
     unsafe extern "C++" {
         include!("rpmostree-cxxrsutil.hpp");
         type CxxGObjectArray;
@@ -554,6 +559,8 @@ use passwd::*;
 mod console_progress;
 pub(crate) use self::console_progress::*;
 mod progress;
+mod rpmverify;
+pub(crate) use self::rpmverify::*;
 mod scripts;
 pub(crate) use self::scripts::*;
 mod rpmutils;

--- a/rust/src/rpmverify.rs
+++ b/rust/src/rpmverify.rs
@@ -1,0 +1,31 @@
+//! Use rpm-oxide to pre-validate structure of RPMs.
+//!
+//! For more information, see https://github.com/QubesOS/qubes-rpm-oxide
+//!
+//! As of this moment, we do not actually use rpm-oxide to validate
+//! GPG signatures.  This only "pre-sanitizes" the RPM to attempt to
+//! avoid memory safety issues in librpm.
+//!
+
+use anyhow::{anyhow, Context, Result};
+use std::fs::File;
+use std::io::BufReader;
+
+/// Validate the GPG signature and payload digest of an RPM.
+// https://github.com/QubesOS/qubes-rpm-oxide/blob/main/rpm-parser/bin/rpmcheck.rs
+pub(crate) fn rpm_gpgcheck_and_payload_validate(path: &str) -> Result<()> {
+    let token = rpm_crypto::init();
+    let mut r =
+        BufReader::new(File::open(path).with_context(|| format!("Failed to open {}", path))?);
+    let package = rpm_parser::RPMPackage::read(&mut r, openpgp_parser::AllowWeakHashes::No, token)?;
+    let _ = package
+        .signature
+        .header_signature
+        .ok_or_else(|| anyhow!("Package header is not signed"))?;
+    let (mut ctx, digest) = package.immutable.payload_digest()?;
+    std::io::copy(&mut r, &mut ctx)?;
+    if ctx.finalize(true) != digest {
+        return Err(anyhow!("Payload digest failed to verify!"));
+    }
+    Ok(())
+}


### PR DESCRIPTION
There are a ton of memory safety issues in librpm that turned
up when QubesOS paid for an audit of their code.  librpm is an old
C codebase using hand-rolled serialization, so it's not
surprising it has a ton of issues.

There are some attempts to fix it, but it's not going to happen
quickly.

In situations like this, the pattern of using Rust code as a
"pre-validator" works really well.  In theory, we could entirely
rely on rpm-oxide for GPG + payload checksum validation, but
in order to be 100% sure we aren't regressing security, add
it as a check in front before librpm sees the content.

While I'm marking this as
Closes: https://github.com/coreos/rpm-ostree/issues/2836
there's still more to do - I think we want to do the full
"rpm canonicalization" once that ends up in the library.
