### PR TITLE
rust/src/client: rpm-ostree cleanup -m on containers calls microdnf c…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "ostree-ext"
 version = "0.5.1"
-source = "git+https://github.com/ostreedev/ostree-rs-ext#1fdc84efede475a8c9ff0eab599bf021047fc266"
+source = "git+https://github.com/ostreedev/ostree-rs-ext#4aa8de5a67a256f9ac8709ffd50d5d2e74af58f9"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -80,10 +80,12 @@ pub mod ffi {
     extern "Rust" {
         fn is_bare_split_xattrs() -> Result<bool>;
         fn is_http_arg(arg: &str) -> bool;
+        fn is_ostree_container() -> Result<bool>;
         fn is_rpm_arg(arg: &str) -> bool;
         fn client_start_daemon() -> Result<()>;
         fn client_handle_fd_argument(arg: &str, arch: &str) -> Result<Vec<i32>>;
         fn client_render_download_progress(progress: Pin<&mut GVariant>) -> String;
+        fn microdnf_clean_all() -> Result<()>;
         fn microdnf_install(args: Vec<String>) -> Result<()>;
         fn running_in_container() -> bool;
     }

--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -262,8 +262,8 @@ rpmostree_option_context_parse (GOptionContext *context,
   if ((flags & RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT) > 0)
     CXX_TRY(client_require_root(), error);
 
-  auto is_bare_split_xattrs = CXX_TRY_VAL(is_bare_split_xattrs(), error);
-  if (use_daemon && !(rpmostreecxx::running_in_container() && is_bare_split_xattrs))
+  auto is_ostree_container = CXX_TRY_VAL(is_ostree_container(), error);
+  if (use_daemon && !is_ostree_container)
     {
       /* More gracefully handle the case where
        * no --sysroot option was specified and we're not booted via ostree

--- a/src/app/rpmostree-builtin-cleanup.cxx
+++ b/src/app/rpmostree-builtin-cleanup.cxx
@@ -81,7 +81,15 @@ rpmostree_builtin_cleanup (int             argc,
   if (opt_rollback)
     g_ptr_array_add (cleanup_types, (char*)"rollback-deploy");
   if (opt_repomd)
-    g_ptr_array_add (cleanup_types, (char*)"repomd");
+    {
+      auto is_ostree_container = CXX_TRY_VAL(is_ostree_container(), error);
+      if (is_ostree_container) 
+        {
+          CXX_TRY(microdnf_clean_all(), error);
+          return TRUE;
+        }
+      g_ptr_array_add (cleanup_types, (char*)"repomd");
+    }
   if (cleanup_types->len == 0)
     {
       glnx_throw (error, "At least one cleanup option must be specified");

--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -194,14 +194,15 @@ rpmostree_builtin_install (int            argc,
   argv++; argc--;
   argv[argc] = NULL;
 
-  auto is_bare_split_xattrs = CXX_TRY_VAL(is_bare_split_xattrs(), error);
-  if (rpmostreecxx::running_in_container() && is_bare_split_xattrs) {
-    auto argv_rust = rust::Vec<rust::String>();
-      for (int i = 0; i < argc; i++)
-        argv_rust.push_back(rust::String(argv[i]));
-    rpmostreecxx::microdnf_install(argv_rust);
-    return TRUE;
-  }
+  auto is_ostree_container = CXX_TRY_VAL(is_ostree_container(), error);
+  if (is_ostree_container)
+    {
+      auto argv_rust = rust::Vec<rust::String>();
+        for (int i = 0; i < argc; i++)
+          argv_rust.push_back(rust::String(argv[i]));
+      CXX_TRY(microdnf_install(argv_rust), error);
+      return TRUE;
+    }
 
   return pkg_change (invocation, sysroot_proxy,
                      (const char *const*)argv,


### PR DESCRIPTION
This Dockerfile:
```
FROM quay.io/cgwalters/fcos
ADD rpm-ostree /usr/bin/
RUN rpm-ostree --version
RUN rpm-ostree install htop && rpm-ostree cleanup -m
```

Ends up in: 
```
STEP 1/4: FROM quay.io/cgwalters/fcos
STEP 2/4: ADD rpm-ostree /usr/bin/
--> f2fe68a8c39
STEP 3/4: RUN rpm-ostree --version
rpm-ostree:
 Version: '2021.14'
 Git: v2021.14-97-g023f86ade5559790fada0780b501e478244207f9
 Features:
  - rust
  - compose
  - fedora-integration
  - bin-unit-tests
--> 6b28e5e31aa
STEP 4/4: RUN rpm-ostree install htop && rpm-ostree cleanup -m
Downloading metadata...
Downloading metadata...
Downloading metadata...
Downloading metadata...
Downloading metadata...
Downloading metadata...
Package                   Repository            Size
Installing:                                         
 htop-3.1.2-1.fc35.x86_64 updates    176.4\xc2\xa0kB
Transaction Summary:
 Installing:        1 packages
 Reinstalling:      0 packages
 Upgrading:         0 packages
 Obsoleting:        0 packages
 Removing:          0 packages
 Downgrading:       0 packages
Downloading packages...
Running transaction test...
Installing: htop;3.1.2-1.fc35;x86_64;updates
Complete.
Complete.
COMMIT localhost/rpm-ostree
--> 45a8c0cd16f
Successfully tagged localhost/rpm-ostree:latest
45a8c0cd16f514108419ae0fc029b86fcd4aa00e60fe8e12e37fb65a2076f2f4
```