### PR TITLE
rust: Drop use of ostree-rs-ext VariantDictExt, bump glib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "gio"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c6823b39d46d22cac2466de261f28d7f049ebc18f7b35296a42c7ed8a88325"
+checksum = "402a7057cd21d64bfa7ac027b344a7f50f677fb3308693df0e8c70fb55d29f0d"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbecad7a3a898ee749d491ce2ae0decb0bce9e736f9747bc49159b1cea5d37f4"
+checksum = "a8fb802e3798d75b415bea8f016eed88d50106ce82f1274e80f31d80cfd4b056"
 dependencies = [
  "bitflags",
  "futures-channel",

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -8,7 +8,6 @@ use crate::cxxrsutil::*;
 use anyhow::Result;
 use glib::prelude::*;
 use openat_ext::OpenatDirExt;
-use ostree_ext::variant_utils::VariantDictExt;
 use ostree_ext::{glib, ostree};
 use std::collections::BTreeMap;
 use std::pin::Pin;
@@ -202,7 +201,8 @@ pub(crate) fn deployment_layeredmeta_from_commit(
     // realistically will always be TRUE). For older versions, we just
     // rely on the treespec being present. */
     let is_layered = dict
-        .lookup_bool("rpmostree.clientlayer")
+        .lookup("rpmostree.clientlayer")
+        .map_err(anyhow::Error::msg)?
         .unwrap_or_else(|| dict.contains("rpmostree.spec"));
     if !is_layered {
         Ok(crate::ffi::DeploymentLayeredMeta {


### PR DESCRIPTION
In favor of the new upstream API methods.  A bit less ergonomic
since we need to `map_err()`, but I think this is cleaner.
