### PR TITLE
daemon: Respect systemd inhibitor locks

### DIFF
--- a/src/daemon/rpmostreed-daemon.cxx
+++ b/src/daemon/rpmostreed-daemon.cxx
@@ -815,6 +815,12 @@ rpmostreed_daemon_is_rebooting (RpmostreedDaemon *self)
   return self->rebooting;
 }
 
+GDBusConnection *
+rpmostreed_daemon_connection(void)
+{
+  g_assert (_daemon_instance->connection);
+  return _daemon_instance->connection;
+}
 
 void
 rpmostreed_daemon_run_until_idle_exit (RpmostreedDaemon *self)

--- a/src/daemon/rpmostreed-daemon.h
+++ b/src/daemon/rpmostreed-daemon.h
@@ -38,6 +38,7 @@ G_BEGIN_DECLS
 
 GType              rpmostreed_daemon_get_type       (void) G_GNUC_CONST;
 RpmostreedDaemon * rpmostreed_daemon_get            (void);
+GDBusConnection  * rpmostreed_daemon_connection     (void);
 gboolean           rpmostreed_get_client_uid        (RpmostreedDaemon *self,
                                                      const char       *client,
                                                      uid_t            *out_uid);

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -546,7 +546,11 @@ rollback_transaction_execute (RpmostreedTransaction *transaction,
     }
 
   if (self->reboot)
-    rpmostreed_daemon_reboot (rpmostreed_daemon_get ());
+    {
+      if (!check_sd_inhibitor_locks (cancellable, error))
+        return FALSE;
+      rpmostreed_daemon_reboot (rpmostreed_daemon_get ());
+    }
 
   return TRUE;
 }
@@ -1526,7 +1530,11 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
         }
 
       if (deploy_has_bool_option (self, "reboot"))
-        rpmostreed_daemon_reboot (rpmostreed_daemon_get ());
+        {
+          if (!check_sd_inhibitor_locks (cancellable, error))
+            return FALSE;
+          rpmostreed_daemon_reboot (rpmostreed_daemon_get ());
+        }
     }
   else
     {
@@ -1928,7 +1936,11 @@ initramfs_etc_transaction_execute (RpmostreedTransaction *transaction,
     return FALSE;
 
   if (vardict_lookup_bool (self->options, "reboot", FALSE))
-    rpmostreed_daemon_reboot (rpmostreed_daemon_get ());
+    {
+      if (!check_sd_inhibitor_locks (cancellable, error))
+        return FALSE;
+      rpmostreed_daemon_reboot (rpmostreed_daemon_get ());
+    }
 
   return TRUE;
 }
@@ -2066,7 +2078,11 @@ initramfs_state_transaction_execute (RpmostreedTransaction *transaction,
     return FALSE;
 
   if (vardict_lookup_bool (self->options, "reboot", FALSE))
-    rpmostreed_daemon_reboot (rpmostreed_daemon_get ());
+    {
+      if (!check_sd_inhibitor_locks (cancellable, error))
+        return FALSE;
+      rpmostreed_daemon_reboot (rpmostreed_daemon_get ());
+    }
 
   return TRUE;
 }
@@ -2581,7 +2597,7 @@ finalize_deployment_transaction_execute (RpmostreedTransaction *transaction,
   FinalizeDeploymentTransaction *self = (FinalizeDeploymentTransaction *) transaction;
   OstreeSysroot *sysroot = rpmostreed_transaction_get_sysroot (transaction);
   OstreeRepo *repo = ostree_sysroot_repo (sysroot);
-
+    
   auto command_line = (const char*)
     vardict_lookup_ptr (self->options, "initiating-command-line", "&s");
 
@@ -2609,6 +2625,10 @@ finalize_deployment_transaction_execute (RpmostreedTransaction *transaction,
   if (expected_checksum && !g_str_equal (checksum, expected_checksum))
     return glnx_throw (error, "Expected staged base checksum %s, but found %s",
                        expected_checksum, checksum);
+
+  // Check for inhibitor locks before unlocking staged deployment.
+  if (!check_sd_inhibitor_locks (cancellable, error))
+    return FALSE;
 
   if (unlink (_OSTREE_SYSROOT_RUNSTATE_STAGED_LOCKED) < 0)
     {
@@ -2802,7 +2822,11 @@ kernel_arg_transaction_execute (RpmostreedTransaction *transaction,
     return FALSE;
 
   if (vardict_lookup_bool (self->options, "reboot", FALSE))
-    rpmostreed_daemon_reboot (rpmostreed_daemon_get ());
+    {
+      if (!check_sd_inhibitor_locks (cancellable, error))
+        return FALSE;
+      rpmostreed_daemon_reboot (rpmostreed_daemon_get ());
+    }
 
   return TRUE;
 }

--- a/src/daemon/rpmostreed-utils.h
+++ b/src/daemon/rpmostreed-utils.h
@@ -83,4 +83,7 @@ gboolean   rpmostreed_parse_revision (const char  *revision,
                                       char       **out_version,
                                       GError     **error);
 
+gboolean   check_sd_inhibitor_locks (GCancellable    *cancellable,
+                                     GError         **error);
+
 G_END_DECLS

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -98,9 +98,6 @@ EOF
 
   vm_setup
 
-  # XXX: hack around https://github.com/systemd/systemd/issues/14328
-  vm_cmd systemctl mask --now systemd-logind
-
   # Some tests expect the ref to be on `vmcheck`. We should drop that
   # requirement, but for now let's just mangle the origin
   local deployment_root


### PR DESCRIPTION
Today, non-interactive processes, including rpm-ostree, are not
inhibited by systemd inhibitor locks. systemd 248 added the
`--check-inhibitors` option to `systemctl` commands, which can be
used to make non-interactive proccesses check for shutdown/sleep
inhibitors. However, it also checks for `delay` mode inhibitors,
which isn't what we want. Replicate this logic prior to reboots,
but ignore `delay` mode inhibitors.