### PR TITLE
src: Simplify CXX_TRY_VAL macro

### DIFF
--- a/src/app/rpmostree-builtin-shlib-backend.cxx
+++ b/src/app/rpmostree-builtin-shlib-backend.cxx
@@ -107,7 +107,7 @@ rpmostree_builtin_shlib_backend (int             argc,
       const char *src = argv[2];
       g_autoptr(DnfContext) ctx = dnf_context_new ();
       auto varsubsts = rpmostree_dnfcontext_get_varsubsts (ctx);
-      auto rets = CXX_TRY_VAL(rust::String, varsubstitute (src, *varsubsts), error);
+      auto rets = CXX_TRY_VAL(varsubstitute (src, *varsubsts), error);
       ret = g_variant_new_string (rets.c_str());
     }
    else if (g_str_equal (arg, "packagelist-from-commit"))
@@ -124,6 +124,6 @@ rpmostree_builtin_shlib_backend (int             argc,
     return glnx_throw (error, "unknown shlib-backend %s", arg);
 
   rust::Slice<const uint8_t> dataslice{(guint8*)g_variant_get_data (ret), g_variant_get_size (ret)};
-  glnx_fd_close int ret_memfd = CXX_TRY_VAL (int, sealed_memfd("rpm-ostree-shlib-backend", dataslice), error);
+  glnx_fd_close int ret_memfd = CXX_TRY_VAL (sealed_memfd("rpm-ostree-shlib-backend", dataslice), error);
   return send_memfd_result (ipc_sock, glnx_steal_fd (&ret_memfd), error);
 }

