### PR TITLE
ci: Try using next so we pick up `microdnf`

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -43,7 +43,7 @@ parallel insttests: {
       }
       stage("Build FCOS") {
         shwrap("""
-          coreos-assembler init --force https://github.com/coreos/fedora-coreos-config
+          coreos-assembler init --force https://github.com/coreos/fedora-coreos-config -b next
           # include our built rpm-ostree in the image
           mkdir -p overrides/rpm
           mv *.rpm overrides/rpm


### PR DESCRIPTION
So we can start using it in our own CI.
