### PR TITLE
rust/main: Move all real logic into inner_main()

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -4,34 +4,8 @@
 use anyhow::Result;
 use nix::sys::signal;
 
+/// The real main function returns a `Result<>`.
 fn inner_main() -> Result<()> {
-    // Gather our arguments.
-    let args: Result<Vec<String>> = std::env::args_os()
-        .map(|s| -> Result<String> {
-            s.into_string()
-                .map_err(|s| anyhow::anyhow!("Argument is invalid UTF-8: {}", s.to_string_lossy()))
-                .into()
-        })
-        .collect();
-    let args = args?;
-    let args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-    match args.get(1).copied() {
-        // Add custom Rust commands here, and also in `libmain.cxx` if user-visible.
-        Some("countme") => rpmostree_rust::countme::entrypoint(&args),
-        Some("ex-container") => rpmostree_rust::container::entrypoint(&args),
-        _ => {
-            // Otherwise fall through to C++ main().
-            Ok(rpmostree_rust::ffi::rpmostree_main(&args)?)
-        }
-    }
-}
-
-// It is only recently that our main() function is in Rust, calling
-// into C++ as a library.  As of right now, the only Rust commands
-// are hidden, i.e. should not appear in --help.  So we just recognize
-// those, and if there's something we don't know about, invoke the C++
-// main().
-fn main() {
     if std::env::var("RPMOSTREE_GDB_HOOK").is_ok() {
         println!("RPMOSTREE_GDB_HOOK detected; stopping...");
         println!("Attach via gdb using `gdb -p {}`.", std::process::id());
@@ -50,6 +24,33 @@ fn main() {
         .with_writer(std::io::stderr)
         .init();
     tracing::trace!("starting");
+    // Gather our arguments.
+    let args: Result<Vec<String>> = std::env::args_os()
+        .map(|s| -> Result<String> {
+            s.into_string()
+                .map_err(|s| anyhow::anyhow!("Argument is invalid UTF-8: {}", s.to_string_lossy()))
+                .into()
+        })
+        .collect();
+    let args = args?;
+    let args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    // It is only recently that our main() function is in Rust, calling
+    // into C++ as a library.  As of right now, the only Rust commands
+    // are hidden, i.e. should not appear in --help.  So we just recognize
+    // those, and if there's something we don't know about, invoke the C++
+    // main().
+    match args.get(1).copied() {
+        // Add custom Rust commands here, and also in `libmain.cxx` if user-visible.
+        Some("countme") => rpmostree_rust::countme::entrypoint(&args),
+        Some("ex-container") => rpmostree_rust::container::entrypoint(&args),
+        _ => {
+            // Otherwise fall through to C++ main().
+            Ok(rpmostree_rust::ffi::rpmostree_main(&args)?)
+        }
+    }
+}
+
+fn main() {
     // Capture any error.  Note that in some cases the C++ code may still call exit(<code>) directly.
     let r = inner_main();
     // Print the error


### PR DESCRIPTION
Followup to previous patch; there's no real reason to have
some stuff in `main()` and some stuff in `inner_main()`.  Move
everything except error formatting into the latter.
