### PR TITLE
daemon: Add `InaccessiblePaths=/var/lib/containers`

### DIFF
--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -16,6 +16,10 @@ MountFlags=slave
 # and have a system rpm-ostreed-transaction.service that runs privileged
 # but as a subprocess.
 ProtectHome=true
+# Explicitly list paths here which we should never access.  The initial
+# entry here ensures that the skopeo process we fork won't interact with
+# application containers.
+InaccessiblePaths=/var/lib/containers
 NotifyAccess=main
 @SYSTEMD_ENVIRON@
 ExecStart=@bindir@/rpm-ostree start-daemon


### PR DESCRIPTION
This is a weaker version of https://github.com/coreos/rpm-ostree/pull/3239
that helps ensure that host updates can't interfere with
application containers (and vice versa).
