### PR TITLE
importer: add unit tests for tmpfiles.d translation

### DIFF
--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -704,6 +704,7 @@ fn convert_path_to_tmpfiles_d_recurse(
             importer::translate_to_tmpfiles_d(&abs_path, &file_info, &username, &groupname)?
         };
         tmpfiles_bufwr.write_all(entry.as_bytes())?;
+        writeln!(tmpfiles_bufwr)?;
 
         if path_type == SimpleType::Dir {
             // New subdirectory discovered, recurse into it.

--- a/src/libpriv/rpmostree-importer.cxx
+++ b/src/libpriv/rpmostree-importer.cxx
@@ -514,10 +514,11 @@ compose_filter_cb (OstreeRepo         *repo,
       get_rpmfi_override (self, path, &user, &group, NULL);
 
       try {
-        auto entry = rpmostreecxx::tmpfiles_translate(path, *file_info,
-                                                      user ?: "root",
-                                                      group ?: "root");
-        g_string_append(self->tmpfiles_d, entry.c_str());
+        auto entry = rpmostreecxx::tmpfiles_translate (path, *file_info,
+                                                       user ?: "root",
+                                                       group ?: "root");
+        g_string_append (self->tmpfiles_d, entry.c_str());
+        g_string_append_c (self->tmpfiles_d, '\n');
       } catch (std::exception& e) {
         g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "%s", e.what());
         return OSTREE_REPO_COMMIT_FILTER_SKIP;


### PR DESCRIPTION
This adds some unit tests for tmpfiles.d translation logic, and
moves newline handling to the calling sites.

Ref: https://github.com/coreos/rpm-ostree/pull/2942#discussion_r661844890
