### PR TITLE
upgrader: Generate "computed" origin

### DIFF
--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -297,14 +297,22 @@ rpmostree_origin_get_unconfigured_state (RpmOstreeOrigin *origin)
 gboolean
 rpmostree_origin_may_require_local_assembly (RpmOstreeOrigin *origin)
 {
-  return 
+  return
         rpmostree_origin_get_cliwrap (origin) || 
         rpmostree_origin_get_regenerate_initramfs (origin) ||
         (g_hash_table_size (origin->cached_initramfs_etc_files) > 0) ||
-        (g_hash_table_size (origin->cached_packages) > 0) ||
-        (g_hash_table_size (origin->cached_local_packages) > 0) ||
-        (g_hash_table_size (origin->cached_overrides_local_replace) > 0) ||
-        (g_hash_table_size (origin->cached_overrides_remove) > 0);
+        rpmostree_origin_has_packages (origin);
+}
+
+/* Returns TRUE if this origin contains overlay or override packages */
+gboolean
+rpmostree_origin_has_packages (RpmOstreeOrigin *origin)
+{
+  return 
+    (g_hash_table_size (origin->cached_packages) > 0) ||
+    (g_hash_table_size (origin->cached_local_packages) > 0) ||
+    (g_hash_table_size (origin->cached_overrides_local_replace) > 0) ||
+    (g_hash_table_size (origin->cached_overrides_remove) > 0);
 }
 
 GKeyFile *

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -104,6 +104,9 @@ rpmostree_origin_get_unconfigured_state (RpmOstreeOrigin *origin);
 gboolean
 rpmostree_origin_may_require_local_assembly (RpmOstreeOrigin *origin);
 
+gboolean
+rpmostree_origin_has_packages (RpmOstreeOrigin *origin);
+
 char *
 rpmostree_origin_get_string (RpmOstreeOrigin *origin,
                              const char *section,


### PR DESCRIPTION
This is is part of reducing internal complexity - in particular
our "representations of state".  The code here is basically
printing a warning if a requested package is already in the base
tree, and avoid passing that package down to the core.
To accomplish this original code here was doing:

origin -> (computed state) -> treespec

Now that we dropped treespec in a recent PR, it's going:

origin -> (computed state) -> treefile

Instead of having anonymous (computed state) we can
just make that a new (filtered) origin file.  IOW
we now do:

origin -> origin -> treefile

This is easier to understand and debug.  Note
how duplication around checking "requires local
assembly" between the upgrader and origin code
just drops out!
