### PR TITLE
rust: Fix clippy lint for extra `&`

### DIFF
--- a/rust/src/cliwrap.rs
+++ b/rust/src/cliwrap.rs
@@ -55,10 +55,10 @@ pub fn entrypoint(args: &[&str]) -> Result<()> {
         Ok(cliutil::exec_real_binary(name, &args)?)
     } else {
         match name {
-            "rpm" => Ok(self::rpm::main(&args)?),
-            "yum" | "dnf" => Ok(self::yumdnf::main(&args)?),
-            "dracut" => Ok(self::dracut::main(&args)?),
-            "grubby" => Ok(self::grubby::main(&args)?),
+            "rpm" => Ok(self::rpm::main(args)?),
+            "yum" | "dnf" => Ok(self::yumdnf::main(args)?),
+            "dracut" => Ok(self::dracut::main(args)?),
+            "grubby" => Ok(self::grubby::main(args)?),
             _ => Err(anyhow!("Unknown wrapped binary: {}", name).into()),
         }
     }

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -428,9 +428,9 @@ pub fn compose_postprocess(
     }
 
     compose_postprocess_rpmdb(rootfs_dfd)?;
-    compose_postprocess_units(&rootfs_dfd, treefile)?;
+    compose_postprocess_units(rootfs_dfd, treefile)?;
     if let Some(t) = treefile.parsed.default_target.as_deref() {
-        compose_postprocess_default_target(&rootfs_dfd, t)?;
+        compose_postprocess_default_target(rootfs_dfd, t)?;
     }
 
     treefile.write_compose_json(rootfs_dfd)?;
@@ -636,7 +636,7 @@ fn var_to_tmpfiles(rootfs: &openat::Dir, cancellable: Option<&gio::Cancellable>)
         0o644,
         |bufwr| -> Result<()> {
             let mut prefix = "var".to_string();
-            convert_path_to_tmpfiles_d_recurse(bufwr, &pwdb, &rootfs, &mut prefix, &cancellable)
+            convert_path_to_tmpfiles_d_recurse(bufwr, &pwdb, rootfs, &mut prefix, &cancellable)
                 .with_context(|| format!("Analyzing /{} content", prefix))?;
             Ok(())
         },

