### PR TITLE
importer: drop some unreachable logic for /opt handling

### DIFF
--- a/tests/vmcheck/test-layering-basic-1.sh
+++ b/tests/vmcheck/test-layering-basic-1.sh
@@ -60,6 +60,10 @@ vm_cmd test -d "'/opt/some lib/subdir'"
 vm_cmd test -d '/opt/quote\"ed/subdir'
 vm_cmd test -d "'/var/app/some lib/subdir'"
 vm_cmd test -d '/var/app/quote\"ed/subdir'
+vm_cmd test -d '/usr/lib/opt/app'
+vm_cmd test -L '/opt/app'
+vm_cmd test -L "'/opt/some lib'"
+vm_cmd test -L '/opt/quote\"ed'
 vm_rpmostree rollback
 
 echo "ok Installed rpm with /opt ended up in /usr/lib/opt"


### PR DESCRIPTION
Do not merge: I'd like to see CI results here first to double-check my current understanding.

---

This simplifies the RPM importing logic by dropping some unused code
for handling the /opt hierarchy.
There is no need to handle this case in the filtering callback, as
paths under /opt have been translated to /usr/lib/opt before
reaching this point.

My understanding is that there was an absolute-vs-relative mixup in
the original implementation, which has been fixed when porting to
Rust. This conditional case was thus left behind but unreachable.