### PR TITLE
daemon/donwload-pkgs: fix a wrong error return

### DIFF
--- a/src/daemon/rpmostreed-os-experimental.cxx
+++ b/src/daemon/rpmostreed-os-experimental.cxx
@@ -241,7 +241,7 @@ prepare_download_pkgs_txn(const gchar * const *queries,
           hy_query_filter (query, HY_PKG_REPONAME, HY_EQ, source_name);
           pkglist = hy_query_run (query);
           if (!pkglist || pkglist->len == 0)
-            return glnx_prefix_error (error, "No matches for \"%s\" in repo '%s'", pkg_name, source_name);
+            return glnx_throw (error, "No matches for \"%s\" in repo '%s'", pkg_name, source_name);
 
           g_ptr_array_add (dnf_pkgs, g_object_ref (pkglist->pdata[0]));
         }


### PR DESCRIPTION
This fixes a buggy error return expression. Due to a "throw vs prefix"
mixup, in this case the function was wrongly returning with a `NULL`
error. It does now correctly generate and return a proper error value.

Fixes: https://github.com/coreos/rpm-ostree/issues/3344