### PR TITLE
rust/utils: Handle PowerPC endianity in rpm_basearch

### DIFF
--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -453,7 +453,8 @@ pub(crate) fn get_rpm_basearch() -> String {
     match std::env::consts::ARCH {
         "arm" => "armhfp".to_string(),
         "powerpc" => "ppc".to_string(),
-        "powerpc64" => "ppc64".to_string(),
+        "powerpc64" if cfg!(target_endian = "big") => "ppc64".to_string(),
+        "powerpc64" if cfg!(target_endian = "little") => "ppc64le".to_string(),
         "sparc64" => "sparc".to_string(),
         "x86" => "i386".to_string(),
         s => s.to_string(),


### PR DESCRIPTION
This got hit in coreos's test ext.config.rpm-ostree-countme failure on ppc64le, incorrect/non-existent url, with this fix it passes.
This is first time for me to seriously touching Rust, so I hope that it is all fine from the Rust perspective.
What is the process to get this picked up by Fedora's rpms eventually? I think backport to f34 and rawhide would be appreciated.