### PR TITLE
builtin/tree: misc fixes related to rpmdb location

### DIFF
--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -172,9 +172,15 @@ fn postprocess_presets(rootfs_dfd: &openat::Dir) -> Result<()> {
     Ok(())
 }
 
-// We keep hitting issues with the ostree-remount preset not being
-// enabled; let's just do this rather than trying to propagate the
-// preset everywhere.
+/// Write an RPM macro file to ensure the rpmdb path is set on the client side.
+pub fn compose_postprocess_rpm_macro(rootfs_dfd: i32) -> CxxResult<()> {
+    let rootfs = &crate::ffiutil::ffi_view_openat_dir(rootfs_dfd);
+    postprocess_rpm_macro(rootfs)?;
+    Ok(())
+}
+
+/// Ensure our own `_dbpath` macro exists in the tree.
+#[context("Writing _dbpath RPM macro")]
 fn postprocess_rpm_macro(rootfs_dfd: &openat::Dir) -> Result<()> {
     let rpm_macros_dir = "usr/lib/rpm/macros.d";
     rootfs_dfd.ensure_dir_all(rpm_macros_dir, 0o755)?;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -160,6 +160,7 @@ pub mod ffi {
             rootfs_dfd: i32,
             cancellable: Pin<&mut GCancellable>,
         ) -> Result<()>;
+        fn compose_postprocess_rpm_macro(rootfs_dfd: i32) -> Result<()>;
     }
 
     // A grab-bag of metadata from the deployment's ostree commit

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -574,6 +574,8 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
 {
   g_autoptr(RpmOstreeTreeComposeContext) self = g_new0 (RpmOstreeTreeComposeContext, 1);
 
+  rpmostreecxx::core_libdnf_process_global_init();
+
   /* Init fds to -1 */
   self->workdir_dfd = self->rootfs_dfd = self->cachedir_dfd = -1;
   /* Test whether or not bwrap is going to work - we will fail inside e.g. a Docker

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -379,6 +379,9 @@ rpmostree_context_new_client (OstreeRepo   *repo)
   dnf_context_set_zchunk (self->dnfctx, FALSE);
 #endif
 
+  /* The rpmdb is at /usr/share/rpm */
+  dnf_context_set_rpm_macro (self->dnfctx, "_dbpath", "/" RPMOSTREE_RPMDB_LOCATION);
+
   return self;
 }
 

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -78,6 +78,10 @@ char* rpmostree_refspec_to_string (RpmOstreeRefspecType  reftype,
 char* rpmostree_refspec_canonicalize (const char           *orig_refspec,
                                       GError              **error);
 
+namespace rpmostreecxx {
+void core_libdnf_process_global_init();
+}
+
 RpmOstreeContext *rpmostree_context_new_client (OstreeRepo   *repo);
 
 RpmOstreeContext *rpmostree_context_new_compose (int basedir_dfd,

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -649,6 +649,9 @@ rpmostree_rootfs_postprocess_common (int           rootfs_fd,
         }
     }
 
+  /* Make sure there is an RPM macro in place pointing to the rpmdb in /usr */
+  rpmostreecxx::compose_postprocess_rpm_macro(rootfs_fd);
+
   if (!rpmostree_cleanup_leftover_rpmdb_files (rootfs_fd, cancellable, error))
     return FALSE;
 

--- a/src/libpriv/rpmostree-rpm-util.cxx
+++ b/src/libpriv/rpmostree-rpm-util.cxx
@@ -851,6 +851,8 @@ get_sack_for_root (int               dfd,
   GLNX_AUTO_PREFIX_ERROR ("Loading sack", error);
   g_assert (out_sack != NULL);
 
+  rpmostreecxx::core_libdnf_process_global_init();
+
   g_autofree char *fullpath = glnx_fdrel_abspath (dfd, path);
 
   g_autoptr(DnfSack) sack = dnf_sack_new ();


### PR DESCRIPTION
This is meant to address https://github.com/coreos/rpm-ostree/issues/2904, although completely fixing that bug also requires a patched libdnf.

---

builtin/tree: inject _dbpath macro file in postprocessing step

This wires the _dbpath macro injection logic to `compose postprocess`,
in order to make sure that the rpm configuration in the commit
matches the location of the rpmdb database.

---

libpriv/core: set _dbpath macro in dnf context

This ensures that the `_dbpath` macro is always in all dnf contexts,
in order to use the rpmdb under /usr.
Setting it explicitly makes sure that there is no logic implicitly
relying on host configuration. This is particularly relevant in
server-side compose cases, which are more likely to be running in
an environment without rpm-ostree macro file.

---
builtin/tree: explicitly set _dbpath macro in global libdnf initialization

This ensures that the `_dbpath` macro is always in all dnf contexts,
in order to use the rpmdb under /usr.
Setting it explicitly makes sure that there is no logic implicitly
relying on host configuration. This is particularly relevant in
server-side compose cases, which are more likely to be running in
an environment without rpm-ostree macro file.

