### PR TITLE
Stabilize `apply-live` flag for deploy, use in `rpm-ostree install -A`

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -112,6 +112,7 @@ pub mod ffi {
     // builtins/apply_live.rs
     extern "Rust" {
         fn applylive_entrypoint(args: &Vec<String>) -> Result<()>;
+        fn applylive_finish(sysroot: Pin<&mut OstreeSysroot>) -> Result<()>;
     }
 
     // builtins/compose/

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -305,6 +305,9 @@
          "custom-origin" (type '(ss)')
 
          Available options:
+         "apply-live" (type 'b')
+            Extend the running filesystem tree with queued changes.  This
+            does not allow replacing existing files/packages.
          "reboot" (type 'b')
             Initiate a reboot after transaction.
          "allow-downgrade" (type 'b')


### PR DESCRIPTION
Since we stabilized the CLI interface `rpm-ostree install -A`, we need
to stabilize the DBus interface as well.  This hence
Closes: https://github.com/coreos/rpm-ostree/issues/2875

Further, by moving this to one transaction we can drop the
incorrect "Run systemctl reboot" line.  While we have the patient
open, also change it to clarify in the non-live case that the
changes are queued.
