### PR TITLE
Start using cap-std/rustix instead of openat/nix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec8ad6edb4840b78c5c3d88de606b22252d552b55f3a4699fbb10fc070ec3049"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +146,49 @@ name = "camino"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d74260d9bf6944e2208aa46841b4b8f0d7ffc0849a06837b2f510337f86b2b"
+
+[[package]]
+name = "cap-primitives"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2737eb174c9482c865789a428bfbddfdf284317d466ebbc637eee2e1242bfaa"
+dependencies = [
+ "ambient-authority",
+ "errno",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "winapi",
+ "winapi-util",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9ba199282865f3e3c3e7afc6907a3a27896435e24209e035c8a24d4fbcf43a"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "rustix",
+]
+
+[[package]]
+name = "cap-tempfile"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c472ee35e2073a74a3d882c21745e7db2d573825e2e0a754dbffaeef97f4458"
+dependencies = [
+ "cap-std",
+ "rand",
+ "uuid",
+]
 
 [[package]]
 name = "capctl"
@@ -678,6 +727,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ebf75299c070b6b4da3c9da0be01fee7388fb919fd4e6bad5b4f94923d08f1"
+dependencies = [
+ "io-lifetimes",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,6 +1141,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9132d2d6504f4e348b8e16787f01613b4d0e587458641a40e727304416ac8d"
+dependencies = [
+ "io-lifetimes",
+ "winapi",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1309,12 @@ name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -1934,6 +2010,9 @@ dependencies = [
  "binread",
  "c_utf8",
  "camino",
+ "cap-primitives",
+ "cap-std",
+ "cap-tempfile",
  "chrono",
  "clap",
  "curl",
@@ -1963,6 +2042,7 @@ dependencies = [
  "regex",
  "rpmostree-client",
  "rust-ini",
+ "rustix",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1998,8 +2078,10 @@ dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
+ "itoa 1.0.1",
  "libc",
  "linux-raw-sys",
+ "once_cell",
  "winapi",
 ]
 
@@ -2593,6 +2675,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
 
 [[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2759,6 +2850,17 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winx"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54de2ce52a3e5839e129c7859e2b1f581769bbef57c0a2a09a12a5a3a5b3c2a"
+dependencies = [
+ "bitflags",
+ "io-lifetimes",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ anyhow = "1.0.52"
 binread = "2.2.0"
 c_utf8 = "0.1.0"
 camino = "1.0.5"
+cap-primitives = "0.22.0"
+cap-std = "0.22.0"
+cap-tempfile = "0.22.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = "2.34.0"
 curl = "0.4.41"
@@ -61,6 +64,7 @@ rayon = "1.5.1"
 regex = "1.5"
 rpmostree-client = { path = "rust/rpmostree-client", version = "0.1.0" }
 rust-ini = "0.17.0"
+rustix = "0.31.3"
 serde = { version = "1.0.133", features = ["derive"] }
 serde_derive = "1.0.118"
 serde_json = "1.0.74"

--- a/rust/src/capstdext.rs
+++ b/rust/src/capstdext.rs
@@ -1,0 +1,44 @@
+//! Helper functions for the [`cap-std` crate].
+//!
+//! [`cap-std` crate]: https://crates.io/crates/cap-std
+//  SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::io::Result;
+use std::os::unix::fs::DirBuilderExt;
+use std::os::unix::prelude::PermissionsExt;
+use std::path::Path;
+
+use cap_std::fs::DirBuilder;
+
+pub(crate) trait CapStdDirExt {
+    /// Create the target directory, but do nothing if it already exists.
+    fn ensure_dir_with(
+        &self,
+        p: impl AsRef<Path>,
+        builder: &cap_std::fs::DirBuilder,
+    ) -> Result<bool>;
+}
+
+impl CapStdDirExt for cap_std::fs::Dir {
+    fn ensure_dir_with(
+        &self,
+        p: impl AsRef<Path>,
+        builder: &cap_std::fs::DirBuilder,
+    ) -> Result<bool> {
+        match self.create_dir_with(p, builder) {
+            Ok(()) => Ok(false),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(true),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+pub(crate) fn dirbuilder_from_mode(m: u32) -> DirBuilder {
+    let mut r = DirBuilder::new();
+    r.mode(m);
+    r
+}
+
+pub(crate) fn perms_from_mode(m: u32) -> cap_std::fs::Permissions {
+    cap_std::fs::Permissions::from_std(std::fs::Permissions::from_mode(m))
+}

--- a/rust/src/ffiutil.rs
+++ b/rust/src/ffiutil.rs
@@ -47,6 +47,19 @@ pub(crate) fn ffi_view_openat_dir(fd: libc::c_int) -> openat::Dir {
     r
 }
 
+/// Create a new cap_std directory for an openat version.
+/// This creates a new file descriptor, because we can't guarantee they are
+/// interchangable; for example right now openat uses `O_PATH`
+pub(crate) unsafe fn ffi_dirfd(fd: libc::c_int) -> std::io::Result<cap_std::fs::Dir> {
+    // TODO replace this with https://github.com/bytecodealliance/cap-std/pull/212
+    let src = unsafe { std::fs::File::from_raw_fd(fd) };
+    // Then convert into a cap-std file
+    let r = cap_primitives::fs::open_dir(&src, std::path::Path::new("."))?;
+    // Now, drop the std wrapper for the fd - we don't want to close it!
+    let _ = src.into_raw_fd();
+    Ok(cap_std::fs::Dir::from_std_file(r))
+}
+
 // View `fd` as an `Option<openat::Dir>` instance.  Lifetime of return value
 // must be less than or equal to that of parameter.
 #[allow(dead_code)]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -670,6 +670,7 @@ pub mod countme;
 pub(crate) use composepost::*;
 mod core;
 use crate::core::*;
+mod capstdext;
 mod daemon;
 mod dirdiff;
 pub mod failpoint_bridge;

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -19,7 +19,7 @@ use regex::Regex;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::io::prelude::*;
-use std::os::unix::io::IntoRawFd;
+use std::os::unix::io::{AsRawFd, IntoRawFd};
 use std::path::Path;
 use std::pin::Pin;
 use std::{fs, io};
@@ -257,6 +257,16 @@ pub(crate) fn shellsafe_quote(input: Cow<str>) -> Cow<str> {
         // SAFETY: if input is UTF-8, so is the quoted string.
         Cow::Owned(quoted.into_string().expect("non UTF-8 quoted output"))
     }
+}
+
+/// Create a new cap_std directory for an openat version.
+/// This creates a new file descriptor, because we can't guarantee they are
+/// interchangable; for example right now openat uses `O_PATH`
+#[allow(dead_code)]
+pub(crate) fn openat_to_dirfd(f: &openat::Dir) -> Result<cap_std::fs::Dir> {
+    // For now we just delegate to the FFI code
+    let r = unsafe { crate::ffiutil::ffi_dirfd(f.as_raw_fd())? };
+    Ok(r)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This will be nontrivial churn with no immediate obvious end user
value.  But, long term, the "cap-std ecosystem" of crates has *much*
more momentum than openat.  (Really, it's mostly just Dan Gohman
right now but his code is really, really good; and we can contribute)

There are a few concrete improvements from this; see
https://github.com/bytecodealliance/cap-std#similar-crates
I have to emphasize this bit:

> However, cap-std uses RESOLVE_BENEATH-style resolution where absolute paths are considered errors,

This is a big deal - a while ago I accidentally created an absolute
path in some of the code, and I only noticed it in review.

And related to this, openat's `open()` path does not follow symlinks
by default, which is a huge ergonomic hit when one *does* want to do
so, as I did in a recent patch.

Other bits as noted are that cap-std and the io-lifetimes crates
correctly handles borrowing and ownership for file descriptors, which
is also incredibly important for us.

I just wanted to get the ball rolling here; we can incrementally
port to cap-std/rustix over time.
