### PR TITLE
treefile: Rename `from` to `base_refspec`

### DIFF
--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -43,7 +43,7 @@ fn origin_to_treefile_inner(kf: &KeyFile) -> Result<Box<Treefile>> {
     };
     let refspec_str = refspec_str
         .ok_or_else(|| anyhow::anyhow!("Failed to find refspec/baserefspec in origin"))?;
-    cfg.derive.from = Some(refspec_str);
+    cfg.derive.base_refspec = Some(refspec_str);
     cfg.packages = parse_stringlist(&kf, PACKAGES, "requested")?;
     cfg.derive.packages_local = parse_localpkglist(&kf, PACKAGES, "requested-local")?;
     cfg.derive.override_remove = parse_stringlist(&kf, OVERRIDES, "remove")?;
@@ -126,7 +126,7 @@ fn treefile_to_origin_inner(tf: &Treefile) -> Result<glib::KeyFile> {
 
     // refspec (note special handling right now for layering)
     let deriving = tf.packages.is_some() || tf.derive.packages_local.is_some();
-    if let Some(r) = tf.derive.from.as_deref() {
+    if let Some(r) = tf.derive.base_refspec.as_deref() {
         let k = if deriving { "baserefspec" } else { "refspec" };
         kf.set_string(ORIGIN, k, r)
     };
@@ -362,7 +362,7 @@ mod test {
         let kf = kf_from_str(BASE)?;
         let tf = origin_to_treefile_inner(&kf)?;
         assert_eq!(
-            tf.parsed.derive.from.as_ref().unwrap(),
+            tf.parsed.derive.base_refspec.as_ref().unwrap(),
             "foo:bar/x86_64/baz"
         );
 
@@ -375,7 +375,7 @@ mod test {
         "})?;
         let tf = origin_to_treefile_inner(&kf)?;
         assert_eq!(
-            tf.parsed.derive.from.as_ref().unwrap(),
+            tf.parsed.derive.base_refspec.as_ref().unwrap(),
             "fedora/33/x86_64/silverblue"
         );
         let pkgs = tf.parsed.packages.as_ref().unwrap();

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -388,7 +388,7 @@ fn treefile_merge(dest: &mut TreeComposeConfig, src: &mut TreeComposeConfig) {
         repo_packages
     );
 
-    merge_basic_field(&mut dest.derive.from, &mut src.derive.from);
+    merge_basic_field(&mut dest.derive.base_refspec, &mut src.derive.base_refspec);
 }
 
 /// Merge the treefile externals. There are currently only two keys that
@@ -1212,7 +1212,7 @@ pub(crate) struct DeriveInitramfs {
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct DeriveConfigFields {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) from: Option<String>,
+    pub(crate) base_refspec: Option<String>,
 
     // Packages
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1246,7 +1246,7 @@ impl DeriveConfigFields {
                 }
             }};
         }
-        check!(from);
+        check!(base_refspec);
         check!(packages_local);
         check!(override_remove);
         check!(override_replace_local);

--- a/tests/compose/test-basic-unified.sh
+++ b/tests/compose/test-basic-unified.sh
@@ -37,14 +37,14 @@ jq -r .ref < treefile.json > ref.txt
 # Test substitution of ${basearch}
 assert_file_has_content_literal ref.txt "${treeref}"
 
-treefile_pyedit "tf['from'] = 'somebaseref'"
+treefile_pyedit "tf['base-refspec'] = 'somebaseref'"
 rpm-ostree compose tree --print-only "${treefile}" > treefile.json
 if runcompose --dry-run &>err.txt; then
   fatal "ran a compose with derivation"
 fi
 assert_file_has_content_literal err.txt 'Cannot currently use derivation field'
 rm -f err.txt
-treefile_pyedit "del tf['from']"
+treefile_pyedit "del tf['base-refspec']"
 echo "ok cannot use derivation for composes yet"
 
 


### PR DESCRIPTION
This clears the `from` keyword for containers as a base, and
aligns the treefile term more closely with the existing
origin field.
