### PR TITLE
Add `rpm-ostree ex rebuild` command

### DIFF
--- a/Makefile-libpriv.am
+++ b/Makefile-libpriv.am
@@ -25,6 +25,8 @@ librpmostreepriv_sources = \
 	src/libpriv/rpmostree-types.h \
 	src/libpriv/rpmostree-refts.h \
 	src/libpriv/rpmostree-refts.cxx \
+	src/libpriv/rpmostree-container.cxx \
+	src/libpriv/rpmostree-container.h \
 	src/libpriv/rpmostree-core.cxx \
 	src/libpriv/rpmostree-core.h \
 	src/libpriv/rpmostree-core-private.h \

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -59,6 +59,7 @@ librpmostreeinternals_la_SOURCES = \
 	src/app/rpmostree-composeutil.cxx \
 	src/app/rpmostree-composeutil.h \
 	src/app/rpmostree-builtin-compose.cxx \
+	src/app/rpmostree-builtin-rebuild.cxx \
 	$(librpmostreed_sources) \
 	$(librpmostreepriv_sources) \
 	$(librpmostree_1_la_SOURCES) \

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -236,28 +236,6 @@ pub(crate) fn client_render_download_progress(
     }
 }
 
-/// Install packages live into the running root filesystem.
-/// This is only intended for use as part of a container builds.
-/// For now, we fork/exec microdnf because this is exactly what its
-/// main use case is, but in the future we may change the rpm-ostree code
-/// to handle this more directly.
-pub(crate) fn microdnf_install(args: Vec<String>) -> Result<()> {
-    let microdnf_status = Command::new(microdnf_location())
-        .arg("install")
-        .arg("-y")
-        .args(&args)
-        .status()
-        .context("Failed to spawn `microdnf`")?;
-    if !microdnf_status.success() {
-        return Err(anyhow!(
-            "Failure installing {:?}, microdnf failed with: {:?}",
-            args,
-            microdnf_status
-        ));
-    }
-    Ok(())
-}
-
 /// Clean up /var/cache/yum/ which so it's not attemped to be
 /// copied to the next container layer. Without calling this
 /// we would see various non-fatal errors during a container build.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -392,6 +392,7 @@ pub mod ffi {
             workdir: i32,
         ) -> Result<Box<Treefile>>;
         fn treefile_new_client(filename: &str, basearch: &str) -> Result<Box<Treefile>>;
+        fn treefile_new_client_from_etc(basearch: &str) -> Result<Box<Treefile>>;
 
         fn get_workdir(&self) -> i32;
         fn get_passwd_fd(&mut self) -> i32;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -86,7 +86,6 @@ pub mod ffi {
         fn client_handle_fd_argument(arg: &str, arch: &str) -> Result<Vec<i32>>;
         fn client_render_download_progress(progress: Pin<&mut GVariant>) -> String;
         fn microdnf_clean_all() -> Result<()>;
-        fn microdnf_install(args: Vec<String>) -> Result<()>;
         fn running_in_container() -> bool;
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -393,6 +393,7 @@ pub mod ffi {
         ) -> Result<Box<Treefile>>;
         fn treefile_new_client(filename: &str, basearch: &str) -> Result<Box<Treefile>>;
         fn treefile_new_client_from_etc(basearch: &str) -> Result<Box<Treefile>>;
+        fn treefile_delete_client_etc() -> Result<()>;
 
         fn get_workdir(&self) -> i32;
         fn get_passwd_fd(&mut self) -> i32;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -85,7 +85,6 @@ pub mod ffi {
         fn client_start_daemon() -> Result<()>;
         fn client_handle_fd_argument(arg: &str, arch: &str) -> Result<Vec<i32>>;
         fn client_render_download_progress(progress: Pin<&mut GVariant>) -> String;
-        fn microdnf_clean_all() -> Result<()>;
         fn running_in_container() -> bool;
     }
 

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -2305,3 +2305,11 @@ pub(crate) fn treefile_new_client_from_etc(basearch: &str) -> CxxResult<Box<Tree
     r.error_if_base()?;
     Ok(Box::new(r))
 }
+
+pub(crate) fn treefile_delete_client_etc() -> CxxResult<()> {
+    // To be nice we don't delete the directory itself; just matching files.
+    for tf in iter_etc_treefiles()? {
+        std::fs::remove_file(&tf?)?;
+    }
+    Ok(())
+}

--- a/src/app/rpmostree-builtin-cleanup.cxx
+++ b/src/app/rpmostree-builtin-cleanup.cxx
@@ -24,6 +24,7 @@
 #include <glib-unix.h>
 
 #include "rpmostree-builtins.h"
+#include "rpmostree-core.h"
 #include "rpmostree-util.h"
 #include "rpmostree-libbuiltin.h"
 #include "rpmostree-clientlib.h"
