### PR TITLE
container: Accept an ostree::Repo directly

### DIFF
--- a/Makefile.bindings
+++ b/Makefile.bindings
@@ -3,7 +3,7 @@
 binding_rust_sources = $(shell find rust/src/ -name '*.rs') Cargo.toml Cargo.lock
 
 rust/cxx.h: Makefile.bindings
-	./target/cxxbridge/bin/cxxbridge --header >$@
+	./target/cxxbridge/bin/cxxbridge --header >$@.tmp && mv $@.tmp $@
 
 rpmostree-cxxrs.h: $(binding_rust_sources)
 	$(AM_V_GEN) if ./target/cxxbridge/bin/cxxbridge rust/src/lib.rs --header > $@.tmp; then \

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -143,7 +143,7 @@ pub mod ffi {
     // sysroot_upgrade.rs
     extern "Rust" {
         fn import_container(
-            sysroot: Pin<&mut OstreeSysroot>,
+            repo: Pin<&mut OstreeRepo>,
             imgref: String,
         ) -> Result<Box<ContainerImport>>;
 

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -10,12 +10,11 @@ use std::pin::Pin;
 
 /// Import ostree commit in container image using ostree-rs-ext's API.
 pub(crate) fn import_container(
-    mut sysroot: Pin<&mut crate::FFIOstreeSysroot>,
+    mut repo: Pin<&mut crate::FFIOstreeRepo>,
     imgref: String,
 ) -> CxxResult<Box<ContainerImport>> {
     // TODO: take a GCancellable and monitor it, and drop the import task (which is how async cancellation works in Rust).
-    let sysroot = &sysroot.gobj_wrap();
-    let repo = &sysroot.repo().unwrap();
+    let repo = repo.gobj_wrap();
     let imgref = imgref.as_str().try_into()?;
     let imported = build_runtime()?
         .block_on(async { ostree_ext::container::import(&repo, &imgref, None).await })?;

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -466,7 +466,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
           }
 
         rpmostree_output_message ("Pulling: %s", refspec);
-        auto import = CXX_TRY_VAL(import_container(*self->sysroot, std::string(refspec)), error);
+        auto import = CXX_TRY_VAL(import_container(*self->repo, std::string(refspec)), error);
 
         rpmostree_origin_set_container_image_reference_digest (self->original_origin, import->image_digest.c_str());
         new_base_rev = strdup (import->ostree_commit.c_str());


### PR DESCRIPTION
container: Accept an ostree::Repo directly

We don't do anything with the sysroot, so just pass the repo
which we already have.

Prep for using this code on the compose side.

---

build-sys: Don't leave empty file on error

---

