### PR TITLE
Demote origin roundtrip warning to a debug message

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -455,7 +455,7 @@ pub mod ffi {
     // origin.rs
     extern "Rust" {
         fn origin_to_treefile(kf: Pin<&mut GKeyFile>) -> Result<Box<Treefile>>;
-        fn origin_validate_roundtrip(mut kf: Pin<&mut GKeyFile>) -> Result<()>;
+        fn origin_validate_roundtrip(mut kf: Pin<&mut GKeyFile>);
     }
 
     // rpmutils.rs

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -157,13 +157,9 @@ rpmostree_origin_parse_keyfile (GKeyFile         *origin,
   ret->cached_initramfs_args =
     g_key_file_get_string_list (ret->kf, "rpmostree", "initramfs-args", NULL, NULL);
 
-  try {
-    rpmostreecxx::origin_validate_roundtrip(*ret->kf);
-  } catch (std::exception& e) {
-    // We don't make this fatal right now until we're confident we're handling
-    // absolutely everything.
-    sd_journal_print (LOG_WARNING, "%s", e.what());
-  }
+  // We will eventually start converting origin to treefile, this helps us
+  // debug cases that may fail currently.
+  rpmostreecxx::origin_validate_roundtrip(*ret->kf);
 
   return util::move_nullify (ret);
 }


### PR DESCRIPTION
Alternative to https://github.com/coreos/rpm-ostree/pull/2956

We are tripping up on `refspec/baserefspec` and need to dedup
things more.  For now just make this a debug message.
