### PR TITLE
extensions: Add a method to convert to treefile

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -426,6 +426,7 @@ pub mod ffi {
         fn state_checksum_changed(&self, chksum: &str, output_dir: &str) -> Result<bool>;
         fn update_state_checksum(&self, chksum: &str, output_dir: &str) -> Result<()>;
         fn serialize_to_dir(&self, output_dir: &str) -> Result<()>;
+        fn generate_treefile(&self, src: &Treefile) -> Result<Box<Treefile>>;
     }
 
     struct LockedPackage {

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1424,10 +1424,11 @@ pub(crate) mod tests {
     "#};
 
     // This one has "comments" (hence unknown keys)
-    static VALID_PRELUDE_JS: &str = indoc! {r#"
+    pub(crate) static VALID_PRELUDE_JS: &str = indoc! {r#"
         {
          "ref": "exampleos/${basearch}/blah",
          "comment-packages": "We want baz to enable frobnication",
+         "repos": ["baserepo"],
          "packages": ["foo", "bar", "baz"],
          "packages-x86_64": ["grub2", "grub2-tools"],
          "comment-packages-s390x": "Note that s390x uses its own bootloader",


### PR DESCRIPTION
Prep for dropping treespec.  This way we can just pass
down the config we need to the core.

Currently the C++ extensions code hand rolls this basically.
