### PR TITLE
Bump to ostree-rs-ext 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "ostree"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f621aa3457c7013e3bead2a9b24c9b0682bc4ddd1a1f8fcbddc681dbe1abfeea"
+checksum = "9358905170a49b82e5baecb879bb944c42736a4b02074a40286a7b20665af381"
 dependencies = [
  "bitflags",
  "gio",
@@ -1325,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "ostree-ext"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c271372230d01abd9b6b7862af4ef41c83c0344b436ce74822e953f381af6679"
+checksum = "f1e40c1a1b52ed5164b0fda610952438afff5162ff2dafa49e55c0a78698228d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1335,11 +1335,12 @@ dependencies = [
  "cjson",
  "flate2",
  "fn-error-context",
- "futures",
+ "futures-util",
  "gvariant",
  "hex",
  "indicatif",
  "libc",
+ "maplit",
  "nix",
  "openat",
  "openat-ext",
@@ -1359,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "ostree-sys"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bab9f0db43a053737bd575364a25f930bc46b24a367965a4671c13ec8dc4744"
+checksum = "46755b75b81ac66623ee86d6eee779a82acf495a8a6a94ab458a96ad3e6880d1"
 dependencies = [
  "gio-sys",
  "glib-sys",
@@ -1835,7 +1836,6 @@ dependencies = [
  "openat-ext",
  "os-release",
  "ostree-ext",
- "ostree-sys",
  "paste",
  "phf 0.10.0",
  "rand 0.8.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,10 @@
 [package]
 name = "rpmostree-rust"
 version = "0.1.0"
-authors = ["Colin Walters <walters@verbum.org>", "Jonathan Lebon <jonathan@jlebon.com>"]
+authors = [
+    "Colin Walters <walters@verbum.org>",
+    "Jonathan Lebon <jonathan@jlebon.com>",
+]
 edition = "2018"
 # See https://rust-lang.github.io/rfcs/2495-min-rust-version.html
 # Usually, we try to keep this to no newer than current RHEL8 rust-toolset version.
@@ -48,8 +51,7 @@ nix = "0.22.1"
 openat = "0.1.21"
 openat-ext = "^0.2.2"
 os-release = "0.1.0"
-ostree-sys = "0.8.2"
-ostree-ext = "0.2.2"
+ostree-ext = "0.3.0"
 paste = "1.0"
 phf = { version = "0.10", features = ["macros"] }
 rand = "0.8.4"

--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -98,7 +98,7 @@ macro_rules! cxxrs_bind {
 cxxrs_bind!(
     Ostree,
     ostree,
-    ostree_sys,
+    ostree::ffi,
     [Deployment, Repo, RepoTransactionStats, Sysroot]
 );
 cxxrs_bind!(G, glib, glib::gobject_ffi, [Object]);

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -27,15 +27,16 @@ libtest_prepare_offline
 cd $(mktemp -d)
 
 image=containers-storage:localhost/fcos:latest
+image_pull=ostree-unverified-image:$image
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "")
     # Test rebase
     checksum=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
-    rpm-ostree ex-container export --repo=/ostree/repo ${checksum} containers-storage:localhost/fcos
-    rpm-ostree rebase "$image" --experimental | tee out.txt
-    assert_file_has_content_literal out.txt 'Pulling: '"$image"
-    rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"containers-storage:localhost/fcos:latest\""
+    rpm-ostree ex-container export --repo=/ostree/repo ${checksum} "${image}"
+    rpm-ostree rebase "$image_pull" --experimental | tee out.txt
+    assert_file_has_content_literal out.txt 'Pulling: '"$image_pull"
+    rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"ostree-unverified-image:containers-storage:localhost/fcos:latest\""
     rpmostree_assert_status ".deployments[0][\"checksum\"] == \"${checksum}\""
     echo "ok rebase to container image reference"
 
@@ -60,7 +61,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
 
     # Test upgrade
     rpm-ostree upgrade | tee out.txt
-    assert_file_has_content_literal out.txt "Pulling manifest: ${image}"
+    assert_file_has_content_literal out.txt "Pulling manifest: ${image_pull}"
     assert_file_has_content out.txt "No upgrade available."
     echo "ok no upgrade available"
 
@@ -68,7 +69,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     with_foo_commit=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
     ostree refs ${with_foo_commit} --create vmcheck_tmp/new_update
     new_commit=$(ostree commit -b vmcheck --tree=ref=vmcheck_tmp/new_update)
-    rpm-ostree ex-container export --repo=/ostree/repo ${new_commit} containers-storage:localhost/fcos
+    rpm-ostree ex-container export --repo=/ostree/repo ${new_commit} "$image"
 
     rpm-ostree uninstall foo
     rpm-ostree upgrade
@@ -77,7 +78,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     /tmp/autopkgtest-reboot 2
     ;;
   2)
-    rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"containers-storage:localhost/fcos:latest\""
+    rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"${image_pull}\""
     assert_streq $(rpm -q foo) foo-1.2-3.x86_64
     echo "ok upgrade"
     ;;


### PR DESCRIPTION
We now support GPG (and signapi) signatures when rebasing to ostree-containers.
We also no longer carry heuristics in our code to distinguish between
ostree remote:ref and container image references - ostree-rs-ext
defines an unambiguous schema for the latter.

Also, we drop the direct dependency on `ostree-sys` since we now
have https://github.com/ostreedev/ostree-rs/pull/25

Closes: https://github.com/coreos/rpm-ostree/issues/3126
