### PR TITLE
builtins/compose: move /dev preparation to Rust

### DIFF
--- a/rust/src/builtins/compose/mod.rs
+++ b/rust/src/builtins/compose/mod.rs
@@ -1,4 +1,74 @@
 //! CLI sub-command `compose`.
+
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 pub(crate) mod commit;
+
+use crate::cxxrsutil::CxxResult;
+use anyhow::{Context, Result};
+use fn_error_context::context;
+use openat_ext::OpenatDirExt;
+use std::ffi::{CStr, CString};
+use std::io::{self, Read};
+
+/// Prepare /dev in the target root with the API devices.
+// TODO: delete this when we implement https://github.com/projectatomic/rpm-ostree/issues/729
+pub fn composeutil_legacy_prep_dev(rootfs_dfd: i32) -> CxxResult<()> {
+    let rootfs = crate::ffiutil::ffi_view_openat_dir(rootfs_dfd);
+    legacy_prepare_dev(&rootfs)?;
+    Ok(())
+}
+
+#[context("Preparing /dev hierarchy (legacy)")]
+fn legacy_prepare_dev(rootfs: &openat::Dir) -> Result<()> {
+    let src_dir = openat::Dir::open("/dev")?;
+    static CHARDEVS: &[&str] = &["full", "null", "random", "tty", "urandom", "zero"];
+
+    rootfs.ensure_dir("dev", 0o755)?;
+    rootfs.set_mode("dev", 0o755)?;
+    let dest_dir = rootfs.sub_dir("dev")?;
+
+    for nodename in CHARDEVS {
+        let src_metadata = match src_dir.metadata_optional(*nodename)? {
+            Some(m) => m,
+            None => continue,
+        };
+        // SAFETY: devnodes entries are plain non-NUL ASCII bytes.
+        let path_cstr = CString::new(*nodename).expect("unexpected NUL byte");
+        make_node_at(
+            &dest_dir,
+            &path_cstr,
+            src_metadata.stat().st_mode,
+            src_metadata.stat().st_rdev,
+        )
+        .with_context(|| format!("Creating /dev/{}", nodename))?;
+        dest_dir.set_mode(*nodename, src_metadata.stat().st_mode)?;
+    }
+    smoketest_dev_null(&dest_dir)?;
+
+    Ok(())
+}
+
+#[context("Testing /dev/null in target root (is 'nodev' set?)")]
+fn smoketest_dev_null(devdir: &openat::Dir) -> Result<()> {
+    let mut devnull = devdir.open_file("null")?;
+    let mut buf = [0u8];
+    devnull.read(&mut buf)?;
+    Ok(())
+}
+
+// TODO(lucab): add a safe `mknodat` helper to nix.
+fn make_node_at(
+    destdir: &openat::Dir,
+    pathname: &CStr,
+    mode: libc::mode_t,
+    dev: libc::dev_t,
+) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let r = unsafe { libc::mknodat(destdir.as_raw_fd(), pathname.as_ptr(), mode, dev) };
+    if r != 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -119,6 +119,7 @@ pub mod ffi {
     // builtins/compose/
     extern "Rust" {
         fn write_commit_id(target_path: &str, revision: &str) -> Result<()>;
+        fn composeutil_legacy_prep_dev(rootfs_dfd: i32) -> Result<()>;
     }
 
     // cliwrap.rs
@@ -580,6 +581,7 @@ pub mod ffi {
 mod builtins;
 pub(crate) use crate::builtins::apply_live::*;
 pub(crate) use crate::builtins::compose::commit::*;
+pub(crate) use crate::builtins::compose::*;
 mod bwrap;
 pub(crate) use bwrap::*;
 mod client;

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -486,8 +486,7 @@ install_packages (RpmOstreeTreeComposeContext  *self,
 
       glnx_console_lock (&console);
 
-      if (!rpmostree_composeutil_legacy_prep_dev (rootfs_dfd, error))
-        return FALSE;
+      rpmostreecxx::composeutil_legacy_prep_dev(rootfs_dfd);
 
       if (!dnf_transaction_commit (dnf_context_get_transaction (dnfctx),
                                    dnf_context_get_goal (dnfctx),

--- a/src/app/rpmostree-composeutil.cxx
+++ b/src/app/rpmostree-composeutil.cxx
@@ -68,58 +68,6 @@ rpmostree_composeutil_checksum (HyGoal             goal,
   return TRUE;
 }
 
-/* Prepare /dev in the target root with the API devices.  TODO:
- * Delete this when we implement https://github.com/projectatomic/rpm-ostree/issues/729
- */
-gboolean
-rpmostree_composeutil_legacy_prep_dev (int         rootfs_dfd,
-                                       GError    **error)
-{
-  GLNX_AUTO_PREFIX_ERROR ("Preparing dev (legacy)", error);
-
-  glnx_autofd int src_fd = openat (AT_FDCWD, "/dev", O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOCTTY);
-  if (src_fd == -1)
-    return glnx_throw_errno (error);
-
-  if (mkdirat (rootfs_dfd, "dev", 0755) != 0)
-    {
-      if (errno != ENOENT)
-        return glnx_throw_errno (error);
-    }
-
-  glnx_autofd int dest_fd = openat (rootfs_dfd, "dev", O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOCTTY);
-  if (dest_fd == -1)
-    return glnx_throw_errno (error);
-
-  static const char *const devnodes[] = { "null", "zero", "full", "random", "urandom", "tty" };
-  for (guint i = 0; i < G_N_ELEMENTS (devnodes); i++)
-    {
-      const char *nodename = devnodes[i];
-      struct stat stbuf;
-      if (!glnx_fstatat_allow_noent (src_fd, nodename, &stbuf, 0, error))
-        return FALSE;
-      if (errno == ENOENT)
-        continue;
-
-      if (mknodat (dest_fd, nodename, stbuf.st_mode, stbuf.st_rdev) != 0)
-        return glnx_throw_errno_prefix (error, "mknodat(%s)", nodename);
-      if (fchmodat (dest_fd, nodename, stbuf.st_mode, 0) != 0)
-        return glnx_throw_errno_prefix (error, "fchmodat");
-    }
-
-  { GLNX_AUTO_PREFIX_ERROR ("Testing /dev/null in target root (is nodev set?)", error);
-    glnx_autofd int devnull_fd = -1;
-    if (!glnx_openat_rdonly (dest_fd, "null", TRUE, &devnull_fd, error))
-      return FALSE;
-    char buf[1];
-    ssize_t s = read (devnull_fd, buf, sizeof (buf));
-    if (s < 0)
-      return glnx_throw_errno_prefix (error, "read");
-  }
-
-  return TRUE;
-}
-
 gboolean
 rpmostree_composeutil_read_json_metadata (JsonNode    *root,
                                           GHashTable  *metadata,

--- a/src/app/rpmostree-composeutil.h
+++ b/src/app/rpmostree-composeutil.h
@@ -36,10 +36,6 @@ rpmostree_composeutil_checksum (HyGoal             goal,
                                 GError           **error);
 
 gboolean
-rpmostree_composeutil_legacy_prep_dev (int         rootfs_dfd,
-                                       GError    **error);
-
-gboolean
 rpmostree_composeutil_read_json_metadata (JsonNode    *root,
                                           GHashTable  *metadata,
                                           GError     **error);


### PR DESCRIPTION
This ports the legacy (non unified core) logic for creating /dev
entries to Rust.