### PR TITLE
daemon: Add socket activation via /run/rpm-ostreed.socket

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -63,14 +63,15 @@ systemdunit_service_in_files = \
 	$(NULL)
 
 systemdunit_service_files = $(systemdunit_service_in_files:.service.in=.service)
-systemdunit_timer_files = \
+systemdunit_other_files = \
+	$(srcdir)/src/daemon/rpm-ostreed.socket \
 	$(srcdir)/src/daemon/rpm-ostreed-automatic.timer \
 	$(srcdir)/src/daemon/rpm-ostree-countme.timer \
 	$(NULL)
 
 systemdunit_DATA = \
 	$(systemdunit_service_files) \
-	$(systemdunit_timer_files) \
+	$(systemdunit_other_files) \
 	$(NULL)
 
 systemdunitdir       = $(prefix)/lib/systemd/system/
@@ -110,7 +111,7 @@ EXTRA_DIST += \
 	$(sysconf_DATA) \
 	$(service_in_files) \
 	$(systemdunit_service_in_files) \
-	$(systemdunit_timer_files) \
+	$(systemdunit_other_files) \
 	$(NULL)
 
 CLEANFILES += \

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -183,6 +183,8 @@ pub mod ffi {
     // daemon.rs
     extern "Rust" {
         fn daemon_sanitycheck_environment(sysroot: Pin<&mut OstreeSysroot>) -> Result<()>;
+        fn daemon_main(debug: bool) -> Result<()>;
+        fn start_daemon_via_socket() -> Result<()>;
         fn deployment_generate_id(deployment: Pin<&mut OstreeDeployment>) -> String;
         fn deployment_populate_variant(
             mut sysroot: Pin<&mut OstreeSysroot>,
@@ -472,6 +474,12 @@ pub mod ffi {
         fn early_main();
         fn rpmostree_main(args: &[&str]) -> Result<()>;
         fn main_print_error(msg: &str);
+    }
+
+    unsafe extern "C++" {
+        include!("rpmostreed-daemon.h");
+        fn daemon_init_inner(debug: bool) -> Result<()>;
+        fn daemon_main_inner() -> Result<()>;
     }
 
     unsafe extern "C++" {

--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -296,6 +296,8 @@ rpmostree_option_context_parse (GOptionContext *context,
             }
         }
 
+      rpmostreecxx::start_daemon_via_socket();
+
       /* root never needs to auth */
       if (getuid () != 0)
         /* ignore errors; we print out a warning if we fail to spawn pkttyagent */

--- a/src/daemon/rpm-ostreed.socket
+++ b/src/daemon/rpm-ostreed.socket
@@ -1,0 +1,9 @@
+[Unit]
+ConditionKernelCommandLine=ostree
+
+[Socket]
+ListenStream=/run/rpm-ostree/client.sock
+SocketMode=0600
+
+[Install]
+WantedBy=sockets.target

--- a/src/daemon/rpmostreed-daemon.h
+++ b/src/daemon/rpmostreed-daemon.h
@@ -36,6 +36,12 @@ G_BEGIN_DECLS
 #define RPMOSTREE_DRIVER_SD_UNIT "driver-sd-unit"
 #define RPMOSTREE_DRIVER_NAME "driver-name"
 
+/* Note: Currently actually defined in rpmostree-builtin-start-daemon.cxx for historical reasons */
+namespace rpmostreecxx {
+void daemon_init_inner (bool debug);
+void daemon_main_inner ();
+}
+
 GType              rpmostreed_daemon_get_type       (void) G_GNUC_CONST;
 RpmostreedDaemon * rpmostreed_daemon_get            (void);
 GDBusConnection  * rpmostreed_daemon_connection     (void);


### PR DESCRIPTION
For historical reasons, the daemon ends up doing a lot of
initialization before even claiming the DBus name.  For example,
it calls `ostree_sysroot_load()`.  We also end up scanning
the RPM database, and actually parse all the GPG keys
in `/etc/pki/rpm-gpg` etc.

This causes two related problems:

- By doing all this work before claiming the bus name, we
  race against the (pretty low) DBus service timeout of 25s.
- If something hard fails at initialization, the client can't
  easily see the error because it just appears in the systemd
  journal.  The client will just see a service timeout.

The solution to this is to adopt systemd socket activation,
which drops out DBus as an intermediary.  On daemon startup,
we now do the process-global initialization (like ostree
sysroot) and if that fails, the daemon just sticks around
(but without claiming the bus name), ready to return the
error message to each client.

After this patch:

```
$ systemctl stop rpm-ostreed
$ umount /boot
$ rpm-ostree status
error: Couldn't start daemon: Error setting up sysroot: loading sysroot: Unexpected state: /run/ostree-booted found, but no /boot/loader directory
```
