### PR TITLE
`Cargo.toml`: Switch to `lto = "thin"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ panic = "abort"
 debug = true
 # We need this to avoid leaking symbols, see
 # https://internals.rust-lang.org/t/rust-staticlibs-and-optimizing-for-size/5746
-lto = true
+lto = "thin"
 
 [features]
 fedora-integration = []


### PR DESCRIPTION
A release build takes four minutes here, which...is just too much.
`lto = "thin"` is much faster, a no-op change on the C/C++ side is
~35s, a 4x reduction.

Eventually thin LTO is going to be equivalent to full LTO:
https://clang.llvm.org/docs/ThinLTO.html
