### PR TITLE
daemon/isolation: Clean up failed units too

### DIFF
--- a/rust/src/isolation.rs
+++ b/rust/src/isolation.rs
@@ -7,7 +7,13 @@ use std::process::Command;
 
 const SELF_UNIT: &str = "rpm-ostreed.service";
 /// Run as a child process, synchronously.
-const BASE_ARGS: &[&str] = &["--wait", "--pipe", "--no-ask-password", "--quiet"];
+const BASE_ARGS: &[&str] = &[
+    "--collect",
+    "--wait",
+    "--pipe",
+    "--no-ask-password",
+    "--quiet",
+];
 
 /// Configuration for transient unit.
 pub(crate) struct UnitConfig<'a> {


### PR DESCRIPTION
We expect to be able to re-run them.  This fixes an issue
where if `systemd-tmpfiles` failed, further `apply-live` invocations
would also fail.

Closes: https://github.com/coreos/rpm-ostree/issues/2877