@@ -83,10 +84,11 @@ rpmostree_builtin_cleanup (int             argc,
   if (opt_repomd)
     {
       auto is_ostree_container = CXX_TRY_VAL(is_ostree_container(), error);
-      if (is_ostree_container) 
+      if (is_ostree_container)
         {
-          CXX_TRY(microdnf_clean_all(), error);
-          return TRUE;
+          /* just directly nuke the cachedir */
+          if (!glnx_shutil_rm_rf_at (AT_FDCWD, RPMOSTREE_CORE_CACHEDIR, cancellable, error))
+            return FALSE;
         }
       g_ptr_array_add (cleanup_types, (char*)"repomd");
     }

--- a/src/app/rpmostree-builtin-ex.cxx
+++ b/src/app/rpmostree-builtin-ex.cxx
@@ -33,6 +33,10 @@ static RpmOstreeCommand ex_subcommands[] = {
     "Inspect rpm-ostree history of the system", rpmostree_ex_builtin_history },
   { "initramfs-etc", (RpmOstreeBuiltinFlags)0,
     "Track initramfs configuration files", rpmostree_ex_builtin_initramfs_etc },
+  /* This is currently only for CoreOS layering; so hide it to not confuse
+   * users. */
+  { "rebuild", (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_HIDDEN),
+    "Rebuild system based on configuration", rpmostree_ex_builtin_rebuild },
   /* To graduate out of experimental, simply revert:
    * https://github.com/coreos/rpm-ostree/pull/3078 */
   { "module", static_cast<RpmOstreeBuiltinFlags>(0),

--- a/src/app/rpmostree-builtin-rebuild.cxx
+++ b/src/app/rpmostree-builtin-rebuild.cxx
@@ -1,0 +1,83 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <glib-unix.h>
+
+#include "rpmostree-ex-builtins.h"
+#include "rpmostree-libbuiltin.h"
+#include "rpmostree-clientlib.h"
+#include "rpmostree-container.h"
+
+#include <libglnx.h>
+
+gboolean
+rpmostree_ex_builtin_rebuild (int             argc,
+                              char          **argv,
+                              RpmOstreeCommandInvocation *invocation,
+                              GCancellable   *cancellable,
+                              GError        **error)
+{
+  g_autoptr(GOptionContext) context = g_option_context_new ("");
+
+  if (!rpmostree_option_context_parse (context,
+                                       NULL,
+                                       &argc, &argv,
+                                       invocation,
+                                       cancellable,
+                                       NULL, NULL, NULL,
+                                       error))
+    return FALSE;
+
+  bool in_container = false;
+  if (rpmostreecxx::running_in_container())
+    {
+      auto is_ostree_container = CXX_TRY_VAL(is_ostree_container(), error);
+      if (!is_ostree_container)
+        return glnx_throw (error, "This command can only run in an OSTree container.");
+      in_container = true;
+    }
+
+  auto basearch = rpmostreecxx::get_rpm_basearch();
+  auto treefile = CXX_TRY_VAL(treefile_new_client_from_etc (basearch), error);
+
+  /* This is the big switch: we support running this command in two modes:
+   * "client containers", where the effect takes place in the active rootfs, and
+   * possibly eventually "client host systems", where the effect takes place in
+   * a new deployment. */
+  if (in_container)
+    {
+      if (!rpmostree_container_rebuild (*treefile, cancellable, error))
+        return FALSE;
+
+      /* In the container flow, we effectively "consume" the treefiles after
+       * modifying the rootfs. */
+      CXX_TRY(treefile_delete_client_etc (), error);
+    }
+  else
+    {
+      return glnx_throw (error, "This command is not yet supported on host systems. "
+                                "See https://github.com/coreos/rpm-ostree/issues/2326.");
+    }
+
+  return TRUE;
+}

--- a/src/app/rpmostree-ex-builtins.h
+++ b/src/app/rpmostree-ex-builtins.h
@@ -35,6 +35,7 @@ BUILTINPROTO(apply_live);
 BUILTINPROTO(history);
 BUILTINPROTO(initramfs_etc);
 BUILTINPROTO(module);
+BUILTINPROTO(rebuild);
 
 #undef BUILTINPROTO
 

--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -25,6 +25,7 @@
 #include "rpmostree-util.h"
 #include "rpmostree-rpm-util.h"
 #include "rpmostree-clientlib.h"
+#include "rpmostree-container.h"
 
 #include <libglnx.h>
 
@@ -196,13 +197,7 @@ rpmostree_builtin_install (int            argc,
 
   auto is_ostree_container = CXX_TRY_VAL(is_ostree_container(), error);
   if (is_ostree_container)
-    {
-      auto argv_rust = rust::Vec<rust::String>();
-        for (int i = 0; i < argc; i++)
-          argv_rust.push_back(rust::String(argv[i]));
-      CXX_TRY(microdnf_install(argv_rust), error);
-      return TRUE;
-    }
+    return rpmostree_container_install_packages (argv, cancellable, error);
 
   return pkg_change (invocation, sysroot_proxy,
                      (const char *const*)argv,

--- a/src/libpriv/rpmostree-container.cxx
+++ b/src/libpriv/rpmostree-container.cxx
@@ -60,3 +60,16 @@ rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile,
 
   return TRUE;
 }
+
+gboolean
+rpmostree_container_install_packages (char **packages,
+                                      GCancellable  *cancellable,
+                                      GError       **error)
+{
+  // XXX: awkward: add a e.g. `treefile_new_client_from_fields()`
+  g_autofree char *joined = g_strjoinv ("\",\"", packages);
+  g_autofree char *treefile_s = g_strdup_printf ("{\"packages\": [\"%s\"]}", joined);
+  auto treefile = CXX_TRY_VAL(treefile_new_from_string (treefile_s, true), error);
+
+  return rpmostree_container_rebuild (*treefile, cancellable, error);
+}

--- a/src/libpriv/rpmostree-container.cxx
+++ b/src/libpriv/rpmostree-container.cxx
@@ -1,0 +1,62 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <glib-unix.h>
+
+#include "rpmostree-core.h"
+#include "rpmostree-container.h"
+
+#include <libglnx.h>
+
+gboolean
+rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile,
+                             GCancellable           *cancellable,
+                             GError                **error)
+{
+  auto packages = treefile.get_packages();
+
+  /* for now, we only support package installs */
+  if (packages.empty())
+    return TRUE;
+
+  g_autoptr(RpmOstreeContext) ctx = rpmostree_context_new_container ();
+  rpmostree_context_set_treefile (ctx, treefile);
+
+  if (!rpmostree_context_setup (ctx, "/", "/", cancellable, error))
+    return FALSE;
+
+  if (!rpmostree_context_prepare (ctx, cancellable, error))
+    return FALSE;
+
+  if (!rpmostree_context_download (ctx, cancellable, error))
+    return FALSE;
+
+  DnfContext *dnfctx = rpmostree_context_get_dnf (ctx);
+
+  /* can't use cancellable here because it wants to re-set it on the state,
+   * which will trigger an assertion; XXX: tweak libdnf */
+  if (!dnf_context_run (dnfctx, NULL, error))
+    return FALSE;
+
+  return TRUE;
+}

--- a/src/libpriv/rpmostree-container.h
+++ b/src/libpriv/rpmostree-container.h
@@ -1,0 +1,30 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+G_BEGIN_DECLS
+
+gboolean
+rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile,
+                             GCancellable           *cancellable,
+                             GError                **error);
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-container.h
+++ b/src/libpriv/rpmostree-container.h
@@ -27,4 +27,9 @@ rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile,
                              GCancellable           *cancellable,
                              GError                **error);
 
