### PR TITLE
Add some more debugging bits when replacing kernel

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -97,6 +97,11 @@ pub(crate) fn prepare_filesystem_script_prep(rootfs: i32) -> CxxResult<Box<Files
     Ok(FilesystemScriptPrep::new(rootfs)?)
 }
 
+/// Using the Rust log infrastructure, print the treefile.
+pub(crate) fn log_treefile(tf: &crate::treefile::Treefile) {
+    tracing::debug!("Using treefile:\n{}", tf.get_json_string());
+}
+
 impl FilesystemScriptPrep {
     /// Filesystem paths that we rename out of the way if present
     const OPTIONAL_PATHS: &'static [&'static str] = &[SSS_CACHE_PATH];

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -160,6 +160,8 @@ pub mod ffi {
 
         fn run_depmod(rootfs_dfd: i32, kver: &str, unified_core: bool) -> Result<()>;
 
+        fn log_treefile(tf: &Treefile);
+
         fn is_container_image_reference(refspec: &str) -> bool;
     }
 

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -473,6 +473,7 @@ enable_repos (RpmOstreeContext  *context,
 void 
 rpmostree_context_set_treefile (RpmOstreeContext *self, rpmostreecxx::Treefile &treefile)
 {
+  rpmostreecxx::log_treefile(treefile);
   self->treefile_rs = &treefile;
 }
 

--- a/src/libpriv/rpmostree-kernel.cxx
+++ b/src/libpriv/rpmostree-kernel.cxx
@@ -138,7 +138,7 @@ find_ensure_one_subdirectory (int            rootfs_dfd,
       if (ret_subdir)
         {
           g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                       "Multiple subdirectories found in: %s", subpath);
+                       "Multiple subdirectories found in: %s: %s %s", subpath, glnx_basename (ret_subdir), dent->d_name);
           return FALSE;
         }
       ret_subdir = g_strconcat (subpath, "/", dent->d_name, NULL);


### PR DESCRIPTION
I'm hitting an issue trying to override the kernel in C9S,
and I wanted to trace through things a bit more.

Let's start using the tracing crate more.  One benefit of
this over `g_debug()` is that we avoid calling any of the code
(in this case the creation of the JSON string) unless the log
level is enabled.
