### PR TITLE
Yumdnf tweaks

### DIFF
--- a/rust/src/cliwrap/cliutil.rs
+++ b/rust/src/cliwrap/cliutil.rs
@@ -61,10 +61,7 @@ pub fn run_unprivileged<T: AsRef<str>>(
     let app_name = "rpm-ostree";
     if with_warning {
         let delay_s = 5;
-        eprintln!(
-            "{name}: NOTE: This system is ostree based.",
-            name = app_name
-        );
+        eprintln!("{}: {}", app_name, super::yumdnf::IMAGEBASED);
         if drop_privileges {
             eprintln!(
                 r#"{name}: Dropping privileges as `{bin}` was executed with not "known safe" arguments."#,

--- a/rust/src/cliwrap/yumdnf.rs
+++ b/rust/src/cliwrap/yumdnf.rs
@@ -108,16 +108,14 @@ pub(crate) fn main(argv: &[&str]) -> Result<()> {
             let mut valid_options = String::new();
             for (cmd, text) in OTHER_OPTIONS {
                 if Path::new(&format!("/usr/bin/{}", cmd)).exists() {
-                    valid_options.push_str(&format!(" - `{}`: {}\n", cmd, text));
+                    valid_options.push_str(&format!("\n - `{}`: {}", cmd, text));
                 }
             }
             let msg = formatdoc! {r#"{}
-            Before installing packages to the host root filesystem, consider other options:
-            {}
+            Before installing packages to the host root filesystem, consider other options:{}
              - `rpm-ostree install`: Install RPM packages layered on the host root filesystem.
-            Consider these "operating system extensions". 
-            Add `--apply-live` to immediately start using the layered packages.
-            "#, IMAGEBASED, valid_options.as_str()};
+                Consider these "operating system extensions".
+                Add `--apply-live` to immediately start using the layered packages."#, IMAGEBASED, valid_options.as_str()};
             Err(anyhow!("{}", msg))
         }
         RunDisposition::Unhandled => Err(anyhow!("{}", UNHANDLED)),

--- a/rust/src/cliwrap/yumdnf.rs
+++ b/rust/src/cliwrap/yumdnf.rs
@@ -111,11 +111,10 @@ pub(crate) fn main(argv: &[&str]) -> Result<()> {
                     valid_options.push_str(&format!("\n - `{}`: {}", cmd, text));
                 }
             }
-            let msg = formatdoc! {r#"{}
-            Before installing packages to the host root filesystem, consider other options:{}
+            let msg = formatdoc! {r#"Before installing packages to the host root filesystem, consider other options:{}
              - `rpm-ostree install`: Install RPM packages layered on the host root filesystem.
                 Consider these "operating system extensions".
-                Add `--apply-live` to immediately start using the layered packages."#, IMAGEBASED, valid_options.as_str()};
+                Add `--apply-live` to immediately start using the layered packages."#, valid_options.as_str()};
             Err(anyhow!("{}", msg))
         }
         RunDisposition::Unhandled => Err(anyhow!("{}", UNHANDLED)),

--- a/rust/src/cliwrap/yumdnf.rs
+++ b/rust/src/cliwrap/yumdnf.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 use structopt::StructOpt;
 
 /// Emitted at the first line.
-const IMAGEBASED: &str = "Note: This system is image (rpm-ostree) based.";
+pub(crate) const IMAGEBASED: &str = "Note: This system is image (rpm-ostree) based.";
 
 /// Emitted for unhandled options.
 const UNHANDLED: &str = indoc::indoc! {r#"


### PR DESCRIPTION
cliwrap/yumdnf: Indent rpm-ostree install info

So the text is clearly associated.

---

cliwrap: Unify yum/dnf+rpm message about ostree

This way we only have one message printed in both cases.

---

cliwrap/yumdnf: Remove duplicated print of IMAGEBASED

---

cliwrap/yumdnf: Fix up indentation

Old:
```
[root@cosa-devsh ~]# dnf install cowsay
Note: This system is image (rpm-ostree) based.
error: Note: This system is image (rpm-ostree) based.
Before installing packages to the host root filesystem, consider other options:
 - `toolbox`: For command-line development and debugging tools in a privileged container
 - `podman`: General purpose containers
 - `docker`: General purpose containers

 - `rpm-ostree install`: Install RPM packages layered on the host root filesystem.
Consider these "operating system extensions".
Add `--apply-live` to immediately start using the layered packages.

[root@cosa-devsh ~]#
```

New:
```
[root@cosa-devsh ~]# dnf install cowsay
Note: This system is image (rpm-ostree) based.
Before installing packages to the host root filesystem, consider other options:
 - `toolbox`: For command-line development and debugging tools in a privileged container
 - `podman`: General purpose containers
 - `docker`: General purpose containers
 - `rpm-ostree install`: Install RPM packages layered on the host root filesystem.
   Consider these "operating system extensions".
   Add `--apply-live` to immediately start using the layered packages.
error: not implemented
[root@cosa-devsh ~]#

```

---

