### PR TITLE
More clearly mark modularity support as experimental

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -79,15 +79,6 @@ It supports the following parameters:
    * `packages`: Array of strings, required: List of packages to install.
    * `repo`: String, required: Name of the repo from which to fetch packages.
 
- * `modules`: Object, optional: Describes RPM modules to enable or install. Two
-   keys are supported:
-   * `enable`: Array of strings, required: Set of RPM module specs to enable
-     (the same formats as dnf are supported, e.g. `NAME[:STREAM]`).
-     One can then cherry-pick specific packages from the enabled modules via
-     `packages`.
-   * `install`: Array of strings, required: Set of RPM module specs to install
-     (the same formats as dnf are supported, e.g. `NAME[:STREAM][/PROFILE]`).
-
  * `ostree-layers`: Array of strings, optional: After all packages are unpacked,
     check out these OSTree refs, which must already be in the destination repository.
     Any conflicts with packages will be an error.
@@ -337,3 +328,11 @@ version of `rpm-ostree`.
    via lockfiles. This is useful when locked packages are kept
    separately from the primary repos and one wants to ensure that
    rpm-ostree will otherwise not select unlocked packages from them.
+ * `modules`: Object, optional: Describes RPM modules to enable or install. Two
+   keys are supported:
+   * `enable`: Array of strings, required: Set of RPM module specs to enable
+     (the same formats as dnf are supported, e.g. `NAME[:STREAM]`).
+     One can then cherry-pick specific packages from the enabled modules via
+     `packages`.
+   * `install`: Array of strings, required: Set of RPM module specs to install
+     (the same formats as dnf are supported, e.g. `NAME[:STREAM][/PROFILE]`).

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -365,6 +365,7 @@ pub mod ffi {
         fn clear_repo_packages(&mut self);
         fn prettyprint_json_stdout(&self);
         fn print_deprecation_warnings(&self);
+        fn print_experimental_notices(&self);
         fn sanitycheck_externals(&self) -> Result<()>;
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -303,6 +303,11 @@ pub mod ffi {
         fn history_prune() -> Result<()>;
     }
 
+    // modularity.rs
+    extern "Rust" {
+        fn modularity_entrypoint(args: &Vec<String>) -> Result<()>;
+    }
+
     // scripts.rs
     extern "Rust" {
         fn script_is_ignored(pkg: &str, script: &str) -> bool;
@@ -629,6 +634,7 @@ pub(crate) use self::lockfile::*;
 mod live;
 pub(crate) use self::live::*;
 pub mod modularity;
+pub(crate) use self::modularity::*;
 mod nameservice;
 mod origin;
 pub(crate) use self::origin::*;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -64,7 +64,6 @@ fn inner_main() -> Result<i32> {
         Some("countme") => rpmostree_rust::countme::entrypoint(&args).map(|_| 0),
         Some("cliwrap") => rpmostree_rust::cliwrap::entrypoint(&args).map(|_| 0),
         Some("ex-container") => rpmostree_rust::container::entrypoint(&args).map(|_| 0),
-        Some("module") => rpmostree_rust::modularity::entrypoint(&args).map(|_| 0),
         // The `unlock` is a hidden alias for "ostree CLI compatibility"
         Some("usroverlay") | Some("unlock") => usroverlay(&args).map(|_| 0),
         _ => {

--- a/rust/src/modularity.rs
+++ b/rust/src/modularity.rs
@@ -34,8 +34,6 @@ struct InstallOpts {
     lock_finalization: bool,
     #[structopt(long)]
     dry_run: bool,
-    #[structopt(long)]
-    experimental: bool,
 }
 
 const OPT_KEY_ENABLE_MODULES: &str = "enable-modules";
@@ -43,8 +41,8 @@ const OPT_KEY_DISABLE_MODULES: &str = "disable-modules";
 const OPT_KEY_INSTALL_MODULES: &str = "install-modules";
 const OPT_KEY_UNINSTALL_MODULES: &str = "uninstall-modules";
 
-pub fn entrypoint(args: &[&str]) -> Result<()> {
-    match Opt::from_iter(args.iter().skip(1)) {
+pub(crate) fn modularity_entrypoint(args: &Vec<String>) -> Result<()> {
+    match Opt::from_iter(args.iter()) {
         Opt::Enable(ref opts) => enable(opts),
         Opt::Disable(ref opts) => disable(opts),
         Opt::Install(ref opts) => install(opts),
@@ -87,10 +85,6 @@ fn uninstall(opts: &InstallOpts) -> Result<()> {
 }
 
 fn modules_impl(key: &str, opts: &InstallOpts) -> Result<()> {
-    if !opts.experimental {
-        bail!("Modularity support is experimental and subject to change. Use --experimental.");
-    }
-
     if opts.modules.is_empty() {
         bail!("At least one module must be specified");
     }

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -820,6 +820,12 @@ impl Treefile {
         }
     }
 
+    /// Given a treefile, print notices about items which are experimental.
+    pub(crate) fn print_experimental_notices(&self) {
+        print_experimental_notice(self.parsed.modules.is_some(), "modules");
+        print_experimental_notice(self.parsed.lockfile_repos.is_some(), "lockfile-repos");
+    }
+
     pub(crate) fn get_checksum(
         &self,
         mut repo: Pin<&mut crate::ffi::OstreeRepo>,
@@ -881,6 +887,15 @@ impl Treefile {
         rootfs_dfd.ensure_dir_all(target.parent().unwrap(), 0o755)?;
         rootfs_dfd.write_file_contents(target, 0o644, self.serialized.as_bytes())?;
         Ok(())
+    }
+}
+
+fn print_experimental_notice(print: bool, key: &str) {
+    if print {
+        eprintln!(
+            "NOTICE: treefile key `{}` is experimental and subject to change\n",
+            key
+        );
     }
 }
 

--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -96,8 +96,6 @@ static RpmOstreeCommand commands[] = {
   /* Rust-implemented commands; they're here so that they show up in `rpm-ostree
    * --help` alongside the other commands, but the command itself is fully
    *  handled Rust side. */
-  { "module", static_cast<RpmOstreeBuiltinFlags>(0),
-    "Commands to install/uninstall modules", NULL },
   { "usroverlay", static_cast<RpmOstreeBuiltinFlags>(RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT),
     "Apply a transient overlayfs to /usr", NULL },
   /* Legacy aliases */

--- a/src/app/rpmostree-builtin-ex.cxx
+++ b/src/app/rpmostree-builtin-ex.cxx
@@ -51,6 +51,7 @@ rpmostree_builtin_ex (int argc, char **argv,
                       RpmOstreeCommandInvocation *invocation,
                       GCancellable *cancellable, GError **error)
 {
+  g_printerr ("NOTICE: Experimental commands are subject to change.\n");
   return rpmostree_handle_subcommand (argc, argv, ex_subcommands,
                                       invocation, cancellable, error);
 }

--- a/src/app/rpmostree-builtin-ex.cxx
+++ b/src/app/rpmostree-builtin-ex.cxx
@@ -33,6 +33,10 @@ static RpmOstreeCommand ex_subcommands[] = {
     "Inspect rpm-ostree history of the system", rpmostree_ex_builtin_history },
   { "initramfs-etc", (RpmOstreeBuiltinFlags)0,
     "Track initramfs configuration files", rpmostree_ex_builtin_initramfs_etc },
+  /* To graduate out of experimental, simply revert:
+   * https://github.com/coreos/rpm-ostree/pull/3078 */
+  { "module", static_cast<RpmOstreeBuiltinFlags>(0),
+    "Commands to install/uninstall modules", rpmostree_ex_builtin_module },
   { NULL, (RpmOstreeBuiltinFlags)0, NULL, NULL }
 };
 
@@ -51,3 +55,16 @@ rpmostree_builtin_ex (int argc, char **argv,
                                       invocation, cancellable, error);
 }
 
+/* Commands that are pure Rust are proxied here. */
+
+gboolean
+rpmostree_ex_builtin_module (int argc, char **argv,
+                             RpmOstreeCommandInvocation *invocation,
+                             GCancellable *cancellable, GError **error)
+{
+  rust::Vec<rust::String> rustargv;
+  for (int i = 0; i < argc; i++)
+    rustargv.push_back(std::string(argv[i]));
+  CXX_TRY(modularity_entrypoint(rustargv), error);
+  return TRUE;
+}

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -716,6 +716,7 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
     return FALSE;
 
   (*self->treefile_rs)->print_deprecation_warnings();
+  (*self->treefile_rs)->print_experimental_notices();
 
   self->treefile_rootval = json_parser_get_root (self->treefile_parser);
   if (!JSON_NODE_HOLDS_OBJECT (self->treefile_rootval))

--- a/src/app/rpmostree-ex-builtins.h
+++ b/src/app/rpmostree-ex-builtins.h
@@ -34,6 +34,7 @@ BUILTINPROTO(unpack);
 BUILTINPROTO(apply_live);
 BUILTINPROTO(history);
 BUILTINPROTO(initramfs_etc);
+BUILTINPROTO(module);
 
 #undef BUILTINPROTO
 

--- a/tests/kolainst/destructive/layering-modules
+++ b/tests/kolainst/destructive/layering-modules
@@ -20,19 +20,19 @@ fi
 assert_file_has_content_literal err.txt "Packages not found: foomodular"
 echo "ok can't install modular pkg by default"
 
-if rpm-ostree module install foomodular --experimental 2>err.txt; then
+if rpm-ostree ex module install foomodular 2>err.txt; then
   assert_not_reached "successfully installed a module with multiple streams without a default stream"
 fi
 assert_file_has_content err.txt "Cannot enable more streams .* at the same time"
 echo "ok can't install module with multiple streams"
 
-if rpm-ostree module enable foomodular --experimental 2>err.txt; then
+if rpm-ostree ex module enable foomodular 2>err.txt; then
   assert_not_reached "successfully enabled a module with multiple streams without a default stream"
 fi
 assert_file_has_content err.txt "Cannot enable more streams .* at the same time"
 echo "ok can't enable module with multiple streams"
 
-rpm-ostree module enable foomodular:no-profile --experimental
+rpm-ostree ex module enable foomodular:no-profile
 rpm-ostree install foomodular
 rpm-ostree status > output.txt
 assert_file_has_content_literal output.txt "EnabledModules: foomodular:no-profile"
@@ -40,19 +40,19 @@ assert_file_has_content_literal output.txt "LayeredPackages: foomodular"
 rpm-ostree cleanup -p
 echo "ok enable module"
 
-if rpm-ostree module install foomodular:no-default-profile --experimental 2>err.txt; then
+if rpm-ostree ex module install foomodular:no-default-profile 2>err.txt; then
   assert_not_reached "successfully installed a module without default profile?"
 fi
 assert_file_has_content_literal err.txt "No default profile found"
 echo "ok can't install module without default profile"
 
-rpm-ostree module install foomodular:no-default-profile/myprof --experimental
+rpm-ostree ex module install foomodular:no-default-profile/myprof
 rpm-ostree status > output.txt
 assert_file_has_content_literal output.txt "LayeredModules: foomodular:no-default-profile/myprof"
 rpm-ostree cleanup -p
 echo "ok install module without default profile"
 
-rpm-ostree module install foomodular:with-default-profile --experimental
+rpm-ostree ex module install foomodular:with-default-profile
 rpm-ostree status > output.txt
 assert_file_has_content_literal output.txt "LayeredModules: foomodular:with-default-profile"
 rpm-ostree cleanup -p


### PR DESCRIPTION
On the client side, we were requiring `--experimental` on the CLI,
though to be clear and consistent, let's instead move it under
`rpm-ostree ex` just like what we usually do with every other new
experimental commands.

On the compose side, move the associated documentation to the
experimental section.