### PR TITLE
build-sys: Rework cxxbridge and add .copr integration

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -6,9 +6,7 @@ parallel rpms: {
   buildPod(memory: "2Gi", cpu: "${n}") {
       checkout scm
       // 2:1 job to CPU at most should keep us from getting kicked out
-      shwrap("""RPM_BUILD_NCPUS=${n} CARGO_BUILD_JOBS=${n} ./ci/coreosci-rpmbuild.sh
-                mv packaging/*/*.rpm .
-             """)
+      shwrap("""RPM_BUILD_NCPUS=${n} CARGO_BUILD_JOBS=${n} ./ci/coreosci-rpmbuild.sh""")
       // make it easy for anyone to download the RPMs
       archiveArtifacts '*.rpm'
       stash excludes: '*.src.rpm', includes: '*.rpm', name: 'rpms'

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,13 @@
+srpm:
+	./ci/installdeps.sh
+	# fetch tags so `git describe` gives a nice NEVRA when building the RPM
+	git fetch origin --tags
+	git submodule update --init --recursive
+	ci/installdeps.sh
+	# Our primary CI build goes via RPM rather than direct to binaries
+	# to better test that path, including our vendored spec file, etc.
+	# The RPM build expects pre-generated bindings, so do that now.
+	make -f Makefile.bindings bindings
+	make -C packaging -f Makefile.dist-packaging srpm
+	if test -n "$$outdir"; then mv packaging/*.src.rpm $$outdir; fi
+

--- a/Makefile.bindings
+++ b/Makefile.bindings
@@ -3,10 +3,10 @@
 binding_rust_sources = $(shell find rust/src/ -name '*.rs') Cargo.toml Cargo.lock
 
 rust/cxx.h: Makefile.bindings
-	cxxbridge --header >$@
+	./target/cxxbridge/bin/cxxbridge --header >$@
 
 rpmostree-cxxrs.h: $(binding_rust_sources)
-	$(AM_V_GEN) if cxxbridge rust/src/lib.rs --header > $@.tmp; then \
+	$(AM_V_GEN) if ./target/cxxbridge/bin/cxxbridge rust/src/lib.rs --header > $@.tmp; then \
 	  if test -f $@ && cmp $@.tmp $@ 2>/dev/null; then rm -f $@.tmp; else \
 	    mv $@.tmp $@; \
 	  fi; \
@@ -14,7 +14,7 @@ rpmostree-cxxrs.h: $(binding_rust_sources)
 	  echo cxxbridge failed; exit 1; \
 	fi
 rpmostree-cxxrs.cxx: $(binding_rust_sources) rpmostree-cxxrs.h
-	$(AM_V_GEN) if cxxbridge --include rpmostree-cxxrs.h rust/src/lib.rs > $@.tmp; then \
+	$(AM_V_GEN) if ./target/cxxbridge/bin/cxxbridge --include rpmostree-cxxrs.h rust/src/lib.rs > $@.tmp; then \
 	  if test -f $@ && cmp $@.tmp $@ 2>/dev/null; then rm -f $@.tmp; else \
 	    mv $@.tmp $@; \
 	  fi; \

--- a/ci/coreosci-rpmbuild.sh
+++ b/ci/coreosci-rpmbuild.sh
@@ -4,13 +4,6 @@ set -euo pipefail
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
 
-# fetch tags so `git describe` gives a nice NEVRA when building the RPM
-git fetch origin --tags
-git submodule update --init --recursive
-ci/installdeps.sh
-# Our primary CI build goes via RPM rather than direct to binaries
-# to better test that path, including our vendored spec file, etc.
-# The RPM build expects pre-generated bindings, so do that now.
-make -f Makefile.bindings bindings
-cd packaging
-make -f Makefile.dist-packaging rpm
+make -f .copr/Makefile srpm
+./packaging/rpmbuild-cwd --rebuild packaging/*.src.rpm
+mv $(arch)/*.rpm .

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -6,21 +6,15 @@ set -xeuo pipefail
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
 
+if [ -z "${SKIP_INSTALLDEPS:-}" ] && test $(id -u) -eq 0; then
+    dnf -y install jq dnf-plugins-core
+    # we have the canonical spec file handy so just builddep from that
+    # XXX: use --allowerasing as a temporary hack to ease the migration to libmodulemd2
+    time dnf builddep --spec -y packaging/rpm-ostree.spec.in --allowerasing
+fi
+
 # cxx.rs (cxxbridge) isn't packaged in Fedora today.  It generates
 # source code, which we vendor along with our dependent crates into release
 # tarballs.
 CXX_VER=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name == "cxx").version')
 time cargo install cxxbridge-cmd --version "${CXX_VER}"
-
-# Everything below here uses dnf/yum; we don't try to use
-# sudo for you right now.  (Though hopefully you're building
-# in an unprivileged podman container at least)
-if [ -n "${SKIP_INSTALLDEPS:-}" ] || test $(id -u) != 0; then
-    exit 0
-fi
-
-# we have the canonical spec file handy so just builddep from that
-# XXX: use --allowerasing as a temporary hack to ease the migration to libmodulemd2
-time dnf builddep --spec -y packaging/rpm-ostree.spec.in --allowerasing
-
-

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -17,4 +17,5 @@ fi
 # source code, which we vendor along with our dependent crates into release
 # tarballs.
 CXX_VER=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name == "cxx").version')
-time cargo install cxxbridge-cmd --version "${CXX_VER}"
+mkdir -p target
+time cargo install --root=target/cxxbridge cxxbridge-cmd --version "${CXX_VER}"

--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -5,8 +5,6 @@
 if test -z "$HOME" || test ! -w "$HOME"; then
     export HOME=$(mktemp -d -t --suffix .prowhome)
 fi
-# In some cases we install tools via cargo, ensure that's in PATH
-export PATH="$HOME/.cargo/bin:$PATH"
 
 pkg_upgrade() {
     echo "Running dnf -y distro-sync... $(date)"


### PR DESCRIPTION
ci: Install system deps before cxxbridge

To ensure we have `jq` which we need; and this is required for COPR.

---

build-sys: Install cxxbridge in target/

Since the binary needs to be version locked with our `Cargo.lock`,
let's move the helper binary into our `target/` directory.  This
should help with the COPR build which doesn't set `$PATH`.

---

Add .copr/Makefile

Prep for re-introducing a coreos/continuous build.

---

