### PR TITLE
postprocess: Oxidize directory size counting

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -192,6 +192,7 @@ pub mod ffi {
         ) -> Result<()>;
         fn compose_postprocess_rpm_macro(rootfs_dfd: i32) -> Result<()>;
         fn rewrite_rpmdb_for_target(rootfs_dfd: i32) -> Result<()>;
+        fn directory_size(dfd: i32, mut cancellable: Pin<&mut GCancellable>) -> Result<u64>;
     }
 
     // A grab-bag of metadata from the deployment's ostree commit


### PR DESCRIPTION


We're getting a weird OOM issue in RHCOS builds:
https://github.com/openshift/os/issues/594
which looks like:
`fstatat(92/4682a3540a7d5f834f5159c024f412ff528600f8a683116ce99a1832251b67.filez): Cannot allocate memory`

Reading some code here I noticed that the "open directory" call
could follow symlinks when it shouldn't.  Let's just RIIR and
make this code more explicit - e.g. we ignore symlinks.

I'm pretty sure this is a no-op, but let's harden the code.

---

