### PR TITLE
override replace: add experimental options

### DIFF
--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -402,6 +402,7 @@
     <method name="DownloadPackages">
       <!-- array of package names -->
       <arg type="as" name="queries" direction="in"/>
+      <arg type="s" name="source" direction="in"/>
       <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
     </method>
   </interface>

--- a/src/libpriv/rpmostree-types.h
+++ b/src/libpriv/rpmostree-types.h
@@ -43,6 +43,10 @@ typedef enum {
   RPM_OSTREE_ADVISORY_SEVERITY_LAST,
 } RpmOstreeAdvisorySeverity;
 
+typedef enum {
+  RPM_OSTREE_OVERRIDE_SOURCE_KIND_REPO,
+} RpmOstreeOverrideSourceKind;
+
 /**
  * RPMOSTREE_DIFF_SINGLE_GVARIANT_FORMAT:
  *

--- a/src/libpriv/rpmostree-util.cxx
+++ b/src/libpriv/rpmostree-util.cxx
@@ -1186,3 +1186,24 @@ rpmostree_cxx_string_vec_to_strv (rust::Vec<rust::String> &v)
   g_ptr_array_add (r, NULL);
   return (char**)g_ptr_array_free (util::move_nullify(r), FALSE);
 }
+
+/* Take a KIND=NAME string and returns the kind of kind side and
++ * errors if the source type is unsupported */
+char*
+rpmostree_parse_override_source (const char *source,
+                                 RpmOstreeOverrideSourceKind *out_source_kind,
+                                 GError **error)
+{
+  const char *eq = strchr (source, '=');
+  if (!eq)
+    return (char*)glnx_null_throw (error, "Missing '=' in KIND=NAME source '%s'", source);
+  g_autofree char * source_kind = g_strndup (source, eq - source);
+  if (g_str_equal (source_kind, "repo"))
+    *out_source_kind = RPM_OSTREE_OVERRIDE_SOURCE_KIND_REPO;
+/* Place for future supported sources */
+  else
+    return (char*)glnx_null_throw (error, "Unsupported source type: %s", source_kind);
+  if (strlen (eq + 1) <= 0)
+    return (char*)glnx_null_throw (error, "Missing 'NAME' in KIND=NAME source '%s'", source);
+  return g_strdup (eq + 1);
+}

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -371,4 +371,8 @@ rpmostree_cxx_string_vec_to_strv (rust::Vec<rust::String> &v);
 void 
 rpmostreed_utils_tests (void);
 
+char*
+rpmostree_parse_override_source (const char *source,
+                                 RpmOstreeOverrideSourceKind *out_source_kind,
+                                 GError **error);
 G_END_DECLS

--- a/tests/kolainst/destructive/override-pinning
+++ b/tests/kolainst/destructive/override-pinning
@@ -39,7 +39,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
 rpmostree_assert_status \
   '.deployments[0]["base-local-replacements"]|length == 0' \
   '.deployments[0]["requested-base-local-replacements"]|length == 0'
-rpm-ostree override replace zincati --ex-pin-from-repos
+rpm-ostree override replace zincati --experimental --freeze --from repo=test-repo
 rpm-ostree status > status.txt
 assert_file_has_content status.txt 'ReplacedBasePackages: zincati .* -> 99.99-3'
 rpmostree_assert_status \


### PR DESCRIPTION
`override replace --experimental` allows experimental options from and
freeze.
`override replace --from` query and fetch for the lastest version of
a package from specified repo, instead of just enabled repos.
`override replace --freeze` pin the overrided package avoiding updates.
Adapt `ex-pin-from-repos` syntax to `--experimental --freeze`

Signed-off-by: Rafael G. Ruiz <llerrak@hotmail.com>
