### PR TITLE
libpriv/diff: allow missing rpmdb

### DIFF
--- a/rust/src/builtins/apply_live.rs
+++ b/rust/src/builtins/apply_live.rs
@@ -88,7 +88,7 @@ pub(crate) fn applylive_finish(mut sysroot: Pin<&mut crate::ffi::OstreeSysroot>)
         cxx::let_cxx_string!(from = booted_commit);
         cxx::let_cxx_string!(to = live_state.commit.as_str());
         let repo = repo.gobj_rewrap();
-        crate::ffi::rpmdb_diff(repo, &from, &to).map_err(anyhow::Error::msg)?
+        crate::ffi::rpmdb_diff(repo, &from, &to, false).map_err(anyhow::Error::msg)?
     };
     pkgdiff.print();
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -542,6 +542,7 @@ pub mod ffi {
             repo: Pin<&mut OstreeRepo>,
             src: &CxxString,
             dest: &CxxString,
+            allow_noent: bool,
         ) -> Result<UniquePtr<RPMDiff>>;
 
         fn print(&self);

--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -425,7 +425,7 @@ pub(crate) fn transaction_apply_live(
         cxx::let_cxx_string!(from = source_commit);
         cxx::let_cxx_string!(to = &*target_commit);
         let repo = repo.gobj_rewrap();
-        crate::ffi::rpmdb_diff(repo, &from, &to).map_err(anyhow::Error::msg)?
+        crate::ffi::rpmdb_diff(repo, &from, &to, false).map_err(anyhow::Error::msg)?
     };
     if !allow_replacement {
         if pkgdiff.n_removed() > 0 {

--- a/src/libpriv/rpmostree-diff.hpp
+++ b/src/libpriv/rpmostree-diff.hpp
@@ -52,6 +52,9 @@ private:
     GPtrArray *modified_new_;
 };
 
-std::unique_ptr<RPMDiff> rpmdb_diff(OstreeRepo &repo, const std::string &src, const std::string &dest);
+std::unique_ptr<RPMDiff> rpmdb_diff(OstreeRepo &repo,
+                                    const std::string &src,
+                                    const std::string &dest,
+                                    bool allow_noent);
 
 } /* namespace */


### PR DESCRIPTION
This adds opt-in support for cases where there is no rpmdb available
for diffing. It enhances the C++ wrapper in order to cover more usecases,
helping further Rust porting.