### PR TITLE
libdnf-sys/build: gracefully handle older gpgme versions

### DIFF
--- a/rust/libdnf-sys/Cargo.toml
+++ b/rust/libdnf-sys/Cargo.toml
@@ -26,7 +26,8 @@ rpm = "4"
 librepo = "1"
 libsolv = "0.7"
 libsolvext = "0.7"
-gpgme = "1"
+# Older libgpgme did not provide a pkg-config file
+gpgme = { version = "1", optional = true }
 openssl = "1"
 libcurl = "7"
 sqlite3 = "3"

--- a/rust/libdnf-sys/build.rs
+++ b/rust/libdnf-sys/build.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 
 fn main() -> Result<()> {
     let libs = system_deps::Config::new().probe()?;
+    let has_gpgme_pkgconfig = libs.get_by_name("gpgme").is_some();
 
     // first, the submodule proper
     let libdnf = cmake::Config::new("../../libdnf")
@@ -31,6 +32,10 @@ fn main() -> Result<()> {
         .always_configure(false)
         .build_target("all")
         .build();
+    // NOTE(lucab): consider using `gpgme-config` it this stops working.
+    if !has_gpgme_pkgconfig {
+        println!("cargo:rustc-link-lib=gpgme");
+    }
     println!(
         "cargo:rustc-link-search=native={}/build/libdnf",
         libdnf.display()


### PR DESCRIPTION
This tries to gracefully handle environments where gpgme
library cannot be directly discovered via pkg-config.
Older gpgme versions (including 1.13) do not provide a
.pc file, so in that case the build-script attempts to
fallback to hardcoded library flags.