### PR TITLE
Prep patches for supporting container overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,6 +2026,7 @@ dependencies = [
  "clap",
  "curl",
  "cxx",
+ "either",
  "env_logger",
  "envsubst",
  "fail",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ clap = "2.34.0"
 curl = "0.4.42"
 cxx = "1.0.62"
 envsubst = "0.2.0"
+either = "1.6.1"
 env_logger = "0.9.0"
 fail = { version = "0.5", features = ["failpoints"] }
 fn-error-context = "0.2.0"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -391,7 +391,7 @@ pub mod ffi {
         ) -> Result<Box<Treefile>>;
         fn treefile_new_client(filename: &str, basearch: &str) -> Result<Box<Treefile>>;
         fn treefile_new_client_from_etc(basearch: &str) -> Result<Box<Treefile>>;
-        fn treefile_delete_client_etc() -> Result<()>;
+        fn treefile_delete_client_etc() -> Result<u32>;
 
         fn get_workdir(&self) -> i32;
         fn get_passwd_fd(&mut self) -> i32;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -2276,18 +2276,25 @@ pub(crate) fn treefile_new_client(filename: &str, basearch: &str) -> CxxResult<B
 }
 
 fn iter_etc_treefiles() -> Result<impl Iterator<Item = Result<PathBuf>>> {
-    Ok(read_dir(CLIENT_TREEFILES_DIR)?.filter_map(|res| match res {
-        Ok(e) => {
-            let path = e.path();
-            if let Some(ext) = path.extension() {
-                if ext == "yaml" {
-                    return Some(anyhow::Result::Ok(path));
+    // TODO use cap-std-ext's https://docs.rs/cap-std-ext/latest/cap_std_ext/dirext/trait.CapStdExtDirExt.html#tymethod.open_dir_optional
+    let p = Path::new(CLIENT_TREEFILES_DIR);
+    if !p.exists() {
+        return Ok(either::Left(std::iter::empty()));
+    }
+    Ok(either::Right(read_dir(CLIENT_TREEFILES_DIR)?.filter_map(
+        |res| match res {
+            Ok(e) => {
+                let path = e.path();
+                if let Some(ext) = path.extension() {
+                    if ext == "yaml" {
+                        return Some(anyhow::Result::Ok(path));
+                    }
                 }
+                None
             }
-            None
-        }
-        Err(err) => Some(Err(anyhow::Error::msg(err))),
-    }))
+            Err(err) => Some(Err(anyhow::Error::msg(err))),
+        },
+    )))
 }
 
 /// Create a new client treefile using the treefile dropins in /etc/rpm-ostree/origin.d/.

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1216,10 +1216,10 @@ pub(crate) struct TreeComposeConfig {
     pub(crate) cliwrap: Option<bool>,
 
     #[serde(flatten)]
-    pub(crate) base: BaseComposeConfigFields,
+    pub(crate) derive: DeriveConfigFields,
 
     #[serde(flatten)]
-    pub(crate) derive: DeriveConfigFields,
+    pub(crate) base: BaseComposeConfigFields,
 }
 
 /// These fields are only useful when composing a new ostree commit.
@@ -1805,6 +1805,19 @@ pub(crate) mod tests {
             automatic-version-prefix: foo
             automatic_version_prefix: bar
         "});
+    }
+
+    #[test]
+    fn basic_derive() {
+        let treefile = append_and_parse(indoc! {"
+            override-remove:
+              - foo
+              - bar
+        "});
+        let v = treefile.derive.override_remove.unwrap();
+        assert_eq!(v.len(), 2);
+        assert_eq!(v[0], "foo");
+        assert_eq!(v[1], "bar");
     }
 
     #[test]

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -2316,10 +2316,12 @@ pub(crate) fn treefile_new_client_from_etc(basearch: &str) -> CxxResult<Box<Tree
     Ok(Box::new(r))
 }
 
-pub(crate) fn treefile_delete_client_etc() -> CxxResult<()> {
+pub(crate) fn treefile_delete_client_etc() -> CxxResult<u32> {
     // To be nice we don't delete the directory itself; just matching files.
+    let mut n = 0u32;
     for tf in iter_etc_treefiles()? {
         std::fs::remove_file(&tf?)?;
+        n = n.saturating_add(1);
     }
-    Ok(())
+    Ok(n)
 }

--- a/src/app/rpmostree-builtin-rebuild.cxx
+++ b/src/app/rpmostree-builtin-rebuild.cxx
@@ -71,7 +71,11 @@ rpmostree_ex_builtin_rebuild (int             argc,
 
       /* In the container flow, we effectively "consume" the treefiles after
        * modifying the rootfs. */
-      CXX_TRY(treefile_delete_client_etc (), error);
+      auto n = CXX_TRY_VAL(treefile_delete_client_etc (), error);
+      if (n == 0)
+        {
+          g_print ("No changes to apply.\n");
+        } 
     }
   else
     {


### PR DESCRIPTION
This is prep for work on https://github.com/coreos/rpm-ostree/issues/3364

---

treefile: Don't bail out if `/etc/rpm-ostree` doesn't exist

As it doesn't by default today, even in a container.

---

ex-rebuild: Print something in the case where we found no files

Now clearly we should have *much* more useful information here,
but this is a start.

---

treefile: Fix parsing of derived config fields

There may be a serde bug going on here.  But I think this is
fallout from https://github.com/coreos/rpm-ostree/pull/3341/commits/72a6a77640c70de0d2a7845b4816727356877bea

Basically we have `#[flatten]` in 3 places; in both the `base`
and `derive` structs, *and* the `base` struct has the `extra` member.

It seems that order matters here.  In order to parse the derive
config fields, it needs to be earlier in the struct.

I am at this moment a bit uncertain why this didn't break other
cases.

But this is prep for supporting `override-remove` in `ex rebuild`
too.

---

