### PR TITLE
daemon: Correctly abort not-started transactions after client exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fail"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3c61c59fdc91f5dbc3ea31ee8623122ce80057058be560654c5d410d181a6"
+dependencies = [
+ "lazy_static",
+ "log",
+ "rand 0.7.3",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,6 +1885,7 @@ dependencies = [
  "cxx",
  "env_logger",
  "envsubst",
+ "fail",
  "fn-error-context 0.2.0",
  "futures",
  "gio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ curl = "0.4.38"
 cxx = "1.0.49"
 envsubst = "0.2.0"
 env_logger = "0.8.4"
+fail = { version = "0.4", features = ["failpoints"] }
 fn-error-context = "0.2.0"
 futures = "0.3.15"
 gio = "0.9.1"

--- a/rust/src/failpoint_bridge.rs
+++ b/rust/src/failpoint_bridge.rs
@@ -1,0 +1,8 @@
+//! C++ bindings for the failpoint crate.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// Expose the `fail::fail_point` macro to C++.
+pub fn failpoint(p: &str) {
+    glib::g_debug!("rpm-ostree", "{}", p);
+    fail::fail_point!(p);
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -202,6 +202,11 @@ pub mod ffi {
         ) -> Result<DeploymentLayeredMeta>;
     }
 
+    // failpoint_bridge.rs
+    extern "Rust" {
+        fn failpoint(p: &str);
+    }
+
     // importer.rs
     extern "Rust" {
         fn importer_compose_filter(
@@ -572,7 +577,9 @@ mod core;
 use crate::core::*;
 mod daemon;
 mod dirdiff;
+pub mod failpoint_bridge;
 pub(crate) use daemon::*;
+use failpoint_bridge::*;
 mod extensions;
 pub(crate) use extensions::*;
 #[cfg(feature = "fedora-integration")]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -27,6 +27,9 @@ fn main() {
         println!("Attach via gdb using `gdb -p {}`.", std::process::id());
         signal::raise(signal::Signal::SIGSTOP).expect("signal(SIGSTOP)");
     }
+    // Initialize failpoints
+    let _scenario = fail::FailScenario::setup();
+    fail::fail_point!("main");
     // Call this early on; it invokes e.g. setenv() so must be done
     // before we create threads.
     rpmostree_rust::ffi::early_main();

--- a/src/app/rpmostree-clientlib.cxx
+++ b/src/app/rpmostree-clientlib.cxx
@@ -714,6 +714,8 @@ impl_transaction_get_response_sync (GDBusConnection *connection,
                         tp);
     }
 
+  rpmostreecxx::failpoint("client::connect");
+
   transaction = transaction_connect (transaction_address, cancellable, error);
   if (!transaction)
     goto out;


### PR DESCRIPTION
Add generalized "debugpoint" via RPMOSTREE_DEBUG

This is the inevitable application-specific, ad-hoc, informally-specified
reimplementation¹ of a tiny subset of BPF+tracepoints.

One way to view this is similar to `strace` + optional fault injection.

The existing `RPMOSTREE_GDB_HOOK` becomes `RPMOSTREE_DEBUG=main=sigstop`.

But one can pair arbitrary debugpoints with a set of arbitrary actions,
e.g. `RPMOSTREE_DEBUG=main=exit` will exit immediately after main instead
of stopping (not that that's very useful, but it illustrates the mechanism).

A bit more useful, I added a new debugpoint just after client transaction
connect to help reliably trigger a bug:
`env RPMOSTREE_DEBUG=client::connect=exit`.

(OK but wait, why not use tracepoints/BPF?  It'd be cool but I
 don't want to actually try dragging all of that in just for this bug.
 This little bit of code will carry us for a while until we get
 up the energy to go that way)

¹ Reference to https://en.wikipedia.org/wiki/Greenspun%27s_tenth_rule

---

daemon: Correctly abort not-started transactions after client exit

https://bugzilla.redhat.com/show_bug.cgi?id=1982389

At least one OpenShift user hit this race:

- MCD starts `rpm-ostree upgrade` (client process)
- Daemon receives DBus request, and waits for client to connect to the transaction progress DBus socket
- MCO is also upgrading the MCD daemonset, and this ends up killing the MCD pod, which also kills the rpm-ostree client process
  (I think, or at least the client process died in some way)
- We're now stuck because the transaction code was buggy and
  didn't actually clear the transaction if the client exited
  before connecting

In this situation one can't even `rpm-ostree cancel` actually,
only `systemctl restart rpm-ostreed`.

The fix is simple; we were emitting "closed" but we actually
need to explicitly clear the transaction.

---

