### PR TITLE
daemon: If we encounter a startup error, set it as our unit status text

### DIFF
--- a/src/app/rpmostree-builtin-start-daemon.cxx
+++ b/src/app/rpmostree-builtin-start-daemon.cxx
@@ -261,8 +261,11 @@ rpmostree_builtin_start_daemon (int             argc,
   g_autoptr(GDBusConnection) bus = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, error);
   if (!bus)
     return FALSE;
-  if (!start_daemon (bus, error))
+  if (!start_daemon (bus, error)) {
+    if (*error)
+      sd_notifyf (0, "STATUS=error: %s", (*error)->message);
     return FALSE;
+  }
 
   state_transition (APPSTATE_RUNNING);
 


### PR DESCRIPTION
This is a much smaller patch related to
https://github.com/coreos/rpm-ostree/pull/2932
which is about ensuring the client gets the actual errors instead
of generic DBus activation failure.

The obvious step then would be to have the client ask systemd
for the status text, but that's slightly messy right now and
I think I'd anyways prefer to go the socket route.

But I think this is a useful pattern; basically systemd's `StatusText`
facility is useful.
