### PR TITLE
Fix disconnected test flake

### DIFF
--- a/rust/src/failpoint_bridge.rs
+++ b/rust/src/failpoint_bridge.rs
@@ -1,8 +1,16 @@
 //! C++ bindings for the failpoint crate.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use anyhow::Result;
+
 /// Expose the `fail::fail_point` macro to C++.
-pub fn failpoint(p: &str) {
+pub fn failpoint(p: &str) -> Result<()> {
     ostree_ext::glib::g_debug!("rpm-ostree", "{}", p);
-    fail::fail_point!(p);
+    fail::fail_point!(p, |r| {
+        Err(match r {
+            Some(ref msg) => anyhow::anyhow!("{}", msg),
+            None => anyhow::anyhow!("failpoint {}", p),
+        })
+    });
+    Ok(())
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -231,7 +231,7 @@ pub mod ffi {
 
     // failpoint_bridge.rs
     extern "Rust" {
-        fn failpoint(p: &str);
+        fn failpoint(p: &str) -> Result<()>;
     }
 
     // importer.rs

--- a/src/app/rpmostree-clientlib.cxx
+++ b/src/app/rpmostree-clientlib.cxx
@@ -602,7 +602,7 @@ impl_transaction_get_response_sync (GDBusConnection *connection,
                         tp);
     }
 
-  rpmostreecxx::failpoint("client::connect");
+  CXX_TRY(failpoint("client::connect"), error);
 
   transaction = transaction_connect (transaction_address, cancellable, error);
   if (!transaction)

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -447,6 +447,21 @@ rpmostree_assert_status() {
     rm -f status.json
 }
 
+# Wait for a non-empty result from journalctl.
+# It's recommended to use arguments like this to search
+# for a message from a specific service `--after-cursor <cursor> --grep=message -u rpm-ostreed`.
+journal_poll() {
+    timeout=60
+    for x in $(seq $timeout); do
+      if journalctl -q -n 1 "$@"; then
+        return
+      fi
+      sleep 1
+    done
+    echo "timed out waiting $timeout seconds for journalctl $@" 1>&2
+    exit 1
+}
+
 # This function below was taken and adapted from coreos-assembler. We
 # should look into sharing this code more easily.
 

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -105,10 +105,10 @@ rpm-ostree reload
 echo "ok reload"
 
 cursor=$(journalctl -o json -n 1 | jq -r '.["__CURSOR"]')
-if env FAILPOINTS=client::connect=panic rpm-ostree initramfs --enable 2>err.txt; then
+if env FAILPOINTS='client::connect=return(synthetic-error)' rpm-ostree initramfs --enable 2>err.txt; then
     fatal "should have errored"
 fi
-assert_file_has_content_literal err.txt "failpoint client::connect panic"
+assert_file_has_content_literal err.txt "error: synthetic-error"
 journalctl -u rpm-ostreed --after-cursor "${cursor}" > out.txt
 assert_file_has_content_literal out.txt 'client disconnected before calling Start'
 rpm-ostree status > out.txt

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -109,8 +109,7 @@ if env FAILPOINTS='client::connect=return(synthetic-error)' rpm-ostree initramfs
     fatal "should have errored"
 fi
 assert_file_has_content_literal err.txt "error: synthetic-error"
-journalctl -u rpm-ostreed --after-cursor "${cursor}" > out.txt
-assert_file_has_content_literal out.txt 'client disconnected before calling Start'
+journal_poll -u rpm-ostreed --after-cursor "${cursor}" --grep="client disconnected before calling Start"
 rpm-ostree status > out.txt
 assert_file_has_content_literal out.txt 'State: idle'
 echo "ok auto-cancel not-started transaction"


### PR DESCRIPTION
tests/misc: Only validate remote if we have one

I'm trying to run this with `cosa build-fast`, and the test
fails because there wasn't a remote configured to start.

---

Change our failpoint to `return Err` instead of panic

Part of looking at https://github.com/coreos/rpm-ostree/issues/3075

I thought there was an issue with us not catching a panic and
the core dump handler being called before stderr was flushed.

In the end, that wasn't the bug, but I think it's just cleaner
for us to return an error rather than panic.

---

tests/misc: Poll journal for error message

We could race in having the client error out and try querying the journal
before the daemon had written the error message.

Closes: https://github.com/coreos/rpm-ostree/issues/3075

---

