### PR TITLE
Allow the platform module to be specified in the Treefile.

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -325,6 +325,16 @@ It supports the following parameters:
    `/usr/lib/systemd/system-presets/XX-example.preset` file as part of a package
    or in the postprocess script.
 
+ * `platform-module`: string, optional.  For the very rare case where you need
+   to either provide or override the platform module.  When using RPM modules
+   libdnf will attempt to derive the appropriate platform module by inspecting
+   various virtual provide entries on the available packages.  If this fails it
+   will fall back to parsing `/etc/os-release` or `/usr/lib/os-release` in that
+   order.  If the first mechanism fails and we are running a compose, we will not
+   have the necessary files to allow the fall back to work.  If you find yourself
+   in this situation you can provide the platform module name yourself using this
+   option. You can also use this to override the platform module if needed.
+
 ## Experimental options
 
 All options listed here are subject to change or removal in a future

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -409,6 +409,7 @@ pub mod ffi {
         fn get_modules_enable(&self) -> Vec<String>;
         fn get_modules_install(&self) -> Vec<String>;
         fn get_exclude_packages(&self) -> Vec<String>;
+        fn get_platform_module(&self) -> String;
         fn get_install_langs(&self) -> Vec<String>;
         fn format_install_langs_macro(&self) -> String;
         fn get_lockfile_repos(&self) -> Vec<String>;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -703,6 +703,10 @@ impl Treefile {
             .unwrap_or_default()
     }
 
+    pub(crate) fn get_platform_module(&self) -> String {
+        self.parsed.platform_module.clone().unwrap_or_default()
+    }
+
     pub(crate) fn get_install_langs(&self) -> Vec<String> {
         self.parsed.base.install_langs.clone().unwrap_or_default()
     }
@@ -1263,6 +1267,9 @@ pub(crate) struct BaseComposeConfigFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "exclude-packages")]
     pub(crate) exclude_packages: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "platform-module")]
+    pub(crate) platform_module: Option<String>,
 
     // Content installation opts
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -704,7 +704,7 @@ impl Treefile {
     }
 
     pub(crate) fn get_platform_module(&self) -> String {
-        self.parsed.platform_module.clone().unwrap_or_default()
+        self.parsed.base.platform_module.clone().unwrap_or_default()
     }
 
     pub(crate) fn get_install_langs(&self) -> Vec<String> {

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -297,6 +297,11 @@ rpmostree_context_new_compose (int               userroot_dfd,
 
   rpmostree_context_set_cache_root (ret, userroot_dfd);
 
+  auto platform_module = treefile_rs.get_platform_module();
+  if (!platform_module.empty()) {
+    dnf_context_set_platform_module(ret->dnfctx, platform_module.c_str());
+  }
+
   // The ref needs special handling as it gets variable-substituted.
   auto ref = ret->treefile_rs->get_ref();
   if (ref.length() > 0)


### PR DESCRIPTION
In some cases the usual mechanisms libdnf uses to establish the platform ID, and thus the platform module, fail. To cater for
this circumstance, and for any case where a user may want to override it, allow the platform module to be specified in the Treefile.

The specific case here is that Oracle Linux currently has the `system-release` and `base-module(platform:el8)` Provide entries on different packages. This has been raised with them and discussion is ongoing. The upshot though is that in a compose scenario we can't establish the platform ID from the package provides and we also lack `/etc/os-release` and `/usr/lib/os-release` and so the fallback mechanisms fail.