+gboolean
+rpmostree_container_install_packages (char **packages,
+                                      GCancellable  *cancellable,
+                                      GError       **error);
+
 G_END_DECLS

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -112,11 +112,18 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
 gpgcheck=0
 baseurl=http://127.0.0.1
 EOF
+    cat >baz.yaml << 'EOF'
+packages:
+  - baz
+EOF
 cat > Dockerfile << 'EOF'
 FROM localhost/fcos
 RUN rm -rf /etc/yum.repos.d/*  # Ensure we work offline
 ADD local.repo /etc/yum.repos.d/
 RUN rpm-ostree install bar
+RUN mkdir -p /etc/rpm-ostree/origin.d
+ADD baz.yaml /etc/rpm-ostree/origin.d/
+RUN rpm-ostree ex rebuild
 RUN echo some config file > /etc/someconfig.conf
 RUN echo somedata > /usr/share/somenewdata
 EOF
@@ -132,6 +139,8 @@ EOF
     grep -qF somedata /usr/share/somenewdata || (echo missing somenewdata; exit 1)
     assert_streq $(rpm -q bar) bar-1.0-1.${arch}
     test -f /usr/bin/bar
+    assert_streq $(rpm -q baz) baz-1.0-1.${arch}
+    test -f /usr/bin/baz
     rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"ostree-unverified-image:oci:$image_dir:derived\""
     ;;
   *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;

--- a/tests/kolainst/kolainst-build.sh
+++ b/tests/kolainst/kolainst-build.sh
@@ -20,6 +20,7 @@ mkdir ${test_tmpdir}/rpm-repos/${repover}
 # The obligatory `foo` and `bar` packages
 build_rpm foo version 1.2 release 3
 build_rpm bar
+build_rpm baz
 # And from here we lose our creativity and name things starting
 # with `testpkg` and grow more content.
 # This one has various files in /etc


### PR DESCRIPTION
This command reads treefile dropins in `/etc` and applies it to the
system. Only the OSTree container flow is supported for now. For the
client-side flow, see coreos#2326.

In the container flow, only `packages` is currently supported. But this
paves the way for supporting more derivation fields as well as making
currently "base" fields only become valid derivation fields too (by
promoting it from the `BaseComposeConfigFields` struct to
`TreeComposeConfig`).

What we're doing here is providing a "container" backend for derivation
treefiles, but coreos#2326 will provide a "client" backend which uses the core
more fully. But the inputs themselves are the exact same, hence
providing symmetry between the two flows. (See also discussions about
this in coreos/fedora-coreos-tracker#1054).

This will also allow us to drop the `microdnf` dependency which will be
done in a following patch.

