### PR TITLE
Drop dead treespec bits

### DIFF
--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -817,10 +817,6 @@ rpmostree_context_setup (RpmOstreeContext    *self,
                                  DNF_TRANSACTION_FLAG_NODOCS);
     }
 
-  /* We could likely delete this, but I'm keeping a log message just in case */
-  if (g_variant_dict_contains (self->spec->dict, "ignore-scripts"))
-    sd_journal_print (LOG_INFO, "ignore-scripts is no longer supported");
-
   bool selinux = !self->disable_selinux && (!self->treefile_rs || self->treefile_rs->get_selinux());
   /* Load policy from / if SELinux is enabled, and we haven't already loaded
    * a policy.  This is mostly for the "compose tree" case.


### PR DESCRIPTION
core: Remove ignore-scripts check

This hasn't been used since 325ee354e9b88c62322949bea14f679dc76164f6 ("core/scripts: Drop support for ignore-scripts")
from `CommitDate: Tue Jul 18 19:21:15 2017 +0000`.

---

core: Remove skip-sanity-check treespec support

As far as I can tell, nothing ever actually set this.  I think
I added it out of an excess of conservatism, perhaps intending
that the flag could be set somewhere.

But because the treespec is an internal only API, it can't be
set.

We really do always want these checks, so just delete the code
that tries to support disabling them.

---

