### PR TITLE
tests/kolainst: Various tweaks

### DIFF
--- a/tests/kolainst/Makefile
+++ b/tests/kolainst/Makefile
@@ -2,7 +2,7 @@ DESTDIR ?=
 
 TESTDIRS := $(shell find -mindepth 1 -maxdepth 1 -type d)
 
-KOLA_TESTDIR = $(DESTDIR)/usr/lib/coreos-assembler/tests/kola/rpm-ostree/
+KOLA_TESTDIR ?= $(DESTDIR)/usr/lib/coreos-assembler/tests/kola/rpm-ostree/
 
 rpm-repos: kolainst-build.sh
 	./kolainst-build.sh
@@ -16,3 +16,6 @@ install: all
 	rsync -prlv ../common/*.sh $(KOLA_TESTDIR)/nondestructive/data/
 	rsync -prlv ../common/*.sh $(KOLA_TESTDIR)/destructive/data/
 	rsync -prlv rpm-repos/ $(KOLA_TESTDIR)/destructive/data/rpm-repos/
+
+localinstall: all
+	make install KOLA_TESTDIR=../kola

--- a/tests/kolainst/kolainst-build.sh
+++ b/tests/kolainst/kolainst-build.sh
@@ -9,14 +9,14 @@ export topsrcdir commondir
 . "${commondir}/libtest.sh"
 
 rm rpm-repos -rf
-mkdir rpm-repos
 
 test_tmpdir=$(mktemp -d)
+mkdir ${test_tmpdir}/rpm-repos
 repover=0
 
-# Right now we build just one rpm, with one repo version,
+# Right now we build a few RPMs, with one repo version,
 # but the idea is to extend this with more.
-mkdir rpm-repos/${repover}
+mkdir ${test_tmpdir}/rpm-repos/${repover}
 # The obligatory `foo` and `bar` packages
 build_rpm foo version 1.2 release 3
 build_rpm bar
@@ -57,4 +57,12 @@ build_rpm testdaemon \
 build_rpm testpkg-post-infinite-loop \
              post "echo entering testpkg-post-infinite-loop 1>&2; while true; do sleep 1h; done"
 
-mv ${test_tmpdir}/yumrepo/* rpm-repos/${repover}
+mv ${test_tmpdir}/yumrepo/* ${test_tmpdir}/rpm-repos/${repover}
+
+# Other repo versions here e.g.
+# repover=1
+# ...
+# mv ${test_tmpdir}/yumrepo/* ${test_tmpdir}/rpm-repos/${repover}
+
+# And finally; put in place. This is the marker for `make` to know we succeeded.
+mv ${test_tmpdir}/rpm-repos rpm-repos


### PR DESCRIPTION
```
commit 29aa02449df38cc0e0974a66b0b983138dbfe328
Date:   Fri Jun 18 13:53:09 2021 -0400

    tests/kolainst: Copy to rpm-repos/ last
    
    Otherwise, if we fail to build e.g. an RPM because of some typo in the
    script, `make` won't know to rerun it on the next invocation.
```

```
commit ea376f150900b6b5add5b8fb289be598bba1df3e
Date:   Fri Jun 18 13:54:52 2021 -0400

    tests/kolainst: Add `make localinstall`
    
    When hacking and testing locally with `cosa build-fast` and `kola run`,
    I don't want to have to `sudo make install` the kola tests when e.g. I
    didn't even e.g. `sudo make install` the built rpm-ostree. That way,
    iterating doesn't touch the build environment and doesn't involve root
    at all.
```