### PR TITLE
Two error prefixing patches

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1148,12 +1148,16 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
   else
     g_print ("Wrote commit: %s\n", new_revision);
 
+  try {
   if (!rpmostree_composeutil_write_composejson (self->repo,
                                                 opt_write_composejson_to, statsp,
                                                 new_revision, new_commit,
                                                 &composemeta_builder,
                                                 cancellable, error))
-    return FALSE;
+    util::throw_gerror(*error);
+  } catch (std::exception &e) {
+    util::rethrow_prefixed(e, "Failed to write composejson");
+  }
 
   if (opt_write_commitid_to)
     rpmostreecxx::write_commit_id(opt_write_commitid_to, new_revision);

--- a/src/lib/rpmostree-db.c
+++ b/src/lib/rpmostree-db.c
@@ -136,14 +136,20 @@ rpm_ostree_db_diff_ext (OstreeRepo               *repo,
   g_autoptr(GPtrArray) orig_pkglist = NULL;
   if (!_rpm_ostree_package_list_for_commit (repo, orig_ref, allow_noent, &orig_pkglist,
                                             cancellable, error))
-    return FALSE;
+    {
+      g_prefix_error (error, "Failed to load package list: ");
+      return FALSE;
+    }
 
   g_autoptr(GPtrArray) new_pkglist = NULL;
   if (orig_pkglist)
     {
       if (!_rpm_ostree_package_list_for_commit (repo, new_ref, allow_noent, &new_pkglist,
                                                 cancellable, error))
-        return FALSE;
+        {
+          g_prefix_error (error, "Failed to load package list: ");
+          return FALSE;
+        }
     }
 
   if (!orig_pkglist || !new_pkglist)

--- a/src/libpriv/rpmostree-editor.cxx
+++ b/src/libpriv/rpmostree-editor.cxx
@@ -95,7 +95,7 @@ ot_editor_prompt (OstreeRepo *repo,
 
   if (!g_subprocess_wait_check (proc, cancellable, error))
     {
-      g_prefix_error (error, "There was a problem with the editor '%s'", editor);
+      g_prefix_error (error, "There was a problem with the editor '%s': ", editor);
       goto out;
     }
 


### PR DESCRIPTION
compose: Add error prefixing when writing compose JSON

This ends up doing some nontrivial work in e.g. `db diff` and
I want to see if an error trace is happening from there.

xref https://github.com/openshift/os/issues/594

---

db: Prefix error when we fail to load the rpmdb

Also add a missing `:` in the editor code.

xref https://github.com/openshift/os/issues/594

---

