### PR TITLE
core: Add an assertion to silence clang-analyzer

### DIFF
--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -1829,6 +1829,7 @@ rpmostree_context_prepare (RpmOstreeContext *self,
       g_autoptr(GPtrArray) locked_pkgs = NULL;
       if (!find_locked_packages (self, &locked_pkgs, error))
         return FALSE;
+      g_assert (locked_pkgs);
 
       /* build a packageset from it */
       DnfPackageSet *locked_pset = dnf_packageset_new (sack);


### PR DESCRIPTION
I think perhaps due to the complexity of the `find_locked_packages`
function it doesn't see that the variable really is always non-`NULL`.
Let's add an assertion to help.
