### PR TITLE
README.md: Link to ostree native container change

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ many of the benefits of both together.
  - OS rollback without affecting user data (`/usr` but not `/etc`, `/var`) via libostree
  - Client-side package layering (and overrides)
  - Easily make your own: `rpm-ostree compose tree` and [CoreOS Assembler](https://github.com/coreos/coreos-assembler)
+   as well as https://fedoraproject.org/wiki/Changes/OstreeNativeContainer
 
 ## Documentation
 


### PR DESCRIPTION
I'm actually doing this to sanity check the state of CI, but
hey I think we should mention the container stuff in the main
README.md now.
