### PR TITLE
build-sys: Symlink, not hard link `ostree-container`

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -138,7 +138,7 @@ BUILT_SOURCES += $(binding_generated_sources)
 install-rpmostree-hook:
 	install -d -m 0755 $(DESTDIR)$(bindir)
 	install -m 0755 -t $(DESTDIR)$(bindir) rpm-ostree
-	ln -T -f $(DESTDIR)$(bindir)/rpm-ostree $(DESTDIR)$(bindir)/ostree-container
+	ln -Tsr -f $(DESTDIR)$(bindir)/rpm-ostree $(DESTDIR)$(bindir)/ostree-container
 INSTALL_EXEC_HOOKS += install-rpmostree-hook
 
 # Wraps `cargo test`.  This is always a debug non-release build;


### PR DESCRIPTION
It seems like the debuginfo processing code in RHEL8 fails in
this scenario:

```
$ Checking for unpackaged file(s): /usr/lib/rpm/check-files /builddir/build/BUILDROOT/rpm-ostree-2022.1-1.el8.x86_64
RPM build errors:
error: Installed (but unpackaged) file(s) found:
   /usr/lib/debug/usr/bin/rpm-ostree-2022.1-1.el8.x86_64.debug.#dwz#.Iybgi6
    Installed (but unpackaged) file(s) found:
   /usr/lib/debug/usr/bin/rpm-ostree-2022.1-1.el8.x86_64.debug.#dwz#.Iybgi6
Child return code was: 1
```

Additionally, while hardlinks are conceptually cleaner, actually
because of SELinux they are highly likely to result in duplicate
disk usage.  IOW we'd have to be sure `/usr/bin/ostree-container`
is also labeled `install_t`, otherwise ostree will compute different
digests for them.
