### PR TITLE
daemon: port the override-source string parser to Rust

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -236,6 +236,11 @@ pub mod ffi {
         clientlayer_version: u32,
     }
 
+    #[derive(Debug)]
+    enum PackageOverrideSourceKind {
+        Repo,
+    }
+
     // daemon.rs
     extern "Rust" {
         fn daemon_sanitycheck_environment(sysroot: Pin<&mut OstreeSysroot>) -> Result<()>;
@@ -253,6 +258,8 @@ pub mod ffi {
             mut repo: Pin<&mut OstreeRepo>,
             mut deployment: Pin<&mut OstreeDeployment>,
         ) -> Result<DeploymentLayeredMeta>;
+        fn parse_override_source(source: &str) -> Result<[String; 2]>;
+        fn parse_override_source_kind(kind_label: &str) -> Result<PackageOverrideSourceKind>;
     }
 
     // failpoint_bridge.rs

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -241,6 +241,12 @@ pub mod ffi {
         Repo,
     }
 
+    #[derive(Debug)]
+    struct PackageOverrideSource {
+        kind: PackageOverrideSourceKind,
+        name: String,
+    }
+
     // daemon.rs
     extern "Rust" {
         fn daemon_sanitycheck_environment(sysroot: Pin<&mut OstreeSysroot>) -> Result<()>;
@@ -258,8 +264,7 @@ pub mod ffi {
             mut repo: Pin<&mut OstreeRepo>,
             mut deployment: Pin<&mut OstreeDeployment>,
         ) -> Result<DeploymentLayeredMeta>;
-        fn parse_override_source(source: &str) -> Result<[String; 2]>;
-        fn parse_override_source_kind(kind_label: &str) -> Result<PackageOverrideSourceKind>;
+        fn parse_override_source(source: &str) -> Result<PackageOverrideSource>;
     }
 
     // failpoint_bridge.rs

--- a/src/daemon/rpmostreed-os-experimental.cxx
+++ b/src/daemon/rpmostreed-os-experimental.cxx
@@ -226,11 +226,10 @@ prepare_download_pkgs_txn(const gchar * const *queries,
 
   DnfSack *sack = dnf_context_get_sack (rpmostree_context_get_dnf (ctx));
   auto parsed_source = CXX_TRY_VAL(parse_override_source(source), error);
-  auto source_kind = CXX_TRY_VAL(parse_override_source_kind(parsed_source[0]), error);
 
-  if (source_kind == rpmostreecxx::PackageOverrideSourceKind::Repo)
+  if (parsed_source.kind == rpmostreecxx::PackageOverrideSourceKind::Repo)
     {
-      const char *source_name = parsed_source[1].c_str();
+      const char *source_name = parsed_source.name.c_str();
       for (const char* const* it = queries; it && *it; it++)
         {
           auto pkg_name = static_cast<const char*> (*it);
@@ -249,7 +248,7 @@ prepare_download_pkgs_txn(const gchar * const *queries,
     }
   /* Future source kinds go here */
   else
-    return glnx_throw (error, "Unsupported source type: %s", parsed_source[0].c_str());
+    return glnx_throw (error, "Unsupported source type");
 
   rpmostree_set_repos_on_packages (rpmostree_context_get_dnf (ctx), dnf_pkgs);
 

--- a/src/libpriv/rpmostree-types.h
+++ b/src/libpriv/rpmostree-types.h
@@ -43,10 +43,6 @@ typedef enum {
   RPM_OSTREE_ADVISORY_SEVERITY_LAST,
 } RpmOstreeAdvisorySeverity;
 
-typedef enum {
-  RPM_OSTREE_OVERRIDE_SOURCE_KIND_REPO,
-} RpmOstreeOverrideSourceKind;
-
 /**
  * RPMOSTREE_DIFF_SINGLE_GVARIANT_FORMAT:
  *

--- a/src/libpriv/rpmostree-util.cxx
+++ b/src/libpriv/rpmostree-util.cxx
@@ -1186,24 +1186,3 @@ rpmostree_cxx_string_vec_to_strv (rust::Vec<rust::String> &v)
   g_ptr_array_add (r, NULL);
   return (char**)g_ptr_array_free (util::move_nullify(r), FALSE);
 }
-
-/* Take a KIND=NAME string and returns the kind of kind side and
-+ * errors if the source type is unsupported */
-char*
-rpmostree_parse_override_source (const char *source,
-                                 RpmOstreeOverrideSourceKind *out_source_kind,
-                                 GError **error)
-{
-  const char *eq = strchr (source, '=');
-  if (!eq)
-    return (char*)glnx_null_throw (error, "Missing '=' in KIND=NAME source '%s'", source);
-  g_autofree char * source_kind = g_strndup (source, eq - source);
-  if (g_str_equal (source_kind, "repo"))
-    *out_source_kind = RPM_OSTREE_OVERRIDE_SOURCE_KIND_REPO;
-/* Place for future supported sources */
-  else
-    return (char*)glnx_null_throw (error, "Unsupported source type: %s", source_kind);
-  if (strlen (eq + 1) <= 0)
-    return (char*)glnx_null_throw (error, "Missing 'NAME' in KIND=NAME source '%s'", source);
-  return g_strdup (eq + 1);
-}

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -371,8 +371,4 @@ rpmostree_cxx_string_vec_to_strv (rust::Vec<rust::String> &v);
 void 
 rpmostreed_utils_tests (void);
 
-char*
-rpmostree_parse_override_source (const char *source,
-                                 RpmOstreeOverrideSourceKind *out_source_kind,
-                                 GError **error);
 G_END_DECLS


### PR DESCRIPTION
This gets rid of the C logic for parsing override sources, moving
to a safe string parser in Rust. It also adds some basic unit tests.