### PR TITLE
make: install ostree-container as a multicall hardlinked binary

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -138,6 +138,7 @@ BUILT_SOURCES += $(binding_generated_sources)
 install-rpmostree-hook:
 	install -d -m 0755 $(DESTDIR)$(bindir)
 	install -m 0755 -t $(DESTDIR)$(bindir) rpm-ostree
+	ln -T -f $(DESTDIR)$(bindir)/rpm-ostree $(DESTDIR)$(bindir)/ostree-container
 INSTALL_EXEC_HOOKS += install-rpmostree-hook
 
 # Wraps `cargo test`.  This is always a debug non-release build;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -76,8 +76,6 @@ async fn multicall_ostree_container(args: Vec<String>) -> Result<i32> {
 /// Dispatch multicall binary to relevant logic, based on callname from `argv[0]`.
 async fn dispatch_multicall(callname: String, args: Vec<String>) -> Result<i32> {
     match callname.as_str() {
-        // TODO(lucab): fix the final callname for this after ostree side at
-        // https://github.com/ostreedev/ostree/issues/2480 is settled.
         "ostree-container" => multicall_ostree_container(args).await,
         "rpm-ostree" | _ => inner_async_main(args).await,
     }

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -4,6 +4,17 @@ set -xeuo pipefail
 . ${KOLA_EXT_DATA}/libtest.sh
 cd $(mktemp -d)
 
+# Ensure multicall is correctly set up and working.
+R_O_DIGEST=$(sha512sum $(which rpm-ostree) | cut -d' ' -f1)
+O_C_DIGEST=$(sha512sum $(which ostree-container) | cut -d' ' -f1)
+if test "${R_O_DIGEST}" != "${O_C_DIGEST}" ; then
+    assert_not_reached "rpm-ostree and ostree-container are not the same binary"
+fi
+ostree-container container --help > cli_help.txt
+assert_file_has_content_literal cli_help.txt 'ostree-container container <SUBCOMMAND>'
+rm cli_help.txt
+echo "ok multicall corectly set up and working"
+
 # make sure that package-related entries are always present,
 # even when they're empty.
 # Validate there's no live state by default.


### PR DESCRIPTION
This installs the `ostree-container` multicall binary as an
hardlink to the existing `rpm-ostree` one.
It also adds a kola tests to make sure it is actually working
at runtime.

Ref: https://github.com/coreos/rpm-ostree/pull/3281
