### PR TITLE
Release 2021.12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2021])
-m4_define([release_version], [11])
+m4_define([release_version], [12])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2021.11
+Version: 2021.12
 Release: 1%{?dist}
 License: LGPLv2+
 URL: https://github.com/coreos/rpm-ostree


### PR DESCRIPTION
# Release 2021.12

There's a notable new feature in this release from our Outreachy intern, which is that `override replace` learned experimental support for fetching from rpm-md repos.  This makes it a bit easier to find newer (or older) packages from repos.
PR: https://github.com/coreos/rpm-ostree/pull/3092

A notable bugfix is that `rpm-ostree rebase` now accepts `ostree://` as a prefix again, which fixes gnome-software:
PR: https://github.com/coreos/rpm-ostree/pull/3157

Other fixes include kernel overrides with newer depmod, and a docs tweak.

Thanks to all contributors!

```
Colin Walters (6):
      rust: Use `opt-level=1` for default `dev`
      extensions: Add support for per-extension repos and modules
      main: Remove pointless `async { ... }` + `.await` pair
      main: Remove lots of `Some` matching
      rebase: Parse `ostree://` prefix again
      Release 2021.12

Jonathan Lebon (2):
      libpriv/kernel: Handle new modules.builtin.alias.bin depmod file
      libpriv/kernel: Point to depmod source of truth

Rafael G. Ruiz (1):
      override replace: add experimental options

Zhangyuan Nie (1):
      docs: fix hyperlinks in architecture-daemon.md

dependabot[bot] (10):
      build(deps): bump tokio from 1.11.0 to 1.12.0
      build(deps): bump subprocess from 0.2.7 to 0.2.8
      build(deps): bump libc from 0.2.102 to 0.2.103
      build(deps): bump cxx from 1.0.54 to 1.0.55
      build(deps): bump tracing from 0.1.27 to 0.1.28
      build(deps): bump serde_json from 1.0.67 to 1.0.68
      build(deps): bump system-deps from 4.0.0 to 5.0.0
      build(deps): bump cxx-build from 1.0.54 to 1.0.55
      build(deps): bump nix from 0.22.1 to 0.23.0
      build(deps): bump curl from 0.4.38 to 0.4.39
```
