### PR TITLE
daemon: Move more deployment-variant bits to Rust using treefile

### DIFF
--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -28,7 +28,7 @@ static UNORDERED_LIST_KEYS: phf::Set<&'static str> = phf::phf_set! {
 };
 
 #[context("Parsing origin")]
-fn origin_to_treefile_inner(kf: &KeyFile) -> Result<Box<Treefile>> {
+pub(crate) fn origin_to_treefile_inner(kf: &KeyFile) -> Result<Box<Treefile>> {
     let mut cfg: crate::treefile::TreeComposeConfig = Default::default();
     let refspec_str = if let Some(r) = keyfile_get_optional_string(&kf, ORIGIN, "refspec")? {
         Some(r)
@@ -299,7 +299,7 @@ fn keyfile_get_optional_string(kf: &KeyFile, group: &str, key: &str) -> Result<O
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use super::*;
     use indoc::indoc;
 
@@ -313,12 +313,12 @@ mod test {
         }};
     }
 
-    const BASE: &str = indoc! {"
+    pub(crate) const BASE: &str = indoc! {"
     [origin]
     refspec=foo:bar/x86_64/baz
     "};
 
-    const COMPLEX: &str = indoc! {"
+    pub(crate) const COMPLEX: &str = indoc! {"
     [origin]
     baserefspec=fedora:fedora/34/x86_64/silverblue
     override-commit=41af286dc0b172ed2f1ca934fd2278de4a1192302ffa07087cea2682e7d372e3
@@ -340,7 +340,7 @@ mod test {
     pinned=true
     "};
 
-    fn kf_from_str(s: &str) -> Result<glib::KeyFile> {
+    pub(crate) fn kf_from_str(s: &str) -> Result<glib::KeyFile> {
         let kf = glib::KeyFile::new();
         kf.load_from_data(s, glib::KeyFileFlags::KEEP_COMMENTS)?;
         Ok(kf)

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -203,15 +203,6 @@ variant_add_commit_details (GVariantDict *dict,
                            "t", timestamp);
 }
 
-static void
-variant_add_from_hash_table (GVariantDict *dict,
-                             const char   *key,
-                             GHashTable   *table)
-{
-  g_autofree char **values = (char**)g_hash_table_get_keys_as_array (table, NULL);
-  g_variant_dict_insert (dict, key, "^as", values);
-}
-
 /* Returns floating GVariant equivalent of `commit_meta` minus blacklisted keys. */
 static GVariant*
 filter_commit_meta (GVariant *commit_meta)
@@ -223,7 +214,6 @@ filter_commit_meta (GVariant *commit_meta)
   g_variant_dict_remove (&dict, "rpmostree.advisories");
   return g_variant_dict_end (&dict);
 }
-
 
 GVariant*
 rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
@@ -345,30 +335,9 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
       break;
     }
 
-  variant_add_from_hash_table (dict, "requested-packages",
-                               rpmostree_origin_get_packages (origin));
-  variant_add_from_hash_table (dict, "requested-local-packages",
-                               rpmostree_origin_get_local_packages (origin));
-  variant_add_from_hash_table (dict, "requested-base-removals",
-                               rpmostree_origin_get_overrides_remove (origin));
-  variant_add_from_hash_table (dict, "requested-base-local-replacements",
-                               rpmostree_origin_get_overrides_local_replace (origin));
-
   g_variant_dict_insert (dict, "packages", "^as", layered_pkgs);
   g_variant_dict_insert_value (dict, "base-removals", removed_base_pkgs);
   g_variant_dict_insert_value (dict, "base-local-replacements", replaced_base_pkgs);
-
-  g_variant_dict_insert (dict, "regenerate-initramfs", "b",
-                         rpmostree_origin_get_regenerate_initramfs (origin));
-  { const char *const* args = rpmostree_origin_get_initramfs_args (origin);
-    if (args && *args)
-      g_variant_dict_insert (dict, "initramfs-args", "^as", args);
-  }
-
-  variant_add_from_hash_table (dict, "initramfs-etc",
-                               rpmostree_origin_get_initramfs_etc_files (origin));
-  if (rpmostree_origin_get_cliwrap (origin))
-    g_variant_dict_insert (dict, "cliwrap", "b", TRUE);
 
   return g_variant_dict_end (dict);
 }


### PR DESCRIPTION
Part of https://github.com/coreos/rpm-ostree/issues/2326
which is trying to orient rpm-ostree more strongly around treefiles.

Move the C/C++ code which is mapping the origin file into
the deployment variant into Rust, using the code which maps
from origin files to treefile.
