### PR TITLE
countme: Trigger on boot and bi-weekly with random delay

### DIFF
--- a/src/daemon/rpm-ostree-countme.timer
+++ b/src/daemon/rpm-ostree-countme.timer
@@ -4,12 +4,11 @@ Documentation=man:rpm-ostree-countme.timer(8)
 ConditionPathExists=/run/ostree-booted
 
 [Timer]
-# Trigger weekly with a random delay
-OnCalendar=weekly UTC
-AccuracySec=1s
-RandomizedDelaySec=1w
+# Trigger shortly after boot and bi-weekly with a random delay of one day
 OnBootSec=5m
-Persistent=yes
+OnUnitInactiveSec=3d
+AccuracySec=1h
+RandomizedDelaySec=1d
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
The current timer will trigger weekly with a potential delay of a week,
which means that if the delay is big enough, an entire week will be
skipped and we will miss counting.

Instead, let's trigger on boot and every three days with a random delay
of one day so that we are sure that we at least trigger once per
counting window.

This does not introduce the risk of over counting as the logic for that
check is in rpm-ostree itself.