### PR TITLE
tests/kolainst: Check layering of `cri-o:1.20/default`

### DIFF
--- a/tests/kolainst/destructive/layering-modules
+++ b/tests/kolainst/destructive/layering-modules
@@ -1,10 +1,15 @@
 #!/bin/bash
+# kola: { "tags": "needs-internet" }
 set -euo pipefail
 
 . ${KOLA_EXT_DATA}/libtest.sh
 cd $(mktemp -d)
 
 set -x
+
+# Let's start by trying to install a bona fide module.
+rpm-ostree ex module install cri-o:1.20/default
+rpm-ostree cleanup -p
 
 rm -rf /etc/yum.repos.d/*
 cat > /etc/yum.repos.d/vmcheck.repo << EOF


### PR DESCRIPTION
That way we exercise the modular bits with a real module instead of only
the synthetic ones we create. `cri-o` is of special relevance for FCOS
so choose that.