### PR TITLE
Allow rebase to OSTree commits in container images

### DIFF
--- a/rust/rpmostree-client/src/lib.rs
+++ b/rust/rpmostree-client/src/lib.rs
@@ -53,7 +53,8 @@ pub struct Deployment {
     pub staged: Option<bool>,
     pub booted: bool,
     pub serial: u32,
-    pub origin: String,
+    pub origin: Option<String>,
+    pub container_image_reference: Option<String>,
     pub version: Option<String>,
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -128,9 +128,22 @@ pub mod ffi {
         fn cliwrap_destdir() -> String;
     }
 
+    /// `ContainerImport` is currently identical to ostree-rs-ext's `Import` struct, because
+    /// cxx.rs currently requires types used as extern Rust types to be defined by the same crate
+    /// that contains the bridge using them, so we redefine an `ContainerImport` struct here.
+    pub(crate) struct ContainerImport {
+        pub ostree_commit: String,
+        pub image_digest: String,
+    }
+
     // sysroot_upgrade.rs
     extern "Rust" {
-        fn import_container(sysroot: Pin<&mut OstreeSysroot>, imgref: String) -> Result<String>;
+        fn import_container(
+            sysroot: Pin<&mut OstreeSysroot>,
+            imgref: String,
+        ) -> Result<Box<ContainerImport>>;
+
+        fn fetch_digest(imgref: String) -> Result<String>;
     }
 
     // core.rs

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -128,6 +128,11 @@ pub mod ffi {
         fn cliwrap_destdir() -> String;
     }
 
+    // sysroot_upgrade.rs
+    extern "Rust" {
+        fn import_container(sysroot: Pin<&mut OstreeSysroot>, imgref: String) -> Result<String>;
+    }
+
     // core.rs
     extern "Rust" {
         type TempEtcGuard;
@@ -140,6 +145,8 @@ pub mod ffi {
         fn undo(self: &FilesystemScriptPrep) -> Result<()>;
 
         fn run_depmod(rootfs_dfd: i32, kver: &str, unified_core: bool) -> Result<()>;
+
+        fn is_container_image_reference(refspec: &str) -> bool;
     }
 
     // composepost.rs
@@ -600,6 +607,8 @@ pub(crate) use self::console_progress::*;
 mod progress;
 mod scripts;
 pub(crate) use self::scripts::*;
+mod sysroot_upgrade;
+pub(crate) use crate::sysroot_upgrade::*;
 mod rpmutils;
 pub(crate) use self::rpmutils::*;
 mod testutils;

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -32,11 +32,14 @@ fn origin_to_treefile_inner(kf: &KeyFile) -> Result<Box<Treefile>> {
     let mut cfg: crate::treefile::TreeComposeConfig = Default::default();
     let refspec_str = if let Some(r) = keyfile_get_optional_string(&kf, ORIGIN, "refspec")? {
         Some(r)
+    } else if let Some(r) = keyfile_get_optional_string(&kf, ORIGIN, "baserefspec")? {
+        Some(r)
     } else {
-        keyfile_get_optional_string(&kf, ORIGIN, "baserefspec")?
+        keyfile_get_optional_string(&kf, ORIGIN, "container-image-reference")?
     };
-    let refspec_str = refspec_str
-        .ok_or_else(|| anyhow::anyhow!("Failed to find refspec/baserefspec in origin"))?;
+    let refspec_str = refspec_str.ok_or_else(|| {
+        anyhow::anyhow!("Failed to find refspec/baserefspec/container-image-reference in origin")
+    })?;
     cfg.derive.base_refspec = Some(refspec_str);
     cfg.packages = parse_stringlist(&kf, PACKAGES, "requested")?;
     cfg.derive.packages_local = parse_localpkglist(&kf, PACKAGES, "requested-local")?;

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -3,22 +3,34 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::cxxrsutil::*;
+use crate::ffi::ContainerImport;
 use anyhow::{Context, Result};
 use std::convert::TryInto;
 use std::pin::Pin;
 
 /// Import ostree commit in container image using ostree-rs-ext's API.
-pub fn import_container(
+pub(crate) fn import_container(
     mut sysroot: Pin<&mut crate::FFIOstreeSysroot>,
     imgref: String,
-) -> CxxResult<String> {
+) -> CxxResult<Box<ContainerImport>> {
     // TODO: take a GCancellable and monitor it, and drop the import task (which is how async cancellation works in Rust).
     let sysroot = &sysroot.gobj_wrap();
     let repo = &sysroot.get_repo(gio::NONE_CANCELLABLE)?;
     let imgref = imgref.as_str().try_into()?;
-    let commit = build_runtime()?
+    let imported = build_runtime()?
         .block_on(async { ostree_ext::container::import(&repo, &imgref, None).await })?;
-    Ok(commit.ostree_commit)
+    Ok(Box::new(ContainerImport {
+        ostree_commit: imported.ostree_commit,
+        image_digest: imported.image_digest,
+    }))
+}
+
+/// Fetch the image digest for `imgref` using ostree-rs-ext's API.
+pub(crate) fn fetch_digest(imgref: String) -> CxxResult<String> {
+    let imgref = imgref.as_str().try_into()?;
+    let digest = build_runtime()?
+        .block_on(async { ostree_ext::container::fetch_manifest_info(&imgref).await })?;
+    Ok(digest.manifest_digest)
 }
 
 fn build_runtime() -> Result<tokio::runtime::Runtime> {

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -1,0 +1,29 @@
+//! Rust portion of `rpmostree-sysroot-upgrader.cxx`.
+
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::cxxrsutil::*;
+use anyhow::{Context, Result};
+use std::convert::TryInto;
+use std::pin::Pin;
+
+/// Import ostree commit in container image using ostree-rs-ext's API.
+pub fn import_container(
+    mut sysroot: Pin<&mut crate::FFIOstreeSysroot>,
+    imgref: String,
+) -> CxxResult<String> {
+    // TODO: take a GCancellable and monitor it, and drop the import task (which is how async cancellation works in Rust).
+    let sysroot = &sysroot.gobj_wrap();
+    let repo = &sysroot.get_repo(gio::NONE_CANCELLABLE)?;
+    let imgref = imgref.as_str().try_into()?;
+    let commit = build_runtime()?
+        .block_on(async { ostree_ext::container::import(&repo, &imgref, None).await })?;
+    Ok(commit.ostree_commit)
+}
+
+fn build_runtime() -> Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("Failed to build tokio runtime")
+}

--- a/src/app/rpmostree-builtin-rebase.cxx
+++ b/src/app/rpmostree-builtin-rebase.cxx
@@ -140,6 +140,16 @@ rpmostree_builtin_rebase (int             argc,
   if (strlen (new_provided_refspec) == 0)
     return glnx_throw (error, "Refspec is empty");
 
+  if (refspectype == RPMOSTREE_REFSPEC_TYPE_CONTAINER)
+    {
+      if (!opt_experimental)
+        return glnx_throw (error, "Rebasing to a container image reference requires --experimental");
+      /* When using the container refspec type, if rebasing to a specific commit, we expect a
+      * specific digest tag in the refspec, not in a separate argument */
+      if (revision)
+        return glnx_throw (error, "Unexpected ostree revision alongside container refspec type");
+    }
+
   /* Check if remote refers to a local repo */
   g_autofree char *local_repo_remote = NULL;
   if (G_IN_SET (refspectype, RPMOSTREE_REFSPEC_TYPE_OSTREE,

--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -559,6 +559,7 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
     return TRUE;
 
   const gchar *origin_refspec;
+  RpmOstreeRefspecType refspectype = RPMOSTREE_REFSPEC_TYPE_OSTREE;
   g_autofree const gchar **origin_packages = NULL;
   g_autofree const gchar **origin_requested_packages = NULL;
   g_autofree const gchar **origin_requested_local_packages = NULL;
@@ -566,7 +567,8 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
   g_autofree const gchar **origin_requested_base_removals = NULL;
   g_autoptr(GVariant) origin_base_local_replacements = NULL;
   g_autofree const gchar **origin_requested_base_local_replacements = NULL;
-  if (g_variant_dict_lookup (dict, "origin", "&s", &origin_refspec))
+  if (g_variant_dict_lookup (dict, "origin", "&s", &origin_refspec) ||
+      g_variant_dict_lookup (dict, "container-image-reference", "&s", &origin_refspec))
     {
       origin_packages =
         lookup_array_and_canonicalize (dict, "packages");
@@ -606,7 +608,6 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
 
   g_print ("%s ", is_booted ? libsd_special_glyph (BLACK_CIRCLE) : " ");
 
-  RpmOstreeRefspecType refspectype = RPMOSTREE_REFSPEC_TYPE_OSTREE;
   const char *custom_origin_url = NULL;
   const char *custom_origin_description = NULL;
   if (origin_refspec)
@@ -637,6 +638,11 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
             g_print ("%s", origin_refspec);
           }
           break;
+        case RPMOSTREE_REFSPEC_TYPE_CONTAINER:
+          {
+            g_print ("%s", origin_refspec);
+          }
+         break;
         }
     }
   else

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -443,6 +443,16 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
 
   switch (refspec_type)
     {
+    case RPMOSTREE_REFSPEC_TYPE_CONTAINER:
+      {
+        if (override_commit)
+          return glnx_throw (error, "Specifying commit overrides for container-image-reference type refspecs is not supported");
+
+        auto commit = rpmostreecxx::import_container(*self->sysroot, std::string(refspec));
+
+        new_base_rev = strdup (commit.c_str());
+        break;
+      }
     case RPMOSTREE_REFSPEC_TYPE_CHECKSUM:
     case RPMOSTREE_REFSPEC_TYPE_OSTREE:
       {

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -253,6 +253,7 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
 
   RpmOstreeRefspecType refspec_type;
   g_autofree char *refspec = rpmostree_origin_get_full_refspec (origin, &refspec_type);
+  g_assert (refspec);
 
   gboolean is_layered = FALSE;
   g_autofree char *base_checksum = NULL;
@@ -301,8 +302,12 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
 
   switch (refspec_type)
     {
+    case RPMOSTREE_REFSPEC_TYPE_CONTAINER:
+      g_variant_dict_insert (dict, "container-image-reference", "s", refspec);
+      break;
     case RPMOSTREE_REFSPEC_TYPE_CHECKSUM:
       {
+        g_variant_dict_insert (dict, "origin", "s", refspec);
         g_autofree char *custom_origin_url = NULL;
         g_autofree char *custom_origin_description = NULL;
         rpmostree_origin_get_custom_description (origin, &custom_origin_url,
@@ -315,6 +320,7 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
       break;
     case RPMOSTREE_REFSPEC_TYPE_OSTREE:
       {
+        g_variant_dict_insert (dict, "origin", "s", refspec);
         if (!variant_add_remote_status (repo, refspec, base_checksum, dict, error))
           return NULL;
 
@@ -338,9 +344,6 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
       }
       break;
     }
-
-  if (refspec)
-    g_variant_dict_insert (dict, "origin", "s", refspec);
 
   variant_add_from_hash_table (dict, "requested-packages",
                                rpmostree_origin_get_packages (origin));

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -59,6 +59,12 @@ rpmostree_refspec_classify (const char *refspec,
                             RpmOstreeRefspecType *out_type,
                             GError     **error)
 {
+  if (rpmostreecxx::is_container_image_reference(refspec))
+    {
+      *out_type = RPMOSTREE_REFSPEC_TYPE_CONTAINER;
+      return TRUE;
+    }
+
   /* Fall back to TYPE_OSTREE if we cannot infer type */
   *out_type = RPMOSTREE_REFSPEC_TYPE_OSTREE;
   if (ostree_validate_checksum_string (refspec, NULL))

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -59,7 +59,12 @@ G_DECLARE_FINAL_TYPE (RpmOstreeContext, rpmostree_context, RPMOSTREE, CONTEXT, G
 typedef enum {
   RPMOSTREE_REFSPEC_TYPE_OSTREE,
   RPMOSTREE_REFSPEC_TYPE_CHECKSUM,
+  RPMOSTREE_REFSPEC_TYPE_CONTAINER,
 } RpmOstreeRefspecType;
+
+#define RPMOSTREE_REFSPEC_OSTREE_ORIGIN_KEY "refspec"
+#define RPMOSTREE_REFSPEC_OSTREE_BASE_ORIGIN_KEY "baserefspec"
+#define RPMOSTREE_REFSPEC_CONTAINER_ORIGIN_KEY "container-image-reference"
 
 gboolean rpmostree_refspec_classify (const char *refspec,
                                      RpmOstreeRefspecType *out_type,

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -58,6 +58,9 @@ void
 rpmostree_origin_remove_transient_state (RpmOstreeOrigin *origin);
 
 const char *
+rpmostree_origin_get_container_image_reference_digest (RpmOstreeOrigin *origin);
+
+const char *
 rpmostree_origin_get_refspec (RpmOstreeOrigin *origin);
 
 void
@@ -133,6 +136,10 @@ void
 rpmostree_origin_set_regenerate_initramfs (RpmOstreeOrigin *origin,
                                            gboolean regenerate,
                                            char **args);
+
+void
+rpmostree_origin_set_container_image_reference_digest (RpmOstreeOrigin *origin,
+                                                       const char      *digest);
 
 void
 rpmostree_origin_set_override_commit (RpmOstreeOrigin *origin,

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. ${KOLA_EXT_DATA}/libtest.sh
+
+set -x
+
+libtest_prepare_offline
+cd $(mktemp -d)
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+    # Test rebase
+    checksum=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
+    rpm-ostree ex-container export --repo=/ostree/repo ${checksum} containers-storage:localhost/fcos
+    rpm-ostree rebase containers-storage:localhost/fcos:latest --experimental
+    rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"containers-storage:localhost/fcos:latest\""
+    rpmostree_assert_status ".deployments[0][\"checksum\"] == \"${checksum}\""
+    echo "ok rebase to container image reference"
+
+    /tmp/autopkgtest-reboot 1
+    ;;
+  1)
+    if rpm-ostree deploy 42 2>err.txt; then
+        fatal "unexpectedly deployed version from container image reference"
+    fi
+    assert_file_has_content err.txt 'Cannot look up version while tracking a container image reference'
+    echo "ok cannot deploy when tracking container image"
+
+    # Test layering
+    if rpm -q foo 2>/dev/null; then
+      fatal "found foo"
+    fi
+    rpm-ostree install ${KOLA_EXT_DATA}/rpm-repos/0/packages/x86_64/foo-1.2-3.x86_64.rpm
+    echo "ok layering package"
+
+    # Test upgrade
+    rpm-ostree upgrade > out.txt;
+    assert_file_has_content out.txt "No upgrade available."
+    echo "ok no upgrade available"
+
+    # Create a new ostree commit containing foo and export the commit as a container image
+    with_foo_commit=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
+    ostree refs ${with_foo_commit} --create vmcheck_tmp/new_update
+    new_commit=$(ostree commit -b vmcheck --tree=ref=vmcheck_tmp/new_update)
+    rpm-ostree ex-container export --repo=/ostree/repo ${new_commit} containers-storage:localhost/fcos
+
+    rpm-ostree uninstall foo
+    rpm-ostree upgrade
+    rpmostree_assert_status ".deployments[0][\"checksum\"] == \"${new_commit}\""
+
+    /tmp/autopkgtest-reboot 2
+    ;;
+  2)
+    rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"containers-storage:localhost/fcos:latest\""
+    assert_streq $(rpm -q foo) foo-1.2-3.x86_64
+    echo "ok upgrade"
+    ;;
+  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac


### PR DESCRIPTION
**UPDATED**:
We can now do e.g. 
```
$ booted_commit=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
$ sudo rpm-ostree ex-container export --repo=/ostree/repo ${booted_commit} containers-storage:localhost/fcos
$ sudo rpm-ostree rebase containers-storage:localhost/fcos:latest --experimental
$ rpm-ostree status
State: idle
Deployments:
  containers-storage:localhost/fcos:latest
                   Version: v2021.6-27-g279ff28768+dirty (2021-06-30T21:49:22Z)

* c57a5d1d1e22c79f4a85187f959d9a16c189f8352b840c9f3d40c55a47d3dc24
                   Version: v2021.6-27-g279ff28768+dirty (2021-06-30T21:49:22Z)

  fedora:fedora/x86_64/coreos/testing-devel
                   Version: 34.20210623.dev.0 (2021-06-23T18:16:51Z)
                    Commit: a59d1ad617e0fd0690e3f00d1f7e0fc7c2c18ad887e0bd57ceee3a9a03119672
              GPGSignature: (unsigned)

$ sudo reboot

...

$ rpm-ostree status
State: idle
Deployments:
* containers-storage:localhost/fcos:latest
                   Version: v2021.6-27-g279ff28768+dirty (2021-06-30T21:49:22Z)

  c57a5d1d1e22c79f4a85187f959d9a16c189f8352b840c9f3d40c55a47d3dc24
                   Version: v2021.6-27-g279ff28768+dirty (2021-06-30T21:49:22Z)
```
Note that a tag must be provided if the refspec is a container image reference when doing `rpm-ostree rebase`.
