### PR TITLE
docs: fix minor bugs in rpm-ostree manpage

### DIFF
--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -322,27 +322,6 @@ Boston, MA 02111-1307, USA.
       </varlistentry>
 
       <varlistentry>
-        <term><command>override</command></term>
-
-        <listitem>
-          <para>
-            <command>remove</command> Remove a package from the base
-            tree.  Note that this is similar to layering in that
-            the original base is retained.
-          </para>
-
-          <para>
-            <command>replace</command> Replace a package in the base tree.
-          </para>
-
-          <para>
-            <command>reset</command> Undo a <literal>remove</literal> or
-            <literal>replace</literal> operation.
-          </para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
         <term><command>rebase</command></term>
 
         <listitem>
@@ -365,11 +344,11 @@ Boston, MA 02111-1307, USA.
           </para>
           <para>
             <command>--branch</command> or <command>-b</command> to
-            to pick a branch name.
+            pick a branch name.
           </para>
           <para>
             <command>--remote</command> or <command>-m</command> to
-            to pick a remote name.
+            pick a remote name.
           </para>
 
           <para>


### PR DESCRIPTION
* Remove duplicated section for the `override` subcommand.
* Fix typos.