### PR TITLE
cxxrs: bind OstreeRepoTransactionStats

### DIFF
--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -55,7 +55,7 @@ macro_rules! impl_wrap {
             fn gobj_rewrap(&'a self) -> Pin<&'a mut Self::ReWrapped> {
                 // Access the underlying raw pointer behind the glib-rs
                 // newtype wrapper, e.g. `ostree_sys::OstreeRepo`.
-                let p: *mut $sys = self.to_glib_none().0;
+                let p: *const $sys = self.to_glib_none().0;
                 // Safety: Pin<T> is a #[repr(transparent)] newtype wrapper
                 // around our #[repr(transparent)] FFI newtype wrapper which
                 // for the glib-rs newtype wrapper, which finally holds the real
@@ -94,7 +94,12 @@ macro_rules! cxxrs_bind {
 
 // When extending this list, also update rpmostree-cxxrs-prelude.h and lib.rs
 // This macro is special to ostree types currently.
-cxxrs_bind!(Ostree, ostree, ostree_sys, [Sysroot, Repo, Deployment]);
+cxxrs_bind!(
+    Ostree,
+    ostree,
+    ostree_sys,
+    [Deployment, Repo, RepoTransactionStats, Sysroot]
+);
 cxxrs_bind!(G, glib, gobject_sys, [Object]);
 cxxrs_bind!(G, gio, gio_sys, [Cancellable, DBusConnection]);
 cxxrs_bind!(G, glib, glib_sys, [KeyFile, Variant, VariantDict]);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -31,10 +31,11 @@ pub mod ffi {
     extern "C++" {
         include!("src/libpriv/rpmostree-cxxrs-prelude.h");
 
-        type OstreeSysroot = crate::FFIOstreeSysroot;
+        type OstreeDeployment = crate::FFIOstreeDeployment;
         #[allow(dead_code)]
         type OstreeRepo = crate::FFIOstreeRepo;
-        type OstreeDeployment = crate::FFIOstreeDeployment;
+        type OstreeRepoTransactionStats = crate::FFIOstreeRepoTransactionStats;
+        type OstreeSysroot = crate::FFIOstreeSysroot;
         type GObject = crate::FFIGObject;
         type GCancellable = crate::FFIGCancellable;
         type GDBusConnection = crate::FFIGDBusConnection;

--- a/src/libpriv/rpmostree-cxxrs-prelude.h
+++ b/src/libpriv/rpmostree-cxxrs-prelude.h
@@ -24,10 +24,11 @@
 
 namespace rpmostreecxx {
     // Currently cxx-rs requires that external bindings are in the same namespace as
-    // its own bindings, so we maintain typedefs.  Update cxx_bridge_gobject.rs first.
-    typedef ::OstreeSysroot OstreeSysroot;
-    typedef ::OstreeRepo OstreeRepo;
+    // its own bindings, so we maintain typedefs.  Update cxxrsutil.rs first.
     typedef ::OstreeDeployment OstreeDeployment;
+    typedef ::OstreeRepo OstreeRepo;
+    typedef ::OstreeRepoTransactionStats OstreeRepoTransactionStats;
+    typedef ::OstreeSysroot OstreeSysroot;
     typedef ::GObject GObject;
     typedef ::GCancellable GCancellable;
     typedef ::GDBusConnection GDBusConnection;


### PR DESCRIPTION
This adds bidirectional binding for `OstreeRepoTransactionStats`.

As this type is a plain C struct (not wrapped by GObject), it
also requires tweaking the auto-binding macro.
In particular, the intermediate pointer is now "const" in order
to cover this kind of cases which lack interior mutability. The
qualifier is anyway discarded by the final transmute.

Ref: https://github.com/coreos/rpm-ostree/pull/2928#discussion_r658332461