### PR TITLE
Unify cliwrap handling into core

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -1070,10 +1070,11 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self,
       if (!rpmostree_context_assemble (self->ctx, cancellable, error))
         return FALSE;
     }
-
-  // TODO Unify with treefile origin handling in core
-  if (rpmostree_origin_get_cliwrap (self->computed_origin))
-    CXX_TRY(cliwrap_write_wrappers (self->tmprootfs_dfd), error);
+  else
+    {
+      if (!rpmostree_context_assemble_end (self->ctx, cancellable, error))
+        return FALSE;
+    }
 
   if (!rpmostree_rootfs_postprocess_common (self->tmprootfs_dfd, cancellable, error))
     return FALSE;

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -3957,22 +3957,29 @@ write_rpmdb (RpmOstreeContext      *self,
   return TRUE;
 }
 
+static gboolean
+ensure_tmprootfs_dfd (RpmOstreeContext      *self,
+                      GError               **error)
+{
+  /* Synthesize a tmpdir if we weren't provided a base */
+  if (self->tmprootfs_dfd != -1)
+    return TRUE;
+  g_assert (!self->repo_tmpdir.initialized);
+  int repo_dfd = ostree_repo_get_dfd (self->ostreerepo); /* Borrowed */
+  if (!glnx_mkdtempat (repo_dfd, "tmp/rpmostree-assemble-XXXXXX", 0700,
+                       &self->repo_tmpdir, error))
+    return FALSE;
+  self->tmprootfs_dfd = self->repo_tmpdir.fd;
+  return TRUE;
+}
+
 gboolean
 rpmostree_context_assemble (RpmOstreeContext      *self,
                             GCancellable          *cancellable,
                             GError               **error)
 {
-  /* Synthesize a tmpdir if we weren't provided a base */
-  if (self->tmprootfs_dfd == -1)
-    {
-      g_assert (!self->repo_tmpdir.initialized);
-      int repo_dfd = ostree_repo_get_dfd (self->ostreerepo); /* Borrowed */
-      if (!glnx_mkdtempat (repo_dfd, "tmp/rpmostree-assemble-XXXXXX", 0700,
-                           &self->repo_tmpdir, error))
-        return FALSE;
-      self->tmprootfs_dfd = self->repo_tmpdir.fd;
-    }
-
+  if (!ensure_tmprootfs_dfd (self, error))
+    return FALSE;
   int tmprootfs_dfd = self->tmprootfs_dfd; /* Alias to avoid bigger diff */
 
   /* In e.g. removing a package we walk librpm which doesn't have canonical
@@ -4411,8 +4418,6 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
         return FALSE;
     }
 
-  if (self->treefile_rs->get_cliwrap())
-    rpmostreecxx::cliwrap_write_wrappers (tmprootfs_dfd);
 
   /* Undo the /etc move above */
   etc_guard->undo();
@@ -4430,6 +4435,19 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
                     have_fileoverrides, cancellable, error))
     return glnx_prefix_error (error, "Writing rpmdb");
 
+  return rpmostree_context_assemble_end (self, cancellable, error);
+}
+
+// Perform any final transformations independent of rpm, such as cliwrap.
+gboolean
+rpmostree_context_assemble_end (RpmOstreeContext      *self,
+                                GCancellable          *cancellable,
+                                GError               **error)
+{
+  if (!ensure_tmprootfs_dfd (self, error))
+    return FALSE;
+  if (self->treefile_rs->get_cliwrap())
+    CXX_TRY(cliwrap_write_wrappers (self->tmprootfs_dfd), error);
   return TRUE;
 }
 

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -205,6 +205,9 @@ gboolean rpmostree_context_get_kernel_changed (RpmOstreeContext *self);
 gboolean rpmostree_context_assemble (RpmOstreeContext      *self,
                                      GCancellable          *cancellable,
                                      GError               **error);
+gboolean rpmostree_context_assemble_end (RpmOstreeContext      *self,
+                                         GCancellable          *cancellable,
+                                         GError               **error);
 gboolean rpmostree_context_commit (RpmOstreeContext      *self,
                                    const char            *parent,
                                    RpmOstreeAssembleType  assemble_type,


### PR DESCRIPTION
This fixes the case of doing cliwrap *and* local package layering,
which ended up wrapping twice, causing an infinite exec loop.

Closes: https://github.com/coreos/rpm-ostree/issues/3184

A lot of history here.  Originally the cliwrap code was duplicated
on the client side (origin files) and the server side (treefiles).
Then lately we've been trying to unify them, which happened via:

https://github.com/coreos/rpm-ostree/pull/2743

I think (but didn't verify) that it was that PR that introduced
this double wrapping.  Basically since we're now passing a synthesized
treefile into the core, it enables cliwrap there too.

However, it's the sysroot upgrader that has the tricky logic right now
around "only invoke libdnf/rpm when necessary" around things like
fetching repodata.  We should drive that into the core too.

For now though, split out the "non-package" bits as a separate API
entrypoint and call it unconditionally from the upgrader, instead
of duplicating the cliwrap logic.
