### PR TITLE
docs: Split pages into three main categories

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,12 +1,15 @@
 ---
-nav_order: 10
+has_children: true
+has_toc: false
+nav_order: 7
 ---
 
 # Contributing
 {: .no_toc }
 
-1. TOC
-{:toc}
+1. [Hacking on rpm-ostree](HACKING.md)
+1. [Repository structure](repo_structure.md)
+1. [Releasing rpm-ostree](RELEASE.md)
 
 ## Submitting patches
 

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -1,5 +1,6 @@
 ---
-nav_order: 7
+parent: Contributing
+nav_order: 1
 ---
 
 # Hacking on rpm-ostree

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,5 +1,6 @@
 ---
-nav_order: 8
+parent: Contributing
+nav_order: 3
 ---
 
 # Releasing rpm-ostree

--- a/docs/apply-live.md
+++ b/docs/apply-live.md
@@ -1,5 +1,6 @@
 ---
-nav_order: 6
+parent: Architecture
+nav_order: 3
 ---
 
 # Architecture of apply-live

--- a/docs/architecture-core.md
+++ b/docs/architecture-core.md
@@ -1,8 +1,9 @@
 ---
-nav_order: 5
+parent: Architecture
+nav_order: 1
 ---
 
-# Architecture: RPM packages, ostree commits
+# RPM packages, ostree commits
 {: .no_toc }
 
 1. TOC

--- a/docs/architecture-daemon.md
+++ b/docs/architecture-daemon.md
@@ -1,8 +1,9 @@
 ---
-nav_order: 5
+parent: Architecture
+nav_order: 2
 ---
 
-# Architecture: daemon model
+# Daemon model
 {: .no_toc }
 
 1. TOC

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,12 @@
+---
+has_children: true
+has_toc: false
+nav_order: 6
+---
+
+# Architecture
+{: .no_toc }
+
+1. [RPM packages, ostree commits](architecture-core.md)
+1. [Daemon model](architecture-daemon.md)
+1. [Architecture of apply-live](apply-live.md)

--- a/docs/compose-server.md
+++ b/docs/compose-server.md
@@ -1,5 +1,6 @@
 ---
-nav_order: 4
+parent: Composing images
+nav_order: 1
 ---
 
 # Compose server

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -1,0 +1,12 @@
+---
+has_children: true
+has_toc: false
+nav_order: 5
+---
+
+# Composing images
+{: .no_toc }
+
+1. [Compose server](compose-server.md)
+1. [Treefile reference page](treefile.md)
+1. [Extensions](extensions.md)

--- a/docs/countme.md
+++ b/docs/countme.md
@@ -5,9 +5,6 @@ nav_order: 4
 # DNF Count Me support
 {: .no_toc }
 
-1. TOC
-{:toc}
-
 Classic DNF based operating systems can use the [DNF Count Me feature][countme]
 to anonymously report how long a system has been running without impacting the
 user privacy. This is implemented as an additional `countme` variable added to

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,5 +1,6 @@
 ---
-nav_order: 6
+parent: Composing images
+nav_order: 3
 ---
 
 # Extensions

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 nav_order: 1
 ---
 
-# rpm-ostree: A true hybrid image/package system
+# A true hybrid image/package system
 {: .no_toc }
 
 1. TOC

--- a/docs/repo_structure.md
+++ b/docs/repo_structure.md
@@ -1,5 +1,6 @@
 ---
-nav_order: 9
+parent: Contributing
+nav_order: 2
 ---
 
 # Repository structure

--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -1,8 +1,9 @@
 ---
-nav_order: 5
+parent: Composing images
+nav_order: 2
 ---
 
-# Treefile
+# Treefile reference
 
 A "treefile" is a made up term for a JSON-formatted specification used
 as input to `rpm-ostree compose tree` to bind "set of RPMs with


### PR DESCRIPTION
This keeps the focus on user CLI docs first, then how to build images,
then how rpm-ostree works under the hood and finally how to contribute.

Preview at https://travier.github.io/rpm-ostree/compose/