### PR TITLE
src: Wrap all throwable CXX calls in try-catch

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -578,7 +578,7 @@ pub mod ffi {
         include!("rpmostree-rpm-util.h");
         // Currently only used in unit tests
         #[allow(dead_code)]
-        fn nevra_to_cache_branch(nevra: &CxxString) -> Result<UniquePtr<CxxString>>;
+        fn nevra_to_cache_branch(nevra: &CxxString) -> Result<String>;
         fn get_repodata_chksum_repr(pkg: &mut DnfPackage) -> Result<String>;
     }
 }

--- a/rust/src/passwd.rs
+++ b/rust/src/passwd.rs
@@ -91,6 +91,7 @@ pub fn passwd_cleanup(rootfs_dfd: i32) -> Result<()> {
 /// in /usr/etc at this point), and splitting it into two streams: a new
 /// /etc/passwd that just contains the root entry, and /usr/lib/passwd which
 /// contains everything else.
+#[context("Migrating 'passwd' to /usr/lib")]
 pub fn migrate_passwd_except_root(rootfs_dfd: i32) -> CxxResult<()> {
     static ETCSRC_PATH: &str = "usr/etc/passwd";
     static USRDEST_PATH: &str = "usr/lib/passwd";
@@ -134,6 +135,7 @@ pub fn migrate_passwd_except_root(rootfs_dfd: i32) -> CxxResult<()> {
 /// in /usr/etc at this point), and splitting it into two streams: a new
 /// /etc/group that just contains roots and preserved entries, and /usr/lib/group
 /// which contains everything else.
+#[context("Migrating 'group' to /usr/lib")]
 pub fn migrate_group_except_root(rootfs_dfd: i32, preserved_groups: &Vec<String>) -> CxxResult<()> {
     static ETCSRC_PATH: &str = "usr/etc/group";
     static USRDEST_PATH: &str = "usr/lib/group";

--- a/rust/src/rpmutils.rs
+++ b/rust/src/rpmutils.rs
@@ -66,7 +66,7 @@ mod test {
         assert_eq!(nevra, exp_nevra);
         cxx::let_cxx_string!(cxx_exp_nevra = exp_nevra);
         let actual_branch = crate::ffi::nevra_to_cache_branch(&cxx_exp_nevra).expect("nevra");
-        assert_eq!(b, actual_branch.to_string_lossy());
+        assert_eq!(b, actual_branch);
     }
 
     #[test]

--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -265,7 +265,7 @@ rpmostree_option_context_parse (GOptionContext *context,
     }
 
   if ((flags & RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT) > 0)
-    rpmostreecxx::client_require_root();
+    CXX_TRY(client_require_root(), error);
 
   if (use_daemon)
     {
@@ -459,7 +459,7 @@ early_main (void)
   dnf_context_set_config_file_path("");
 }
 
-// The C++ `main()`, invoked from Rust for most CLI commands currently.
+// The C++ `main()`, invoked from Rust only for most CLI commands currently.
 // This may throw an exception which will be converted into a `Result` in Rust.
 int
 rpmostree_main (const rust::Slice<const rust::Str> args)

--- a/src/app/rpmostree-builtin-applylive.cxx
+++ b/src/app/rpmostree-builtin-applylive.cxx
@@ -40,6 +40,6 @@ rpmostree_ex_builtin_apply_live (int             argc,
   rust::Vec<rust::String> rustargv;
   for (int i = 0; i < argc; i++)
     rustargv.push_back(std::string(argv[i]));
-  rpmostreecxx::applylive_entrypoint(rustargv);
+  CXX_TRY(applylive_entrypoint(rustargv), error);
   return TRUE;
 }

--- a/src/app/rpmostree-builtin-deploy.cxx
+++ b/src/app/rpmostree-builtin-deploy.cxx
@@ -235,8 +235,8 @@ rpmostree_builtin_deploy (int            argc,
 
       /* do diff without dbus: https://github.com/projectatomic/rpm-ostree/pull/116 */
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
-      rpmostreecxx::print_treepkg_diff_from_sysroot_path (rust::Str(sysroot_path),
-            RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0, cancellable);
+      CXX_TRY(print_treepkg_diff_from_sysroot_path (rust::Str(sysroot_path),
+            RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0, cancellable), error);
 
       g_print ("Run \"systemctl reboot\" to start a reboot\n");
     }

--- a/src/app/rpmostree-builtin-shlib-backend.cxx
+++ b/src/app/rpmostree-builtin-shlib-backend.cxx
@@ -107,7 +107,7 @@ rpmostree_builtin_shlib_backend (int             argc,
       const char *src = argv[2];
       g_autoptr(DnfContext) ctx = dnf_context_new ();
       auto varsubsts = rpmostree_dnfcontext_get_varsubsts (ctx);
-      auto rets = rpmostreecxx::varsubstitute (src, *varsubsts);
+      auto rets = CXX_TRY_VAL(rust::String, varsubstitute (src, *varsubsts), error);
       ret = g_variant_new_string (rets.c_str());
     }
    else if (g_str_equal (arg, "packagelist-from-commit"))
@@ -124,6 +124,6 @@ rpmostree_builtin_shlib_backend (int             argc,
     return glnx_throw (error, "unknown shlib-backend %s", arg);
 
   rust::Slice<const uint8_t> dataslice{(guint8*)g_variant_get_data (ret), g_variant_get_size (ret)};
-  glnx_fd_close int ret_memfd = rpmostreecxx::sealed_memfd("rpm-ostree-shlib-backend", dataslice);
+  glnx_fd_close int ret_memfd = CXX_TRY_VAL (int, sealed_memfd("rpm-ostree-shlib-backend", dataslice), error);
   return send_memfd_result (ipc_sock, glnx_steal_fd (&ret_memfd), error);
 }

--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -802,8 +802,8 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
     {
       /* No cached update, but we can still print a diff summary */
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
-      rpmostreecxx::print_treepkg_diff_from_sysroot_path (rust::Str(sysroot_path), diff_format,
-                                                          max_key_len, NULL);
+      CXX_TRY(print_treepkg_diff_from_sysroot_path (rust::Str(sysroot_path), diff_format,
+                                                          max_key_len, NULL), error);
     }
 
   /* print base overrides before overlays */
@@ -1395,7 +1395,7 @@ rpmostree_ex_builtin_history (int             argc,
   /* initiate a history context, then iterate over each (boot time, deploy time), then print */
 
   /* XXX: enhance with option for going in reverse (oldest first) */
-  auto history_ctx = rpmostreecxx::history_ctx_new ();
+  auto history_ctx = CXX_TRY_VAL(rust::Box<rpmostreecxx::HistoryCtx>, history_ctx_new (), error);
 
   /* XXX: use pager here */
 

--- a/src/app/rpmostree-builtin-testutils.cxx
+++ b/src/app/rpmostree-builtin-testutils.cxx
@@ -65,7 +65,7 @@ rpmostree_builtin_testutils (int argc, char **argv,
   rust::Vec<rust::String> rustargv;
   for (int i = 0; i < argc; i++)
     rustargv.push_back(std::string(argv[i]));
-  rpmostreecxx::testutils_entrypoint (rustargv);
+  CXX_TRY(testutils_entrypoint (rustargv), error);
   return TRUE;
 }
 

--- a/src/app/rpmostree-builtin-upgrade.cxx
+++ b/src/app/rpmostree-builtin-upgrade.cxx
@@ -243,8 +243,8 @@ rpmostree_builtin_upgrade (int             argc,
 
       /* do diff without dbus: https://github.com/projectatomic/rpm-ostree/pull/116 */
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
-      rpmostreecxx::print_treepkg_diff_from_sysroot_path (rust::Str(sysroot_path),
-            RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0, cancellable);
+      CXX_TRY(print_treepkg_diff_from_sysroot_path (rust::Str(sysroot_path),
+            RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0, cancellable), error);
 
       g_print ("Run \"systemctl reboot\" to start a reboot\n");
     }

--- a/src/app/rpmostree-db-builtin-diff.cxx
+++ b/src/app/rpmostree-db-builtin-diff.cxx
@@ -102,7 +102,7 @@ print_diff (OstreeRepo   *repo,
 
   if (opt_advisories)
     {
-      auto diff = rpmostreecxx::calculate_advisories_diff(*repo, from_checksum, to_checksum);
+      auto diff = CXX_TRY_VAL(GVariant*, calculate_advisories_diff(*repo, from_checksum, to_checksum), error);
       g_print ("\n");
       rpmostree_print_advisories (diff, TRUE, 0);
     }
@@ -272,7 +272,8 @@ rpmostree_db_builtin_diff (int argc, char **argv,
                                        FALSE, &diffv, cancellable, error))
         return FALSE;
       g_variant_builder_add (&builder, "{sv}", "pkgdiff", diffv);
-      auto adv_diff = rpmostreecxx::calculate_advisories_diff(*repo, from_checksum, to_checksum);
+      auto adv_diff = CXX_TRY_VAL(GVariant*,
+             calculate_advisories_diff(*repo, from_checksum, to_checksum), error);
       g_variant_builder_add (&builder, "{sv}", "advisories", adv_diff);
       g_autoptr(GVariant) metadata = g_variant_builder_end (&builder);
 

--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -123,8 +123,8 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
         return TRUE;
 
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
-      rpmostreecxx::print_treepkg_diff_from_sysroot_path (rust::Str(sysroot_path),
-            RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0, cancellable);
+      CXX_TRY(print_treepkg_diff_from_sysroot_path (rust::Str(sysroot_path),
+            RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0, cancellable), error);
 
       if (override_replace || override_remove)
         g_print ("Use \"rpm-ostree override reset\" to undo overrides\n");

--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -22,6 +22,7 @@
 
 #include "rpmostree-builtins.h"
 #include "rpmostree-libbuiltin.h"
+#include "rpmostree-util.h"
 #include "rpmostree-rpm-util.h"
 #include "rpmostree-clientlib.h"
 

--- a/src/daemon/rpmostreed-deployment-utils.h
+++ b/src/daemon/rpmostreed-deployment-utils.h
@@ -27,9 +27,12 @@ G_BEGIN_DECLS
 
 char *          rpmostreed_deployment_generate_id (OstreeDeployment *deployment);
 
-OstreeDeployment *
-                rpmostreed_deployment_get_for_id (OstreeSysroot *sysroot,
-                                                  const gchar *deploy_id);
+gboolean
+rpmostreed_deployment_get_for_id (OstreeSysroot     *sysroot,
+                                  const gchar       *deploy_id,
+                                  OstreeDeployment **out_deployment,
+                                  GError           **error);
+
 OstreeDeployment *
                 rpmostreed_deployment_get_for_index (OstreeSysroot *sysroot,
                                                      const gchar   *index,
@@ -37,11 +40,12 @@ OstreeDeployment *
 
 GVariant *      rpmostreed_deployment_generate_blank_variant (void);
 
-GVariant *      rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
+gboolean        rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
                                                         OstreeDeployment *deployment,
                                                         const char       *booted_id,
                                                         OstreeRepo       *repo,
                                                         gboolean          filter,
+                                                        GVariant        **out_variant,
                                                         GError          **error);
 
 GVariant *      rpmostreed_commit_generate_cached_details_variant (OstreeDeployment *deployment,

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1442,7 +1442,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
           OstreeDeployment *deployment =
             rpmostree_sysroot_upgrader_get_merge_deployment (upgrader);
 
-          auto is_live = rpmostreecxx::has_live_apply_state(*sysroot, *deployment);
+          auto is_live = CXX_TRY_VAL(bool, has_live_apply_state(*sysroot, *deployment), error);
           if (is_live)
             changed = TRUE;
         }
@@ -1609,7 +1609,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
         {
           g_autoptr(GVariantDict) dictv = g_variant_dict_new (NULL);
           g_autoptr(GVariant) live_opts = g_variant_ref_sink (g_variant_dict_end (dictv));
-          rpmostreecxx::transaction_apply_live(*sysroot, *live_opts);
+          CXX_TRY(transaction_apply_live(*sysroot, *live_opts), error);
         }
       else if (deploy_has_bool_option (self, "reboot"))
         {
@@ -2674,7 +2674,8 @@ finalize_deployment_transaction_execute (RpmostreedTransaction *transaction,
   if (!g_str_equal (ostree_deployment_get_osname (default_deployment), self->osname))
     return glnx_throw (error, "Staged deployment is not for osname '%s'", self->osname);
 
-  auto layeredmeta = rpmostreecxx::deployment_layeredmeta_load(*repo, *default_deployment);
+  auto layeredmeta = CXX_TRY_VAL(rpmostreecxx::DeploymentLayeredMeta,
+          deployment_layeredmeta_load(*repo, *default_deployment), error);
   const char *checksum = layeredmeta.base_commit.c_str();
 
   auto expected_checksum =

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -158,10 +158,11 @@ GPtrArray *rpmostree_context_get_packages (RpmOstreeContext *self);
 
 GPtrArray *rpmostree_context_get_packages_to_import (RpmOstreeContext *self);
 
-void
+gboolean
 rpmostree_context_set_lockfile (RpmOstreeContext *self,
                                 char            **lockfiles,
-                                gboolean          strict);
+                                gboolean          strict,
+                                GError          **error);
 
 gboolean rpmostree_download_packages (GPtrArray      *packages,
                                       GCancellable   *cancellable,

--- a/src/libpriv/rpmostree-diff.cxx
+++ b/src/libpriv/rpmostree-diff.cxx
@@ -21,6 +21,7 @@
 #include "rpmostree-db.h"
 #include "rpmostree-util.h"
 
+// Only used by Rust side.
 namespace rpmostreecxx {
 
 RPMDiff::RPMDiff(GPtrArray *removed, GPtrArray *added, GPtrArray *modified_old, GPtrArray *modified_new) {

--- a/src/libpriv/rpmostree-importer.cxx
+++ b/src/libpriv/rpmostree-importer.cxx
@@ -454,7 +454,7 @@ build_metadata_variant (RpmOstreeImporter *self,
 
       /* include a checksum of the RPM as a whole; the actual algo used depends
        * on how the repodata was created, so just keep a repr */
-      auto chksum_repr = rpmostreecxx::get_repodata_chksum_repr(*self->pkg);
+      auto chksum_repr = CXX_TRY_VAL(rust::String, get_repodata_chksum_repr(*self->pkg), error);
       g_variant_builder_add (&metadata_builder, "{sv}",
                              "rpmostree.repodata_checksum",
                              g_variant_new_string (chksum_repr.c_str()));

--- a/src/libpriv/rpmostree-rpm-util.cxx
+++ b/src/libpriv/rpmostree-rpm-util.cxx
@@ -851,7 +851,7 @@ get_sack_for_root (int               dfd,
   GLNX_AUTO_PREFIX_ERROR ("Loading sack", error);
   g_assert (out_sack != NULL);
 
-  rpmostreecxx::core_libdnf_process_global_init();
+  CXX_TRY(core_libdnf_process_global_init(), error);
 
   g_autofree char *fullpath = glnx_fdrel_abspath (dfd, path);
 
@@ -1324,7 +1324,7 @@ rpmostree_decompose_nevra (const char  *nevra,
 
 /* translates NEVRA to its cache branch */
 namespace rpmostreecxx {
-std::unique_ptr<std::string>
+rust::String
 nevra_to_cache_branch (const std::string &nevra)
 {
   /* It's cumbersome, but we have to decompose the NEVRA and the rebuild it into a cache
@@ -1342,8 +1342,7 @@ nevra_to_cache_branch (const std::string &nevra)
   g_autofree char *evr = rpmostree_custom_nevra_strdup (name, epoch, version, release, arch,
                                                         PKG_NEVRA_FLAGS_EVR);
   g_autofree char *branch = rpmostree_get_cache_branch_for_n_evr_a (name, evr, arch);
-  auto ret = std::string (branch);
-  return std::make_unique<std::string>(ret);
+  return rust::String (util::move_nullify(branch));
 }
 }
 

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -35,7 +35,7 @@
 
 // C++ code
 namespace rpmostreecxx {
-  std::unique_ptr<std::string> nevra_to_cache_branch(const std::string &nevra);
+  rust::String nevra_to_cache_branch(const std::string &nevra);
   rust::String get_repodata_chksum_repr(DnfPackage &pkg);
 }
 

--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -342,7 +342,8 @@ rpmostree_run_script_in_bwrap_container (int rootfs_fd,
     strcmp (pkg_script, "glibc-common.post") == 0;
   rpmostreecxx::BubblewrapMutability mutability =
     (is_glibc_locales || !enable_fuse) ? rpmostreecxx::BubblewrapMutability::MutateFreely : rpmostreecxx::BubblewrapMutability::RoFiles;
-  auto bwrap = rpmostreecxx::bubblewrap_new_with_mutability (rootfs_fd, mutability);
+  auto bwrap = CXX_TRY_VAL(rust::Box<rpmostreecxx::Bubblewrap>,
+      bubblewrap_new_with_mutability (rootfs_fd, mutability), error);
   /* Scripts can see a /var with compat links like alternatives */
   bwrap->var_tmp_tmpfs();
 
@@ -406,7 +407,7 @@ rpmostree_run_script_in_bwrap_container (int rootfs_fd,
   else
     {
       rust::Slice<const uint8_t> scriptslice{(guint8*)script, strlen (script)};
-      glnx_fd_close int script_memfd = rpmostreecxx::sealed_memfd (pkg_script, scriptslice);
+      glnx_fd_close int script_memfd = CXX_TRY_VAL(int, sealed_memfd (pkg_script, scriptslice), error);
 
       /* Only try to log to the journal if we're already set up that way (normally
        * rpm-ostreed for host system management). Otherwise we might be in a Docker
@@ -960,7 +961,8 @@ rpmostree_deployment_sanitycheck_true (int           rootfs_fd,
     return TRUE;
 
   g_assert(cancellable);
-  auto bwrap = rpmostreecxx::bubblewrap_new_with_mutability(rootfs_fd, rpmostreecxx::BubblewrapMutability::Immutable);
+  auto bwrap = CXX_TRY_VAL(rust::Box<::rpmostreecxx::Bubblewrap>,
+      bubblewrap_new_with_mutability(rootfs_fd, rpmostreecxx::BubblewrapMutability::Immutable), error);
   bwrap->append_child_arg("/usr/bin/true");
   try {
     bwrap->run(*cancellable);

--- a/src/libpriv/rpmostree-util.cxx
+++ b/src/libpriv/rpmostree-util.cxx
@@ -521,7 +521,8 @@ rpmostree_deployment_get_layered_info (OstreeRepo        *repo,
   if (!ostree_repo_load_commit (repo, csum, &commit, NULL, error))
     return FALSE;
 
-  auto layeredmeta = rpmostreecxx::deployment_layeredmeta_from_commit(*deployment, *commit);
+  auto layeredmeta = CXX_TRY_VAL(rpmostreecxx::DeploymentLayeredMeta,
+      deployment_layeredmeta_from_commit(*deployment, *commit), error);
 
   g_autoptr(GVariant) metadata = g_variant_get_child_value (commit, 0);
   g_autoptr(GVariantDict) dict = g_variant_dict_new (metadata);


### PR DESCRIPTION
With the migration to Rust via C++, we've been adding more calls on the
C side which can throw. This in turn means that we lose precious error
context when it finally percolates all the way up.

This patch introduces a new `CXX_TRY` macro (and its variant
`CXX_TRY_VAL`) which is used to wrap every call to C++/Rust code capable
of throwing. This in effect restores error-prefixing for many potential
errors.

Of course, there are exceptions (pun intended). Code which already does
special exception handling was left untouched. C++ code marked as
`noexcept` isn't wrapped (which also means bridged Rust code which don't
return a `Result`).

I'd like to play around a bit more with the macros to see if we can get
rid of having to write out the type in `CXX_TRY_VAL`, but this works for
now.

So essentially after this, everytime we call a throwable C++ function or
CXX-bridged function from a vanilla C code with `GError`-semantics, we
should almost always use `CXX_TRY` or `CXX_TRY_VAL`.

See related discussions in
https://github.com/coreos/rpm-ostree/pull/3026.