### PR TITLE
rust: Use `opt-level=1` for default `dev`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,9 @@ path = "rust/src/lib.rs"
 name = "rpm-ostree"
 path = "rust/src/main.rs"
 
+[profile.dev]
+opt-level = 1 # No optimizations are too slow for us.
+
 [profile.release]
 # Unwinding across FFI boundaries is undefined behavior, and anyways, we're
 # [crash-only](https://en.wikipedia.org/wiki/Crash-only_software)


### PR DESCRIPTION
This has been extensively discussed elsewhere; this tweak
is in the official docs:
https://doc.rust-lang.org/cargo/reference/profiles.html

Basically among other things, at the default `opt-level=0` almost
no inlining occurs, and Rust *heavily* depends on inlining.

So we're trading off some debuggability for much improved debug
build performance.

The release profile uses LTO right now which takes 2.5 minutes
on my workstation, which seriously hampers iteration time.

For another random link, e.g:
https://erasin.wang/books/bevy-cheatbook/pitfalls/performance.html
