### PR TITLE
Fix or quiet unused field warnings

### DIFF
--- a/rust/src/cliwrap/yumdnf.rs
+++ b/rust/src/cliwrap/yumdnf.rs
@@ -51,11 +51,13 @@ enum Opt {
     /// Perform a search of packages.
     Search {
         /// Search terms
+        #[allow(dead_code)]
         terms: Vec<String>,
     },
     /// Will return an error suggesting other approaches.
     Install {
         /// Set of packages to install
+        #[allow(dead_code)]
         packages: Vec<String>,
     },
 }

--- a/rust/src/countme/repo.rs
+++ b/rust/src/countme/repo.rs
@@ -16,7 +16,8 @@ pub const YUM_REPOS_D: &str = "/etc/yum.repos.d";
 /// Not exhaustive and only includes the options needed for Count Me support.
 #[derive(Debug)]
 pub struct Repo {
-    name: String,
+    // Not needed right now
+    // name: String,
     enabled: bool,
     count_me: bool,
     meta_link: String,
@@ -58,8 +59,7 @@ fn parse_repo_file(path: &PathBuf) -> Result<Vec<Repo>> {
             None => {
                 continue;
             }
-            Some(s) => Repo {
-                name: String::from(s),
+            Some(_s) => Repo {
                 enabled: false,
                 count_me: false,
                 meta_link: "".to_string(),

--- a/rust/src/normalization.rs
+++ b/rust/src/normalization.rs
@@ -199,6 +199,7 @@ mod bdb_normalize {
     // Database metadata header.
     #[derive(BinRead, Debug)]
     #[br(little)]
+    #[allow(dead_code)]
     struct MetaHeader {
         lsn: u64,            // Log sequence number
         pgno: u32,           // Number of this page
@@ -233,6 +234,7 @@ mod bdb_normalize {
     // The per-header page used in both BTree and Hash databases.
     #[derive(BinRead, Debug)]
     #[br(little)]
+    #[allow(dead_code)]
     struct PageHeader {
         lsn: u64,            // Log sequence number
         pgno: u32,           // Number of this page


### PR DESCRIPTION
Newer rust warns about these by default.  For most of them
I just chose to `#[allow(dead_code)]` because these structs
are intended to mirror external things, and it just happens
that we're not reading all of the fields right now.
