### PR TITLE
core: Nuke auto-generated tmpfiles.d when removing packages

### DIFF
--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -2964,6 +2964,16 @@ delete_package_from_root (RpmOstreeContext *self,
         }
     }
 
+  /* And finally, delete any automatically generated tmpfiles.d dropin. Though
+   * ideally we'd have a way to be sure that this was the rpm-ostree generated
+   * one. */
+  glnx_autofd int tmpfiles_dfd = -1;
+  if (!glnx_opendirat (rootfs_dfd, "usr/lib/tmpfiles.d", TRUE, &tmpfiles_dfd, error))
+    return FALSE;
+  g_autofree char *dropin = g_strdup_printf ("pkg-%s.conf", rpmteN(pkg));
+  if (!glnx_shutil_rm_rf_at (tmpfiles_dfd, dropin, cancellable, error))
+    return FALSE;
+
   return TRUE;
 }
 


### PR DESCRIPTION
It's auto-generated by rpm-ostree, but it's associated with the package.
Otherwise, it's possible that the new package will fail to checkout a
different auto-generated dropin.

Someone hit this internally when trying to override openvswitch:

```
sh-4.4# rpm-ostree override replace openvswitch2.15-2.15.0-51.bz1944550.6.el8fdp.x86_64.rpm
Checking out tree a654ec9... done
No enabled rpm-md repositories.
Importing rpm-md... done
Resolving dependencies... done
Applying 1 override
Processing packages... done
error: Checkout openvswitch2.15-2.15.0-51.bz1944550.6.el8fdp.x86_64: Hardlinking 40/4a5bddb5292f74e4a679f4e93c11d13e6097d69d1f0806ed59200398e7d2a8.file to pkg-openvswitch2.15.conf: File exists
```

```
$ diff <(rpm -q --dump -p openvswitch2.15-2.15.0-38.el8fdp.x86_64.rpm | grep /var) <(rpm -q --dump -p openvswitch2.15-2.15.0-51.bz1944550.6.el8fdp.x86_64.rpm | grep /var)
1,3c1,3
< /var/lib/openvswitch 0 1631726383 0000000000000000000000000000000000000000000000000000000000000000 040755 root root 0 0 0 X
< /var/lib/openvswitch/pki 0 1631726383 0000000000000000000000000000000000000000000000000000000000000000 040755 root root 0 0 0 X
< /var/log/openvswitch 0 1631726383 0000000000000000000000000000000000000000000000000000000000000000 040750 openvswitch openvswitch 0 0 0 X
---
> /var/lib/openvswitch 0 1636377654 0000000000000000000000000000000000000000000000000000000000000000 040755 root root 0 0 0 X
> /var/lib/openvswitch/pki 0 1636377654 0000000000000000000000000000000000000000000000000000000000000000 040755 root root 0 0 0 X
> /var/log/openvswitch 0 1636377654 0000000000000000000000000000000000000000000000000000000000000000 040750 openvswitch hugetlbfs 0 0 0 X
```