### PR TITLE
treefile: Use `Deref` trait for something like inheritance

### DIFF
--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1222,6 +1222,20 @@ pub(crate) struct TreeComposeConfig {
     pub(crate) derive: DeriveConfigFields,
 }
 
+impl std::ops::Deref for TreeComposeConfig {
+    type Target = BaseComposeConfigFields;
+
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
+}
+
+impl std::ops::DerefMut for TreeComposeConfig {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.base
+    }
+}
+
 /// These fields are only useful when composing a new ostree commit.
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
@@ -1508,7 +1522,7 @@ impl TreeComposeConfig {
     fn substitute_vars(mut self) -> Result<Self> {
         let mut substvars: collections::HashMap<String, String> = collections::HashMap::new();
         // Substitute ${basearch} and ${releasever}
-        if let Some(arch) = &self.base.basearch {
+        if let Some(arch) = &self.basearch {
             substvars.insert("basearch".to_string(), arch.clone());
         }
         if let Some(releasever) = &self.base.releasever {


### PR DESCRIPTION
I just changed a single use as a demo, but if we decide
to merge this I can do more of them.  (I want to avoid a conflict
fest though)

This will make it easier to migrate fields between the two structs.

Now, I think what we *really* want here is to flip everything around
here so that we have `DeriveTreefile` and `ComposeTreefile` that
include the base, and deref to that.
But that would be a much larger churn.

The status quo means we can't implement `Deref` to the derive.
