### PR TITLE
libpriv/importer: move mode-tweaking logic to Rust

### DIFF
--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -101,7 +101,7 @@ cxxrs_bind!(
     [Deployment, Repo, RepoTransactionStats, Sysroot]
 );
 cxxrs_bind!(G, glib, gobject_sys, [Object]);
-cxxrs_bind!(G, gio, gio_sys, [Cancellable, DBusConnection]);
+cxxrs_bind!(G, gio, gio_sys, [Cancellable, DBusConnection, FileInfo]);
 cxxrs_bind!(G, glib, glib_sys, [KeyFile, Variant, VariantDict]);
 
 // An error type helper; separate from the GObject bridging

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -39,6 +39,7 @@ pub mod ffi {
         type GObject = crate::FFIGObject;
         type GCancellable = crate::FFIGCancellable;
         type GDBusConnection = crate::FFIGDBusConnection;
+        type GFileInfo = crate::FFIGFileInfo;
         type GVariant = crate::FFIGVariant;
         type GVariantDict = crate::FFIGVariantDict;
         type GKeyFile = crate::FFIGKeyFile;
@@ -202,6 +203,7 @@ pub mod ffi {
     extern "Rust" {
         fn path_is_in_opt(path: &str) -> bool;
         fn path_is_ostree_compliant(path: &str) -> bool;
+        fn tweak_imported_file_info(mut file_info: Pin<&mut GFileInfo>, ro_executables: bool);
     }
 
     // initramfs.rs

--- a/src/libpriv/rpmostree-cxxrs-prelude.h
+++ b/src/libpriv/rpmostree-cxxrs-prelude.h
@@ -32,6 +32,7 @@ namespace rpmostreecxx {
     typedef ::GObject GObject;
     typedef ::GCancellable GCancellable;
     typedef ::GDBusConnection GDBusConnection;
+    typedef ::GFileInfo GFileInfo;
     typedef ::GVariant GVariant;
     typedef ::GVariantDict GVariantDict;
     typedef ::GKeyFile GKeyFile;

--- a/src/libpriv/rpmostree-importer.cxx
+++ b/src/libpriv/rpmostree-importer.cxx
@@ -470,20 +470,6 @@ typedef struct
   GError  **error;
 } cb_data;
 
-/* See this bug:
- * https://bugzilla.redhat.com/show_bug.cgi?id=517575
- */
-static void
-ensure_directories_user_writable (GFileInfo *file_info)
-{
-  if (g_file_info_get_file_type (file_info) == G_FILE_TYPE_DIRECTORY)
-    {
-      guint32 mode = g_file_info_get_attribute_uint32 (file_info, "unix::mode");
-      mode |= S_IWUSR;
-      g_file_info_set_attribute_uint32 (file_info, "unix::mode", mode);
-    }
-}
-
 /* systemd-tmpfiles complains loudly about writing to /var/run; ideally,
  * all of the packages get fixed for this but...eh.
  */
@@ -622,19 +608,8 @@ compose_filter_cb (OstreeRepo         *repo,
         }
     }
 
-  ensure_directories_user_writable (file_info);
-
-  /* See similar code in `ostree commit` - https://github.com/ostreedev/ostree/pull/2091/commits/7392259332e00c33ed45b904deabde08f4da3e3c */
-  if ((self->flags & RPMOSTREE_IMPORTER_FLAGS_RO_EXECUTABLES) > 0 &&
-      g_file_info_get_file_type (file_info) == G_FILE_TYPE_REGULAR)
-    {
-      guint32 mode = g_file_info_get_attribute_uint32 (file_info, "unix::mode");
-      if (mode & (S_IXUSR | S_IXGRP | S_IXOTH))
-        {
-          mode &= ~(S_IWUSR | S_IWGRP | S_IWOTH);
-          g_file_info_set_attribute_uint32 (file_info, "unix::mode", mode);
-        }
-    }
+  bool ro_executables = (self->flags & RPMOSTREE_IMPORTER_FLAGS_RO_EXECUTABLES) != 0;
+  rpmostreecxx::tweak_imported_file_info (*file_info, ro_executables);
 
   return OSTREE_REPO_COMMIT_FILTER_ALLOW;
 }


### PR DESCRIPTION
This groups all the mode-tweaking logic in the importer, and moves
it to Rust.

---

Context: I'm trying to unify more of this logic with the server-side composing one. Currently hoping to meet in the middle in gio+rust land.
