### PR TITLE
builtin/kargs: fix editor flow

### DIFF
--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -288,6 +288,11 @@
     </method>
 
    <!-- Available options:
+        "append-if-missing" (type 'as')
+        "delete-if-present" (type 'as')
+        "final-kernel-args" (type 's')
+        "initiating-command-line" (type 's')
+        "lock-finalization" (type 'b')
         "reboot" (type 'b')
     -->
     <method name="KernelArgs">

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -202,7 +202,8 @@ vm_clean_caches() {
 # run rpm-ostree in vm
 # - $@    args
 vm_rpmostree() {
-    vm_cmd env ASAN_OPTIONS=detect_leaks=false rpm-ostree "$@"
+    TESTEDITOR="${EDITOR:-}"
+    vm_cmd -- env \"EDITOR=${TESTEDITOR}\" ASAN_OPTIONS=detect_leaks=false rpm-ostree "$@"
 }
 
 # copy the test repo to the vm

--- a/tests/vmcheck/test-kernel-args.sh
+++ b/tests/vmcheck/test-kernel-args.sh
@@ -167,19 +167,33 @@ vm_rpmostree kargs > if_not_present.txt
 diff kargs.txt if_not_present.txt
 echo "ok kargs deleted with delete-if-present only if present"
 
-#Test for rpm-ostree kargs unchanged-exit-77
+# Test for rpm-ostree kargs unchanged-exit-77
+vm_rpmostree kargs --append-if-missing=PACKAGE3=TEST3 --unchanged-exit-77
 rc=0
-vm_rpmostree kargs --append-if-missing=PACKAGE3=TEST3 --unchanged-exit-77 || rc=$?
-assert_streq $rc 0
 vm_rpmostree kargs --append-if-missing=PACKAGE3=TEST3 --unchanged-exit-77 || rc=$?
 assert_streq $rc 77
+vm_rpmostree kargs --delete-if-present=PACKAGE3=TEST3 --unchanged-exit-77
 rc=0
-vm_rpmostree kargs --delete-if-present=PACKAGE3=TEST3 --unchanged-exit-77 || rc=$?
-assert_streq $rc 0
 vm_rpmostree kargs --delete-if-present=PACKAGE3=TEST3 --unchanged-exit-77 || rc=$?
 assert_streq $rc 77
 echo "ok exit 77 when unchanged kargs with unchanged-exit-77"
 
+# Test for 'rpm-ostree kargs --editor'.
+vm_rpmostree kargs > kargs.txt
+assert_not_file_has_content_literal kargs.txt 'nonexisting'
+rc=0
+EDITOR="sed -i 's/nonexisting//'" vm_rpmostree kargs --editor || rc=$?
+assert_streq $rc 1
+rc=0
+EDITOR="sed -i 's/nonexisting//'" vm_rpmostree kargs --editor --unchanged-exit-77 || rc=$?
+assert_streq $rc 77
+vm_rpmostree kargs > kargs.txt
+assert_not_file_has_content_literal kargs.txt 'nonexisting'
+assert_not_file_has_content_literal kargs.txt 'editorkey=editorvalue'
+EDITOR="sed -i 's/$/ editorkey=editorvalue/'" vm_rpmostree kargs --editor
+vm_rpmostree kargs > kargs.txt
+assert_file_has_content_literal kargs.txt 'editorkey=editorvalue'
+echo "ok kargs editor"
 
 # XXX: uncomment this when we migrate CI to FCOS
 # # And reset this bit


### PR DESCRIPTION
This reworks the `kargs --editor` flow, fixing an existing regression and
adding support for `--unchanged-exit-77` too (for the sake of easier
testing).

Closes: https://github.com/coreos/rpm-ostree/issues/3182
