### PR TITLE
rebase: Remove support for providing prefixes

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,4 +1,4 @@
-//! rpm-ostree a hybrid Rust and C/C++ application.  This is the
+//! rpm-ostree is a hybrid Rust and C/C++ application. This is the
 //! main library used by the executable, which also links to the
 //! C/C++ `librpmostreeinternals.a` static library.
 

--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -611,10 +611,8 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
   const char *custom_origin_description = NULL;
   if (origin_refspec)
     {
-      const char *refspec_data;
-      if (!rpmostree_refspec_classify (origin_refspec, &refspectype, &refspec_data, error))
+      if (!rpmostree_refspec_classify (origin_refspec, &refspectype, error))
         return FALSE;
-      g_autofree char *canonrefspec = rpmostree_refspec_to_string (refspectype, refspec_data);
       switch (refspectype)
         {
         case RPMOSTREE_REFSPEC_TYPE_CHECKSUM:
@@ -631,12 +629,12 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
                 g_print ("%s", custom_origin_url);
               }
             else
-              g_print ("%s", canonrefspec);
+              g_print ("%s", origin_refspec);
           }
           break;
         case RPMOSTREE_REFSPEC_TYPE_OSTREE:
           {
-            g_print ("%s", canonrefspec);
+            g_print ("%s", origin_refspec);
           }
           break;
         }

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -406,10 +406,8 @@ add_all_commit_details_to_vardict (OstreeDeployment *deployment,
     }
   else
     {
-      const char *refspec_remainder = NULL;
-      if (!rpmostree_refspec_classify (refspec, &refspec_type, &refspec_remainder, error))
+      if (!rpmostree_refspec_classify (refspec, &refspec_type, error))
         return FALSE;
-      refspec = refspec_remainder;
     }
   (void)refspec_owned; /* Pacify static analysis */
   refspec_is_ostree = refspec_type == RPMOSTREE_REFSPEC_TYPE_OSTREE;
