### PR TITLE
Release 2022.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,8 +2,8 @@ AC_PREREQ([2.63])
 dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
-m4_define([year_version], [2021])
-m4_define([release_version], [14])
+m4_define([year_version], [2022])
+m4_define([release_version], [1])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2021.14
+Version: 2022.1
 Release: 1%{?dist}
 License: LGPLv2+
 URL: https://github.com/coreos/rpm-ostree


### PR DESCRIPTION

Various smaller bugfixes, but also an update the ostree 2022.1 stack,
support for "multicall", support for `rpm-ostree install` inside
a container (with microdnf).


