### PR TITLE
tree-wide: Replace `nix::get*[ug]id` with rustix equivalents

### DIFF
--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -229,7 +229,7 @@ impl Bubblewrap {
          *
          * Also this way we drop out any new capabilities that appear.
          */
-        if nix::unistd::getuid() == nix::unistd::Uid::from_raw(0) {
+        if rustix::process::getuid().as_raw() == 0 {
             argv.extend(&["--cap-drop", "ALL"]);
             for cap in ADDED_CAPABILITIES {
                 argv.push("--cap-add");

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -159,7 +159,7 @@ pub(crate) fn client_handle_fd_argument(arg: &str, arch: &str) -> CxxResult<Vec<
 pub(crate) fn client_start_daemon() -> CxxResult<()> {
     let service = "rpm-ostreed.service";
     // Assume non-root can't use systemd right now.
-    if !nix::unistd::getuid().is_root() {
+    if rustix::process::getuid().as_raw() != 0 {
         return Ok(());
     }
     let res = Command::new("systemctl")

--- a/rust/src/cliwrap/cliutil.rs
+++ b/rust/src/cliwrap/cliutil.rs
@@ -21,7 +21,7 @@ pub fn is_unlocked() -> Result<bool> {
 
 /// Returns true if the current process is running as root.
 pub fn am_privileged() -> bool {
-    nix::unistd::getuid() == nix::unistd::Uid::from_raw(0)
+    rustix::process::getuid().as_raw() == 0
 }
 
 /// Return the absolute path to the underlying wrapped binary

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -1184,7 +1184,7 @@ OSTREE_VERSION='33.4'
     #[test]
     fn test_tmpfiles_d_translation() {
         use nix::sys::stat::{umask, Mode};
-        use nix::unistd::{getegid, geteuid};
+        use rustix::process::{getegid, geteuid};
 
         // Prepare a minimal rootfs as playground.
         umask(Mode::empty());
@@ -1201,14 +1201,18 @@ OSTREE_VERSION='33.4'
                 .write_file_contents(
                     "usr/etc/passwd",
                     0o755,
-                    format!("test-user:x:{}:{}:::", geteuid(), getegid()),
+                    format!(
+                        "test-user:x:{}:{}:::",
+                        geteuid().as_raw(),
+                        getegid().as_raw()
+                    ),
                 )
                 .unwrap();
             rootfs
                 .write_file_contents(
                     "usr/etc/group",
                     0o755,
-                    format!("test-group:x:{}:", getegid()),
+                    format!("test-group:x:{}:", getegid().as_raw()),
                 )
                 .unwrap();
         }

--- a/rust/src/countme.rs
+++ b/rust/src/countme.rs
@@ -4,7 +4,6 @@
 
 use anyhow::{bail, Context, Result};
 use curl::easy::Easy;
-use nix::unistd::geteuid;
 use os_release::OsRelease;
 use std::path;
 
@@ -42,7 +41,7 @@ pub fn entrypoint(_args: &[&str]) -> Result<()> {
     }
 
     // Skip if we are not running with an unprivileged user
-    if geteuid().is_root() {
+    if rustix::process::geteuid().as_raw() == 0 {
         bail!("Must run under an unprivileged user");
     }
 


### PR DESCRIPTION
Part of porting to cap-std/rustix.

