### PR TITLE
compose: Apply SELinux regex timestamp hack before reloading policy

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -451,8 +451,8 @@ install_packages (RpmOstreeTreeComposeContext  *self,
       /* Now reload the policy from the tmproot, and relabel the pkgcache - this
        * is the same thing done in rpmostree_context_commit().
        */
-      g_autoptr(OstreeSePolicy) sepolicy = ostree_sepolicy_new_at (rootfs_dfd, cancellable, error);
-      if (sepolicy == NULL)
+      g_autoptr(OstreeSePolicy) sepolicy = NULL;
+      if (!rpmostree_prepare_rootfs_get_sepolicy (rootfs_dfd, &sepolicy, cancellable, error))
         return FALSE;
 
       rpmostree_context_set_sepolicy (self->corectx, sepolicy);


### PR DESCRIPTION
Otherwise, we can get log messages like:

> Regex version mismatch, expected: 10.37 2021-05-26 actual: 10.32 2018-09-10

when building RHCOS, which is a new log message from libselinux:
https://www.spinics.net/lists/selinux/msg37626.html.

I think previously it was just silently falling back to re-parsing the
text file which is why we didn't notice this? (Possibly all the way
since the introduction of unified core.)

Closes: https://github.com/openshift/os/issues/669