### PR TITLE
core: Honor `repo-packages` in treefile on client too

### DIFF
--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -116,13 +116,19 @@ EOF
 packages:
   - baz
 EOF
+    cat >testdaemon-query.yaml << 'EOF'
+repo-packages:
+  - repo: local
+    packages:
+      - testdaemon
+EOF
 cat > Dockerfile << 'EOF'
 FROM localhost/fcos
 RUN rm -rf /etc/yum.repos.d/*  # Ensure we work offline
 ADD local.repo /etc/yum.repos.d/
 RUN rpm-ostree install bar
 RUN mkdir -p /etc/rpm-ostree/origin.d
-ADD baz.yaml /etc/rpm-ostree/origin.d/
+ADD baz.yaml testdaemon-query.yaml /etc/rpm-ostree/origin.d/
 RUN rpm-ostree ex rebuild
 RUN echo some config file > /etc/someconfig.conf
 RUN echo somedata > /usr/share/somenewdata
@@ -137,10 +143,10 @@ EOF
   3) 
     grep -qF 'some config file' /etc/someconfig.conf || (echo missing someconfig.conf; exit 1)
     grep -qF somedata /usr/share/somenewdata || (echo missing somenewdata; exit 1)
-    assert_streq $(rpm -q bar) bar-1.0-1.${arch}
-    test -f /usr/bin/bar
-    assert_streq $(rpm -q baz) baz-1.0-1.${arch}
-    test -f /usr/bin/baz
+    for p in bar baz testdaemon; do
+      assert_streq $(rpm -q $p) $p-1.0-1.${arch}
+      test -f /usr/bin/$p
+    done
     rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"ostree-unverified-image:oci:$image_dir:derived\""
     ;;
   *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;


### PR DESCRIPTION
As far as I know, it's not possible with the client today to
inject `repo-packages` *except* for the new `ex rebuild` container
path.

But it does make sense to support there too.
