### PR TITLE
Release 2021.7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2021])
-m4_define([release_version], [6])
+m4_define([release_version], [7])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,8 +7,8 @@ nav_order: 3
 
 1. Increment the `year_version` and `release_version` macros in `configure.ac`.
 2. Increment the `Version` field in `rpm-ostree.spec.in`.
-3. Verify the libdnf deps in `rpm-ostree.spec.in` are up to date by comparing to
-   the spec of the bundled version (`libdnf/libdnf.spec`).
+3. Verify the libdnf deps in `rpm-ostree.spec.in` are up to date by copy/pasting
+   the relevant bits from the spec in the git submodule (`libdnf/libdnf.spec`).
 4. Submit as a PR and wait until reviewed *and* CI is green.
 5. Once merged, do `git pull $upstream && git reset --hard $upstream/main` on
    your local `main` branch to make sure you're on the right commit.

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2021.6
+Version: 2021.7
 Release: 1%{?dist}
 License: LGPLv2+
 URL: https://github.com/coreos/rpm-ostree
@@ -78,32 +78,46 @@ BuildRequires: pkgconfig(check)
 # but duplicating to be clear)
 BuildRequires: pkgconfig(libsolv)
 
-# We need g++ for libdnf
-BuildRequires: gcc-c++
+#########################################################################
+#                         libdnf build deps                             #
+#                                                                       #
+# Copy/pasted from libdnf/libdnf.spec. Removed the irrelevant bits like #
+# valgrind, rhsm, swig, python, and sanitizer stuff.                    #
+#########################################################################
 
 
-# more libdnf build deps (see libdnf's spec for versions; maintain ordering)
 %global libsolv_version 0.7.17
 %global libmodulemd_version 2.11.2-2
-%global librepo_version 1.13.0
-%global swig_version 3.0.12
-BuildRequires:  swig >= %{swig_version}
-BuildRequires:  pkgconfig(modulemd-2.0) >= %{libmodulemd_version}
-BuildRequires:  pkgconfig(librepo) >= %{librepo_version}
+%global librepo_version 1.13.1
+
+BuildRequires:  cmake
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
 BuildRequires:  libsolv-devel >= %{libsolv_version}
-BuildRequires:  pkgconfig(json-c)
-BuildRequires:  pkgconfig(cppunit)
-BuildRequires:  pkgconfig(sqlite3)
-BuildRequires:  pkgconfig(smartcols)
+BuildRequires:  pkgconfig(librepo) >= %{librepo_version}
+BuildRequires:  pkgconfig(check)
+BuildRequires:  pkgconfig(gio-unix-2.0) >= 2.46.0
+BuildRequires:  pkgconfig(gtk-doc)
+BuildRequires:  rpm-devel >= 4.11.0
 %if %{with zchunk}
 BuildRequires:  pkgconfig(zck) >= 0.9.11
 %endif
+BuildRequires:  pkgconfig(sqlite3)
+BuildRequires:  pkgconfig(json-c)
+BuildRequires:  pkgconfig(cppunit)
+BuildRequires:  pkgconfig(libcrypto)
+BuildRequires:  pkgconfig(modulemd-2.0) >= %{libmodulemd_version}
+BuildRequires:  pkgconfig(smartcols)
+BuildRequires:  gettext
 BuildRequires:  gpgme-devel
 
-# Runtime libdnf deps
 Requires:       libmodulemd%{?_isa} >= %{libmodulemd_version}
 Requires:       libsolv%{?_isa} >= %{libsolv_version}
 Requires:       librepo%{?_isa} >= %{librepo_version}
+
+#########################################################################
+#                     end of libdnf build deps                          #
+#########################################################################
 
 # For now...see https://github.com/projectatomic/rpm-ostree/pull/637
 # and https://github.com/fedora-infra/fedmsg-atomic-composer/pull/17


### PR DESCRIPTION
While we're here, mechanize the libdnf dep updating process a bit more.
And by doing that, we drop the swig build dep at least.