### PR TITLE
builtin/compose: move commit-id write logic to Rust

### DIFF
--- a/rust/src/builtins/compose/commit.rs
+++ b/rust/src/builtins/compose/commit.rs
@@ -1,0 +1,36 @@
+//! CLI sub-command `compose commit`.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::cxxrsutil::CxxResult;
+use anyhow::anyhow;
+use fn_error_context::context;
+
+#[context("Writing commit-id to {}", target_path)]
+pub fn write_commit_id(target_path: &str, revision: &str) -> CxxResult<()> {
+    if target_path.is_empty() {
+        return Err(anyhow!("empty target path").into());
+    }
+    if revision.is_empty() {
+        return Err(anyhow!("empty revision content").into());
+    }
+    std::fs::write(target_path, revision)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_write_commit_id() {
+        write_commit_id("", "foo").unwrap_err();
+        write_commit_id("/foo", "").unwrap_err();
+
+        let tmpdir = tempfile::tempdir().unwrap();
+        let filepath = tmpdir.path().join("commit-id");
+        let expected_id = "my-revision-id";
+        write_commit_id(&filepath.to_string_lossy(), &expected_id).unwrap();
+        let read = std::fs::read_to_string(&filepath).unwrap();
+        assert_eq!(read, expected_id);
+    }
+}

--- a/rust/src/builtins/compose/mod.rs
+++ b/rust/src/builtins/compose/mod.rs
@@ -1,0 +1,4 @@
+//! CLI sub-command `compose`.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+pub(crate) mod commit;

--- a/rust/src/builtins/mod.rs
+++ b/rust/src/builtins/mod.rs
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 pub(crate) mod apply_live;
+pub(crate) mod compose;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -111,6 +111,11 @@ pub mod ffi {
         fn applylive_entrypoint(args: &Vec<String>) -> Result<()>;
     }
 
+    // builtins/compose/
+    extern "Rust" {
+        fn write_commit_id(target_path: &str, revision: &str) -> Result<()>;
+    }
+
     // cliwrap.rs
     extern "Rust" {
         fn cliwrap_write_wrappers(rootfs: i32) -> Result<()>;
@@ -515,7 +520,8 @@ pub mod ffi {
 }
 
 mod builtins;
-pub(crate) use self::builtins::apply_live::*;
+pub(crate) use crate::builtins::apply_live::*;
+pub(crate) use crate::builtins::compose::commit::*;
 mod bwrap;
 pub(crate) use bwrap::*;
 mod client;

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1119,6 +1119,7 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
                                  metadata, gpgkey, selinux, self->devino_cache,
                                  &new_revision, cancellable, error))
     return FALSE;
+  g_assert(new_revision != NULL);
 
   OstreeRepoTransactionStats stats = { 0, };
   OstreeRepoTransactionStats *statsp = NULL;
@@ -1166,10 +1167,7 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
     return FALSE;
 
   if (opt_write_commitid_to)
-    {
-      if (!g_file_set_contents (opt_write_commitid_to, new_revision, -1, error))
-        return glnx_prefix_error (error, "While writing to '%s'", opt_write_commitid_to);
-    }
+    rpmostreecxx::write_commit_id(opt_write_commitid_to, new_revision);
 
   return TRUE;
 }


### PR DESCRIPTION
This moves the commit-id writing logic to Rust, as a small incremental step
in porting the `compose` builtin.