### PR TITLE
Set up Tokio runtime in main()

### DIFF
--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -2,19 +2,15 @@
 
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 /// Main entrypoint for container
-pub fn entrypoint(args: &[&str]) -> Result<()> {
+pub async fn entrypoint(args: &[&str]) -> Result<i32> {
     // Right now we're only exporting the `container` bits, not tar.  So inject that argument.
     // And we also need to skip the main arg and the `ex-container` arg.
     let args = ["rpm-ostree", "container"]
         .iter()
         .chain(args.iter().skip(2));
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .context("Failed to build tokio runtime")?
-        .block_on(async { ostree_ext::cli::run_from_iter(args).await })?;
-    Ok(())
+    ostree_ext::cli::run_from_iter(args).await?;
+    Ok(0)
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -308,6 +308,15 @@ pub mod ffi {
         fn modularity_entrypoint(args: &Vec<String>) -> Result<()>;
     }
 
+    // tokio_ffi.rs
+    extern "Rust" {
+        type TokioHandle;
+        type TokioEnterGuard<'a>;
+
+        fn tokio_handle_get() -> Box<TokioHandle>;
+        unsafe fn enter<'a>(self: &'a TokioHandle) -> Box<TokioEnterGuard<'a>>;
+    }
+
     // scripts.rs
     extern "Rust" {
         fn script_is_ignored(pkg: &str, script: &str) -> bool;
@@ -644,6 +653,8 @@ use passwd::*;
 mod console_progress;
 pub(crate) use self::console_progress::*;
 mod progress;
+mod tokio_ffi;
+pub(crate) use self::tokio_ffi::*;
 mod scripts;
 pub(crate) use self::scripts::*;
 mod sysroot_upgrade;

--- a/rust/src/tokio_ffi.rs
+++ b/rust/src/tokio_ffi.rs
@@ -1,0 +1,16 @@
+//! Helpers to bridge tokio to C++
+
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+pub(crate) struct TokioHandle(tokio::runtime::Handle);
+pub(crate) struct TokioEnterGuard<'a>(tokio::runtime::EnterGuard<'a>);
+
+pub(crate) fn tokio_handle_get() -> Box<TokioHandle> {
+    Box::new(TokioHandle(tokio::runtime::Handle::current()))
+}
+
+impl TokioHandle {
+    pub(crate) fn enter(&self) -> Box<TokioEnterGuard> {
+        Box::new(TokioEnterGuard(self.0.enter()))
+    }
+}


### PR DESCRIPTION
Each entrypoint to the container bits sets up a tokio runtime,
which is inefficient and duplicative.  We're also likely
to start using Rust async in more places.

Instead, create a Tokio runtime early in our `main`, and
change the CLI entrypoint to be an `async fn`.

The other setup of a runtime we have is deep inside the
sysroot upgrader bits, also for the container.  In this
case we actually have another thread (distinct from the main one
where we set up Tokio) created by C/C++, so we need to pass
a `tokio::runtime::Handle` across, and call `enter()` on it
to set up the thread local bindings to access tokio async
from there.

I was initially looking at properly handling `GCancellable`
with tokio and wanted to clean this up first.
