### PR TITLE
compose: Fix RPMOSTREE_PRESERVE_TMPDIR

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1233,11 +1233,17 @@ rpmostree_compose_builtin_install (int             argc,
     return FALSE;
   g_assert (self); /* Pacify static analysis */
   gboolean changed;
-  if (!impl_install_tree (self, &changed, cancellable, error))
-    {
-      self->failed = TRUE;
-      return FALSE;
-    }
+  /* Need to handle both GError and C++ exceptions here */
+  try {
+    if (!impl_install_tree (self, &changed, cancellable, error))
+      {
+        self->failed = TRUE;
+        return FALSE;
+      }
+  } catch (std::exception &e) {
+    self->failed = TRUE;
+    throw;
+  }
   if (opt_unified_core)
     {
       if (!glnx_renameat (self->workdir_tmp.src_dfd, self->workdir_tmp.path,
@@ -1399,11 +1405,17 @@ rpmostree_compose_builtin_tree (int             argc,
     return FALSE;
   g_assert (self); /* Pacify static analysis */
   gboolean changed;
-  if (!impl_install_tree (self, &changed, cancellable, error))
-    {
-      self->failed = TRUE;
-      return FALSE;
-    }
+  /* Need to handle both GError and C++ exceptions here */
+  try {
+    if (!impl_install_tree (self, &changed, cancellable, error))
+      {
+        self->failed = TRUE;
+        return FALSE;
+      }
+  } catch (std::exception &e) {
+    self->failed = TRUE;
+    throw;
+  }
   if (changed)
     {
       /* Do the ostree commit */


### PR DESCRIPTION
Software engineering in a nutshell: While trying to debug
something, discovering the mechanism
added a while ago to debug things itself broke silently a while
ago.

(The addition of C++ exceptions to the mix means the `failed`
 variable wasn't set if one was thrown)
