### PR TITLE
More txn cleanup

### DIFF
--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -725,6 +725,8 @@ rpmostree_origin_add_packages (RpmOstreeOrigin   *origin,
                                gboolean          *out_changed,
                                GError           **error)
 {
+  if (!packages)
+    return TRUE;
   gboolean changed = FALSE;
 
   for (char **it = packages; it && *it; it++)


### PR DESCRIPTION
daemon: Move more deploy transaction init into execute()

---

deploy: Move local_repo_remote_dfd into function scope

---

deploy: Move install_local_pkgs into function scope

---

deploy: Move package overrides into function scope

---

origin: Change add_packages to ignore NULL

For symmetry with previous commits, even though this won't be
used right now.

---

