### PR TITLE
 daemon: Authorize uid 0 when polkit is not available

### DIFF
--- a/src/daemon/rpmostreed-daemon.h
+++ b/src/daemon/rpmostreed-daemon.h
@@ -68,6 +68,8 @@ gboolean           rpmostreed_daemon_reload_config  (RpmostreedDaemon *self,
                                                      gboolean         *out_changed,
                                                      GError          **error);
 
+gboolean rpmostreed_authorize_method_for_uid0 (GDBusMethodInvocation *invocation);
+
 RpmostreedAutomaticUpdatePolicy
 rpmostreed_get_automatic_update_policy (RpmostreedDaemon *self);
 

--- a/src/daemon/rpmostreed-os.cxx
+++ b/src/daemon/rpmostreed-os.cxx
@@ -98,9 +98,10 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
   if (rpmostreed_sysroot_is_on_session_bus (sysroot))
     {
       /* The daemon is on the session bus, running self tests */
-      authorized = TRUE;
+      return TRUE;
     }
-  else if (g_strcmp0 (method_name, "GetDeploymentsRpmDiff") == 0 ||
+
+  if (g_strcmp0 (method_name, "GetDeploymentsRpmDiff") == 0 ||
            g_strcmp0 (method_name, "GetCachedDeployRpmDiff") == 0 ||
            g_strcmp0 (method_name, "DownloadDeployRpmDiff") == 0 ||
            g_strcmp0 (method_name, "GetCachedUpdateRpmDiff") == 0 ||

--- a/src/daemon/rpmostreed-os.cxx
+++ b/src/daemon/rpmostreed-os.cxx
@@ -240,6 +240,15 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
                                                           NULL, &error);
       if (result == NULL)
         {
+          g_assert (error);
+          if (g_dbus_error_is_remote_error (error))
+            {
+              g_autofree char *remote_err = g_dbus_error_get_remote_error (error);
+              if (g_str_equal (remote_err, "org.freedesktop.DBus.Error.NameHasNoOwner"))
+                {
+                  return rpmostreed_authorize_method_for_uid0 (invocation);
+                }
+            }
           g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
                                                  "Authorization error: %s", error->message);
           return FALSE;

--- a/src/daemon/rpmostreed-sysroot.cxx
+++ b/src/daemon/rpmostreed-sysroot.cxx
@@ -624,6 +624,15 @@ sysroot_authorize_method (GDBusInterfaceSkeleton *interface,
                                                    NULL, &local_error);
       if (result == NULL)
         {
+          g_assert (local_error);
+          if (g_dbus_error_is_remote_error (local_error))
+            {
+              g_autofree char *remote_err = g_dbus_error_get_remote_error (local_error);
+              if (g_str_equal (remote_err, "org.freedesktop.DBus.Error.NameHasNoOwner"))
+                {
+                  return rpmostreed_authorize_method_for_uid0 (invocation);
+                }
+            }
           g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR,
                                                  G_DBUS_ERROR_FAILED,
                                                  "Authorization error: %s",


### PR DESCRIPTION
os: Minor code style cleanup

Just return early here if we detect the session bus case.

Prep for further work which will add another early return
case.

---

daemon: Authorize uid 0 when polkit is not available

I did an RHCOS build that didn't contain polkit, and noticed
rpm-ostree no longer worked.

But we should work in this scenario.  While zincati currently
relies on this, we should support custom builds that don't
have polkit.

---

