### PR TITLE
compose/commit: decouple JSON summary logic, move stats to Rust

### DIFF
--- a/rust/src/builtins/compose/commit.rs
+++ b/rust/src/builtins/compose/commit.rs
@@ -1,9 +1,31 @@
 //! CLI sub-command `compose commit`.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::cxxrsutil::CxxResult;
+use crate::cxxrsutil::{CxxResult, FFIGObjectWrapper};
 use anyhow::anyhow;
 use fn_error_context::context;
+use indoc::printdoc;
+use std::pin::Pin;
+
+/// Print statistics related to an ostree transaction.
+pub fn print_ostree_txn_stats(mut stats: Pin<&mut crate::FFIOstreeRepoTransactionStats>) {
+    let stats = &stats.gobj_wrap();
+    printdoc!(
+        "Metadata Total: {meta_total}
+        Metadata Written: {meta_written}
+        Content Total: {content_total}
+        Content Written: {content_written}
+        Content Cache Hits: {cache_hits}
+        Content Bytes Written: {content_bytes}
+        ",
+        meta_total = stats.get_metadata_objects_total(),
+        meta_written = stats.get_metadata_objects_written(),
+        content_total = stats.get_content_objects_total(),
+        content_written = stats.get_content_objects_written(),
+        cache_hits = stats.get_devino_cache_hits(),
+        content_bytes = stats.get_content_bytes_written()
+    );
+}
 
 #[context("Writing commit-id to {}", target_path)]
 pub fn write_commit_id(target_path: &str, revision: &str) -> CxxResult<()> {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -118,8 +118,9 @@ pub mod ffi {
 
     // builtins/compose/
     extern "Rust" {
-        fn write_commit_id(target_path: &str, revision: &str) -> Result<()>;
         fn composeutil_legacy_prep_dev(rootfs_dfd: i32) -> Result<()>;
+        fn print_ostree_txn_stats(stats: Pin<&mut OstreeRepoTransactionStats>);
+        fn write_commit_id(target_path: &str, revision: &str) -> Result<()>;
     }
 
     // cliwrap.rs

--- a/src/app/rpmostree-composeutil.h
+++ b/src/app/rpmostree-composeutil.h
@@ -55,7 +55,7 @@ rpmostree_composeutil_write_composejson (OstreeRepo  *repo,
                                          const OstreeRepoTransactionStats *stats,
                                          const char *new_revision,
                                          GVariant   *new_commit,
-                                         GVariantBuilder *builder,
+                                         const char *new_ref,
                                          GCancellable *cancellable,
                                          GError    **error);
 


### PR DESCRIPTION
This refactors the JSON summary logic in order to make it more
explicitly scoped and decoupled from the rest of the surrounding
commit steps. In particular with this:
 * the whole logic is skipped if the JSON summary is not requested
 * the GVariant builder is scoped within the summary logic
 * transaction stats are printed as soon as available, through a
   Rust helper