### PR TITLE
tests/vmcheck: tweak some hackish direct access to /ostree

### DIFF
--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -684,10 +684,10 @@ vm_ostreeupdate_lift_commit() {
   checksum=$1; shift
   # ostree doesn't support tags, so just shove it in a branch
   branch=vmcheck_tmp/$1; shift
-  vm_cmd ostree pull-local --repo=$REMOTE_OSTREE --disable-fsync \
+  vm_cmd_sysroot_rw ostree pull-local --repo=$REMOTE_OSTREE --disable-fsync \
     /ostree/repo $checksum
-  vm_cmd ostree --repo=$REMOTE_OSTREE refs $branch --delete
-  vm_cmd ostree --repo=$REMOTE_OSTREE refs $checksum --create=$branch
+  vm_cmd_sysroot_rw ostree --repo=$REMOTE_OSTREE refs $branch --delete
+  vm_cmd_sysroot_rw ostree --repo=$REMOTE_OSTREE refs $checksum --create=$branch
 }
 
 _commit_and_inject_pkglist() {

--- a/tests/vmcheck/test-layering-basic-2.sh
+++ b/tests/vmcheck/test-layering-basic-2.sh
@@ -73,10 +73,10 @@ vm_shell_inline_sysroot_rw <<EOF
 test -L ${OLD_PKGCACHE_DIR}
 rm ${OLD_PKGCACHE_DIR}
 mkdir ${OLD_PKGCACHE_DIR}
-EOF
-vm_cmd ostree init --repo ${OLD_PKGCACHE_DIR} --mode=bare
-vm_cmd ostree pull-local --repo ${OLD_PKGCACHE_DIR} /ostree/repo \
+ostree init --repo ${OLD_PKGCACHE_DIR} --mode=bare
+ostree pull-local --repo ${OLD_PKGCACHE_DIR} /ostree/repo \
   rpmostree/pkg/test-pkgcache-migrate-pkg{1,2}/1.0-1.x86__64
+EOF
 vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck
 cursor=$(vm_get_journal_cursor)
 vm_rpmostree upgrade | tee output.txt


### PR DESCRIPTION
This is a workaround for a change of behavior that happened in ostree-2021.06 (possibly in https://github.com/ostreedev/ostree/pull/2486), related to specifying a custom `--repo` which happens to be on a ready-only sysroot.
We should fix `ostree` to detect this case and behave in a better way, but the broken tests here are also quite hackish so let's improve these first.