### PR TITLE
rebase: Parse `ostree://` prefix again

### DIFF
--- a/src/app/rpmostree-builtin-rebase.cxx
+++ b/src/app/rpmostree-builtin-rebase.cxx
@@ -132,6 +132,11 @@ rpmostree_builtin_rebase (int             argc,
     }
   (void)new_refspec_owned; /* Pacify static analysis */
 
+  // We previously supported prefixing with ostree:// - so continue to parse this for now.
+  // https://gitlab.gnome.org/GNOME/gnome-software/-/issues/1463#note_1279157
+  if (g_str_has_prefix (new_provided_refspec, "ostree://"))
+    new_provided_refspec += strlen ("ostree://");
+
   RpmOstreeRefspecType refspectype;
   if (!rpmostree_refspec_classify (new_provided_refspec, &refspectype, error))
     return FALSE;

--- a/tests/vmcheck/test-upgrades.sh
+++ b/tests/vmcheck/test-upgrades.sh
@@ -45,7 +45,9 @@ vm_rpmostree reload
 vm_rpmostree rebase otherremote:
 vm_assert_status_jq ".deployments[0][\"origin\"] == \"otherremote:vmcheck\"" \
                     ".deployments[0][\"booted\"]|not"
-vm_rpmostree rebase vmcheckmote:
+# Also test with ostree://
+# https://gitlab.gnome.org/GNOME/gnome-software/-/issues/1463#note_1279157
+vm_rpmostree rebase ostree://vmcheckmote:
 vm_assert_status_jq ".deployments[0][\"origin\"] == \"vmcheckmote:vmcheck\"" \
                     ".deployments[0][\"booted\"]|not"
 


### PR DESCRIPTION
We did this in the past, I don't think it was truly intentional.
But, let's continue to support it since it turned out
gnome-software used it:
https://gitlab.gnome.org/GNOME/gnome-software/-/issues/1463
