### PR TITLE
builtins/compose: move basearch and pretty-print logic to Rust

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -345,12 +345,13 @@ pub mod ffi {
         fn get_releasever(&self) -> &str;
         fn rpmdb_backend_is_target(&self) -> bool;
         fn get_files_remove_regex(&self, package: &str) -> Vec<String>;
-        fn print_deprecation_warnings(&self);
-        fn sanitycheck_externals(&self) -> Result<()>;
         fn get_checksum(&self, repo: Pin<&mut OstreeRepo>) -> Result<String>;
         fn get_ostree_ref(&self) -> String;
         fn get_repo_packages(&self) -> &[RepoPackage];
         fn clear_repo_packages(&mut self);
+        fn prettyprint_json_stdout(&self);
+        fn print_deprecation_warnings(&self);
+        fn sanitycheck_externals(&self) -> Result<()>;
     }
 
     // treefile.rs (split out from above to make &self nice to use)
@@ -365,6 +366,7 @@ pub mod ffi {
     extern "Rust" {
         fn varsubstitute(s: &str, vars: &Vec<StringMapping>) -> Result<String>;
         fn get_features() -> Vec<String>;
+        fn get_rpm_basearch() -> String;
         fn sealed_memfd(description: &str, content: &[u8]) -> Result<i32>;
         fn running_in_systemd() -> bool;
         fn calculate_advisories_diff(

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -739,6 +739,13 @@ impl Treefile {
         self.parsed.derive.error_if_nonempty()
     }
 
+    /// Pretty-print treefile content as JSON to stdout.
+    pub fn prettyprint_json_stdout(&self) {
+        std::io::stdout()
+            .write_all(self.serialized.as_bytes())
+            .unwrap();
+    }
+
     /// Given a treefile, print warnings about items which are deprecated.
     pub(crate) fn print_deprecation_warnings(&self) {
         let mut deprecated = false;

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -469,9 +469,10 @@ pub(crate) fn sealed_memfd(description: &str, content: &[u8]) -> CxxResult<i32> 
 }
 
 /// Map Rust architecture constants to the ones used by DNF.
+///
 /// Rust architecture constants: https://doc.rust-lang.org/std/env/consts/constant.ARCH.html
 /// DNF mapping: https://github.com/rpm-software-management/dnf/blob/4.5.2/dnf/rpm/__init__.py#L88
-pub(crate) fn get_rpm_basearch() -> String {
+pub fn get_rpm_basearch() -> String {
     match std::env::consts::ARCH {
         "arm" => "armhfp".to_string(),
         "powerpc" => "ppc".to_string(),


### PR DESCRIPTION
This moves the treefile JSON pretty-printing logic to Rust.
It also avoids redundant steps in retrieving host basearch, by
using the internal Rust build-arch mapping and caching the value
upfront.