### PR TITLE
compose: add some error prefixes

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1118,7 +1118,7 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
   if (!rpmostree_compose_commit (self->rootfs_dfd, self->build_repo, parent_revision,
                                  metadata, gpgkey, selinux, self->devino_cache,
                                  &new_revision, cancellable, error))
-    return FALSE;
+    return glnx_prefix_error (error, "Writing commit");
   g_assert(new_revision != NULL);
 
   OstreeRepoTransactionStats stats = { 0, };

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -924,7 +924,7 @@ rpmostree_compose_commit (int            rootfs_fd,
   // Unfortunately this API takes GVariantDict, not GVariantBuilder, so convert
   g_autoptr(GVariantDict) metadata_dict = g_variant_dict_new (src_metadata);
   if (!ostree_commit_metadata_for_bootable (root_tree, metadata_dict, cancellable, error))
-    return FALSE;
+    return glnx_prefix_error (error, "Looking for bootable kernel");
   g_autoptr(GVariant) metadata = g_variant_dict_end (metadata_dict);
 
   g_autofree char *new_revision = NULL;


### PR DESCRIPTION
This introduces a couple of context prefixes in order to make some
error paths/outputs more useful to human readers.