### PR TITLE
ci: Switch back to `testing-devel`

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -43,7 +43,7 @@ parallel insttests: {
       }
       stage("Build FCOS") {
         shwrap("""
-          coreos-assembler init --force https://github.com/coreos/fedora-coreos-config -b next
+          coreos-assembler init --force https://github.com/coreos/fedora-coreos-config
           # include our built rpm-ostree in the image
           mkdir -p overrides/rpm
           mv *.rpm overrides/rpm

--- a/ci/prow/fcos-e2e.sh
+++ b/ci/prow/fcos-e2e.sh
@@ -8,7 +8,7 @@ export COSA_SUPPRESS_DEPCHECK=1
 ls -al /usr/bin/rpm-ostree
 rpm-ostree --version
 cd $(mktemp -d)
-cosa init https://github.com/coreos/fedora-coreos-config/ -b next-devel
+cosa init https://github.com/coreos/fedora-coreos-config/
 rsync -rlv /cosa/component-install/ overrides/rootfs/
 /ci/cosa-overrides.sh
 cosa fetch


### PR DESCRIPTION
We only did the `next/next-devel` switch to pull in microdnf,
which is no longer needed.

At the current moment `next` is broken, and it's good we found
that, but let's be consistent with other things and build/test
against `testing-devel.
