### PR TITLE
libpriv/importer: move filtering logic to Rust

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -201,8 +201,11 @@ pub mod ffi {
 
     // importer.rs
     extern "Rust" {
-        fn path_is_in_opt(path: &str) -> bool;
-        fn path_is_ostree_compliant(path: &str) -> bool;
+        fn importer_compose_filter(
+            path: &str,
+            mut file_info: Pin<&mut GFileInfo>,
+            skip_extraneous: bool,
+        ) -> Result<bool>;
         fn tweak_imported_file_info(mut file_info: Pin<&mut GFileInfo>, ro_executables: bool);
     }
 

--- a/tests/vmcheck/test-layering-basic-1.sh
+++ b/tests/vmcheck/test-layering-basic-1.sh
@@ -75,7 +75,7 @@ vm_build_rpm test-usrlocal \
 if vm_rpmostree install test-usrlocal-1.0 2>err.txt; then
     assert_not_reached "Was able to install a package in /usr/local/"
 fi
-assert_file_has_content err.txt "See https://github.com/projectatomic/rpm-ostree/issues/233"
+assert_file_has_content err.txt "Unsupported path; see https://github.com/projectatomic/rpm-ostree/issues/233"
 
 echo "ok failed to install in /usr/local"
 


### PR DESCRIPTION
This splits importer logic concerning path-filtering from the
one doing tmpfiles.d translation. The former is moved to Rust,
while the latter is left untouched here but could be later
unified with similar server-side composing logic already in Rust.

---

Context: I'm trying to unify more of this logic with the server-side composing one. Currently hoping to meet in the middle in gio+rust land.

