### PR TITLE
extensions: support enabling/installing modules

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -30,6 +30,17 @@ extension packages and places them in an output directory.
 The format of the `extensions.yaml` file is as follow:
 
 ```yaml
+# Any additional repos to enable on top of treefile repos
+repos:
+  - myrepo
+
+# Any modules to enable/install
+modules:
+  enable:
+    - foo:bar
+  install:
+    - baz:boo/default
+
 # The top-level object is a dict. The only supported key
 # right now is `extensions`, which is a dict of extension
 # names to extension objects.

--- a/rust/src/extensions.rs
+++ b/rust/src/extensions.rs
@@ -25,6 +25,8 @@ pub struct Extensions {
     extensions: HashMap<String, Extension>,
     #[serde(skip_serializing_if = "Option::is_none")]
     repos: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    modules: Option<crate::treefile::ModulesConfig>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -162,6 +164,7 @@ impl Extensions {
             repos: Some(repos),
             packages: Some(self.get_os_extension_packages()),
             releasever: src.parsed.releasever.clone(),
+            modules: self.modules.clone(),
             ..Default::default()
         };
         Ok(Box::new(Treefile::new_from_config(ret, None)?))

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1290,7 +1290,7 @@ pub(crate) struct RepoPackage {
     pub(crate) packages: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq, Clone)]
 pub(crate) struct ModulesConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) enable: Option<Vec<String>>,


### PR DESCRIPTION
Fix that gap now since RHCOS does use modular packages in its
extensions. This ended up being easier than I thought because we're just
converting to a treefile underneath.