### PR TITLE
core: Neuter /usr/sbin/sss_cache during compose/layering

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -121,9 +121,13 @@ pub mod ffi {
     // core.rs
     extern "Rust" {
         type TempEtcGuard;
+        type FilesystemScriptPrep;
 
         fn prepare_tempetc_guard(rootfs: i32) -> Result<Box<TempEtcGuard>>;
         fn undo(self: &TempEtcGuard) -> Result<()>;
+
+        fn prepare_filesystem_script_prep(rootfs: i32) -> Result<Box<FilesystemScriptPrep>>;
+        fn undo(self: &FilesystemScriptPrep) -> Result<()>;
 
         fn run_depmod(rootfs_dfd: i32, kver: &str, unified_core: bool) -> Result<()>;
 

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -4110,6 +4110,7 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
   g_variant_dict_lookup (self->spec->dict, "skip-sanity-check", "b", &skip_sanity_check);
 
   auto etc_guard = rpmostreecxx::prepare_tempetc_guard (tmprootfs_dfd);
+  auto fs_prep = rpmostreecxx::prepare_filesystem_script_prep (tmprootfs_dfd);
 
   /* NB: we're not running scripts right now for removals, so this is only for overlays and
    * replacements */
@@ -4318,6 +4319,8 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
   if (self->treefile_rs && self->treefile_rs->get_cliwrap())
     rpmostreecxx::cliwrap_write_wrappers (tmprootfs_dfd);
 
+  // And revert our filesystem changes.
+  fs_prep->undo();
   /* Undo the /etc move above */
   etc_guard->undo();
 


### PR DESCRIPTION
This fixes the immense spam of errors from `useradd` trying
to refresh the sssd cache in an `rpm-ostree compose tree`.
It doesn't work when sssd isn't running (as it won't be in a non-systemd container).

xref https://pagure.io/SSSD/sssd/pull-request/3959

I named the struct generically as I'd like in the future to
generalize this code to also do the systemctl wrapper, etc.
