### PR TITLE
upgrader: Make container pulls cancellable

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -144,10 +144,11 @@ pub mod ffi {
     extern "Rust" {
         fn import_container(
             repo: Pin<&mut OstreeRepo>,
+            cancellable: Pin<&mut GCancellable>,
             imgref: String,
         ) -> Result<Box<ContainerImport>>;
 
-        fn fetch_digest(imgref: String) -> Result<String>;
+        fn fetch_digest(imgref: String, cancellable: Pin<&mut GCancellable>) -> Result<String>;
     }
 
     // core.rs

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -428,6 +428,8 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
                                       GCancellable           *cancellable,
                                       GError                **error)
 {
+  g_assert (cancellable);
+
   const gboolean allow_older =
     (self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_ALLOW_OLDER) > 0;
   const gboolean synthetic =
@@ -456,7 +458,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
         if (cur_digest)
           {
             rpmostree_output_message ("Pulling manifest: %s", refspec);
-            auto new_digest = CXX_TRY_VAL(fetch_digest(std::string(refspec)), error);
+            auto new_digest = CXX_TRY_VAL(fetch_digest(std::string(refspec), *cancellable), error);
             if (strcmp (new_digest.c_str(), cur_digest) == 0)
               {
                 /* No new digest. */
@@ -466,7 +468,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
           }
 
         rpmostree_output_message ("Pulling: %s", refspec);
-        auto import = CXX_TRY_VAL(import_container(*self->repo, std::string(refspec)), error);
+        auto import = CXX_TRY_VAL(import_container(*self->repo, *cancellable, std::string(refspec)), error);
 
         rpmostree_origin_set_container_image_reference_digest (self->original_origin, import->image_digest.c_str());
         new_base_rev = strdup (import->ostree_commit.c_str());


### PR DESCRIPTION


There may be a better way to bridge `GCancellable` into tokio.
I still need to join the gtk-rs Matrix chat so I can ask questions.

Anyways, this wasn't really hard to put together in the end.
What took me a while actually was that one can't use `tokio::sync::oneshot`
from a `Fn` (needed in `cancellable_connect()` and instead we need
to use this notify thingy that's threadsafe/`Send` etc.).

---

