### PR TITLE
deploy: Only hold local variant pointer, not in struct

### DIFF
--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1168,27 +1168,18 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
     }
   else
     {
-      if (uninstall_pkgs)
-        {
-          /* In reality, there may not be any new layer required even if `remove_changed` is TRUE
-           * (if e.g. we're removing a duplicate provides). But the origin has changed so we need to
-           * create a new deployment; see https://github.com/projectatomic/rpm-ostree/issues/753 */
-          if (!rpmostree_origin_remove_packages (origin, uninstall_pkgs,
-                                                 idempotent_layering, &changed, error))
-            return FALSE;
-        }
-      if (disable_modules)
-        {
-          if (!rpmostree_origin_remove_modules (origin, disable_modules,
-                                                TRUE, &changed, error))
-            return FALSE;
-        }
-      if (uninstall_modules)
-        {
-          if (!rpmostree_origin_remove_modules (origin, uninstall_modules,
-                                                FALSE, &changed, error))
-            return FALSE;
-        }
+      /* In reality, there may not be any new layer required even if `remove_changed` is TRUE
+       * (if e.g. we're removing a duplicate provides). But the origin has changed so we need to
+       * create a new deployment; see https://github.com/projectatomic/rpm-ostree/issues/753 */
+      if (!rpmostree_origin_remove_packages (origin, uninstall_pkgs,
+                                             idempotent_layering, &changed, error))
+        return FALSE;
+      if (!rpmostree_origin_remove_modules (origin, disable_modules,
+                                            TRUE, &changed, error))
+        return FALSE;
+      if (!rpmostree_origin_remove_modules (origin, uninstall_modules,
+                                            FALSE, &changed, error))
+        return FALSE;
     }
 
   /* lazily loaded cache that's used in a few conditional blocks */
@@ -1231,17 +1222,10 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
         return FALSE;
     }
 
-  if (enable_modules)
-    {
-      if (!rpmostree_origin_add_modules (origin, enable_modules, TRUE, &changed, error))
-        return FALSE;
-    }
-
-  if (install_modules)
-    {
-      if (!rpmostree_origin_add_modules (origin, install_modules, FALSE, &changed, error))
-        return FALSE;
-    }
+  if (!rpmostree_origin_add_modules (origin, enable_modules, TRUE, &changed, error))
+    return FALSE;
+  if (!rpmostree_origin_add_modules (origin, install_modules, FALSE, &changed, error))
+    return FALSE;
 
   if (self->install_local_pkgs != NULL)
     {

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -809,6 +809,8 @@ rpmostree_origin_remove_packages (RpmOstreeOrigin  *origin,
                                   gboolean         *out_changed,
                                   GError          **error)
 {
+  if (!packages)
+    return TRUE;
   gboolean changed = FALSE;
   gboolean local_changed = FALSE;
 
@@ -862,6 +864,8 @@ rpmostree_origin_add_modules (RpmOstreeOrigin  *origin,
                               gboolean        *out_changed,
                               GError         **error)
 {
+  if (!modules)
+    return TRUE;
   const char *key = enable_only ? "enable" : "install";
   GHashTable *target = enable_only ? origin->cached_modules_enable
                                    : origin->cached_modules_install;
@@ -883,6 +887,8 @@ rpmostree_origin_remove_modules (RpmOstreeOrigin  *origin,
                                  gboolean        *out_changed,
                                  GError         **error)
 {
+  if (!modules)
+    return TRUE;
   const char *key = enable_only ? "enable" : "install";
   GHashTable *target = enable_only ? origin->cached_modules_enable
                                    : origin->cached_modules_install;


### PR DESCRIPTION
deploy: Only hold local variant pointer, not in struct

This is part of reducing the number of places that need to
be touched when adding new API.  There's no good reason to parse
the options variant into a struct member; we can just keep
it as a local variable.

---

origin: Make some package/module mutation functions no-ops for NULL

Rather than having the caller do conditionals for `NULL`, do it
inside the function.  This simplifies the control flow and avoids
duplication.

---