--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -1395,7 +1395,7 @@ rpmostree_ex_builtin_history (int             argc,
   /* initiate a history context, then iterate over each (boot time, deploy time), then print */
 
   /* XXX: enhance with option for going in reverse (oldest first) */
-  auto history_ctx = CXX_TRY_VAL(rust::Box<rpmostreecxx::HistoryCtx>, history_ctx_new (), error);
+  auto history_ctx = CXX_TRY_VAL(history_ctx_new (), error);
 
   /* XXX: use pager here */
 

--- a/src/app/rpmostree-clientlib.cxx
+++ b/src/app/rpmostree-clientlib.cxx
@@ -1035,7 +1035,7 @@ rpmostree_sort_pkgs_strv (const char *const* pkgs,
   for (const char *const* pkgiter = pkgs; pkgiter && *pkgiter; pkgiter++)
     {
       auto pkg = *pkgiter;
-      auto fds = CXX_TRY_VAL(rust::Vec<int>, client_handle_fd_argument(pkg, basearch), error);
+      auto fds = CXX_TRY_VAL(client_handle_fd_argument(pkg, basearch), error);
       if (fds.size() > 0)
         {
           for (const auto & fd: fds)

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -690,9 +690,8 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
     }
 
   self->treefile_path = g_file_new_for_path (treefile_pathstr);
-  self->treefile_rs = CXX_TRY_VAL(rust::Box<rpmostreecxx::Treefile>,
-      treefile_new_compose(gs_file_get_path_cached (self->treefile_path),
-                           basearch, self->workdir_dfd), error);
+  self->treefile_rs = CXX_TRY_VAL(treefile_new_compose(gs_file_get_path_cached (self->treefile_path),
+                                                       basearch, self->workdir_dfd), error);
   self->corectx = rpmostree_context_new_compose (self->cachedir_dfd, self->build_repo,
                                                  **self->treefile_rs);
   /* In the legacy compose path, we don't want to use any of the core's selinux stuff,
@@ -891,7 +890,7 @@ impl_install_tree (RpmOstreeTreeComposeContext *self,
           (void)g_variant_lookup (previous_metadata, OSTREE_COMMIT_META_KEY_VERSION, "s", &last_version);
         }
 
-      next_version = CXX_TRY_VAL(rust::String, util_next_version (ver_prefix, ver_suffix ?: "", last_version ?: ""), error);
+      next_version = CXX_TRY_VAL(util_next_version (ver_prefix, ver_suffix ?: "", last_version ?: ""), error);
       g_hash_table_insert (self->metadata, g_strdup (OSTREE_COMMIT_META_KEY_VERSION),
                            g_variant_ref_sink (g_variant_new_string (next_version.c_str())));
     }
@@ -1198,7 +1197,7 @@ rpmostree_compose_builtin_install (int             argc,
 
   if (opt_print_only)
     {
-      auto treefile = CXX_TRY_VAL(rust::Box<rpmostreecxx::Treefile>, treefile_new (treefile_path, basearch, -1), error);
+      auto treefile = CXX_TRY_VAL(treefile_new (treefile_path, basearch, -1), error);
       treefile->prettyprint_json_stdout ();
       return TRUE;
     }
@@ -1286,8 +1285,7 @@ rpmostree_compose_builtin_postprocess (int             argc,
     {
       if (!glnx_mkdtempat (AT_FDCWD, "/var/tmp/rpm-ostree.XXXXXX", 0700, &workdir_tmp, error))
         return FALSE;
-      auto treefile_rs = CXX_TRY_VAL(rust::Box<rpmostreecxx::Treefile>,
-        treefile_new_compose(treefile_path, "", workdir_tmp.fd), error);
+      auto treefile_rs = CXX_TRY_VAL(treefile_new_compose(treefile_path, "", workdir_tmp.fd), error);
       auto serialized = treefile_rs->get_json_string();
       treefile_parser = json_parser_new ();
       if (!json_parser_load_from_data (treefile_parser, serialized.c_str(), -1, error))
@@ -1387,8 +1385,7 @@ rpmostree_compose_builtin_tree (int             argc,
 
   if (opt_print_only)
     {
-      auto treefile = CXX_TRY_VAL(rust::Box<rpmostreecxx::Treefile>,
-          treefile_new (treefile_path, basearch, -1), error);
+      auto treefile = CXX_TRY_VAL(treefile_new (treefile_path, basearch, -1), error);
       treefile->prettyprint_json_stdout ();
       return TRUE;
     }
@@ -1472,8 +1469,7 @@ rpmostree_compose_builtin_extensions (int             argc,
   const char *extensions_path = argv[2];
 
   auto basearch = rpmostreecxx::get_rpm_basearch ();
-  auto src_treefile = CXX_TRY_VAL(rust::Box<rpmostreecxx::Treefile>,
-        treefile_new_compose(treefile_path, basearch, -1), error);
+  auto src_treefile = CXX_TRY_VAL(treefile_new_compose(treefile_path, basearch, -1), error);
 
   g_autoptr(OstreeRepo) repo = ostree_repo_open_at (AT_FDCWD, opt_repo, cancellable, error);
   if (!repo)
@@ -1529,8 +1525,7 @@ rpmostree_compose_builtin_extensions (int             argc,
       packages_mapping->push_back(rpmostreecxx::StringMapping{name, evr});
     }
 
-  auto extensions = CXX_TRY_VAL(rust::Box<rpmostreecxx::Extensions>,
-      extensions_load (extensions_path, basearch, *packages_mapping), error);
+  auto extensions = CXX_TRY_VAL(extensions_load (extensions_path, basearch, *packages_mapping), error);
 
   // This treefile basically tells the core to download the extension packages
   // from the repos, and that's it.

--- a/src/app/rpmostree-db-builtin-diff.cxx
+++ b/src/app/rpmostree-db-builtin-diff.cxx
@@ -102,7 +102,7 @@ print_diff (OstreeRepo   *repo,
 
   if (opt_advisories)
     {
-      auto diff = CXX_TRY_VAL(GVariant*, calculate_advisories_diff(*repo, from_checksum, to_checksum), error);
+      auto diff = CXX_TRY_VAL(calculate_advisories_diff(*repo, from_checksum, to_checksum), error);
       g_print ("\n");
       rpmostree_print_advisories (diff, TRUE, 0);
     }
@@ -272,8 +272,7 @@ rpmostree_db_builtin_diff (int argc, char **argv,
                                        FALSE, &diffv, cancellable, error))
         return FALSE;
       g_variant_builder_add (&builder, "{sv}", "pkgdiff", diffv);
-      auto adv_diff = CXX_TRY_VAL(GVariant*,
-             calculate_advisories_diff(*repo, from_checksum, to_checksum), error);
+      auto adv_diff = CXX_TRY_VAL(calculate_advisories_diff(*repo, from_checksum, to_checksum), error);
       g_variant_builder_add (&builder, "{sv}", "advisories", adv_diff);
       g_autoptr(GVariant) metadata = g_variant_builder_end (&builder);
 

--- a/src/daemon/rpmostree-sysroot-core.cxx
+++ b/src/daemon/rpmostree-sysroot-core.cxx
@@ -190,7 +190,7 @@ generate_pkgcache_refs (OstreeSysroot            *sysroot,
       GHashTable *local_replace = rpmostree_origin_get_overrides_local_replace (origin);
       GLNX_HASH_TABLE_FOREACH (local_replace, const char*, nevra)
         {
-          auto cachebranch = CXX_TRY_VAL(rust::String, nevra_to_cache_branch (std::string(nevra)), error);
+          auto cachebranch = CXX_TRY_VAL(nevra_to_cache_branch (std::string(nevra)), error);
           g_hash_table_add (referenced_pkgs, g_strdup (cachebranch.c_str()));
         }
     }
@@ -413,7 +413,7 @@ rpmostree_syscore_write_deployment (OstreeSysroot           *sysroot,
       OstreeDeployment *booted = ostree_sysroot_get_booted_deployment (sysroot);
       if (booted)
         {
-          auto is_live = CXX_TRY_VAL(bool, has_live_apply_state(*sysroot, *booted), error);
+          auto is_live = CXX_TRY_VAL(has_live_apply_state(*sysroot, *booted), error);
           if (is_live)
             flags = static_cast<OstreeSysrootSimpleWriteDeploymentFlags>(flags | OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_RETAIN_ROLLBACK);
         }

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -456,7 +456,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
         if (cur_digest)
           {
             rpmostree_output_message ("Pulling manifest: %s", refspec);
-            auto new_digest = CXX_TRY_VAL(rust::String, fetch_digest(std::string(refspec)), error);
+            auto new_digest = CXX_TRY_VAL(fetch_digest(std::string(refspec)), error);
             if (strcmp (new_digest.c_str(), cur_digest) == 0)
               {
                 /* No new digest. */
@@ -466,7 +466,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
           }
 
         rpmostree_output_message ("Pulling: %s", refspec);
-        auto import = CXX_TRY_VAL(rust::Box<rpmostreecxx::ContainerImport>, import_container(*self->sysroot, std::string(refspec)), error);
+        auto import = CXX_TRY_VAL(import_container(*self->sysroot, std::string(refspec)), error);
 
         rpmostree_origin_set_container_image_reference_digest (self->original_origin, import->image_digest.c_str());
         new_base_rev = strdup (import->ostree_commit.c_str());
@@ -617,15 +617,13 @@ try_load_base_rsack_from_pending (RpmOstreeSysrootUpgrader *self,
                                   GCancellable             *cancellable,
                                   GError                  **error)
 {
-  auto is_live = CXX_TRY_VAL(bool,
-          has_live_apply_state(*self->sysroot, *self->origin_merge_deployment), error);
+  auto is_live = CXX_TRY_VAL(has_live_apply_state(*self->sysroot, *self->origin_merge_deployment), error);
   /* livefs invalidates the deployment */
   if (is_live)
     return TRUE;
 
   auto repo = ostree_sysroot_repo(self->sysroot);
-  auto layeredmeta = CXX_TRY_VAL(rpmostreecxx::DeploymentLayeredMeta,
-          deployment_layeredmeta_load(*repo, *self->origin_merge_deployment), error);
+  auto layeredmeta = CXX_TRY_VAL(deployment_layeredmeta_load(*repo, *self->origin_merge_deployment), error);
   /* older client layers have a bug blocking us from using their base rpmdb:
    * https://github.com/projectatomic/rpm-ostree/pull/1560 */
   if (layeredmeta.is_layered && layeredmeta.clientlayer_version < 4)
@@ -962,7 +960,7 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self,
 
   {
     g_autoptr(GKeyFile) computed_origin_kf = rpmostree_origin_dup_keyfile (self->computed_origin);
-    self->treefile = CXX_TRY_VAL(rust::Box<::rpmostreecxx::Treefile>, origin_to_treefile (*computed_origin_kf), error);
+    self->treefile = CXX_TRY_VAL(origin_to_treefile (*computed_origin_kf), error);
   }
   rpmostree_context_set_treefile (self->ctx, **self->treefile);
 
@@ -1411,7 +1409,7 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
           etc_files.push_back(std::string(key));
         }
       try {
-        fd = CXX_TRY_VAL(int, initramfs_overlay_generate (etc_files, *cancellable), error);
+        fd = CXX_TRY_VAL(initramfs_overlay_generate (etc_files, *cancellable), error);
       } catch (std::exception& e) {
         util::rethrow_prefixed(e, "Generating initramfs overlay");
       }

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -44,7 +44,7 @@ rpmostreed_deployment_get_for_id (OstreeSysroot     *sysroot,
   for (guint i = 0; i < deployments->len; i++)
     {
       auto deployment = static_cast<OstreeDeployment*>(deployments->pdata[i]);
-      auto id = CXX_TRY_VAL(rust::String, deployment_generate_id(*deployment), error);
+      auto id = CXX_TRY_VAL(deployment_generate_id(*deployment), error);
       if (g_strcmp0 (deploy_id, id.c_str()) == 0)
         {
           *out_deployment = (OstreeDeployment*)g_object_ref (deployment);
@@ -920,7 +920,7 @@ rpmostreed_update_generate_variant (OstreeDeployment  *booted_deployment,
 
   if (staged_deployment)
     {
-      auto id = CXX_TRY_VAL(rust::String, deployment_generate_id (*staged_deployment), error);
+      auto id = CXX_TRY_VAL(deployment_generate_id (*staged_deployment), error);
       g_variant_dict_insert (&dict, "deployment", "s", id.c_str());
     }
 

--- a/src/daemon/rpmostreed-os.cxx
+++ b/src/daemon/rpmostreed-os.cxx
@@ -1810,7 +1810,7 @@ rpmostreed_os_load_internals (RpmostreedOS *self, GError **error)
                                                    booted_id, ot_repo, TRUE, &booted_variant, error))
         return FALSE;
       g_variant_ref_sink (booted_variant);
-      auto bootedid_v = CXX_TRY_VAL(rust::String, deployment_generate_id(*booted_deployment), error);
+      auto bootedid_v = CXX_TRY_VAL(deployment_generate_id(*booted_deployment), error);
       booted_id = g_strdup(bootedid_v.c_str());
     }
   else

--- a/src/daemon/rpmostreed-sysroot.cxx
+++ b/src/daemon/rpmostreed-sysroot.cxx
@@ -274,7 +274,7 @@ sysroot_populate_deployments_unlocked (RpmostreedSysroot *self,
       const gchar *os = ostree_deployment_get_osname (booted);
       g_autofree gchar *path = rpmostreed_generate_object_path (BASE_DBUS_PATH, os, NULL);
       rpmostree_sysroot_set_booted (RPMOSTREE_SYSROOT (self), path);
-      auto bootedid_v = CXX_TRY_VAL(rust::String, deployment_generate_id(*booted), error);
+      auto bootedid_v = CXX_TRY_VAL(deployment_generate_id(*booted), error);
       booted_id = g_strdup(bootedid_v.c_str());
     }
   else

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1442,7 +1442,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
           OstreeDeployment *deployment =
             rpmostree_sysroot_upgrader_get_merge_deployment (upgrader);
 
-          auto is_live = CXX_TRY_VAL(bool, has_live_apply_state(*sysroot, *deployment), error);
+          auto is_live = CXX_TRY_VAL(has_live_apply_state(*sysroot, *deployment), error);
           if (is_live)
             changed = TRUE;
         }
@@ -2674,8 +2674,7 @@ finalize_deployment_transaction_execute (RpmostreedTransaction *transaction,
   if (!g_str_equal (ostree_deployment_get_osname (default_deployment), self->osname))
     return glnx_throw (error, "Staged deployment is not for osname '%s'", self->osname);
 
-  auto layeredmeta = CXX_TRY_VAL(rpmostreecxx::DeploymentLayeredMeta,
-          deployment_layeredmeta_load(*repo, *default_deployment), error);
+  auto layeredmeta = CXX_TRY_VAL(deployment_layeredmeta_load(*repo, *default_deployment), error);
   const char *checksum = layeredmeta.base_commit.c_str();
 
   auto expected_checksum =

--- a/src/libpriv/rpmostree-importer.cxx
+++ b/src/libpriv/rpmostree-importer.cxx
@@ -454,7 +454,7 @@ build_metadata_variant (RpmOstreeImporter *self,
 
       /* include a checksum of the RPM as a whole; the actual algo used depends
        * on how the repodata was created, so just keep a repr */
-      auto chksum_repr = CXX_TRY_VAL(rust::String, get_repodata_chksum_repr(*self->pkg), error);
+      auto chksum_repr = CXX_TRY_VAL(get_repodata_chksum_repr(*self->pkg), error);
       g_variant_builder_add (&metadata_builder, "{sv}",
                              "rpmostree.repodata_checksum",
                              g_variant_new_string (chksum_repr.c_str()));

--- a/src/libpriv/rpmostree-kernel.cxx
+++ b/src/libpriv/rpmostree-kernel.cxx
@@ -516,10 +516,9 @@ rpmostree_run_dracut (int     rootfs_dfd,
    * today.  Though maybe in the future we should add it, but
    * in the end we want to use systemd-sysusers of course.
    **/
-  auto etc_guard = CXX_TRY_VAL(rust::Box<rpmostreecxx::TempEtcGuard>,
-      prepare_tempetc_guard (rootfs_dfd), error);
+  auto etc_guard = CXX_TRY_VAL(prepare_tempetc_guard (rootfs_dfd), error);
 
-  gboolean have_passwd = CXX_TRY_VAL(bool, prepare_rpm_layering (rootfs_dfd, ""), error);
+  gboolean have_passwd = CXX_TRY_VAL(prepare_rpm_layering (rootfs_dfd, ""), error);
 
   /* Note rebuild_from_initramfs now is only used as a fallback in the client-side regen
    * path when we can't fetch the canonical initramfs args to use. */
@@ -566,7 +565,7 @@ rpmostree_run_dracut (int     rootfs_dfd,
                                       &tmpf, error))
     return FALSE;
 
-  auto bwrap = CXX_TRY_VAL(rust::Box<rpmostreecxx::Bubblewrap>, bubblewrap_new(rootfs_dfd), error);
+  auto bwrap = CXX_TRY_VAL(bubblewrap_new(rootfs_dfd), error);
   if (use_root_etc)
     {
       bwrap->bind_read("/etc", "/etc");

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -820,7 +820,7 @@ rpmostree_compose_commit (int            rootfs_fd,
   if (devino_cache)
     ostree_repo_commit_modifier_set_devino_cache (commit_modifier, devino_cache);
 
-  auto n_bytes = CXX_TRY_VAL(uint64_t, directory_size(rootfs_fd, *cancellable), error);
+  auto n_bytes = CXX_TRY_VAL(directory_size(rootfs_fd, *cancellable), error);
 
   tdata.n_bytes = n_bytes;
   tdata.repo = repo;

--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -342,8 +342,7 @@ rpmostree_run_script_in_bwrap_container (int rootfs_fd,
     strcmp (pkg_script, "glibc-common.post") == 0;
   rpmostreecxx::BubblewrapMutability mutability =
     (is_glibc_locales || !enable_fuse) ? rpmostreecxx::BubblewrapMutability::MutateFreely : rpmostreecxx::BubblewrapMutability::RoFiles;
-  auto bwrap = CXX_TRY_VAL(rust::Box<rpmostreecxx::Bubblewrap>,
-      bubblewrap_new_with_mutability (rootfs_fd, mutability), error);
+  auto bwrap = CXX_TRY_VAL(bubblewrap_new_with_mutability (rootfs_fd, mutability), error);
   /* Scripts can see a /var with compat links like alternatives */
   bwrap->var_tmp_tmpfs();
 
@@ -407,7 +406,7 @@ rpmostree_run_script_in_bwrap_container (int rootfs_fd,
   else
     {
       rust::Slice<const uint8_t> scriptslice{(guint8*)script, strlen (script)};
-      glnx_fd_close int script_memfd = CXX_TRY_VAL(int, sealed_memfd (pkg_script, scriptslice), error);
+      glnx_fd_close int script_memfd = CXX_TRY_VAL(sealed_memfd (pkg_script, scriptslice), error);
 
       /* Only try to log to the journal if we're already set up that way (normally
        * rpm-ostreed for host system management). Otherwise we might be in a Docker
@@ -961,8 +960,7 @@ rpmostree_deployment_sanitycheck_true (int           rootfs_fd,
     return TRUE;
 
   g_assert(cancellable);
-  auto bwrap = CXX_TRY_VAL(rust::Box<::rpmostreecxx::Bubblewrap>,
-      bubblewrap_new_with_mutability(rootfs_fd, rpmostreecxx::BubblewrapMutability::Immutable), error);
+  auto bwrap = CXX_TRY_VAL(bubblewrap_new_with_mutability(rootfs_fd, rpmostreecxx::BubblewrapMutability::Immutable), error);
   bwrap->append_child_arg("/usr/bin/true");
   try {
     bwrap->run(*cancellable);

--- a/src/libpriv/rpmostree-util.cxx
+++ b/src/libpriv/rpmostree-util.cxx
@@ -521,8 +521,7 @@ rpmostree_deployment_get_layered_info (OstreeRepo        *repo,
   if (!ostree_repo_load_commit (repo, csum, &commit, NULL, error))
     return FALSE;
 
-  auto layeredmeta = CXX_TRY_VAL(rpmostreecxx::DeploymentLayeredMeta,
-      deployment_layeredmeta_from_commit(*deployment, *commit), error);
+  auto layeredmeta = CXX_TRY_VAL(deployment_layeredmeta_from_commit(*deployment, *commit), error);
 
   g_autoptr(GVariant) metadata = g_variant_get_child_value (commit, 0);
   g_autoptr(GVariantDict) dict = g_variant_dict_new (metadata);

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -87,14 +87,14 @@ throw_gerror (GError *&error)
 // Also the constructor might be explicitly deleted (e.g. rust::Box). The C++ compiler
 // doesn't understand that the final value will always be initialized since we return in the
 // catch block.
-#define CXX_TRY_VAL(t, cxxfn, err)             \
-  ({ std::optional<t> v;                       \
-     try {                                     \
-       v.emplace(rpmostreecxx::cxxfn);         \
-     } catch (std::exception &e) {             \
-       return glnx_throw(err, "%s", e.what()); \
-     }                                         \
-     std::move(v.value());                     \
+#define CXX_TRY_VAL(cxxfn, err)                      \
+  ({ std::optional<decltype(rpmostreecxx::cxxfn)> v; \
+     try {                                           \
+       v.emplace(rpmostreecxx::cxxfn);               \
+     } catch (std::exception &e) {                   \
+       return glnx_throw(err, "%s", e.what());       \
+     }                                               \
+     std::move(v.value());                           \
   })
 
 // Duplicate a non-empty Rust Str to a NUL-terminated C string.


### PR DESCRIPTION
We can use the `decltype` built-in to avoid having to pass the type.