### PR TITLE
client: Explicitly `systemctl start rpm-ostreed` if root, dump status

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -63,6 +63,7 @@ pub mod ffi {
 
     // client.rs
     extern "Rust" {
+        fn client_start_daemon() -> Result<()>;
         fn client_handle_fd_argument(arg: &str, arch: &str) -> Result<Vec<i32>>;
     }
 

--- a/src/app/rpmostree-clientlib.cxx
+++ b/src/app/rpmostree-clientlib.cxx
@@ -82,6 +82,8 @@ app_load_sysroot_impl (const char       *sysroot,
 {
   const char *bus_name = NULL;
 
+  rpmostreecxx::client_start_daemon();
+
   g_autoptr(GDBusConnection) connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, cancellable, error);
   if (!connection)
     return glnx_prefix_error (error, "Connecting to system bus");


### PR DESCRIPTION
This is a hackier an alternative to https://github.com/coreos/rpm-ostree/pull/2932
that we can ship immediately because we won't block on SELinux policy.

For historical reasons, the daemon ends up doing a lot of
initialization before even claiming the DBus name.  For example,
it calls `ostree_sysroot_load()`.  We also end up scanning
the RPM database, and actually parse all the GPG keys
in `/etc/pki/rpm-gpg` etc.

This causes two related problems:

- By doing all this work before claiming the bus name, we
  race against the (pretty low) DBus service timeout of 25s.
- If something hard fails at initialization, the client can't
  easily see the error because it just appears in the systemd
  journal.  The client will just see a service timeout.

By explicitly using `systemctl start rpm-ostreed.service`,
systemd does all of the error checking for us without involving
`dbus-broker` as a middleman.

Further, by using `systemctl status rpm-ostreed.service` on
failure, we reuse systemd's nice rendering of the status
of the unit instead of reinventing our own.

This PR effectively replicates https://github.com/openshift/machine-config-operator/pull/2642
in our code.
