### PR TITLE
main: Cleanly error out on arguments that are not valid UTF-8

### DIFF
--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -31,6 +31,12 @@ while read cmd; do
 done < commands.txt
 echo "ok error on unknown command options"
 
+if rpm-ostree status "--track=/etc/NetworkManager/system-connections`echo -n -e \"\xE2\x80\"`" 2>err.txt; then
+    fatal "handled non UTF-8 args"
+fi
+assert_file_has_content_literal err.txt 'error: Argument is invalid UTF-8'
+echo "ok error on non UTF-8"
+
 rpm-ostree status --jsonpath '$.deployments[0].booted' > jsonpath.txt
 assert_file_has_content_literal jsonpath.txt 'true'
 echo "ok jsonpath"


### PR DESCRIPTION
The default Rust API for this panics.  Let's provide a clean
error.

Implementation note: Since argument gathering now returns a `Result<>`,
move it into `inner_main()`.

Closes: https://github.com/coreos/rpm-ostree/issues/2943
