### PR TITLE
client: Use `--no-pager` for `systemctl status`

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -158,7 +158,7 @@ pub(crate) fn client_start_daemon() -> CxxResult<()> {
         .status()?;
     if !res.success() {
         let _ = Command::new("systemctl")
-            .args(&["status", service])
+            .args(&["--no-pager", "status", service])
             .status();
         return Err(anyhow!("{}", res).into());
     }


### PR DESCRIPTION
I noticed in gnome-terminal at the default tiny 80x24 size, when
we hit this case `systemctl` will spawn a pager because the status
is too long.  This is confusing and unexpected - I have learned
`systemctl` and `journalctl` may (for the latter, usually) spawn a pager
but I don't expect it from random commands like this.
