### PR TITLE
tests/compose.sh: Bump frozen FCOS commit for f35

### DIFF
--- a/tests/compose.sh
+++ b/tests/compose.sh
@@ -45,6 +45,14 @@ if [ ! -d compose-cache ]; then
   rm manifest.yaml
   mv manifests/{passwd,group} .
   rm -rf manifests/
+  # also make sure to download glibc-all-langpacks which is no longer in FCOS by
+  # default; we'll want it to test `install-langs`
+  python3 -c '
+import sys, json
+y = json.load(sys.stdin)
+y["packages"] += ["glibc-all-langpacks"]
+json.dump(y, sys.stdout)' < manifest.json > manifest.json.new
+  mv manifest.json{.new,}
   popd # config
 
   mkdir cachedir

--- a/tests/compose.sh
+++ b/tests/compose.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # freeze on a specific commit for tests for reproducibility and since it should
 # always work to target older treefiles
-FEDORA_COREOS_CONFIG_COMMIT=2763cb1662e304aef0aae6156aafe8b5ed43973a
+FEDORA_COREOS_CONFIG_COMMIT=28e1f50e596219e58b196e7f8be4f6214287339f
 
 dn=$(cd "$(dirname "$0")" && pwd)
 topsrcdir=$(cd "$dn/.." && pwd)

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -1,4 +1,5 @@
 #!/bin/bash
+# kola: { "timeoutMin": 20 }
 #
 # Copyright (C) 2021 Red Hat, Inc.
 #


### PR DESCRIPTION
Fedora 33 packages have been untagged from the pool so CI will start
failing on the next repo regen. Let's just bump to a recent f35 commit.

See: https://github.com/coreos/fedora-coreos-tracker/issues/884