### PR TITLE
override replace: allow not freeze for --from option

### DIFF
--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -112,6 +112,11 @@ fn deployment_populate_variant_origin(
         "requested-base-local-replacements",
         tf.derive.override_replace_local.as_ref(),
     );
+    vdict_insert_optmap(
+        dict,
+        "requested-base-replacements",
+        tf.derive.override_replace.as_ref(),
+    );
 
     // Initramfs data.
     if let Some(initramfs) = tf.derive.initramfs.as_ref() {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -405,6 +405,7 @@ pub mod ffi {
         fn get_packages_local(&self) -> Vec<String>;
         fn get_packages_local_fileoverride(&self) -> Vec<String>;
         fn get_packages_override_replace_local(&self) -> Vec<String>;
+        fn get_packages_override_replace(&self) -> Vec<String>;
         fn get_packages_override_remove(&self) -> Vec<String>;
         fn get_modules_enable(&self) -> Vec<String>;
         fn get_modules_install(&self) -> Vec<String>;

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -27,7 +27,8 @@ const OVERRIDES: &str = "overrides";
 static UNORDERED_LIST_KEYS: phf::Set<&'static str> = phf::phf_set! {
     "packages/local",
     "packages/local-fileoverride",
-    "overrides/replace-local"
+    "overrides/replace-local",
+    "override/replace"
 };
 
 #[context("Parsing origin")]
@@ -60,6 +61,7 @@ pub(crate) fn origin_to_treefile_inner(kf: &KeyFile) -> Result<Box<Treefile>> {
     }
     cfg.derive.override_remove = parse_stringlist(kf, OVERRIDES, "remove")?;
     cfg.derive.override_replace_local = parse_localpkglist(kf, OVERRIDES, "replace-local")?;
+    cfg.derive.override_replace = parse_localpkglist(kf, OVERRIDES, "replace")?;
 
     let regenerate_initramfs = kf
         .boolean(RPMOSTREE, "regenerate-initramfs")
@@ -162,6 +164,9 @@ fn treefile_to_origin_inner(tf: &Treefile) -> Result<glib::KeyFile> {
     }
     if let Some(pkgs) = tf.derive.override_replace_local.as_ref() {
         set_sha256_nevra_pkgs(&kf, OVERRIDES, "replace-local", pkgs)
+    }
+    if let Some(pkgs) = tf.derive.override_replace.as_ref() {
+        set_sha256_nevra_pkgs(&kf, OVERRIDES, "replace", pkgs)
     }
     if let Some(ref modcfg) = tf.modules {
         if let Some(modules) = modcfg.enable.as_deref() {

--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -590,6 +590,8 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
   g_autofree const gchar **origin_requested_base_removals = NULL;
   g_autoptr(GVariant) origin_base_local_replacements = NULL;
   g_autofree const gchar **origin_requested_base_local_replacements = NULL;
+  g_autoptr(GVariant) origin_base_replacements = NULL;
+  g_autofree const gchar **origin_requested_base_replacements = NULL;
   if (g_variant_dict_lookup (dict, "origin", "&s", &origin_refspec) ||
       g_variant_dict_lookup (dict, "container-image-reference", "&s", &origin_refspec))
     {
@@ -616,6 +618,11 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
                                      G_VARIANT_TYPE ("a(vv)"));
       origin_requested_base_local_replacements =
         lookup_array_and_canonicalize (dict, "requested-base-local-replacements");
+      origin_base_replacements =
+        g_variant_dict_lookup_value (dict, "base-replacements",
+                                     G_VARIANT_TYPE ("a(vv)"));
+      origin_requested_base_replacements =
+        lookup_array_and_canonicalize (dict, "requested-base-replacements");
     }
   else
     origin_refspec = NULL;
@@ -970,6 +977,10 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
                   NULL,
                   FALSE);
     }
+//  if (origin_requested_base_replacements)
+//    {
+//      
+//    }
 
   if (origin_requested_base_local_replacements && opt_verbose)
     print_packages ("InactiveBaseReplacements", max_key_len,

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -93,6 +93,9 @@ GHashTable *
 rpmostree_origin_get_overrides_remove (RpmOstreeOrigin *origin);
 
 GHashTable *
+rpmostree_origin_get_overrides_replace (RpmOstreeOrigin *origin);
+
+GHashTable *
 rpmostree_origin_get_overrides_local_replace (RpmOstreeOrigin *origin);
 
 const char *
@@ -199,7 +202,7 @@ rpmostree_origin_remove_modules (RpmOstreeOrigin  *origin,
                                  GError         **error);
 
 typedef enum {
-  /* RPMOSTREE_ORIGIN_OVERRIDE_REPLACE, */
+  RPMOSTREE_ORIGIN_OVERRIDE_REPLACE,
   RPMOSTREE_ORIGIN_OVERRIDE_REPLACE_LOCAL,
   RPMOSTREE_ORIGIN_OVERRIDE_REMOVE
 } RpmOstreeOriginOverrideType;


### PR DESCRIPTION
`override replace --experimental --from KIND=NAME` do not pin the
overrided package allowing updates

Signed-off-by: Rafael G. Ruiz <llerrak@hotmail.com>