### PR TITLE
Bump to ostree-ext 0.5.1 and containers-image-proxy 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d74260d9bf6944e2208aa46841b4b8f0d7ffc0849a06837b2f510337f86b2b"
 
 [[package]]
+name = "capctl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea0d91a34c56f0a0779e1cc2ec7040fa7f672819c4d3fe7d9dd4af3d2e78aca"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,14 +271,16 @@ dependencies = [
 
 [[package]]
 name = "containers-image-proxy"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1740fa7c4f7f0cbee0bb65e98f6ea0262de0c0e6bf26f62e6a394ec7ce94a2"
+checksum = "612d1c462d0d7e94720bff7896ee22d3162937de2362b0f09637fdb0c9689527"
 dependencies = [
  "anyhow",
+ "capctl",
  "fn-error-context",
  "futures-util",
  "lazy_static",
+ "libc",
  "nix 0.22.0",
  "semver",
  "serde",
@@ -1472,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "ostree-ext"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec2653766938ce18820e42a7889244b47a412c2496aa651eaee3b531623f64f"
+checksum = "942f0ba250af236c6d9b275a305f06676c917cd7857a6bcdfd96aca2791cf920"
 dependencies = [
  "anyhow",
  "async-compression",


### PR DESCRIPTION
To pick up build+runtime fixes for RHEL8.
