### PR TITLE
daemon: Die if /var/lib/rpm exists and is not a symlink

### DIFF
--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -30,7 +30,7 @@ use std::pin::Pin;
 const RPMOSTREE_BASE_RPMDB: &str = "usr/lib/sysimage/rpm-ostree-base-db";
 const RPMOSTREE_RPMDB_LOCATION: &str = "usr/share/rpm";
 const RPMOSTREE_SYSIMAGE_RPMDB: &str = "usr/lib/sysimage/rpm";
-const TRADITIONAL_RPMDB_LOCATION: &str = "var/lib/rpm";
+pub(crate) const TRADITIONAL_RPMDB_LOCATION: &str = "var/lib/rpm";
 
 #[context("Moving {}", name)]
 fn dir_move_if_exists(src: &openat::Dir, dest: &openat::Dir, name: &str) -> Result<()> {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -171,6 +171,7 @@ pub mod ffi {
 
     // daemon.rs
     extern "Rust" {
+        fn daemon_sanitycheck_environment(sysroot: Pin<&mut OstreeSysroot>) -> Result<()>;
         fn deployment_generate_id(deployment: Pin<&mut OstreeDeployment>) -> String;
         fn deployment_populate_variant(
             mut sysroot: Pin<&mut OstreeSysroot>,

--- a/src/daemon/rpmostreed-sysroot.cxx
+++ b/src/daemon/rpmostreed-sysroot.cxx
@@ -760,6 +760,8 @@ rpmostreed_sysroot_populate (RpmostreedSysroot *self,
   if (!sysroot_populate_deployments_unlocked (self, NULL, error))
     return FALSE;
 
+  rpmostreecxx::daemon_sanitycheck_environment(*self->ot_sysroot);
+
   if (!reset_config_properties (self, error))
     return FALSE;
 

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -95,6 +95,17 @@ mv /etc/ostree/remotes.d{.orig,}
 rpm-ostree reload
 echo "ok remote not found"
 
+systemctl stop rpm-ostreed
+mv /var/lib/rpm{,.orig}
+cp -a $(realpath /usr/share/rpm) /var/lib/rpm
+if systemctl start rpm-ostreed; then
+    fatal "Started rpm-ostreed with /var/lib/rpm"
+fi
+rm /var/lib/rpm -rf
+mv /var/lib/rpm{.orig,}
+systemctl reset-failed rpm-ostreed
+echo "ok validated rpmdb"
+
 rpm-ostree cleanup -p
 originpath=$(ostree admin --print-current-dir).origin
 unshare -m /bin/bash -c "mount -o remount,rw /sysroot && cp -a ${originpath}{,.orig} && 


### PR DESCRIPTION
Came out of seeing discussion from a non-public proprietary chat
system where a build system was incorrectly generating ostree commits
and had an empty `/var/lib/rpm`.

Without this the error is much less obvious, we end up triggering
an assertion failure due to an empty rpmdb.
