### PR TITLE
Move all error printing into Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,6 +1923,7 @@ dependencies = [
  "system-deps 3.1.2",
  "systemd",
  "tempfile",
+ "termcolor",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ tracing = "0.1"
 tracing-subscriber = "0.2"
 tokio = { version = "1.8.1", features = ["full"] }
 xmlrpc = "0.15.0"
+termcolor = "1.1.2"
 
 [build-dependencies]
 anyhow = "1.0"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -512,8 +512,8 @@ pub mod ffi {
     unsafe extern "C++" {
         include!("rpmostreemain.h");
         fn early_main();
-        fn rpmostree_main(args: &[&str]) -> Result<()>;
-        fn main_print_error(msg: &str);
+        fn rpmostree_main(args: &[&str]) -> Result<i32>;
+        fn rpmostree_process_global_teardown();
     }
 
     unsafe extern "C++" {

--- a/src/app/rpmostreemain.h
+++ b/src/app/rpmostreemain.h
@@ -5,7 +5,7 @@
 namespace rpmostreecxx {
 
 void early_main ();
-void main_print_error (rust::Str msg);
-void rpmostree_main (rust::Slice<const rust::Str> args);
+void rpmostree_process_global_teardown ();
+int rpmostree_main (rust::Slice<const rust::Str> args);
 
 }


### PR DESCRIPTION
Propagate exceptions from the C++ `rpmostree_main()` to the
Rust `main` as a `Result`.
Add a depenency on `termcolor` (also used by `cargo`).
Drop the C code to print colored errors, and move it to Rust
using `termcolor`.  (Which, wow is that not ergonomic, but
hey it's more Rust and less C)
