### PR TITLE
 core: Move systemctl interception into Rust, fix wrapping only for scripts

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -11,7 +11,7 @@ use openat_ext::OpenatDirExt;
 /// The binary forked from useradd that pokes the sss cache.
 /// It spews warnings (and sometimes fatal errors) when used
 /// in a non-systemd container (default treecompose side) so
-/// we replace it with `true`.
+/// we temporarily remove it.  https://github.com/SSSD/sssd/issues/5687
 const SSS_CACHE: &str = "usr/sbin/sss_cache";
 
 /// Guard for running logic in a context with temporary /etc.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -130,8 +130,6 @@ pub mod ffi {
         fn undo(self: &FilesystemScriptPrep) -> Result<()>;
 
         fn run_depmod(rootfs_dfd: i32, kver: &str, unified_core: bool) -> Result<()>;
-
-        fn get_systemctl_wrapper() -> &'static [u8];
     }
 
     // composepost.rs


### PR DESCRIPTION


Right now we're just making filesystem changes if we're going
to be running scripts, so move the bits that temporarily remove
`sss_cache` into the conditional for (if layering).

And move the systemctl wrapper bits fully into Rust, which cleans
up the code too.