### PR TITLE
make-git-snapshot: Use generated `cargo vendor` config

### DIFF
--- a/cargo-vendor-config
+++ b/cargo-vendor-config
@@ -1,8 +1,0 @@
-# This is used after `cargo vendor` is run from `make dist` 
-
-[source.crates-io]
-registry = 'https://github.com/rust-lang/crates.io-index'
-replace-with = 'vendored-sources'
-
-[source.vendored-sources]
-directory = './vendor'

--- a/packaging/make-git-snapshot.sh
+++ b/packaging/make-git-snapshot.sh
@@ -27,7 +27,8 @@ ls -al ${TARFILE_TMP}
     tar -A -f ${TARFILE_TMP} submodule.tar
     rm submodule.tar
 done
-tmpd=${TOP}/.dist-tmp
+disttmp=.dist-tmp
+tmpd=${TOP}/$disttmp
 trap cleanup EXIT
 function cleanup () {
     if test -f ${tmpd}/.tmp; then
@@ -40,9 +41,8 @@ mkdir ${tmpd} && touch ${tmpd}/.tmp
 
 (cd ${tmpd}
  mkdir -p .cargo vendor
- (cd ${TOP} && cargo vendor ${tmpd}/vendor)
+ (cd ${TOP} && cargo vendor ${tmpd}/vendor | sed -e "s,^directory *=.*,directory = './vendor',") > .cargo/config
  cp ${TOP}/Cargo.lock .
- cp ${TOP}/cargo-vendor-config .cargo/config
  # Filter out bundled libcurl and systemd; we always want the pkgconfig ones
  for crate_subdir in curl-sys/curl \
                      libz-sys/src/zlib \


### PR DESCRIPTION
Nowadays it prints the result to stdout, so we can just use that
directly.

In particular, this fixes an issue for me where trying to use
direct `git` dependencies (not via crates.io) needs a separate
config stanza.
