### PR TITLE
two build system fixes for bindings

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -124,6 +124,7 @@ rust/cxx.h:
 	ln -sfr rust/cxx-prebuilt.h $@
 else
 include Makefile.bindings
+CLEANFILES += rpmostree-cxxrs.h rpmostree-cxxrs.cxx rust/cxx.h
 endif
 
 noinst_LTLIBRARIES += librpmostreecxxrs.la

--- a/Makefile.bindings
+++ b/Makefile.bindings
@@ -5,7 +5,7 @@ binding_rust_sources = $(shell find rust/src/ -name '*.rs') Cargo.toml Cargo.loc
 rust/cxx.h: Makefile.bindings
 	./target/cxxbridge/bin/cxxbridge --header >$@.tmp && mv $@.tmp $@
 
-rpmostree-cxxrs.h: $(binding_rust_sources)
+rpmostree-cxxrs.h: $(binding_rust_sources) ./target/cxxbridge/bin/cxxbridge
 	$(AM_V_GEN) if ./target/cxxbridge/bin/cxxbridge rust/src/lib.rs --header > $@.tmp; then \
 	  if test -f $@ && cmp $@.tmp $@ 2>/dev/null; then rm -f $@.tmp; else \
 	    mv $@.tmp $@; \


### PR DESCRIPTION
Joseph just hit the trap of https://github.com/coreos/rpm-ostree/pull/3274 landing, but it means that the bindings currently need to be regenerated manually.  This also hit me in the past.  The very broken thing here is we need to remove the generated bindings in `make clean`.

---

build-sys: Remove generated bindings in `make clean`

This was a double trap because they become invalid when `cxxbridge`
is updated.

---

build-sys: Ensure bindings depend on cxxbridge binary

This way if it's updated, the bindings will be regenerated.

---

