### PR TITLE
spec: Disable LTO on 32 bit architectures

### DIFF
--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -133,6 +133,9 @@ The %{name}-devel package includes the header files for %{name}-libs.
 
 %prep
 %autosetup -Sgit -n %{name}-%{version}
+%if 0%{?__isa_bits} == 32
+sed -ie 's,^lto = true,lto = false,' Cargo.toml
+%endif
 
 %build
 env NOCONFIGURE=1 ./autogen.sh


### PR DESCRIPTION
We hit "LLVM ERROR: out of memory" with LTO on 32 bit.

https://bugzilla.redhat.com/show_bug.cgi?id=1974927
