### PR TITLE
compose: Support writing rpmdb with target rootfs to support RHEL8+bdb

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -171,6 +171,7 @@ pub mod ffi {
             cancellable: Pin<&mut GCancellable>,
         ) -> Result<()>;
         fn compose_postprocess_rpm_macro(rootfs_dfd: i32) -> Result<()>;
+        fn rewrite_rpmdb_for_target(rootfs_dfd: i32) -> Result<()>;
     }
 
     // A grab-bag of metadata from the deployment's ostree commit
@@ -319,6 +320,7 @@ pub mod ffi {
         fn get_releasever(&self) -> &str;
         fn get_rpmdb(&self) -> String;
         fn validate_rpmdb(&self) -> Result<()>;
+        fn rpmdb_backend_is_default(&self) -> bool;
         fn get_files_remove_regex(&self, package: &str) -> Vec<String>;
         fn print_deprecation_warnings(&self);
         fn sanitycheck_externals(&self) -> Result<()>;


### PR DESCRIPTION
This is a key bit to resolve https://github.com/openshift/os/issues/552
(But we'll close that issue when the PR to use cosa master lands)

We want to support "cross building" where e.g. a Fedora 34+ host
(or container) is generating a RHEL8 ostree commit.  The
status quo right now is that F34+ librpm supports read/write
of sqlite and just reading bdb.  And rhel8 librpm only supports
read/write of bdb.

To deal with this, detect if the input manifest specifies an rpmdb format
(namely `bdb`) that is not the current default (namely `sqlite`
in Fedora 34+/RHEL9+) and if so, fork of the *host* rpm to export
the database we wrote back into memory, and then pass that
down to a bwrap container with the *target* rootfs `rpm`.
