### PR TITLE
builtins/compose: always return computed input-hash

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -387,7 +387,9 @@ install_packages (RpmOstreeTreeComposeContext  *self,
                                        &ret_new_inputhash, error))
     return FALSE;
 
+  g_assert (ret_new_inputhash != NULL);
   g_print ("Input state hash: %s\n", ret_new_inputhash);
+  *out_new_inputhash = g_strdup (ret_new_inputhash);
 
   /* Only look for previous checksum if caller has passed *out_unmodified */
   if (self->previous_checksum && out_unmodified != NULL)
@@ -498,7 +500,7 @@ install_packages (RpmOstreeTreeComposeContext  *self,
 
   if (out_unmodified)
     *out_unmodified = FALSE;
-  *out_new_inputhash = util::move_nullify (ret_new_inputhash);
+
   return TRUE;
 }
 


### PR DESCRIPTION
This moves the logic for setting input-hash early on, so that a
meaningful value is always returned even in case of early returns
(e.g. dry runs or no changes).

---

Context: the surrounding code seems to assume this value is always populated, but there are conditional early returns in the middle of this function which can leave it NULL. While I think NULL-dereferencing cases aren't currently reachable, it doesn't hurt making sure the value is populated before any of the possible early returns. 
