### PR TITLE
core: Disable all modules upfront

### DIFF
--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -1895,6 +1895,17 @@ rpmostree_context_prepare (RpmOstreeContext *self,
   GLNX_HASH_TABLE_FOREACH_V (local_pkgs_to_install, DnfPackage*, pkg)
     hy_goal_install (goal,  pkg);
 
+  /* All modules are opt-in, so start off with everything disabled. We'll
+   * enable/install user-provided ones down below. */
+  {
+    // XXX: Replace with dnf_context_module_disable_all() once we have it:
+    // https://github.com/rpm-software-management/libdnf/pull/1303
+    // Until then, we have to ignore errors, because '*' won't expand to
+    // anything if no modules exist in the rpm-md.
+    const char *all_modules[] = {"*", NULL};
+    dnf_context_module_disable (dnfctx, all_modules, NULL);
+  }
+
   /* Now repo-packages; only supported during server composes for now. */
   g_autoptr(DnfPackageSet) pinned_pkgs = NULL;
   if (!self->is_system)
@@ -1960,7 +1971,7 @@ rpmostree_context_prepare (RpmOstreeContext *self,
       dnf_sack_set_module_excludes (sack, excludes);
     }
 
-  /* And finally, handle repo packages to install */
+  /* And finally, handle packages to install from all enabled repos */
   g_autoptr(GPtrArray) missing_pkgs = NULL;
   for (auto &pkgname_v : packages)
     {

--- a/tests/compose/libbasic-test.sh
+++ b/tests/compose/libbasic-test.sh
@@ -108,10 +108,10 @@ assert_file_has_content ls.txt rpmdb.sqlite
 assert_not_file_has_content ls.txt /usr/share/rpm/Packages
 echo "ok rpmdb is sqlite"
 
-ostree --repo=${repo} show ${treeref} \
-  --print-metadata-key rpmostree.rpmdb.pkglist > pkglist.txt
+rpm-ostree db list --repo=${repo} ${treeref} > pkglist.txt
 assert_file_has_content pkglist.txt 'systemd'
-assert_file_has_content_literal pkglist.txt 'foobar'
+# this implicitly checks it didn't pick the modular version of foobar
+assert_file_has_content_literal pkglist.txt 'foobar-1.0-1.x86_64'
 assert_not_file_has_content pkglist.txt 'foobar-rec'
 echo "ok compose pkglist"
 

--- a/tests/compose/test-basic-unified.sh
+++ b/tests/compose/test-basic-unified.sh
@@ -11,6 +11,13 @@ treefile_append "repos" '["test-repo"]'
 build_rpm foobar recommends foobar-rec
 build_rpm foobar-rec
 
+# check that even a modular version of a pinned pkg is ignored, even if it's
+# higher version
+build_rpm foobar version 99.9
+build_module foo \
+  stream foo \
+  rpm foobar-0:99.9-1.x86_64
+
 uinfo_cmd add TEST-SEC-LOW security low
 build_rpm vuln-pkg uinfo TEST-SEC-LOW
 uinfo_cmd add-ref TEST-SEC-LOW 1 http://example.com/vuln1 "CVE-12-34 vuln1"


### PR DESCRIPTION
Let's be strict and not enable/install any modules by default.  Instead,
we require all module requests to be done explicitly. Note this is
slightly different from dnf, where it automatically enables modules if
trying to install a modular package (e.g. `podman` in RHEL8).

This is also required for proper `repo-packages` handling.

Early iterations of the modularity patches used to have something
similar but it got lost somewhere along the way.

Related: https://github.com/coreos/rpm-ostree/issues/3035