### PR TITLE
Move `ostree://` parsing to daemon

### DIFF
--- a/src/app/rpmostree-builtin-rebase.cxx
+++ b/src/app/rpmostree-builtin-rebase.cxx
@@ -132,11 +132,6 @@ rpmostree_builtin_rebase (int             argc,
     }
   (void)new_refspec_owned; /* Pacify static analysis */
 
-  // We previously supported prefixing with ostree:// - so continue to parse this for now.
-  // https://gitlab.gnome.org/GNOME/gnome-software/-/issues/1463#note_1279157
-  if (g_str_has_prefix (new_provided_refspec, "ostree://"))
-    new_provided_refspec += strlen ("ostree://");
-
   RpmOstreeRefspecType refspectype;
   if (!rpmostree_refspec_classify (new_provided_refspec, &refspectype, error))
     return FALSE;

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -68,6 +68,11 @@ change_origin_refspec (GVariantDict    *options,
                        gchar **out_new_refspec,
                        GError **error)
 {
+  // We previously supported prefixing with ostree:// - so continue to parse this for now.
+  // https://gitlab.gnome.org/GNOME/gnome-software/-/issues/1463#note_1279157
+  if (g_str_has_prefix (refspec, "ostree://"))
+    refspec += strlen ("ostree://");
+
   RpmOstreeRefspecType refspectype;
   if (!rpmostree_refspec_classify (refspec, &refspectype, error))
     return FALSE;


### PR DESCRIPTION
Follow-up to df8315a262 (#3157).

GNOME Software uses the D-Bus API directly, not the CLI. So let's move
handling of `ostree://` there.

The test added in #3157 will verify that we're parsing it correctly.

Closes: #3192