### PR TITLE
ci: Only run our own external tests

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -59,7 +59,7 @@ parallel insttests: {
       stage("Kola") {
         // TODO upstream this into coreos-ci-lib
         shwrap("make -C tests/kolainst install")
-        fcosKola(cosaDir: "${env.WORKSPACE}", extraArgs: "ext.*", parallel: nhosts)
+        fcosKola(cosaDir: "${env.WORKSPACE}", extraArgs: "ext.rpm-ostree.*", parallel: nhosts)
       }
       stage("vmcheck") {
         try {


### PR DESCRIPTION
The `ext.*` glob was selecting all external tests, instead of just the
rpm-ostree specific ones we just built, which I think was the intent
here.