### PR TITLE
More lints

### DIFF
--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -81,6 +81,7 @@ macro_rules! cxxrs_bind {
         paste! {
             $(
                 #[repr(transparent)]
+                #[derive(Debug)]
                 pub struct [<FFI $ns $i>](pub(crate) $sys::[<$ns $i>]);
 
                 unsafe impl ExternType for [<FFI $ns $i>] {

--- a/rust/src/history.rs
+++ b/rust/src/history.rs
@@ -59,6 +59,8 @@ static RPMOSTREE_DEPLOY_MSG: &str = "9bddbda177cd44d891b1b561a8a0ce9e";
 static RPMOSTREE_HISTORY_DIR: &str = "/var/lib/rpm-ostree/history";
 
 /// Context object used to iterate through `HistoryEntry` events.
+// TODO use https://crates.io/crates/derivative to skip journal field
+#[allow(missing_debug_implementations)]
 pub struct HistoryCtx {
     journal: journal::Journal,
     marker_queue: VecDeque<Marker>,
@@ -425,6 +427,7 @@ mod mock_journal {
     use super::Result;
     pub use systemd::journal::{JournalRecord, JournalSeek};
 
+    #[derive(Debug)]
     pub struct Journal {
         pub entries: Vec<(u64, JournalRecord)>,
         pub current_timestamp: Option<u64>,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -8,7 +8,9 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-#![deny(unused_must_use)]
+// See https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+#![deny(missing_debug_implementations)]
+#![forbid(unused_must_use)]
 #![allow(clippy::ptr_arg)]
 
 // pub(crate) utilities
@@ -136,6 +138,7 @@ pub mod ffi {
     /// `ContainerImageState` is currently identical to ostree-rs-ext's `LayeredImageState` struct, because
     /// cxx.rs currently requires types used as extern Rust types to be defined by the same crate
     /// that contains the bridge using them, so we redefine an `ContainerImport` struct here.
+    #[derive(Debug)]
     pub(crate) struct ContainerImageState {
         pub base_commit: String,
         pub merge_commit: String,
@@ -209,7 +212,7 @@ pub mod ffi {
 
     // A grab-bag of metadata from the deployment's ostree commit
     // around layering/derivation
-    #[derive(Default)]
+    #[derive(Debug, Default)]
     struct DeploymentLayeredMeta {
         is_layered: bool,
         base_commit: String,
@@ -408,7 +411,7 @@ pub mod ffi {
         ) -> Result<*mut GVariant>;
     }
 
-    #[derive(Default)]
+    #[derive(Debug, Default)]
     /// A copy of LiveFsState that is bridged to C++; the main
     /// change here is we can't use Option<> yet, so empty values
     /// are represented by the empty string.
@@ -490,6 +493,7 @@ pub mod ffi {
         fn generate_treefile(&self, src: &Treefile) -> Result<Box<Treefile>>;
     }
 
+    #[derive(Debug)]
     struct LockedPackage {
         name: String,
         evr: String,
@@ -525,6 +529,7 @@ pub mod ffi {
 
     unsafe extern "C++" {
         include!("rpmostree-cxxrsutil.hpp");
+        #[allow(missing_debug_implementations)]
         type CxxGObjectArray;
         fn length(self: Pin<&mut CxxGObjectArray>) -> u32;
         fn get(self: Pin<&mut CxxGObjectArray>, i: u32) -> &mut GObject;
@@ -553,6 +558,7 @@ pub mod ffi {
     unsafe extern "C++" {
         include!("rpmostree-clientlib.h");
         fn client_require_root() -> Result<()>;
+        #[allow(missing_debug_implementations)]
         type ClientConnection;
         fn new_client_connection() -> Result<UniquePtr<ClientConnection>>;
         fn get_connection<'a>(self: Pin<&'a mut ClientConnection>) -> Pin<&'a mut GDBusConnection>;
@@ -561,6 +567,7 @@ pub mod ffi {
 
     unsafe extern "C++" {
         include!("rpmostree-diff.hpp");
+        #[allow(missing_debug_implementations)]
         type RPMDiff;
         fn n_removed(&self) -> i32;
         fn n_added(&self) -> i32;
@@ -576,6 +583,7 @@ pub mod ffi {
     }
 
     // https://cxx.rs/shared.html#extern-enums
+    #[derive(Debug)]
     enum RpmOstreeDiffPrintFormat {
         RPMOSTREE_DIFF_PRINT_FORMAT_SUMMARY,
         RPMOSTREE_DIFF_PRINT_FORMAT_FULL_ALIGNED,
@@ -585,6 +593,7 @@ pub mod ffi {
     unsafe extern "C++" {
         include!("rpmostree-libbuiltin.h");
         include!("rpmostree-util.h");
+        #[allow(missing_debug_implementations)]
         type RpmOstreeDiffPrintFormat;
         /// # Safety: ensure @cancellable is a valid pointer
         unsafe fn print_treepkg_diff_from_sysroot_path(
@@ -597,6 +606,7 @@ pub mod ffi {
 
     unsafe extern "C++" {
         include!("rpmostree-output.h");
+        #[allow(missing_debug_implementations)]
         type Progress;
 
         fn progress_begin_task(msg: &str) -> UniquePtr<Progress>;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,9 +7,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
-
 // See https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
 #![deny(missing_debug_implementations)]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![forbid(unused_must_use)]
 #![allow(clippy::ptr_arg)]
 
@@ -27,6 +27,7 @@ pub(crate) use cxxrsutil::*;
 ///   side you currently *should* use `CxxResult`; see the docs of that for more information.
 #[cxx::bridge(namespace = "rpmostreecxx")]
 #[allow(clippy::needless_lifetimes)]
+#[allow(unsafe_op_in_unsafe_fn)]
 pub mod ffi {
     // Types that are defined by gtk-rs generated bindings that
     // we want to pass across the cxx-rs boundary.  For more

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -48,7 +48,7 @@ const COMPOSE_JSON_PATH: &str = "usr/share/rpm-ostree/treefile.json";
 
 /// This struct holds file descriptors for any external files/data referenced by
 /// a TreeComposeConfig.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(crate) struct TreefileExternals {
     postprocess_script: Option<fs::File>,
     add_files: collections::BTreeMap<String, fs::File>,
@@ -57,6 +57,7 @@ pub(crate) struct TreefileExternals {
 }
 
 // This type name is exposed through ffi.
+#[derive(Debug)]
 pub struct Treefile {
     // This one isn't used today, but we may do more in the future.
     _workdir: Option<openat::Dir>,

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -26,7 +26,7 @@ use std::{fs, io};
 
 use curl::easy::Easy;
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 /// Supported config serialization used by treefile and lockfile
 pub enum InputFormat {
     YAML,


### PR DESCRIPTION
Deny missing `Debug` impls by default, add more of them

Came out of discussion in https://github.com/ostreedev/ostree-rs-ext/pull/178

---

lib: Add `unsafe_op_in_unsafe_fn` lint

But allow it in the cxxrs-generated code.

---

