### PR TITLE
upgrader: Print messages when we're fetching container bits

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -455,6 +455,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
         const char *cur_digest = rpmostree_origin_get_container_image_reference_digest (self->original_origin);
         if (cur_digest)
           {
+            rpmostree_output_message ("Pulling manifest: %s", refspec);
             auto new_digest = rpmostreecxx::fetch_digest(std::string(refspec));
             if (strcmp (new_digest.c_str(), cur_digest) == 0)
               {
@@ -464,6 +465,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
               }
           }
 
+        rpmostree_output_message ("Pulling: %s", refspec);
         auto import = rpmostreecxx::import_container(*self->sysroot, std::string(refspec));
 
         rpmostree_origin_set_container_image_reference_digest (self->original_origin, import->image_digest.c_str());

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -26,12 +26,15 @@ set -x
 libtest_prepare_offline
 cd $(mktemp -d)
 
+image=containers-storage:localhost/fcos:latest
+
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
     # Test rebase
     checksum=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
     rpm-ostree ex-container export --repo=/ostree/repo ${checksum} containers-storage:localhost/fcos
-    rpm-ostree rebase containers-storage:localhost/fcos:latest --experimental
+    rpm-ostree rebase "$image" --experimental | tee out.txt
+    assert_file_has_content_literal out.txt 'Pulling: '"$image"
     rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"containers-storage:localhost/fcos:latest\""
     rpmostree_assert_status ".deployments[0][\"checksum\"] == \"${checksum}\""
     echo "ok rebase to container image reference"
@@ -53,7 +56,8 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     echo "ok layering package"
 
     # Test upgrade
-    rpm-ostree upgrade > out.txt;
+    rpm-ostree upgrade | tee out.txt
+    assert_file_has_content_literal out.txt "Pulling manifest: ${image}"
     assert_file_has_content out.txt "No upgrade available."
     echo "ok no upgrade available"
 


### PR DESCRIPTION
Ideally we expose full progress messages, but right now one
could say "It's quiet...too quiet."
