### PR TITLE
core: Add error prefixing when applying rpmfi overrides

### DIFF
--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -3590,7 +3590,7 @@ apply_rpmfi_overrides (RpmOstreeContext *self,
       if (!S_ISDIR (stbuf.st_mode))
         {
           if (!ostree_break_hardlink (tmprootfs_dfd, fn, FALSE, cancellable, error))
-            return FALSE;
+            return glnx_prefix_error (error, "Copyup %s", fn);
         }
 
       uid_t uid = 0;
@@ -3628,7 +3628,7 @@ apply_rpmfi_overrides (RpmOstreeContext *self,
           g_autoptr(GVariant) xattrs = rpmostree_fcap_to_xattr_variant (fcaps);
           if (!glnx_dfd_name_set_all_xattrs (tmprootfs_dfd, fn, xattrs,
                                              cancellable, error))
-            return FALSE;
+            return glnx_prefix_error (error, "%s", fn);
         }
 
       /* also reapply chmod since e.g. at least the setuid gets taken off */


### PR DESCRIPTION
I'm currently getting an error from trying to run
`sudo env TMPDIR=/var/tmp TESTS=installroot ./tests/compose.sh` like:
`installroot: error: While applying overrides for pkg shadow-utils: xattrs: fsetxattr(security.selinux): Operation not supported`

And here it'd be useful to know which file it was.  This adds
error prefixing in both the actual error path as well as the path I thought it was.