### PR TITLE
Add container image digest and print it in status

### DIFF
--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -610,6 +610,7 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
 
   const char *custom_origin_url = NULL;
   const char *custom_origin_description = NULL;
+  const char *container_image_reference_digest = NULL;
   if (origin_refspec)
     {
       if (!rpmostree_refspec_classify (origin_refspec, &refspectype, error))
@@ -640,6 +641,7 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
           break;
         case RPMOSTREE_REFSPEC_TYPE_CONTAINER:
           {
+            g_assert (g_variant_dict_lookup (dict, "container-image-reference-digest", "s", &container_image_reference_digest));
             g_print ("%s", origin_refspec);
           }
          break;
@@ -649,7 +651,9 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
     g_print ("%s", checksum);
   g_print ("\n");
 
-  if (custom_origin_description)
+  if (container_image_reference_digest)
+    rpmostree_print_kv ("Digest", max_key_len, container_image_reference_digest);
+  else if (custom_origin_description)
     rpmostree_print_kv ("CustomOrigin", max_key_len, custom_origin_description);
 
   const char *remote_not_found = NULL;

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -303,7 +303,11 @@ rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
   switch (refspec_type)
     {
     case RPMOSTREE_REFSPEC_TYPE_CONTAINER:
-      g_variant_dict_insert (dict, "container-image-reference", "s", refspec);
+      {
+        g_variant_dict_insert (dict, "container-image-reference", "s", refspec);
+        auto digest = rpmostree_origin_get_container_image_reference_digest (origin);
+        g_variant_dict_insert (dict, "container-image-reference-digest", "s", digest);
+      }
       break;
     case RPMOSTREE_REFSPEC_TYPE_CHECKSUM:
       {

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -36,6 +36,9 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     rpmostree_assert_status ".deployments[0][\"checksum\"] == \"${checksum}\""
     echo "ok rebase to container image reference"
 
+    rpm-ostree status | tee out.txt
+    assert_file_has_content_literal out.txt 'Digest: sha256:'
+
     /tmp/autopkgtest-reboot 1
     ;;
   1)


### PR DESCRIPTION
I think an important part of this story will be that people
will use the `@sha256:` digested container image references
as a way to track operating system snapshots.  The container
image version isn't always useful because not everyone will
make a container tag for every image.  The ostree commit
hash isn't useful because we can't look it up from the registry.

So let's show the digest front and center.
