### PR TITLE
Fix remaining clippy lints

### DIFF
--- a/rust/src/builtins/compose/mod.rs
+++ b/rust/src/builtins/compose/mod.rs
@@ -53,7 +53,8 @@ fn legacy_prepare_dev(rootfs: &openat::Dir) -> Result<()> {
 fn smoketest_dev_null(devdir: &openat::Dir) -> Result<()> {
     let mut devnull = devdir.open_file("null")?;
     let mut buf = [0u8];
-    devnull.read(&mut buf)?;
+    let n = devnull.read(&mut buf)?;
+    assert_eq!(n, 0);
     Ok(())
 }
 

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -128,11 +128,9 @@ pub(crate) fn client_handle_fd_argument(arg: &str, arch: &str) -> CxxResult<Vec<
     if is_http_arg(arg) {
         Ok(utils::download_url_to_tmpfile(arg, true).map(|f| vec![f.into_raw_fd()])?)
     } else if is_rpm_arg(arg) {
-        if arg.starts_with("file://") {
-            let formatted_arg: &str = &arg[7..];
-            Ok(vec![std::fs::File::open(formatted_arg)?.into_raw_fd()])
-        } else {
-            Ok(vec![std::fs::File::open(arg)?.into_raw_fd()])
+        match arg.strip_prefix("file://") {
+            Some(rest) => Ok(vec![std::fs::File::open(rest)?.into_raw_fd()]),
+            None => Ok(vec![std::fs::File::open(arg)?.into_raw_fd()]),
         }
     } else {
         Ok(Vec::new())

--- a/rust/src/cliwrap.rs
+++ b/rust/src/cliwrap.rs
@@ -42,7 +42,7 @@ pub fn entrypoint(args: &[&str]) -> Result<()> {
     let name = args[0];
     let name = match std::path::Path::new(name).file_name() {
         Some(name) => name,
-        None => return Err(anyhow!("Invalid wrapped binary: {}", name).into()),
+        None => return Err(anyhow!("Invalid wrapped binary: {}", name)),
     };
     // We know we had a string from above
     let name = name.to_str().unwrap();
@@ -52,14 +52,14 @@ pub fn entrypoint(args: &[&str]) -> Result<()> {
 
     // If we're not booted into ostree, just run the child directly.
     if !cliutil::is_ostree_booted() {
-        Ok(cliutil::exec_real_binary(name, &args)?)
+        Ok(cliutil::exec_real_binary(name, args)?)
     } else {
         match name {
             "rpm" => Ok(self::rpm::main(args)?),
             "yum" | "dnf" => Ok(self::yumdnf::main(args)?),
             "dracut" => Ok(self::dracut::main(args)?),
             "grubby" => Ok(self::grubby::main(args)?),
-            _ => Err(anyhow!("Unknown wrapped binary: {}", name).into()),
+            _ => Err(anyhow!("Unknown wrapped binary: {}", name)),
         }
     }
 }

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -197,7 +197,7 @@ fn postprocess_rpm_macro(rootfs_dfd: &openat::Dir) -> Result<()> {
     rpm_macros_dfd.write_file_with(&MACRO_FILENAME, 0o644, |w| -> Result<()> {
         w.write_all(b"%_dbpath /")?;
         w.write_all(RPMOSTREE_RPMDB_LOCATION.as_bytes())?;
-        w.write(b"\n")?;
+        w.write_all(b"\n")?;
         Ok(())
     })?;
     rpm_macros_dfd.set_mode(MACRO_FILENAME, 0o644)?;

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -61,11 +61,7 @@ fn vdict_insert_optvec(dict: &glib::VariantDict, k: &str, v: Option<&Vec<String>
 }
 
 /// Insert keys from the provided map into the target `dict` with key `k`.
-fn vdict_insert_optmap(
-    dict: &glib::VariantDict,
-    k: &str,
-    v: Option<&BTreeMap<String, String>>,
-) {
+fn vdict_insert_optmap(dict: &glib::VariantDict, k: &str, v: Option<&BTreeMap<String, String>>) {
     let v = v.iter().map(|s| s.keys()).flatten().map(|s| s.as_str());
     vdict_insert_strv(dict, k, v);
 }

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -55,13 +55,13 @@ fn vdict_insert_strv<'a>(dict: &glib::VariantDict, k: &str, v: impl IntoIterator
 }
 
 /// Insert values from `v` into the target `dict` with key `k`.
-fn vdict_insert_optvec<'a>(dict: &glib::VariantDict, k: &str, v: Option<&Vec<String>>) {
+fn vdict_insert_optvec(dict: &glib::VariantDict, k: &str, v: Option<&Vec<String>>) {
     let v = v.iter().map(|s| s.iter()).flatten().map(|s| s.as_str());
     vdict_insert_strv(dict, k, v);
 }
 
 /// Insert keys from the provided map into the target `dict` with key `k`.
-fn vdict_insert_optmap<'a>(
+fn vdict_insert_optmap(
     dict: &glib::VariantDict,
     k: &str,
     v: Option<&BTreeMap<String, String>>,

--- a/rust/src/extensions.rs
+++ b/rust/src/extensions.rs
@@ -159,7 +159,7 @@ impl Extensions {
     /// Create a treefile representing just what needs to be installed for extensions.
     pub(crate) fn generate_treefile(&self, src: &Treefile) -> CxxResult<Box<Treefile>> {
         let mut repos = src.parsed.repos.clone().unwrap_or_default();
-        repos.extend(self.repos.iter().flatten().map(|s| s.clone()));
+        repos.extend(self.repos.iter().flatten().cloned());
         let ret = TreeComposeConfig {
             repos: Some(repos),
             packages: Some(self.get_os_extension_packages()),

--- a/rust/src/fedora_integration.rs
+++ b/rust/src/fedora_integration.rs
@@ -97,10 +97,7 @@ mod koji {
         }
     }
 
-    fn xmlrpc_require_str(
-        val: &BTreeMap<String, Value>,
-        k: impl AsRef<str>,
-    ) -> Result<&str> {
+    fn xmlrpc_require_str(val: &BTreeMap<String, Value>, k: impl AsRef<str>) -> Result<&str> {
         let k = k.as_ref();
         let s = val.get(k).ok_or_else(|| anyhow!("Missing key {}", k))?;
         s.as_str()

--- a/rust/src/fedora_integration.rs
+++ b/rust/src/fedora_integration.rs
@@ -97,14 +97,14 @@ mod koji {
         }
     }
 
-    fn xmlrpc_require_str<'a>(
-        val: &'a BTreeMap<String, Value>,
+    fn xmlrpc_require_str(
+        val: &BTreeMap<String, Value>,
         k: impl AsRef<str>,
-    ) -> Result<&'a str> {
+    ) -> Result<&str> {
         let k = k.as_ref();
         let s = val.get(k).ok_or_else(|| anyhow!("Missing key {}", k))?;
-        Ok(s.as_str()
-            .ok_or_else(|| anyhow!("Key {} is not a string", k))?)
+        s.as_str()
+            .ok_or_else(|| anyhow!("Key {} is not a string", k))
     }
 
     pub(crate) fn rpm_path_from_koji_rpm(

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -24,6 +24,7 @@ pub(crate) use cxxrsutil::*;
 /// - While the return type here will be `Result<T>` on the implementation
 ///   side you currently *should* use `CxxResult`; see the docs of that for more information.
 #[cxx::bridge(namespace = "rpmostreecxx")]
+#[allow(clippy::needless_lifetimes)]
 pub mod ffi {
     // Types that are defined by gtk-rs generated bindings that
     // we want to pass across the cxx-rs boundary.  For more

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -579,6 +579,7 @@ pub mod ffi {
         include!("rpmostree-libbuiltin.h");
         include!("rpmostree-util.h");
         type RpmOstreeDiffPrintFormat;
+        /// # Safety: ensure @cancellable is a valid pointer
         unsafe fn print_treepkg_diff_from_sysroot_path(
             sysroot_path: &str,
             format: RpmOstreeDiffPrintFormat,

--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -175,7 +175,7 @@ fn apply_diff(
         .par_iter()
         .chain(diff.removed_dirs.par_iter())
         .try_for_each(|d| -> Result<()> {
-            let d = d.strip_prefix("/").expect("prefix");
+            let d = d.strip_prefix('/').expect("prefix");
             destdir
                 .remove_all(d)
                 .with_context(|| format!("Failed to remove {:?}", d))?;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -33,14 +33,14 @@ async fn inner_async_main(args: &[&str]) -> Result<i32> {
     // main().
     match args.get(1).copied() {
         // Add custom Rust commands here, and also in `libmain.cxx` if user-visible.
-        Some("countme") => rpmostree_rust::countme::entrypoint(&args).map(|_| 0),
-        Some("cliwrap") => rpmostree_rust::cliwrap::entrypoint(&args).map(|_| 0),
-        Some("ex-container") => rpmostree_rust::container::entrypoint(&args).await,
+        Some("countme") => rpmostree_rust::countme::entrypoint(args).map(|_| 0),
+        Some("cliwrap") => rpmostree_rust::cliwrap::entrypoint(args).map(|_| 0),
+        Some("ex-container") => rpmostree_rust::container::entrypoint(args).await,
         // The `unlock` is a hidden alias for "ostree CLI compatibility"
-        Some("usroverlay") | Some("unlock") => usroverlay(&args).map(|_| 0),
+        Some("usroverlay") | Some("unlock") => usroverlay(args).map(|_| 0),
         _ => {
             // Otherwise fall through to C++ main().
-            Ok(rpmostree_rust::ffi::rpmostree_main(&args)?)
+            Ok(rpmostree_rust::ffi::rpmostree_main(args)?)
         }
     }
 }
@@ -70,7 +70,6 @@ fn inner_main() -> Result<i32> {
         .map(|s| -> Result<String> {
             s.into_string()
                 .map_err(|s| anyhow::anyhow!("Argument is invalid UTF-8: {}", s.to_string_lossy()))
-                .into()
         })
         .collect();
     let args = args?;

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -122,7 +122,7 @@ fn set_sha256_nevra_pkgs(
         .map(|(nevra, sha256)| format!("{}:{}", sha256, nevra))
         .collect();
     let pkgs = pkgs.iter().map(|s| s.as_str());
-    kf_set_string_list(&kf, group, k, pkgs)
+    kf_set_string_list(kf, group, k, pkgs)
 }
 
 /// Convert a treefile to an origin file.
@@ -270,9 +270,9 @@ fn origin_validate_roundtrip_inner(kf: &glib::KeyFile) -> Result<()> {
 /// is understood by the core.
 pub(crate) fn origin_validate_roundtrip(mut kf: Pin<&mut crate::ffi::GKeyFile>) {
     let kf = kf.gobj_wrap();
-    origin_validate_roundtrip_inner(&kf).err().map(|e| {
+    if let Some(e) = origin_validate_roundtrip_inner(&kf).err() {
         tracing::debug!("Failed to roundtrip origin: {}", e);
-    });
+    }
 }
 
 fn map_keyfile_optional<T>(res: StdResult<T, glib::Error>) -> StdResult<Option<T>, glib::Error> {

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1453,7 +1453,7 @@ impl TreeComposeConfig {
 
     // we need to ensure that appended repo packages override earlier ones
     fn handle_repo_packages_overrides(&mut self) {
-        self.repo_packages.as_mut().map(|repo_packages| {
+        if let Some(repo_packages) = self.repo_packages.as_mut() {
             let mut seen_pkgs: HashSet<String> = HashSet::new();
             // Create a temporary new filtered vec; see
             // https://doc.rust-lang.org/std/iter/struct.Map.html#notes-about-side-effects for why
@@ -1470,7 +1470,7 @@ impl TreeComposeConfig {
             // Now replace the original, re-reversing.
             v.reverse();
             *repo_packages = v;
-        });
+        }
     }
 }
 

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -460,6 +460,7 @@ pub(crate) fn varsubstitute(s: &str, subs: &Vec<crate::ffi::StringMapping>) -> C
     Ok(varsubst(s, &m)?)
 }
 
+#[allow(clippy::vec_init_then_push)]
 pub(crate) fn get_features() -> Vec<String> {
     let mut r = Vec::new();
     #[cfg(feature = "fedora-integration")]

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -134,22 +134,22 @@ pub(crate) fn download_urls_to_tmpfiles<S: AsRef<str>>(
 
 /// Open file for reading and provide context containing filename on failures.
 pub fn open_file<P: AsRef<Path>>(filename: P) -> Result<fs::File> {
-    Ok(fs::File::open(filename.as_ref()).with_context(|| {
+    fs::File::open(filename.as_ref()).with_context(|| {
         format!(
             "Can't open file {:?} for reading",
             filename.as_ref().display()
         )
-    })?)
+    })
 }
 
 /// Open file for writing and provide context containing filename on failures.
 pub fn create_file<P: AsRef<Path>>(filename: P) -> Result<fs::File> {
-    Ok(fs::File::create(filename.as_ref()).with_context(|| {
+    fs::File::create(filename.as_ref()).with_context(|| {
         format!(
             "Can't open file {:?} for writing",
             filename.as_ref().display()
         )
-    })?)
+    })
 }
 
 // Surprising we need a wrapper for this... parent() returns a slice of its buffer, so doesn't


### PR DESCRIPTION
rust: Fix misc clippy lints

No major problems here.

---

rust: Fix two clippy errors

These are marked as errors, and while they're not important bugs
let's fix them.

---

rust: Fix more clippy lints

All low priority stuff

---

rust: Allow a few clippy lints

I think the vec pattern is fine.  And we want lifetimes in the cxxrs code.

---

rust: Fix a clippy lint about manual `strip_prefix()`

Man, clippy is smart.

---

