### PR TITLE
client: Add context to microdnf failure to exec

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -4,7 +4,7 @@
 
 use crate::cxxrsutil::*;
 use crate::utils;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use gio::prelude::*;
 use ostree_ext::{gio, glib};
 use std::os::unix::io::IntoRawFd;
@@ -246,7 +246,8 @@ pub(crate) fn microdnf_install(args: Vec<String>) -> Result<()> {
         .arg("install")
         .arg("-y")
         .args(&args)
-        .status()?;
+        .status()
+        .context("Failed to spawn `microdnf`")?;
     if !microdnf_status.success() {
         return Err(anyhow!(
             "Failure installing {:?}, microdnf failed with: {:?}",


### PR DESCRIPTION
I was writing a test against a FCOS base that doesn't have `microdnf`
and was getting:

```
STEP 4/6: RUN rpm-ostree install ./bar-1.0*.rpm
error: No such file or directory (os error 2)
```

This confused me because I thought it was talking about `bar.rpm`.
Add an error context for clarity.
