### PR TITLE
origin: Switch baserefspec → refspec when de-layering

### DIFF
--- a/tests/vmcheck/test-layering-basic-2.sh
+++ b/tests/vmcheck/test-layering-basic-2.sh
@@ -96,6 +96,10 @@ echo "ok layered pkglist"
 # remove accumulated crud from previous tests
 vm_rpmostree uninstall --all
 vm_reboot
+deploydir=$(vm_cmd ostree admin --print-current-dir)
+vm_cmd cat ${deploydir}.origin > origin.txt
+assert_file_has_content origin.txt "^refspec="
+echo "ok refspec"
 
 if vm_rpmostree install glibc &>out.txt; then
   assert_not_reached "Successfully requested glibc without --allow-inactive?"


### PR DESCRIPTION
The idea originally was that we'd switch to `baserefspec` when
performing changes such that `ostree admin upgrade` would no longer
work.  But that has long since been buggy since the introduction
of things like `rpm-ostree initramfs --enable` etc.

The only goal of this PR is to avoid "leaking state" across
origin switches, so that the work to map origin ⇔ treefile
can also (correctly) be stateless.
