### PR TITLE
rust: Add some more comments around cxx.rs, particularly `Result<T>`

### DIFF
--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -106,7 +106,15 @@ cxxrs_bind!(G, glib, glib::gobject_ffi, [Object]);
 cxxrs_bind!(G, gio, gio::ffi, [Cancellable, DBusConnection, FileInfo]);
 cxxrs_bind!(G, glib, glib::ffi, [KeyFile, Variant, VariantDict]);
 
-// An error type helper; separate from the GObject bridging
+/// Error type helpers; separate from the GObject bridging.
+///
+/// # Use CxxResult in cxx.rs-bridged APIs (i.e. in `lib.rs`)
+///
+/// The `CxxResult<T>` type is necessarily primarily because
+/// we want to change the default error formatting.  It
+/// implements `From<T>` for many other error types, such as
+/// `anyhow::Error` and `glib::Error`, so the default conversion
+/// from `?` should work.
 mod err {
     use ostree_ext::glib;
     use std::error::Error as StdError;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -20,11 +20,22 @@ pub(crate) use cxxrsutil::*;
 
 /// APIs defined here are automatically bridged between Rust and C++ using https://cxx.rs/
 ///
-/// Usage guidelines:
+/// # File layout
 ///
-/// - Keep this content roughly ordered alphabetically
-/// - While the return type here will be `Result<T>` on the implementation
-///   side you currently *should* use `CxxResult`; see the docs of that for more information.
+/// Try to keep APIs defined here roughly alphabetical.  When adding a new file,
+/// add a comment with the filename so that it shows up in searches too.
+///
+/// # Error handling
+///
+/// For falliable APIs that return a `Result<T>`:
+///
+/// - Use `Result<T>` inside `lib.rs` below
+/// - On the Rust *implementation* side, use `CxxResult<T>` which does error
+///   formatting in a more preferred way
+/// - On the C++ side, use our custom `CXX_TRY` API which converts the C++ exception
+///   into a GError.  In the future, we might try a hard switch to C++ exceptions
+///   instead, but at the moment having two is problematic, so we prefer `GError`.
+///
 #[cxx::bridge(namespace = "rpmostreecxx")]
 #[allow(clippy::needless_lifetimes)]
 #[allow(unsafe_op_in_unsafe_fn)]


### PR DESCRIPTION
Came up in review of
https://github.com/coreos/rpm-ostree/pull/3285#pullrequestreview-836664044
