### PR TITLE
Misc fixes for defects detected by static analysis

### DIFF
--- a/src/app/rpmostree-clientlib.cxx
+++ b/src/app/rpmostree-clientlib.cxx
@@ -202,7 +202,7 @@ rpmostree_load_sysroot (const char        *sysroot,
   if (!app_load_sysroot_impl (sysroot, cancellable, &connection, error))
     return FALSE;
 
-  const char *bus_name;
+  const char *bus_name = NULL;
   if (g_dbus_connection_get_unique_name (connection) != NULL)
     bus_name = BUS_NAME;
 

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -2715,16 +2715,14 @@ kernel_arg_transaction_execute (RpmostreedTransaction *transaction,
   g_autoptr(RpmOstreeSysrootUpgrader) upgrader =
     rpmostree_sysroot_upgrader_new (sysroot, self->osname, static_cast<RpmOstreeSysrootUpgraderFlags>(upgrader_flags),
                                     cancellable, error);
+  if (upgrader == NULL)
+    return FALSE;
   rpmostree_sysroot_upgrader_set_caller_info (upgrader, command_line, 
                                               rpmostreed_transaction_get_agent_id (RPMOSTREED_TRANSACTION(self)),
                                               rpmostreed_transaction_get_sd_unit (RPMOSTREED_TRANSACTION(self)));
   g_auto(GStrv) existing_kargs = g_strsplit (self->existing_kernel_args, " ", -1);
 
-  /* We need the upgrader to perform the deployment */
-  if (upgrader == NULL)
-    return FALSE;
-
-      /* Delete all the entries included in the kernel args */
+  /* Delete all the entries included in the kernel args */
   for (char **iter = self->kernel_args_deleted; iter && *iter; iter++)
     {
       const char*  arg =  *iter;


### PR DESCRIPTION
daemon/transaction: perform upfront null check on upgrader

This moves a null check on an sysroot upgrader instance, in order
to check pointer validity before dereferencing it.
The issue was detected by covscan.

---

app/clientlib: initialize bus_name

This initializes a string pointer which could otherwise be left
floating and passed around uninitialized.