### PR TITLE
rust/src/client: Use microdnf when installing pkgs on a container

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -72,6 +72,9 @@ pub mod ffi {
         fn client_start_daemon() -> Result<()>;
         fn client_handle_fd_argument(arg: &str, arch: &str) -> Result<Vec<i32>>;
         fn client_render_download_progress(progress: Pin<&mut GVariant>) -> String;
+        fn microdnf_install(args: Vec<String>) -> Result<()>;
+        fn running_in_container() -> bool;
+        fn ostree_path_exists() -> bool;
     }
 
     #[derive(Debug)]

--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -262,7 +262,7 @@ rpmostree_option_context_parse (GOptionContext *context,
   if ((flags & RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT) > 0)
     CXX_TRY(client_require_root(), error);
 
-  if (use_daemon)
+  if (use_daemon && !(rpmostreecxx::running_in_container() && rpmostreecxx::ostree_path_exists()))
     {
       /* More gracefully handle the case where
        * no --sysroot option was specified and we're not booted via ostree

--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -194,6 +194,14 @@ rpmostree_builtin_install (int            argc,
   argv++; argc--;
   argv[argc] = NULL;
 
+  if (rpmostreecxx::running_in_container() && rpmostreecxx::ostree_path_exists()) {
+    auto argv_rust = rust::Vec<rust::String>();
+      for (int i = 0; i < argc; i++)
+        argv_rust.push_back(rust::String(argv[i]));
+    rpmostreecxx::microdnf_install(argv_rust);
+    return TRUE;
+  }
+
   return pkg_change (invocation, sysroot_proxy,
                      (const char *const*)argv,
                      (const char *const*)opt_uninstall,


### PR DESCRIPTION
proof of concept, current version works. Example Dockerfile:
```
FROM localhost/myfcos
RUN mkdir /tmp
ADD rpm-ostree /usr/bin/

RUN rpm-ostree install htop
RUN rpm-ostree install zsh strace
```