### PR TITLE
rust/src/client: detect src.rpms

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -115,6 +115,10 @@ pub(crate) fn is_rpm_arg(arg: &str) -> bool {
     arg.ends_with(".rpm") || arg.starts_with("file://")
 }
 
+pub(crate) fn is_src_rpm_arg(arg: &str) -> bool {
+    arg.ends_with(".src.rpm")
+}
+
 /// Given a string from the command line, determine if it represents one or more
 /// RPM URLs we need to fetch, and if so download those URLs and return file
 /// descriptors for the content.
@@ -125,7 +129,13 @@ pub(crate) fn client_handle_fd_argument(arg: &str, arch: &str) -> CxxResult<Vec<
         return Ok(fds.into_iter().map(|f| f.into_raw_fd()).collect());
     }
 
-    if is_http_arg(arg) {
+    if is_src_rpm_arg(arg) {
+        return Err(anyhow!(
+            "{} appears to be a source RPM which are not usually intended to be installed",
+            arg
+        )
+        .into());
+    } else if is_http_arg(arg) {
         Ok(utils::download_url_to_tmpfile(arg, true).map(|f| vec![f.into_raw_fd()])?)
     } else if is_rpm_arg(arg) {
         match arg.strip_prefix("file://") {
@@ -222,5 +232,18 @@ pub(crate) fn client_render_download_progress(
         format!("Writing objects: {}", outstanding_writes)
     } else {
         format!("Scanning metadata: {}", n_scanned_metadata)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_src_rpm() {
+        let rpm = "https://fedora.org/rpms/src/kernel-2.6.1.rpm";
+        let src_rpm = "file://linux-kernel-2.2.2.src.rpm";
+        assert!(!is_src_rpm_arg(rpm));
+        assert!(is_src_rpm_arg(src_rpm));
     }
 }


### PR DESCRIPTION
Fixes #2893 by checking for src.rpm on the client code.
