### PR TITLE
tests/compose: Add updates-archive repo for glibc-all-langpacks

### DIFF
--- a/tests/compose.sh
+++ b/tests/compose.sh
@@ -45,11 +45,14 @@ if [ ! -d compose-cache ]; then
   rm manifest.yaml
   mv manifests/{passwd,group} .
   rm -rf manifests/
-  # also make sure to download glibc-all-langpacks which is no longer in FCOS by
-  # default; we'll want it to test `install-langs`
+  # Also make sure to download glibc-all-langpacks which is no longer in FCOS by
+  # default; we'll want it to test `install-langs`. This also means that we have
+  # to add updates-archive to the repo list.
+  curl -LO https://src.fedoraproject.org/rpms/fedora-repos/raw/f35/f/fedora-updates-archive.repo
   python3 -c '
 import sys, json
 y = json.load(sys.stdin)
+y["repos"] += ["updates-archive"]
 y["packages"] += ["glibc-all-langpacks"]
 json.dump(y, sys.stdout)' < manifest.json > manifest.json.new
   mv manifest.json{.new,}


### PR DESCRIPTION
Since it's not officially in FCOS, it's not in the pool. But it's
subject to version binding with `glibc-common`. Let's just add the
`updates-archive` repo to the compose to fix this.

Fixes: #3217 (6b0d4f280bec)