### PR TITLE
Error out if sqlite is default, but configured for something else

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -318,6 +318,7 @@ pub mod ffi {
         fn get_selinux(&self) -> bool;
         fn get_releasever(&self) -> &str;
         fn get_rpmdb(&self) -> String;
+        fn validate_rpmdb(&self) -> Result<()>;
         fn get_files_remove_regex(&self, package: &str) -> Vec<String>;
         fn print_deprecation_warnings(&self);
         fn sanitycheck_externals(&self) -> Result<()>;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -681,6 +681,17 @@ impl Treefile {
         s.to_string()
     }
 
+    /// Error out if the default is sqlite, but something else is configured.
+    /// xref https://bugzilla.redhat.com/show_bug.cgi?id=1938928
+    pub(crate) fn validate_rpmdb(&self) -> CxxResult<()> {
+        if let Some(rpmdb) = self.parsed.rpmdb.as_ref() {
+            if DEFAULT_RPMDB_BACKEND == RpmdbBackend::Sqlite && *rpmdb != DEFAULT_RPMDB_BACKEND {
+                return Err(anyhow!("Cannot write rpmdb backend: {:?}", rpmdb).into());
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) fn get_files_remove_regex(&self, package: &str) -> Vec<String> {
         let mut files_to_remove: Vec<String> = Vec::new();
         if let Some(ref packages) = self.parsed.remove_from_packages {

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -401,6 +401,9 @@ rpmostree_context_new_compose (int               userroot_dfd,
   /* Compose contexts always have a treefile */
   ret->treefile_rs = &treefile_rs;
 
+  // Check this early
+  ret->treefile_rs->validate_rpmdb();
+
   rpmostree_context_set_cache_root (ret, userroot_dfd);
 
   // The ref needs special handling as it gets variable-substituted.
@@ -780,6 +783,7 @@ rpmostree_context_setup (RpmOstreeContext    *self,
    */
   if (!self->is_system && self->treefile_rs)
     {
+      // See also validate_rpmdb() that we called early
       auto rpmdb_backend = self->treefile_rs->get_rpmdb();
       dnf_context_set_rpm_macro (self->dnfctx, "_db_backend", rpmdb_backend.c_str());
     }


### PR DESCRIPTION
In Fedora 34+ librpm can no longer write bdb, so we fail
to build RHCOS.  But the error for this is obscure.  Make
this an obvious, up front error.

This relies on the implicit "sqlite default == fedora34+ == rpm without bdb write".

xref https://github.com/openshift/os/issues/552
xref https://bugzilla.redhat.com/show_bug.cgi?id=1938928
