### PR TITLE
Use treefile instead of treespec for local layering

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -277,6 +277,7 @@ pub mod ffi {
         type Treefile;
 
         fn treefile_new(filename: &str, basearch: &str, workdir: i32) -> Result<Box<Treefile>>;
+        fn treefile_new_from_string(buf: &str) -> Result<Box<Treefile>>;
         fn treefile_new_compose(
             filename: &str,
             basearch: &str,
@@ -292,6 +293,9 @@ pub mod ffi {
         fn get_all_ostree_layers(&self) -> Vec<String>;
         fn get_repos(&self) -> Vec<String>;
         fn get_packages(&self) -> Vec<String>;
+        fn get_packages_local(&self) -> Vec<String>;
+        fn get_packages_override_replace_local(&self) -> Vec<String>;
+        fn get_packages_override_remove(&self) -> Vec<String>;
         fn get_exclude_packages(&self) -> Vec<String>;
         fn get_install_langs(&self) -> Vec<String>;
         fn format_install_langs_macro(&self) -> String;

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -110,6 +110,7 @@ GVariant *rpmostree_context_get_rpmmd_repo_commit_metadata (RpmOstreeContext  *s
 
 GVariant *rpmostree_treespec_to_variant (RpmOstreeTreespec *spec);
 
+void rpmostree_context_set_treefile (RpmOstreeContext *self, rpmostreecxx::Treefile &treefile);
 void rpmostree_context_set_treespec (RpmOstreeContext *self, RpmOstreeTreespec *treespec);
 
 gboolean rpmostree_context_setup (RpmOstreeContext     *self,


### PR DESCRIPTION
Part of https://github.com/coreos/rpm-ostree/issues/2947

This makes the core code temporarily uglier, but when we
remove treespec all the conditionals and duplication drop out.
