### PR TITLE
Two small sha256-nevra fixes

### DIFF
--- a/src/libpriv/rpmostree-util.cxx
+++ b/src/libpriv/rpmostree-util.cxx
@@ -721,7 +721,7 @@ rpmostree_decompose_sha256_nevra (const char **nevra, /* gets incremented */
 
   if (strlen (sha256_nevra) < 66 || /* 64 + ":" + at least 1 char for nevra */
       sha256_nevra[64] != ':')
-    return FALSE;
+    return glnx_throw (error, "Invalid sha256-nevra: %s", sha256_nevra);
 
   sha256 = g_strndup (sha256_nevra, 64);
   if (!ostree_validate_checksum_string (sha256, error))


### PR DESCRIPTION
util: Fix missing error in decompose_sha256_nevra

We can't just `return FALSE` here, we need to set an error.
Noticed by code inspection.

---

rust/utils: Fix ordering of decompose_sha256_nevra

The C API returns effectively a tuple in (nevra, sha256) order,
so let's have the Rust API do the same to avoid confusion.  Also
fix the broken test.

---

