### PR TITLE
two minor prep patches for treespec removal

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -286,6 +286,7 @@ pub mod ffi {
         type Treefile;
 
         fn treefile_new(filename: &str, basearch: &str, workdir: i32) -> Result<Box<Treefile>>;
+        fn treefile_new_empty() -> Result<Box<Treefile>>;
         fn treefile_new_from_string(buf: &str) -> Result<Box<Treefile>>;
         fn treefile_new_compose(
             filename: &str,

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -20,7 +20,7 @@
  */
 
 use crate::cxxrsutil::*;
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use c_utf8::CUtf8Buf;
 use nix::unistd::{Gid, Uid};
 use openat_ext::OpenatDirExt;
@@ -1436,6 +1436,11 @@ pub(crate) mod tests {
     "#};
 
     #[test]
+    fn from_string() {
+        let _ = Treefile::new_from_string("{}").unwrap();
+    }
+
+    #[test]
     fn basic_valid() {
         let mut input = io::BufReader::new(VALID_PRELUDE.as_bytes());
         let mut treefile =
@@ -2010,7 +2015,12 @@ pub(crate) fn treefile_new(
 
 /// Create a new treefile from a string.
 pub(crate) fn treefile_new_from_string(buf: &str) -> CxxResult<Box<Treefile>> {
-    Ok(Treefile::new_from_string(buf)?)
+    Ok(Treefile::new_from_string(buf).context("Parsing treefile from string")?)
+}
+
+/// Create a new empty treefile.
+pub(crate) fn treefile_new_empty() -> CxxResult<Box<Treefile>> {
+    Ok(Treefile::new_from_string("{}")?)
 }
 
 /// Create a new treefile, returning an error if any (currently) client-side options are set.

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -91,6 +91,15 @@ ruststr_or_empty (const char *c_str) {
   return rust::Str(c_str ?: "");
 }
 
+// Copy convert a NULL-terminated C string array to a Rust vector of owned strings.
+static inline rust::Vec<rust::String>
+rust_stringvec_from_strv(const char *const*strv) {
+  rust::Vec<rust::String> ret;
+  for (const char *const*it = strv; it && *it; it++)
+    ret.push_back(*it);
+  return ret;
+}
+
 }
 
 namespace rpmostreecxx {


### PR DESCRIPTION
treefile: Add an API to generate an empty config

Prep for switching the core over to treefile only.  Today
we use "empty treespec", after this we'll use "empty treefile".

---

util: Add an API to convert `char **` → `rust::Vec<rust::String>`

Since this occurs a fair bit in our code.

---

