### PR TITLE
compose: Always commit under a shared repo lock

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1093,9 +1093,17 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
     g_print ("Network filesystem detected for repo; disabling transaction\n");
   const gboolean use_txn = !(txn_explicitly_disabled || using_netfs);
 
+  g_autoptr(OstreeRepoAutoLock) lock = NULL;
   if (use_txn)
     {
       if (!ostree_repo_prepare_transaction (self->build_repo, NULL, cancellable, error))
+        return FALSE;
+    }
+  else
+    {
+      /* if we're not using transactions, then get a shared lock ourselves */
+      lock = ostree_repo_auto_lock_push (self->build_repo, OSTREE_REPO_LOCK_SHARED, cancellable, error);
+      if (!lock)
         return FALSE;
     }
 


### PR DESCRIPTION
In the case we're using transactions, that's already done for us.
Otherwise, we should do it ourselves. Otherwise we run the risk of
racing with e.g. a prune operation.

For more context, see:
https://github.com/ostreedev/ostree/issues/2474
https://github.com/coreos/fedora-coreos-releng-automation/pull/79