### PR TITLE
core: Fix minor regression on colorless arches

### DIFF
--- a/tests/kolainst/destructive/layering-modules
+++ b/tests/kolainst/destructive/layering-modules
@@ -7,8 +7,18 @@ cd $(mktemp -d)
 
 set -x
 
+versionid=$(grep -E '^VERSION_ID=' /etc/os-release)
+versionid=${versionid:11} # trim off VERSION_ID=
+
 # Let's start by trying to install a bona fide module.
-rpm-ostree ex module install cri-o:1.20/default
+case $versionid in
+  34) module=cri-o:1.20/default;;
+  # yes, this is going backwards, see:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/767#issuecomment-917191270
+  35) module=cri-o:1.19/default;;
+  *) assert_not_reached "Unsupported Fedora version: $versionid";;
+esac
+rpm-ostree ex module install "${module}"
 rpm-ostree cleanup -p
 
 rm -rf /etc/yum.repos.d/*

--- a/tests/vmcheck/test-override-kernel.sh
+++ b/tests/vmcheck/test-override-kernel.sh
@@ -45,6 +45,7 @@ case $versionid in
   32) kernel_release=5.6.6-300.fc32.x86_64;;
   33) kernel_release=5.8.15-301.fc33.x86_64;;
   34) kernel_release=5.11.12-300.fc34.x86_64;;
+  35) kernel_release=5.14.10-300.fc35.x86_64;;
   *) assert_not_reached "Unsupported Fedora version: $versionid";;
 esac
 assert_not_file_has_content current-dblist.txt $kernel_release


### PR DESCRIPTION
In 11aeb825d2cb ("core: Handle RPM file colors more efficiently"), we
added an early exit in `handle_file_dispositions` on arches which don't
use colours. However, this is incorrect because that function does more
than just colour handling; it also handles files shared between RPMs.

Fix this and expand the function's docstring.

We have tests for this, but it passed through because CI runs on x86_64.
But this would matter or i686 or armhfp (which is relevant for Fedora
IoT).