### PR TITLE
status: Add version into `status --json`

### DIFF
--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -1194,6 +1194,9 @@ rpmostree_builtin_status (int             argc,
       glnx_unref_object JsonBuilder *builder = json_builder_new ();
       json_builder_begin_object (builder);
 
+      json_builder_set_member_name (builder, "version");
+      json_builder_add_string_value (builder, PACKAGE_VERSION);
+
       json_builder_set_member_name (builder, "deployments");
       json_builder_add_value (builder, json_gvariant_serialize (deployments));
       json_builder_set_member_name (builder, "transaction");

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -9,6 +9,7 @@ cd $(mktemp -d)
 # Validate there's no live state by default.
 rpm-ostree status --json > status.json
 assert_jq status.json \
+  '.version' \
   '.deployments[0]["packages"]' \
   '.deployments[0]["requested-packages"]' \
   '.deployments[0]["requested-local-packages"]' \


### PR DESCRIPTION
I wanted to add some code into openshift/machine-config-operator
which checked the rpm-ostree version.  We can do this today with
`rpm-ostree --version` or `rpm -q rpm-ostree`, but the MCO today
already reads `rpm-ostree status --json`.

It's much more natural to parse JSON for this as opposed to forking
the binary again or querying rpm.  (The latter in particular would
require splitting on the upstream version vs release tag etc.)