--- a/rust/src/countme.rs
+++ b/rust/src/countme.rs
@@ -24,8 +24,8 @@ fn send_countme(url: &str, ua: &str) -> Result<()> {
     let mut handle = Easy::new();
     handle.follow_location(true)?;
     handle.fail_on_error(true)?;
-    handle.url(&url)?;
-    handle.useragent(&ua)?;
+    handle.url(url)?;
+    handle.useragent(ua)?;
     {
         let mut transfer = handle.transfer();
         transfer.write_function(|new_data| Ok(new_data.len()))?;

--- a/rust/src/countme/repo.rs
+++ b/rust/src/countme/repo.rs
@@ -99,7 +99,7 @@ impl Repo {
     pub fn metalink(&self, version_id: &str) -> String {
         self.meta_link
             .clone()
-            .replace("$releasever", &version_id)
+            .replace("$releasever", version_id)
             .replace("$basearch", &utils::get_rpm_basearch())
     }
 }

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -77,33 +77,33 @@ fn deployment_populate_variant_origin(
 ) -> Result<()> {
     // Convert the origin to a treefile, and operate on that.
     // See https://github.com/coreos/rpm-ostree/issues/2326
-    let tf = crate::origin::origin_to_treefile_inner(&origin)?;
+    let tf = crate::origin::origin_to_treefile_inner(origin)?;
     let tf = &tf.parsed;
 
     // Package mappings.  Note these are inserted unconditionally, even if empty.
-    vdict_insert_optvec(&dict, "requested-packages", tf.packages.as_ref());
+    vdict_insert_optvec(dict, "requested-packages", tf.packages.as_ref());
     vdict_insert_optvec(
-        &dict,
+        dict,
         "requested-modules",
         tf.modules.as_ref().map(|m| m.install.as_ref()).flatten(),
     );
     vdict_insert_optvec(
-        &dict,
+        dict,
         "modules-enabled",
         tf.modules.as_ref().map(|m| m.enable.as_ref()).flatten(),
     );
     vdict_insert_optmap(
-        &dict,
+        dict,
         "requested-local-packages",
         tf.derive.packages_local.as_ref(),
     );
     vdict_insert_optvec(
-        &dict,
+        dict,
         "requested-base-removals",
         tf.derive.override_remove.as_ref(),
     );
     vdict_insert_optmap(
-        &dict,
+        dict,
         "requested-base-local-replacements",
         tf.derive.override_replace_local.as_ref(),
     );

--- a/rust/src/history.rs
+++ b/rust/src/history.rs
@@ -295,8 +295,8 @@ impl HistoryCtx {
     /// Returns a marker of the appropriate kind for a given journal message.
     fn record_to_marker(&self, record: &JournalRecord) -> Result<Option<Marker>> {
         Ok(match record.get("MESSAGE_ID").unwrap() {
-            m if m == OSTREE_BOOT_MSG => self.boot_record_to_marker(&record)?,
-            m if m == RPMOSTREE_DEPLOY_MSG => self.deployment_record_to_marker(&record)?,
+            m if m == OSTREE_BOOT_MSG => self.boot_record_to_marker(record)?,
+            m if m == RPMOSTREE_DEPLOY_MSG => self.deployment_record_to_marker(record)?,
             m => panic!("matched an unwanted message: {:?}", m),
         })
     }

--- a/rust/src/initramfs.rs
+++ b/rust/src/initramfs.rs
@@ -38,7 +38,7 @@ fn list_files_recurse<P: glib::IsA<gio::Cancellable>>(
                 let e = e.context("readdir")?;
                 let name: &Utf8Path = Path::new(e.file_name()).try_into()?;
                 let subpath = format!("{}/{}", path, name);
-                list_files_recurse(&d, &subpath, filelist, cancellable)?;
+                list_files_recurse(d, &subpath, filelist, cancellable)?;
             }
         }
         _ => anyhow::bail!("Invalid non-regfile/symlink/directory: {}", path),
@@ -79,7 +79,7 @@ fn gather_filelist<P: glib::IsA<gio::Cancellable>>(
             }
         }
 
-        list_files_recurse(&d, file, &mut filelist, cancellable)
+        list_files_recurse(d, file, &mut filelist, cancellable)
             .with_context(|| format!("Adding {}", file))?;
     }
     Ok(filelist)

--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -139,13 +139,13 @@ fn apply_diff(
     };
     // Check out new directories and files
     for d in diff.added_dirs.iter().map(Path::new) {
-        opts.subpath = subpath(diff, &d);
+        opts.subpath = subpath(diff, d);
         let t = d.strip_prefix("/")?;
         repo.checkout_at(Some(&opts), destdir.as_raw_fd(), t, commit, cancellable)
             .with_context(|| format!("Checking out added dir {:?}", d))?;
     }
     for d in diff.added_files.iter().map(Path::new) {
-        opts.subpath = subpath(diff, &d);
+        opts.subpath = subpath(diff, d);
         repo.checkout_at(
             Some(&opts),
             destdir.as_raw_fd(),
@@ -157,7 +157,7 @@ fn apply_diff(
     }
     // Changed files in existing directories
     for d in diff.changed_files.iter().map(Path::new) {
-        opts.subpath = subpath(diff, &d);
+        opts.subpath = subpath(diff, d);
         repo.checkout_at(
             Some(&opts),
             destdir.as_raw_fd(),
@@ -464,7 +464,7 @@ pub(crate) fn transaction_apply_live(
 
     // Record that we're targeting this commit
     state.inprogress = target_commit.to_string();
-    write_live_state(&repo, &booted, &state)?;
+    write_live_state(repo, &booted, &state)?;
 
     // Gather the current diff of /etc - we need to avoid changing
     // any files which are locally modified.
@@ -496,7 +496,7 @@ pub(crate) fn transaction_apply_live(
     // Success! Update the recorded state.
     state.commit = target_commit.to_string();
     state.inprogress = "".to_string();
-    write_live_state(&repo, &booted, &state)?;
+    write_live_state(repo, &booted, &state)?;
 
     Ok(())
 }
@@ -514,13 +514,13 @@ pub(crate) fn applylive_sync_ref(
     } else {
         return Ok(());
     };
-    if get_live_state(&repo, &booted)?.is_some() {
+    if get_live_state(repo, &booted)?.is_some() {
         return Ok(());
     }
 
     // Set the live state to empty
     let state = Default::default();
-    write_live_state(&repo, &booted, &state).context("apply-live: failed to write state")?;
+    write_live_state(repo, &booted, &state).context("apply-live: failed to write state")?;
     Ok(())
 }
 
@@ -546,7 +546,7 @@ pub(crate) fn get_live_apply_state(
     let sysroot = sysroot.gobj_wrap();
     let deployment = deployment.gobj_wrap();
     let repo = &sysroot.repo().unwrap();
-    if let Some(state) = get_live_state(&repo, &deployment)? {
+    if let Some(state) = get_live_state(repo, &deployment)? {
         Ok(state)
     } else {
         Ok(Default::default())

--- a/rust/src/lockfile.rs
+++ b/rust/src/lockfile.rs
@@ -342,7 +342,7 @@ mod tests {
 }
 
 pub(crate) fn lockfile_read(filenames: &Vec<String>) -> CxxResult<Box<LockfileConfig>> {
-    Ok(Box::new(lockfile_parse_multiple(&filenames)?))
+    Ok(Box::new(lockfile_parse_multiple(filenames)?))
 }
 
 pub(crate) fn lockfile_write(

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -32,29 +32,29 @@ static UNORDERED_LIST_KEYS: phf::Set<&'static str> = phf::phf_set! {
 #[context("Parsing origin")]
 pub(crate) fn origin_to_treefile_inner(kf: &KeyFile) -> Result<Box<Treefile>> {
     let mut cfg: crate::treefile::TreeComposeConfig = Default::default();
-    let refspec_str = if let Some(r) = keyfile_get_optional_string(&kf, ORIGIN, "refspec")? {
+    let refspec_str = if let Some(r) = keyfile_get_optional_string(kf, ORIGIN, "refspec")? {
         Some(r)
-    } else if let Some(r) = keyfile_get_optional_string(&kf, ORIGIN, "baserefspec")? {
+    } else if let Some(r) = keyfile_get_optional_string(kf, ORIGIN, "baserefspec")? {
         Some(r)
     } else {
-        keyfile_get_optional_string(&kf, ORIGIN, "container-image-reference")?
+        keyfile_get_optional_string(kf, ORIGIN, "container-image-reference")?
     };
     let refspec_str = refspec_str.ok_or_else(|| {
         anyhow::anyhow!("Failed to find refspec/baserefspec/container-image-reference in origin")
     })?;
     cfg.derive.base_refspec = Some(refspec_str);
-    cfg.packages = parse_stringlist(&kf, PACKAGES, "requested")?;
-    cfg.derive.packages_local = parse_localpkglist(&kf, PACKAGES, "requested-local")?;
-    let modules_enable = parse_stringlist(&kf, MODULES, "enable")?;
-    let modules_install = parse_stringlist(&kf, MODULES, "install")?;
+    cfg.packages = parse_stringlist(kf, PACKAGES, "requested")?;
+    cfg.derive.packages_local = parse_localpkglist(kf, PACKAGES, "requested-local")?;
+    let modules_enable = parse_stringlist(kf, MODULES, "enable")?;
+    let modules_install = parse_stringlist(kf, MODULES, "install")?;
     if modules_enable.is_some() || modules_install.is_some() {
         cfg.modules = Some(crate::treefile::ModulesConfig {
             enable: modules_enable,
             install: modules_install,
         });
     }
-    cfg.derive.override_remove = parse_stringlist(&kf, OVERRIDES, "remove")?;
-    cfg.derive.override_replace_local = parse_localpkglist(&kf, OVERRIDES, "replace-local")?;
+    cfg.derive.override_remove = parse_stringlist(kf, OVERRIDES, "remove")?;
+    cfg.derive.override_replace_local = parse_localpkglist(kf, OVERRIDES, "replace-local")?;
 
     let regenerate_initramfs = kf
         .boolean(RPMOSTREE, "regenerate-initramfs")
@@ -70,8 +70,8 @@ pub(crate) fn origin_to_treefile_inner(kf: &KeyFile) -> Result<Box<Treefile>> {
         cfg.derive.initramfs = Some(initramfs);
     }
 
-    if let Some(url) = keyfile_get_optional_string(&kf, ORIGIN, "custom-url")? {
-        let description = keyfile_get_optional_string(&kf, ORIGIN, "custom-description")?;
+    if let Some(url) = keyfile_get_optional_string(kf, ORIGIN, "custom-url")? {
+        let description = keyfile_get_optional_string(kf, ORIGIN, "custom-description")?;
         cfg.derive.custom = Some(crate::treefile::DeriveCustom { url, description })
     }
 

--- a/rust/src/passwd.rs
+++ b/rust/src/passwd.rs
@@ -344,7 +344,7 @@ fn data_from_json(
             CheckPasswd::File(cfg) => cfg,
             _ => return Ok(false),
         };
-        treefile.externals.passwd_file_mut(&check_passwd_file)?
+        treefile.externals.passwd_file_mut(check_passwd_file)?
     } else if target == "group" {
         let check_groups_file = match treefile.parsed.get_check_groups() {
             CheckGroups::File(cfg) => cfg,

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -199,9 +199,7 @@ fn take_archful_pkgs(
     }
 
     // and drop it from the map
-    treefile
-        .extra
-        .retain(|ref k, _| !k.starts_with("packages-"));
+    treefile.extra.retain(|k, _| !k.starts_with("packages-"));
 
     Ok(archful_pkgs)
 }
@@ -249,7 +247,7 @@ fn treefile_parse<P: AsRef<Path>>(
         None
     };
     let mut add_files: BTreeMap<String, fs::File> = BTreeMap::new();
-    if let Some(ref add_file_names) = tf.add_files.as_ref() {
+    if let Some(add_file_names) = tf.add_files.as_ref() {
         for (name, _) in add_file_names.iter() {
             add_files.insert(
                 name.clone(),
@@ -749,7 +747,7 @@ impl Treefile {
         // check add-files
         if let Some(files) = &config.add_files {
             for (_, dest) in files.iter() {
-                if !add_files_path_is_valid(&dest) {
+                if !add_files_path_is_valid(dest) {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidInput,
                         format!("Unsupported path in add-files: {}", dest),


### PR DESCRIPTION
Tempting to just allow this tree wide since it's harmless, but
fixing this isn't too hard and helps us see the actually important
clippy lints/errors.