@@ -800,12 +798,8 @@ rpmostreed_update_generate_variant (OstreeDeployment  *booted_deployment,
 
   const char *refspec = rpmostree_origin_get_refspec (origin);
   { RpmOstreeRefspecType refspectype = RPMOSTREE_REFSPEC_TYPE_OSTREE;
-    const char *refspec_data;
-    if (!rpmostree_refspec_classify (refspec, &refspectype, &refspec_data, error))
+    if (!rpmostree_refspec_classify (refspec, &refspectype, error))
       return FALSE;
-
-    /* just skip over "ostree://" so we can talk with libostree without thinking about it */
-    refspec = refspec_data;
   }
 
   /* let's start with the ostree side of things */

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -53,39 +53,28 @@ static gboolean
 change_origin_refspec (GVariantDict    *options,
                        OstreeSysroot *sysroot,
                        RpmOstreeOrigin *origin,
-                       const gchar *src_refspec,
+                       const gchar *refspec,
                        GCancellable *cancellable,
                        gchar **out_old_refspec,
                        gchar **out_new_refspec,
                        GError **error)
 {
-  RpmOstreeRefspecType refspectype;
-  const char *refspecdata;
-  if (!rpmostree_refspec_classify (src_refspec, &refspectype, &refspecdata, error))
-    return FALSE;
-
   RpmOstreeRefspecType current_refspectype;
-  const char *current_refspecdata;
-  rpmostree_origin_classify_refspec (origin, &current_refspectype, &current_refspecdata);
-
-  /* Now here we "peel" it since the rest of the code assumes libostree */
-  const char *refspec = refspecdata;
-
-  g_autofree gchar *current_refspec =
-    g_strdup (rpmostree_origin_get_refspec (origin));
+  g_autofree gchar *current_refspec = rpmostree_origin_get_full_refspec (origin, &current_refspectype);
+  
   g_autofree gchar *new_refspec = NULL;
-
   if (!rpmostreed_refspec_parse_partial (refspec,
                                          current_refspec,
                                          &new_refspec,
                                          error))
     return FALSE;
 
-  /* Re-classify after canonicalization to ensure we handle TYPE_CHECKSUM */
-  if (!rpmostree_refspec_classify (new_refspec, &refspectype, &refspecdata, error))
+  /* Classify to ensure we handle TYPE_CHECKSUM */
+  RpmOstreeRefspecType new_refspectype;
+  if (!rpmostree_refspec_classify (new_refspec, &new_refspectype, error))
     return FALSE;
 
-  if (refspectype == RPMOSTREE_REFSPEC_TYPE_CHECKSUM)
+  if (new_refspectype == RPMOSTREE_REFSPEC_TYPE_CHECKSUM)
     {
       const char *custom_origin_url = NULL;
       const char *custom_origin_description = NULL;
@@ -1041,8 +1030,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
       g_assert (self->refspec);
 
       RpmOstreeRefspecType refspectype;
-      const char *ref;
-      if (!rpmostree_refspec_classify (self->refspec, &refspectype, &ref, error))
+      if (!rpmostree_refspec_classify (self->refspec, &refspectype, error))
         return FALSE;
 
       g_autoptr(OstreeRepo) local_repo_remote =
@@ -1050,7 +1038,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
       if (!local_repo_remote)
         return glnx_prefix_error (error, "Failed to open local repo");
       g_autofree char *rev = NULL;
-      if (!ostree_repo_resolve_rev (local_repo_remote, ref, FALSE, &rev, error))
+      if (!ostree_repo_resolve_rev (local_repo_remote, self->refspec, FALSE, &rev, error))
         return FALSE;
 
       g_autoptr(OstreeAsyncProgress) progress = ostree_async_progress_new ();
@@ -1721,16 +1709,9 @@ rpmostreed_transaction_new_deploy (GDBusMethodInvocation *invocation,
   self->flags = deploy_flags_from_options (self->options, default_flags);
 
   auto refspec = (const char *)vardict_lookup_ptr (self->modifiers, "set-refspec", "&s");
-  /* Canonicalize here; the later code actually ends up peeling it
-   * again, but long term we want to manipulate canonicalized refspecs
-   * internally, and only peel when writing origin files for ostree:// types.
-   */
   if (refspec)
-    {
-      self->refspec = rpmostree_refspec_canonicalize (refspec, error);
-      if (!self->refspec)
-        return NULL;
-    }
+    self->refspec = g_strdup (refspec);
+
   const gboolean refspec_or_revision = (self->refspec != NULL || self->revision != NULL);
 
   self->revision = (char*)vardict_lookup_ptr (self->modifiers, "set-revision", "&s");

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -65,18 +65,9 @@ typedef enum {
   RPMOSTREE_REFSPEC_TYPE_CHECKSUM,
 } RpmOstreeRefspecType;
 
-#define RPMOSTREE_REFSPEC_OSTREE_PREFIX "ostree://"
-
 gboolean rpmostree_refspec_classify (const char *refspec,
                                      RpmOstreeRefspecType *out_type,
-                                     const char **out_remainder,
                                      GError     **error);
-
-char* rpmostree_refspec_to_string (RpmOstreeRefspecType  reftype,
-                                   const char           *data);
-
-char* rpmostree_refspec_canonicalize (const char           *orig_refspec,
-                                      GError              **error);
 
 namespace rpmostreecxx {
 void core_libdnf_process_global_init();

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -123,7 +123,7 @@ rpmostree_origin_parse_keyfile (GKeyFile         *origin,
         return (RpmOstreeOrigin *)glnx_null_throw (error, "No origin/refspec, or origin/baserefspec in current deployment origin; cannot handle via rpm-ostree");
     }
 
-  if (!rpmostree_refspec_classify (refspec, &ret->refspec_type, NULL, error))
+  if (!rpmostree_refspec_classify (refspec, &ret->refspec_type, error))
     return FALSE;
   /* Note the lack of a prefix here so that code that just calls
    * rpmostree_origin_get_refspec() in the ostree:// case
@@ -208,11 +208,11 @@ rpmostree_origin_get_full_refspec (RpmOstreeOrigin *origin,
 void
 rpmostree_origin_classify_refspec (RpmOstreeOrigin      *origin,
                                    RpmOstreeRefspecType *out_type,
-                                   const char          **out_refspecdata)
+                                   const char          **out_refspec)
 {
   *out_type = origin->refspec_type;
-  if (out_refspecdata)
-    *out_refspecdata = origin->cached_refspec;
+  if (out_refspec)
+    *out_refspec = rpmostree_origin_get_refspec (origin);
 }
 
 static char *
@@ -500,11 +500,10 @@ rpmostree_origin_set_rebase_custom (RpmOstreeOrigin *origin,
   rpmostree_origin_set_override_commit (origin, NULL, NULL);
 
   /* See related code in rpmostree_origin_parse_keyfile() */
-  const char *refspecdata;
-  if (!rpmostree_refspec_classify (new_refspec, &origin->refspec_type, &refspecdata, error))
+  if (!rpmostree_refspec_classify (new_refspec, &origin->refspec_type, error))
     return FALSE;
   g_free (origin->cached_refspec);
-  origin->cached_refspec = g_strdup (refspecdata);
+  origin->cached_refspec = g_strdup (new_refspec);
   switch (origin->refspec_type)
     {
     case RPMOSTREE_REFSPEC_TYPE_CHECKSUM:

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -61,7 +61,6 @@ runuser -u bin rpm-ostree status
 echo "ok status doesn't require active PAM session"
 
 rpm-ostree status -b > status.txt
-assert_streq $(grep -F -e 'ostree://' status.txt | wc -l) "1"
 assert_file_has_content status.txt BootedDeployment:
 echo "ok status -b"
 

--- a/tests/vmcheck/test-pinned-commit.sh
+++ b/tests/vmcheck/test-pinned-commit.sh
@@ -28,7 +28,6 @@ checksum=$(vm_get_booted_csum)
 vm_rpmostree rebase :${checksum}
 vm_assert_status_jq ".deployments[0][\"origin\"] == \"${checksum}\""
 vm_rpmostree status > status.txt
-assert_file_has_content status.txt '^  ostree://'${checksum}
 echo "ok pin to commit"
 
 vm_rpmostree upgrade >out.txt


### PR DESCRIPTION
This mainly undoes
https://github.com/coreos/rpm-ostree/commit/2c270a6644810c9fb5956b02a74abc4ef277ef74,
and follows up on https://github.com/coreos/rpm-ostree/pull/2842/.
Also serves as some cleanup to make way for the introduction of a
new `container-image-reference` refspec type.

We no longer have any use for `ostree://` or `rojig://`-style
prefixes in the refspecs. There had been efforts to "canonicalize"
refspecs to always include such prefixes into the code internally,
but that hasn't gotten too far. Crucially, since such prefixes were
never introduced to libostree, the refspecs in the origin file
were never meant to contain such prefixes anyway.
