### PR TITLE
tests/misc: Update regexp to match fixed ostree error

### DIFF
--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -210,8 +210,8 @@ if vm_rpmostree install conflict-pkg 2>err.txt; then
     assert_not_reached "Install packages with conflicting files unexpected succeeded"
 fi
 assert_not_file_has_content err.txt "Writing rpmdb"
-# this used to trigger EEXIST, but in f34 changed to EPERM
-assert_file_has_content err.txt "Operation not permitted"
+# Should be "File exists", but work around a bug in older ostree
+assert_file_has_content err.txt "\(Operation not permitted\)\|\(File exists\)"
 echo "ok detecting file name conflicts before writing rpmdb"
 
 # check that the way we detect deployment changes is not dependent on pending-*


### PR DESCRIPTION
This was correctly fixed by
https://github.com/ostreedev/ostree/pull/2425
