### PR TITLE
Release 2021.13

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2021])
-m4_define([release_version], [12])
+m4_define([release_version], [13])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2021.12
+Version: 2021.13
 Release: 1%{?dist}
 License: LGPLv2+
 URL: https://github.com/coreos/rpm-ostree
@@ -86,7 +86,7 @@ BuildRequires: jq
 
 
 %global libsolv_version 0.7.17
-%global libmodulemd_version 2.11.2-2
+%global libmodulemd_version 2.13.0
 %global librepo_version 1.13.1
 
 BuildRequires:  cmake


### PR DESCRIPTION
# Release 2021.13

This release contains mostly bugfixes and UX enhancements.

Some changes were made to help with reproducible builds. For example, rpm-ostree now passes the `SOURCE_DATE_EPOCH` to scripts during composes. Also, the `lstchg` timestamp field is now scrubbed from shadow files, and the content of generated `tmpfiles.d` fragments is sorted. #3163 #3174

A notable improvement for users is related to RPM packages with overlapping files color/disposition (i.e. multilib support), which are now properly handled at install time. This used to be a blocker for `unixODBC.i686`, a dependency of `wine`. #3125

A new `rpm-ostree install --force-replacefiles` flag allows overriding files without replacing the package. This may be useful in "quick testing" or hotfix scenarios. #3125

This release now consistently holds the ostree repository locked during a build, even when committing to a remote NFS repository. #3193

Thanks to all contributors!

---

```
Benno Rice (5):
      compose: pass SOURCE_DATE_EPOCH into bubblewrap environments
      nameservice: fix some comments and messages
      nameservice: Add data structures and parsers for shadow(5)
      compose: remove lstchg values from [/usr]/etc/shadow
      compose: make "unified core" arguments common

Colin Walters (1):
      make-git-snapshot: Use generated `cargo vendor` config

Jonathan Lebon (15):
      core: Inline back add_te_files_to_ht function
      core: Track file disposition by NEVRA
      core: Compare rpm file coloring within layered packages
      core: Free files_skip_add hash table after we're done
      core: Handle RPM file colors more efficiently
      app/pkg-builtins: Tweak pkgs strv passing to D-Bus
      app/pkg-builtins: Account for 'file://' when choosing D-Bus method
      daemon/upgrader: Factor out local pkgs handler
      libpriv/core: Add rpmprob filter flags one by one
      libpriv/origin: Use if-statement rather than ternary operator
      Add `install --force-replacefiles`
      docs/admin-handbook: Add docs about modularity support
      compose: Always commit under a shared repo lock
      ci: Remove `install-extra-builddeps.sh`
      Make `jq` a `BuildRequires`

Luca BRUNO (1):
      composepost: output translated /var entries in lexicographic order

Timothée Ravier (2):
      docs: Do not convert -- & --- to en/em-dash
      docs: Update links to code, man pages and projects
```