### PR TITLE
compose: Support `/run/ostree-booted` also in legacy mode

### DIFF
--- a/rust/src/builtins/compose/mod.rs
+++ b/rust/src/builtins/compose/mod.rs
@@ -11,11 +11,15 @@ use openat_ext::OpenatDirExt;
 use std::ffi::{CStr, CString};
 use std::io::{self, Read};
 
-/// Prepare /dev in the target root with the API devices.
+use crate::core::OSTREE_BOOTED;
+
+/// Prepare /dev and /run in the target root with the API devices.
 // TODO: delete this when we implement https://github.com/projectatomic/rpm-ostree/issues/729
-pub fn composeutil_legacy_prep_dev(rootfs_dfd: i32) -> CxxResult<()> {
+pub fn composeutil_legacy_prep_dev_and_run(rootfs_dfd: i32) -> CxxResult<()> {
     let rootfs = crate::ffiutil::ffi_view_openat_dir(rootfs_dfd);
     legacy_prepare_dev(&rootfs)?;
+    rootfs.create_dir("run", 0o755)?;
+    rootfs.write_file(&OSTREE_BOOTED[1..], 0o755)?;
     Ok(())
 }
 

--- a/rust/src/cliwrap/cliutil.rs
+++ b/rust/src/cliwrap/cliutil.rs
@@ -7,9 +7,11 @@ use std::{path, thread, time};
 
 use crate::cliwrap;
 
+use crate::core::OSTREE_BOOTED;
+
 /// Returns true if the current process is booted via ostree.
 pub fn is_ostree_booted() -> bool {
-    path::Path::new("/run/ostree-booted").exists()
+    path::Path::new(OSTREE_BOOTED).exists()
 }
 
 /// Returns true if /usr is not a read-only bind mount

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -27,6 +27,8 @@ const SSS_CACHE_PATH: &str = "usr/sbin/sss_cache";
 const SYSTEMCTL_PATH: &str = "usr/bin/systemctl";
 const SYSTEMCTL_WRAPPER: &[u8] = include_bytes!("../../src/libpriv/systemctl-wrapper.sh");
 
+pub(crate) const OSTREE_BOOTED: &str = "/run/ostree-booted";
+
 /// Guard for running logic in a context with temporary /etc.
 ///
 /// We have a messy dance in dealing with /usr/etc and /etc; the

--- a/rust/src/countme.rs
+++ b/rust/src/countme.rs
@@ -7,6 +7,8 @@ use curl::easy::Easy;
 use os_release::OsRelease;
 use std::path;
 
+use crate::core::OSTREE_BOOTED;
+
 mod cookie;
 mod repo;
 
@@ -36,7 +38,7 @@ fn send_countme(url: &str, ua: &str) -> Result<()> {
 /// Main entrypoint for countme
 pub fn entrypoint(_args: &[&str]) -> Result<()> {
     // Skip if we are not run on an ostree booted system
-    if !path::Path::new("/run/ostree-booted").exists() {
+    if !path::Path::new(OSTREE_BOOTED).exists() {
         bail!("Not running on an ostree based system");
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -141,7 +141,7 @@ pub mod ffi {
 
     // builtins/compose/
     extern "Rust" {
-        fn composeutil_legacy_prep_dev(rootfs_dfd: i32) -> Result<()>;
+        fn composeutil_legacy_prep_dev_and_run(rootfs_dfd: i32) -> Result<()>;
         fn print_ostree_txn_stats(stats: Pin<&mut OstreeRepoTransactionStats>);
         fn write_commit_id(target_path: &str, revision: &str) -> Result<()>;
     }

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -492,7 +492,7 @@ install_packages (RpmOstreeTreeComposeContext  *self,
 
       glnx_console_lock (&console);
 
-      CXX_TRY(composeutil_legacy_prep_dev(rootfs_dfd), error);
+      CXX_TRY(composeutil_legacy_prep_dev_and_run(rootfs_dfd), error);
 
       if (!dnf_transaction_commit (dnf_context_get_transaction (dnfctx),
                                    dnf_context_get_goal (dnfctx),

--- a/tests/compose/test-basic-unified.sh
+++ b/tests/compose/test-basic-unified.sh
@@ -8,7 +8,7 @@ dn=$(cd "$(dirname "$0")" && pwd)
 # Add a local rpm-md repo so we can mutate local test packages
 treefile_append "repos" '["test-repo"]'
 # test `recommends: false` (test-misc-tweaks tests the true path)
-build_rpm foobar recommends foobar-rec
+build_rpm foobar recommends foobar-rec post "test -f /run/ostree-booted"
 build_rpm foobar-rec
 
 # check that even a modular version of a pinned pkg is ignored, even if it's

--- a/tests/compose/test-basic.sh
+++ b/tests/compose/test-basic.sh
@@ -10,7 +10,7 @@ dn=$(cd "$(dirname "$0")" && pwd)
 # Add a local rpm-md repo so we can mutate local test packages
 treefile_append "repos" '["test-repo"]'
 # test `recommends: false` (test-misc-tweaks tests the true path)
-build_rpm foobar recommends foobar-rec
+build_rpm foobar recommends foobar-rec post "test -f /run/ostree-booted"
 build_rpm foobar-rec
 
 echo gpgcheck=0 >> yumrepo.repo


### PR DESCRIPTION
Otherwise, practically speaking today, scriptlets which need to work on
both FSB and FCOS can't use it.