### PR TITLE
scripts: Replace `authselect-libs` prein

### DIFF
--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -26,7 +26,7 @@ use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::convert::TryInto;
 use std::fmt::Write as FmtWrite;
-use std::io::{BufRead, BufReader, Seek, Write};
+use std::io::{BufRead, BufReader, Read, Seek, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::prelude::IntoRawFd;
@@ -575,9 +575,19 @@ fn add_altfiles(buf: &str) -> Result<String> {
 pub fn composepost_nsswitch_altfiles(rootfs_dfd: i32) -> CxxResult<()> {
     let rootfs_dfd = &crate::ffiutil::ffi_view_openat_dir(rootfs_dfd);
     let path = "usr/etc/nsswitch.conf";
-    let nsswitch = rootfs_dfd.read_to_string(path)?;
-    let nsswitch = add_altfiles(&nsswitch)?;
-    rootfs_dfd.write_file_contents(path, 0o644, nsswitch.as_bytes())?;
+    if let Some(meta) = rootfs_dfd.metadata_optional(path)? {
+        // If it's a symlink, then something else e.g. authselect must own it.
+        if meta.simple_type() == openat::SimpleType::Symlink {
+            return Ok(());
+        }
+        let fd = rootfs_dfd.open_file(path)?;
+        let mut fd = std::io::BufReader::new(fd);
+        let mut nsswitch = String::new();
+        fd.read_to_string(&mut nsswitch)?;
+        let nsswitch = add_altfiles(&nsswitch)?;
+        rootfs_dfd.write_file_contents(path, 0o644, nsswitch.as_bytes())?;
+    }
+
     Ok(())
 }
 

--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -192,6 +192,11 @@ static const RpmOstreeLuaReplacement lua_replacements[] = {
     "  ln -sf $f " SYSCONFDIR "/crypto-policies/back-ends/$(basename $f .txt).config\n"
     "done"
   },
+  // Replicating https://src.fedoraproject.org/rpms/authselect/blob/e597fee6295c4334214b306acbbf8dabff67c4da/f/authselect.spec#_284
+  { "authselect-libs.prein",
+    "/usr/bin/bash",
+    "touch /var/lib/rpm-state/authselect.force"
+  },
   /* Just for the tests */
   { "rpmostree-lua-override-test.post",
     "/usr/bin/sh",


### PR DESCRIPTION

Half of it is an upgrade hack that is incompatible with rpm-ostree
model; we always generate a fresh root.  Just touch the stamp
file so that authselect knows to rerun.

---

