### PR TITLE
extensions: Add support for per-extension repos and modules

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -55,6 +55,18 @@ extensions:
     packages:
         - strace
         - ltrace
+    # Optional additional repos (still added globally).
+    # The reason use per-extension `repos` and `modules`
+    # is that it more closely groups them (where relevant)
+    # and further these are only added after architecture conditionals
+    # apply, so one can use repositories that only exist
+    # on a particular architecture.
+    repos:
+      - sooper-repo
+    # Optional additional modules (this also affects global state)
+    modules:
+      enable:
+        - sooper:latest
     # Optional list of architectures on which this extension
     # is valid. These are RPM basearches. If omitted,
     # defaults to all architectures.

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -324,7 +324,7 @@ fn merge_hashset_field<T: Eq + std::hash::Hash>(
 }
 
 /// Merge modules fields.
-fn merge_modules(dest: &mut Option<ModulesConfig>, src: &mut Option<ModulesConfig>) {
+pub(crate) fn merge_modules(dest: &mut Option<ModulesConfig>, src: &mut Option<ModulesConfig>) {
     if let Some(mut srcv) = src.take() {
         if let Some(mut destv) = dest.take() {
             merge_vec_field(&mut destv.enable, &mut srcv.enable);


### PR DESCRIPTION
While we support arch-specific extensions today, the state of
repos and modules are global.  Which means if a module-using
extension is only available on one architecture (as is the
case in RHEL8/OCP with the `av` module) then it's not
possible to build on other architectures.

The most powerful mechanism here is the `arch-include` design
that we have in the treefile, but...since we already have
an architecture filter per extension, it's easier to add
repos and modules per extension.

Note that the repos and modules are still *global* state, so
we're not supporting actively conflicting extensions right now
still.

Closes: https://github.com/coreos/rpm-ostree/issues/3150
