### PR TITLE
WIP/RFC: Add support for modifying sysroots without a daemon

### DIFF
--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -301,7 +301,7 @@ rpmostree_option_context_parse (GOptionContext *context,
         /* ignore errors; we print out a warning if we fail to spawn pkttyagent */
         (void)rpmostree_polkit_agent_open ();
 
-      if (!rpmostree_load_sysroot (opt_sysroot, cancellable,
+      if (!rpmostree_load_sysroot (cancellable,
                                    out_sysroot_proxy,
                                    error))
         return FALSE;

--- a/src/app/rpmostree-builtin-cancel.cxx
+++ b/src/app/rpmostree-builtin-cancel.cxx
@@ -72,7 +72,7 @@ rpmostree_builtin_cancel (int             argc,
                                        invocation,
                                        cancellable,
                                        NULL, NULL,
-                                       &sysroot_proxy,
+                                       &sysroot_proxy, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-cleanup.cxx
+++ b/src/app/rpmostree-builtin-cleanup.cxx
@@ -64,7 +64,7 @@ rpmostree_builtin_cleanup (int             argc,
                                        invocation,
                                        cancellable,
                                        NULL, NULL,
-                                       &sysroot_proxy,
+                                       &sysroot_proxy, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-db.cxx
+++ b/src/app/rpmostree-builtin-db.cxx
@@ -61,7 +61,7 @@ rpmostree_db_option_context_parse (GOptionContext *context,
                                        argc, argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-deploy.cxx
+++ b/src/app/rpmostree-builtin-deploy.cxx
@@ -85,7 +85,7 @@ rpmostree_builtin_deploy (int            argc,
                                        cancellable,
                                        &install_pkgs,
                                        &uninstall_pkgs,
-                                       &sysroot_proxy,
+                                       &sysroot_proxy, NULL,
                                        error))
     return FALSE;
 
@@ -226,7 +226,8 @@ rpmostree_builtin_deploy (int            argc,
     }
   else if (!opt_reboot)
     {
-      if (!rpmostree_has_new_default_deployment (os_proxy, previous_deployment))
+      g_autoptr(GVariant) new_deployment = rpmostree_os_dup_default_deployment (os_proxy);
+      if (!rpmostree_has_new_default_deployment (previous_deployment, new_deployment))
         {
           if (opt_unchanged_exit_77)
             invocation->exit_code = RPM_OSTREE_EXIT_UNCHANGED;

--- a/src/app/rpmostree-builtin-finalize-deployment.cxx
+++ b/src/app/rpmostree-builtin-finalize-deployment.cxx
@@ -48,7 +48,7 @@ rpmostree_builtin_finalize_deployment (int             argc,
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   if (!rpmostree_option_context_parse (context, option_entries, &argc, &argv,
                                        invocation, cancellable, NULL, NULL,
-                                       &sysroot_proxy, error))
+                                       &sysroot_proxy, NULL, error))
     return FALSE;
 
   const char *checksum = NULL;

--- a/src/app/rpmostree-builtin-initramfs-etc.cxx
+++ b/src/app/rpmostree-builtin-initramfs-etc.cxx
@@ -58,25 +58,24 @@ rpmostree_ex_builtin_initramfs_etc (int             argc,
                                     GCancellable   *cancellable,
                                     GError        **error)
 {
+  g_autoptr(RpmOstreeMux) mux = NULL;
   g_autoptr(GOptionContext) context = g_option_context_new ("");
-
-  glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
                                        NULL, NULL,
-                                       &sysroot_proxy,
+                                       NULL, &mux,
                                        error))
     return FALSE;
 
-  glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
-  if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname,
-                                cancellable, &os_proxy, error))
+  if (!rpmostree_mux_load_os (mux, opt_osname, cancellable, error))
     return FALSE;
 
-  g_autoptr(GVariant) previous_deployment = rpmostree_os_dup_default_deployment (os_proxy);
+  g_autoptr(GVariant) previous_deployment = rpmostree_mux_get_default_deployment (mux, error);
+  if (!previous_deployment)
+    return FALSE;
 
   if (!(opt_track || opt_untrack || opt_untrack_all || opt_force_sync))
     {
@@ -84,7 +83,10 @@ rpmostree_ex_builtin_initramfs_etc (int             argc,
         return glnx_throw (error, "Cannot use ---reboot without --track, --untrack, --untrack-all, or --force-sync");
 
       g_autofree char **files = NULL;
-      g_autoptr(GVariant) deployments = rpmostree_sysroot_dup_deployments (sysroot_proxy);
+      g_autoptr(GVariant) deployments = rpmostree_mux_get_deployments (mux, error);
+      if (!deployments)
+        return FALSE;
+
       if (g_variant_n_children (deployments) > 0)
         {
           g_autoptr(GVariant) pending = g_variant_get_child_value (deployments, 0);
@@ -112,41 +114,37 @@ rpmostree_ex_builtin_initramfs_etc (int             argc,
   if (!opt_untrack)
     opt_untrack = empty_strv;
 
-  GVariantDict dict;
+  g_auto(GVariantDict) dict;
   g_variant_dict_init (&dict, NULL);
   g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
   g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
   g_variant_dict_insert (&dict, "lock-finalization", "b", opt_lock_finalization);
-  g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
-  g_autofree char *transaction_address = NULL;
-  if (!rpmostree_os_call_initramfs_etc_sync (os_proxy,
-                                             (const char *const*)opt_track,
-                                             (const char *const*)opt_untrack,
-                                             opt_untrack_all,
-                                             opt_force_sync,
-                                             options,
-                                             &transaction_address,
-                                             cancellable,
-                                             error))
-    return FALSE;
-
-  if (!rpmostree_transaction_get_response_sync (sysroot_proxy,
-                                                transaction_address,
-                                                cancellable,
-                                                error))
+  if (!rpmostree_mux_call_initramfs_etc (mux,
+                                         (const char *const*)opt_track,
+                                         (const char *const*)opt_untrack,
+                                         opt_untrack_all,
+                                         opt_force_sync,
+                                         &dict,
+                                         cancellable,
+                                         error))
     return FALSE;
 
   if (!opt_reboot)
     {
-      if (!rpmostree_has_new_default_deployment (os_proxy, previous_deployment))
+      g_autoptr(GVariant) new_deployment = rpmostree_mux_get_default_deployment (mux, error);
+      if (!new_deployment)
+        return FALSE;
+
+      if (!rpmostree_has_new_default_deployment (previous_deployment, new_deployment))
         {
           if (opt_unchanged_exit_77)
             invocation->exit_code = RPM_OSTREE_EXIT_UNCHANGED;
           return TRUE;
         }
 
-      g_print ("Run \"systemctl reboot\" to start a reboot\n");
+      if (rpmostree_mux_is_dbus (mux))
+        g_print ("Run \"systemctl reboot\" to start a reboot\n");
     }
 
   return TRUE;

--- a/src/app/rpmostree-builtin-initramfs.cxx
+++ b/src/app/rpmostree-builtin-initramfs.cxx
@@ -62,7 +62,7 @@ rpmostree_builtin_initramfs (int             argc,
                                        invocation,
                                        cancellable,
                                        NULL, NULL,
-                                       &sysroot_proxy,
+                                       &sysroot_proxy, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-kargs.cxx
+++ b/src/app/rpmostree-builtin-kargs.cxx
@@ -180,7 +180,7 @@ rpmostree_builtin_kargs (int            argc,
                                        invocation,
                                        cancellable,
                                        NULL, NULL,
-                                       &sysroot_proxy,
+                                       &sysroot_proxy, NULL,
                                        error))
     return FALSE;
 
@@ -357,7 +357,8 @@ rpmostree_builtin_kargs (int            argc,
                                                 error))
     return FALSE;
 
-  if (rpmostree_has_new_default_deployment (os_proxy, previous_deployment))
+  g_autoptr(GVariant) new_deployment = rpmostree_os_dup_default_deployment (os_proxy);
+  if (!rpmostree_has_new_default_deployment (previous_deployment, new_deployment))
     g_print("Kernel arguments updated.\nRun \"systemctl reboot\" to start a reboot\n");
   else if (opt_unchanged_exit_77)
     invocation->exit_code = RPM_OSTREE_EXIT_UNCHANGED;

--- a/src/app/rpmostree-builtin-rebase.cxx
+++ b/src/app/rpmostree-builtin-rebase.cxx
@@ -90,7 +90,7 @@ rpmostree_builtin_rebase (int             argc,
                                        cancellable,
                                        &install_pkgs,
                                        &uninstall_pkgs,
-                                       &sysroot_proxy,
+                                       &sysroot_proxy, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-refresh-md.cxx
+++ b/src/app/rpmostree-builtin-refresh-md.cxx
@@ -64,7 +64,7 @@ rpmostree_builtin_refresh_md (int             argc,
                                        invocation,
                                        cancellable,
                                        NULL, NULL,
-                                       &sysroot_proxy,
+                                       &sysroot_proxy, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-reload.cxx
+++ b/src/app/rpmostree-builtin-reload.cxx
@@ -49,7 +49,7 @@ rpmostree_builtin_reload (int             argc,
                                        invocation,
                                        cancellable,
                                        NULL, NULL,
-                                       &sysroot_proxy,
+                                       &sysroot_proxy, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-reset.cxx
+++ b/src/app/rpmostree-builtin-reset.cxx
@@ -67,7 +67,7 @@ rpmostree_builtin_reset (int             argc,
                                        cancellable,
                                        &install_pkgs,
                                        &uninstall_pkgs,
-                                       &sysroot_proxy,
+                                       &sysroot_proxy, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-rollback.cxx
+++ b/src/app/rpmostree-builtin-rollback.cxx
@@ -65,7 +65,7 @@ rpmostree_builtin_rollback (int             argc,
                                        invocation,
                                        cancellable,
                                        NULL, NULL,
-                                       &sysroot_proxy,
+                                       &sysroot_proxy, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-upgrade.cxx
+++ b/src/app/rpmostree-builtin-upgrade.cxx
@@ -84,7 +84,7 @@ rpmostree_builtin_upgrade (int             argc,
                                        cancellable,
                                        &install_pkgs,
                                        &uninstall_pkgs,
-                                       &sysroot_proxy,
+                                       &sysroot_proxy, NULL,
                                        error))
     return FALSE;
 
@@ -234,7 +234,8 @@ rpmostree_builtin_upgrade (int             argc,
     }
   else if (!opt_reboot)
     {
-      if (!rpmostree_has_new_default_deployment (os_proxy, previous_deployment))
+      g_autoptr(GVariant) new_deployment = rpmostree_os_dup_default_deployment (os_proxy);
+      if (!rpmostree_has_new_default_deployment (previous_deployment, new_deployment))
         {
           if (opt_upgrade_unchanged_exit_77 || opt_unchanged_exit_77)
             invocation->exit_code = RPM_OSTREE_EXIT_UNCHANGED;

--- a/src/app/rpmostree-builtin-usroverlay.cxx
+++ b/src/app/rpmostree-builtin-usroverlay.cxx
@@ -49,7 +49,7 @@ rpmostree_builtin_usroverlay (int             argc,
                                        invocation,
                                        cancellable,
                                        NULL, NULL,
-                                       &sysroot_proxy,
+                                       &sysroot_proxy, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -72,6 +72,7 @@ rpmostree_option_context_parse (GOptionContext *context,
                                 const char *const* *out_install_pkgs,
                                 const char *const* *out_uninstall_pkgs,
                                 RPMOSTreeSysroot **out_sysroot_proxy,
+                                RpmOstreeMux **out_mux,
                                 GError **error);
 
 int

--- a/src/app/rpmostree-clientlib.cxx
+++ b/src/app/rpmostree-clientlib.cxx
@@ -75,8 +75,7 @@ await_reload_sync (RPMOSTreeSysroot *sysroot_proxy)
  * is in the process of auto-exiting.
  */
 static gboolean
-app_load_sysroot_impl (const char       *sysroot,
-                       GCancellable *cancellable, 
+app_load_sysroot_impl (GCancellable *cancellable, 
                        GDBusConnection **out_conn,
                        GError **error)
 {
@@ -160,7 +159,7 @@ new_client_connection()
   g_autoptr(GError) local_error = NULL;
   GDBusConnection *conn = NULL;
 
-  if (!app_load_sysroot_impl("/", NULL, &conn, &local_error))
+  if (!app_load_sysroot_impl(NULL, &conn, &local_error))
     util::throw_gerror(local_error);
   return std::make_unique<ClientConnection>(conn);
 }
@@ -194,14 +193,13 @@ ClientConnection::transaction_connect_progress_sync(const rust::Str address) con
 * Returns: True on success
 **/
 gboolean
-rpmostree_load_sysroot (const char        *sysroot, 
-                        GCancellable      *cancellable,
+rpmostree_load_sysroot (GCancellable      *cancellable,
                         RPMOSTreeSysroot **out_sysroot_proxy,
                         GError           **error)
 {
   g_autoptr(GDBusConnection) connection = NULL;
 
-  if (!app_load_sysroot_impl (sysroot, cancellable, &connection, error))
+  if (!app_load_sysroot_impl (cancellable, &connection, error))
     return FALSE;
 
   const char *bus_name = NULL;

--- a/src/app/rpmostree-clientlib.h
+++ b/src/app/rpmostree-clientlib.h
@@ -67,7 +67,7 @@ rpmostree_load_sysroot                       (GCancellable      *cancellable,
 
 gboolean
 rpmostree_load_os_proxy                      (RPMOSTreeSysroot *sysroot_proxy,
-                                              gchar *opt_osname,
+                                              const char *opt_osname,
                                               GCancellable *cancellable,
                                               RPMOSTreeOS **out_os_proxy,
                                               GError **error);
@@ -166,5 +166,69 @@ gboolean
 error_if_driver_registered (RPMOSTreeSysroot *sysroot_proxy,
                             GCancellable     *cancellable,
                             GError          **error);
+
+typedef struct RpmOstreeMux RpmOstreeMux;
+
+gboolean
+rpmostree_mux_should_direct (const char *sysroot_path);
+
+RpmOstreeMux*
+rpmostree_mux_new (const char *sysroot_path,
+                   GCancellable *cancellable,
+                   GError **error);
+
+void
+rpmostree_mux_free (RpmOstreeMux *mux);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeMux, rpmostree_mux_free);
+
+gboolean
+rpmostree_mux_is_dbus (RpmOstreeMux *mux);
+
+RPMOSTreeSysroot*
+rpmostree_mux_get_sysroot_proxy (RpmOstreeMux *mux);
+
+RPMOSTreeOS*
+rpmostree_mux_get_os_proxy (RpmOstreeMux *mux);
+
+gboolean
+rpmostree_mux_load_os (RpmOstreeMux *mux,
+                       const char *osname,
+                       GCancellable *cancellable,
+                       GError **error);
+
+GVariant*
+rpmostree_mux_get_default_deployment (RpmOstreeMux *mux,
+                                      GError **error);
+
+GVariant*
+rpmostree_mux_get_deployments (RpmOstreeMux *mux,
+                               GError **error);
+
+gboolean
+rpmostree_mux_call_initramfs_etc (RpmOstreeMux *mux,
+                                  const char *const *arg_track,
+                                  const char *const *arg_untrack,
+                                  gboolean arg_untrack_all,
+                                  gboolean arg_force_sync,
+                                  GVariantDict *arg_options,
+                                  GCancellable *cancellable,
+                                  GError **error);
+
+gboolean
+rpmostree_mux_call_update_deployment (RpmOstreeMux *mux,
+                                      RpmOstreeCommandInvocation *invocation,
+                                      const char   *set_refspec,
+                                      const char   *set_revision,
+                                      const char *const* install_pkgs,
+                                      const char *const* uninstall_pkgs,
+                                      const char *const* override_replace_pkgs,
+                                      const char *const* override_remove_pkgs,
+                                      const char *const* override_reset_pkgs,
+                                      const char   *local_repo_remote,
+                                      GVariant     *options,
+                                      gboolean      unchanged_exit_77,
+                                      GCancellable *cancellable,
+                                      GError      **error);
 
 G_END_DECLS

--- a/src/app/rpmostree-clientlib.h
+++ b/src/app/rpmostree-clientlib.h
@@ -61,8 +61,7 @@ G_BEGIN_DECLS
 #define BUS_NAME "org.projectatomic.rpmostree1"
 
 gboolean
-rpmostree_load_sysroot                       (const char        *sysroot,
-                                              GCancellable      *cancellable,
+rpmostree_load_sysroot                       (GCancellable      *cancellable,
                                               RPMOSTreeSysroot **out_sysroot_proxy,
                                               GError **error);
 

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1187,7 +1187,7 @@ rpmostree_compose_builtin_install (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 
@@ -1260,7 +1260,7 @@ rpmostree_compose_builtin_postprocess (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 
@@ -1323,7 +1323,7 @@ rpmostree_compose_builtin_commit (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 
@@ -1369,7 +1369,7 @@ rpmostree_compose_builtin_tree (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 
@@ -1439,7 +1439,7 @@ rpmostree_compose_builtin_extensions (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-libbuiltin.cxx
+++ b/src/app/rpmostree-libbuiltin.cxx
@@ -69,11 +69,9 @@ get_id_from_deployment_variant (GVariant *deployment)
 }
 
 gboolean
-rpmostree_has_new_default_deployment (RPMOSTreeOS *os_proxy,
-                                      GVariant    *previous_deployment)
+rpmostree_has_new_default_deployment (GVariant *previous_deployment,
+                                      GVariant *new_deployment)
 {
-  g_autoptr(GVariant) new_deployment = rpmostree_os_dup_default_deployment (os_proxy);
-
   /* trivial case */
   if (g_variant_equal (previous_deployment, new_deployment))
     return FALSE;

--- a/src/app/rpmostree-libbuiltin.h
+++ b/src/app/rpmostree-libbuiltin.h
@@ -60,8 +60,8 @@ rpmostree_usage_error (GOptionContext  *context,
                        GError         **error);
 
 gboolean
-rpmostree_has_new_default_deployment (RPMOSTreeOS *os_proxy,
-                                      GVariant    *previous_deployment);
+rpmostree_has_new_default_deployment (GVariant *previous_deployment,
+                                      GVariant *new_deployment);
 
 namespace rpmostreecxx {
 

--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -119,7 +119,8 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
   else if (!opt_reboot)
     {
       /* only print diff if a new deployment was laid down (e.g. reset --all may not) */
-      if (!rpmostree_has_new_default_deployment (os_proxy, previous_deployment))
+      g_autoptr(GVariant) new_deployment = rpmostree_os_dup_default_deployment (os_proxy);
+      if (!rpmostree_has_new_default_deployment (previous_deployment, new_deployment))
         return TRUE;
 
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
@@ -155,7 +156,7 @@ rpmostree_override_builtin_replace (int argc, char **argv,
                                        cancellable,
                                        &install_pkgs,
                                        &uninstall_pkgs,
-                                       &sysroot_proxy,
+                                       &sysroot_proxy, NULL,
                                        error))
     return FALSE;
 
@@ -196,7 +197,7 @@ rpmostree_override_builtin_remove (int argc, char **argv,
                                        cancellable,
                                        &install_pkgs,
                                        &uninstall_pkgs,
-                                       &sysroot_proxy,
+                                       &sysroot_proxy, NULL,
                                        error))
     return FALSE;
 
@@ -237,7 +238,7 @@ rpmostree_override_builtin_reset (int argc, char **argv,
                                        cancellable,
                                        &install_pkgs,
                                        &uninstall_pkgs,
-                                       &sysroot_proxy,
+                                       &sysroot_proxy, NULL,
                                        error))
     return FALSE;
 

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -517,9 +517,6 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
             if (!ostree_repo_pull_with_options (self->repo, origin_remote, opts, progress,
                                                 cancellable, error))
               return glnx_prefix_error (error, "While pulling %s", override_commit ?: origin_ref);
-
-            if (progress)
-              ostree_async_progress_finish (progress);
           }
 
         if (override_commit)
@@ -1259,7 +1256,7 @@ write_history (RpmOstreeSysrootUpgrader *self,
                GError                  **error)
 {
   g_autoptr(GVariant) deployment_variant =
-    rpmostreed_deployment_generate_variant (self->sysroot, new_deployment, NULL,
+    rpmostreed_deployment_generate_variant (self->sysroot, new_deployment,
                                             self->repo, FALSE, error);
   if (!deployment_variant)
     return FALSE;

--- a/src/daemon/rpmostreed-daemon.cxx
+++ b/src/daemon/rpmostreed-daemon.cxx
@@ -799,14 +799,21 @@ idle_initiate_reboot (void *_unused)
 void
 rpmostreed_daemon_reboot (RpmostreedDaemon *self)
 {
-  g_assert (!self->rebooting);
-  self->rebooting = TRUE;
-  /* Queue actually starting the reboot until we return to the client, so
-   * that they get a success message for the transaction.  Otherwise
-   * if the daemon gets killed via SIGTERM they just see the bus connection
-   * broken and may spuriously error out.
-   */
-  g_idle_add_full (G_PRIORITY_LOW, idle_initiate_reboot, NULL, NULL);
+  if (self)
+    {
+      g_assert (!self->rebooting);
+      self->rebooting = TRUE;
+      /* Queue actually starting the reboot until we return to the client, so
+       * that they get a success message for the transaction.  Otherwise
+       * if the daemon gets killed via SIGTERM they just see the bus connection
+       * broken and may spuriously error out.
+       */
+      g_idle_add_full (G_PRIORITY_LOW, idle_initiate_reboot, NULL, NULL);
+    }
+  else
+    {
+      (void)idle_initiate_reboot (NULL);
+    }
 }
 
 gboolean

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -228,7 +228,6 @@ filter_commit_meta (GVariant *commit_meta)
 GVariant*
 rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
                                         OstreeDeployment *deployment,
-                                        const char       *booted_id,
                                         OstreeRepo       *repo,
                                         gboolean          filter,
                                         GError          **error)

--- a/src/daemon/rpmostreed-deployment-utils.h
+++ b/src/daemon/rpmostreed-deployment-utils.h
@@ -39,7 +39,6 @@ GVariant *      rpmostreed_deployment_generate_blank_variant (void);
 
 GVariant *      rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
                                                         OstreeDeployment *deployment,
-                                                        const char       *booted_id,
                                                         OstreeRepo       *repo,
                                                         gboolean          filter,
                                                         GError          **error);

--- a/src/daemon/rpmostreed-os.cxx
+++ b/src/daemon/rpmostreed-os.cxx
@@ -1809,7 +1809,7 @@ rpmostreed_os_load_internals (RpmostreedOS *self, GError **error)
       booted_variant =
         g_variant_ref_sink (
             rpmostreed_deployment_generate_variant (ot_sysroot, booted_deployment,
-                                                    booted_id, ot_repo, TRUE, error));
+                                                    ot_repo, TRUE, error));
       if (!booted_variant)
         return FALSE;
       auto bootedid_v = rpmostreecxx::deployment_generate_id(*booted_deployment);
@@ -1831,7 +1831,6 @@ rpmostreed_os_load_internals (RpmostreedOS *self, GError **error)
       default_variant =
         g_variant_ref_sink (rpmostreed_deployment_generate_variant (ot_sysroot,
                                                                     pending_deployment,
-                                                                    booted_id,
                                                                     ot_repo, TRUE, error));
       if (!default_variant)
         return FALSE;
@@ -1844,7 +1843,7 @@ rpmostreed_os_load_internals (RpmostreedOS *self, GError **error)
   if (rollback_deployment)
     {
       rollback_variant =
-        rpmostreed_deployment_generate_variant (ot_sysroot, rollback_deployment, booted_id,
+        rpmostreed_deployment_generate_variant (ot_sysroot, rollback_deployment,
                                                 ot_repo, TRUE, error);
       if (!rollback_variant)
         return FALSE;

--- a/src/daemon/rpmostreed-sysroot.cxx
+++ b/src/daemon/rpmostreed-sysroot.cxx
@@ -290,7 +290,7 @@ sysroot_populate_deployments_unlocked (RpmostreedSysroot *self,
       auto deployment = static_cast<OstreeDeployment *>(deployments->pdata[i]);
       GVariant *variant =
         rpmostreed_deployment_generate_variant (self->ot_sysroot, deployment,
-                                                booted_id, self->repo, TRUE, error);
+                                                self->repo, TRUE, error);
       if (!variant)
         return glnx_prefix_error (error, "Reading deployment %u", i);
 

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -59,6 +59,16 @@ typedef enum {
   RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_METADATA_ONLY = (1 << 9),
 } RpmOstreeTransactionDeployFlags;
 
+gboolean
+rpmostree_callimpl_update_deployment (OstreeSysroot         *sysroot,
+                                      char                  *osname,
+                                      RpmOstreeTransactionDeployFlags default_flags,
+                                      GVariant              *options_v,
+                                      GVariant              *modifiers_v,
+                                      GUnixFDList           *fd_list,
+                                      RpmostreedTransaction *transaction,
+                                      GCancellable          *cancellable,
+                                      GError               **error);
 
 RpmostreedTransaction *
 rpmostreed_transaction_new_deploy (GDBusMethodInvocation *invocation,
@@ -78,6 +88,20 @@ rpmostreed_transaction_new_finalize_deployment (GDBusMethodInvocation *invocatio
                                                 GVariant              *options,
                                                 GCancellable          *cancellable,
                                                 GError               **error);
+
+
+/* XXX: this method should go in a different file */
+gboolean
+rpmostree_callimpl_initramfs_etc (OstreeSysroot         *sysroot,
+                                  char                  *osname,
+                                  char                 **track,
+                                  char                 **untrack,
+                                  gboolean               untrack_all,
+                                  gboolean               force_sync,
+                                  GVariantDict          *options,
+                                  RpmostreedTransaction *transaction,
+                                  GCancellable          *cancellable,
+                                  GError               **error);
 
 RpmostreedTransaction *
 rpmostreed_transaction_new_initramfs_etc (GDBusMethodInvocation *invocation,

--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -418,12 +418,12 @@ rpmostree_run_script_in_bwrap_container (int rootfs_fd,
         {
           stdout_fd = sd_journal_stream_fd (id, LOG_INFO, 0);
           if (stdout_fd < 0)
-            return glnx_prefix_error (error, "While creating stdout stream fd");
+            return glnx_throw (error, "While creating stdout stream fd: %s", g_strerror (-stdout_fd));
           bwrap->take_stdout_fd(stdout_fd);
 
           stderr_fd = sd_journal_stream_fd (id, LOG_ERR, 0);
           if (stderr_fd < 0)
-            return glnx_prefix_error (error, "While creating stderr stream fd");
+            return glnx_throw (error, "While creating stderr stream fd: %s", g_strerror (-stderr_fd));
           bwrap->take_stderr_fd(stderr_fd);
         }
       else


### PR DESCRIPTION
Hack day project. This is really rough but functional. Came out of discussions in https://github.com/coreos/rpm-ostree/pull/2854. The way this works is we add a new "mux" layer which handles either calling through D-Bus or running the transaction code directly. On the "transaction" side, we factor out `callimpl` functions which just take in simpler parameters to untie it a bit from the daemon stuff. It's actually not that much *new* code. It's more a lot of reshuffling code we already have.

Some demos. For example, adding config files needed for the rootfs at installation time:

```
[root@cosa-devsh ~]# coreos-installer install /dev/vda
[root@cosa-devsh ~]# mount /dev/disk/by-label/root /mnt
[root@cosa-devsh ~]# mount /dev/disk/by-label/boot /mnt/boot
[root@cosa-devsh ~]# systemctl mask --now rpm-ostreed # not needed; just to verify that we're not using the daemon in the following commands
[root@cosa-devsh ~]# rpm-ostree ex initramfs-etc --track /etc/multipath.conf --sysroot /mnt
Checking out tree 39936e0... done
Writing OSTree commit... done
[root@cosa-devsh ~]# rpm-ostree status --sysroot /mnt
Deployments:
  fedora:fedora/x86_64/coreos/testing-devel
                   Version: 34.20210716.dev.0 (2021-07-16T15:30:30Z)
                BaseCommit: 39936e04bf12f50017300d01abee8073eef8923f7c6a277280df1366a3599259
              GPGSignature: (unsigned)
              InitramfsEtc: /etc/multipath.conf

  fedora:fedora/x86_64/coreos/testing-devel
                   Version: 34.20210716.dev.0 (2021-07-16T15:30:30Z)
                    Commit: 39936e04bf12f50017300d01abee8073eef8923f7c6a277280df1366a3599259
              GPGSignature: (unsigned)
[root@cosa-devsh ~]# reboot
```

Another example is running `rpm-ostree install` from the initramfs and rebooting so that the packages are installed from first boot:

```
sh-5.1# mount /dev/disk/by-label/boot /sysroot/boot
sh-5.1# # should use bwrap for this
sh-5.1# for mnt in dev proc sys; do mount --bind /$mnt /sysroot/$mnt; done
sh-5.1# chroot /sysroot
sh-5.1# unset INVOCATION_ID
sh-5.1# load_policy -i
sh-5.1# echo 'nameserver 10.0.2.3' > /etc/resolv.conf
sh-5.1# rpm-ostree install strace --sysroot /
Checking out tree 0f28eb2... done
Enabled rpm-md repositories: fedora-cisco-openh264 updates fedora updates-archive
Updating metadata for 'fedora-cisco-openh264'... done
Updating metadata for 'updates'... done
Updating metadata for 'fedora'... done
Updating metadata for 'updates-archive'... done
Importing rpm-md... done
rpm-md repo 'fedora-cisco-openh264'; generated: 2021-02-23T00:49:00Z solvables: 4
rpm-md repo 'updates'; generated: 2021-07-20T00:55:02Z solvables: 15683
rpm-md repo 'fedora'; generated: 2021-04-23T10:47:57Z solvables: 63586
rpm-md repo 'updates-archive'; generated: 2021-07-20T01:26:43Z solvables: 20515
Resolving dependencies... done
Will download: 1 package (1.2 MB)
Downloading from 'fedora'... done
Importing packages... done
Checking out packages... done
Running pre scripts... 0 done
Running post scripts... done
Running posttrans scripts... 4 done
Writing rpmdb... done
Writing OSTree commit... done
note: Deploying commit ef1f5c9394d9296c7618af33f4b5eb2843b6a38ef2f1fd882a20e655daed2796 which contains content in /var/lib that will be ignored.
Changes queued for next boot. Run "systemctl reboot" to start a reboot
sh-5.1# rpm-ostree status --sysroot /
Deployments:
  0f28eb244bafd3b249fc38c66b2679e36d20dd570972baf811da95f0afdb32f4
                   Version: v2021.7-3-g7e93eada85 (2021-07-20T16:08:06Z)
           LayeredPackages: strace

  0f28eb244bafd3b249fc38c66b2679e36d20dd570972baf811da95f0afdb32f4
                   Version: v2021.7-3-g7e93eada85 (2021-07-20T16:08:06Z)
sh-5.1#
exit
sh-5.1# reboot
...
[root@cosa-devsh ~]# rpm-ostree status
State: idle
Deployments:
● 0f28eb244bafd3b249fc38c66b2679e36d20dd570972baf811da95f0afdb32f4
                   Version: v2021.7-3-g7e93eada85 (2021-07-20T16:08:06Z)
           LayeredPackages: strace

  0f28eb244bafd3b249fc38c66b2679e36d20dd570972baf811da95f0afdb32f4
                   Version: v2021.7-3-g7e93eada85 (2021-07-20T16:08:06Z)
```

(Obviously, `apply-live` would be nicer to avoid the reboot, though need to unwind more things there first.)

There's a bunch of details I'm glossing over here and maybe that initramfs example isn't feasible, though I found it interesting as a POC to show the possibilities of supporting sysroots like this.