### PR TITLE
compose: Throw prefixed C++ exception

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1103,11 +1103,10 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
     }
 
   /* The penultimate step, just basically `ostree commit` */
-  g_autofree char *new_revision = NULL;
-  if (!rpmostree_compose_commit (self->rootfs_dfd, self->build_repo, parent_revision,
-                                 metadata, gpgkey, selinux, self->devino_cache,
-                                 &new_revision, cancellable, error))
-    return glnx_prefix_error (error, "Writing commit");
+  auto new_revision_str =
+    rpmostreecxx::compose_commit(self->rootfs_dfd, self->build_repo, parent_revision,
+                                 metadata, gpgkey, selinux, self->devino_cache,cancellable);
+  const char *new_revision = new_revision_str.c_str();
   g_assert(new_revision != NULL);
 
   OstreeRepoTransactionStats stats = { 0, };

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -54,16 +54,16 @@ rpmostree_postprocess_final (int            rootfs_dfd,
                              GCancellable  *cancellable,
                              GError       **error);
 
-gboolean
-rpmostree_compose_commit (int            rootfs_dfd,
-                          OstreeRepo    *repo,
-                          const char    *parent,
-                          GVariant      *metadata,
-                          const char    *gpg_keyid,
-                          gboolean       enable_selinux,
-                          OstreeRepoDevInoCache *devino_cache,
-                          char         **out_new_revision,
-                          GCancellable  *cancellable,
-                          GError       **error);
-
 G_END_DECLS
+
+namespace rpmostreecxx {
+rust::String
+compose_commit (int            rootfs_fd,
+                OstreeRepo    *repo,
+                const char    *parent_revision,
+                GVariant      *src_metadata,
+                const char    *gpg_keyid,
+                bool           enable_selinux,
+                OstreeRepoDevInoCache *devino_cache,
+                GCancellable  *cancellable);
+}


### PR DESCRIPTION
A big thing we lost with the cxx work is having `glnx_prefix_error`
reliably work because C++ directly unwinds and doesn't set `GError`.

We have a CI failure in RHCOS and I want to know in the future
if it's actually comming from the commit path.
