### PR TITLE
`ex rebuild`: Support `override-replace-query` 

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -426,6 +426,7 @@ pub mod ffi {
         fn get_checksum(&self, repo: Pin<&mut OstreeRepo>) -> Result<String>;
         fn get_ostree_ref(&self) -> String;
         fn get_repo_packages(&self) -> &[RepoPackage];
+        fn get_override_replace_query(&self) -> &[RepoPackage];
         fn clear_repo_packages(&mut self);
         fn prettyprint_json_stdout(&self);
         fn print_deprecation_warnings(&self);

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1025,7 +1025,8 @@ impl TreefileExternals {
         Ok(())
     }
 
-    fn assert_nonempty(&self) {
+    // Panic if there is externally referenced data.
+    fn assert_empty(&self) {
         // can't use the Default trick here because we can't auto-derive Eq because of `File`
         assert!(self.postprocess_script.is_none());
         assert!(self.add_files.is_empty());
@@ -2330,7 +2331,7 @@ pub(crate) fn treefile_new_client_from_etc(basearch: &str) -> CxxResult<Box<Tree
         let new_cfg = treefile_parse_and_process(tf, basearch)?;
         new_cfg.config.base.error_if_nonempty()?;
         new_cfg.config.derive.error_if_nonempty()?;
-        new_cfg.externals.assert_nonempty();
+        new_cfg.externals.assert_empty();
         let mut new_cfg = new_cfg.config;
         treefile_merge(&mut new_cfg, &mut cfg);
         cfg = new_cfg;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1221,6 +1221,20 @@ pub(crate) struct TreeComposeConfig {
     pub(crate) base: BaseComposeConfigFields,
 }
 
+impl std::ops::Deref for TreeComposeConfig {
+    type Target = BaseComposeConfigFields;
+
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
+}
+
+impl std::ops::DerefMut for TreeComposeConfig {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.base
+    }
+}
+
 /// These fields are only useful when composing a new ostree commit.
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
@@ -1504,7 +1518,7 @@ impl TreeComposeConfig {
     fn substitute_vars(mut self) -> Result<Self> {
         let mut substvars: collections::HashMap<String, String> = collections::HashMap::new();
         // Substitute ${basearch} and ${releasever}
-        if let Some(arch) = &self.base.basearch {
+        if let Some(arch) = &self.basearch {
             substvars.insert("basearch".to_string(), arch.clone());
         }
         if let Some(releasever) = &self.base.releasever {

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -2329,6 +2329,7 @@ pub(crate) fn treefile_new_client_from_etc(basearch: &str) -> CxxResult<Box<Tree
     for tf in tfs {
         let new_cfg = treefile_parse_and_process(tf, basearch)?;
         new_cfg.config.base.error_if_nonempty()?;
+        new_cfg.config.derive.error_if_nonempty()?;
         new_cfg.externals.assert_nonempty();
         let mut new_cfg = new_cfg.config;
         treefile_merge(&mut new_cfg, &mut cfg);

--- a/src/libpriv/rpmostree-container.cxx
+++ b/src/libpriv/rpmostree-container.cxx
@@ -33,12 +33,6 @@ rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile,
                              GCancellable           *cancellable,
                              GError                **error)
 {
-  auto packages = treefile.get_packages();
-
-  /* for now, we only support package installs */
-  if (packages.empty())
-    return TRUE;
-
   g_autoptr(RpmOstreeContext) ctx = rpmostree_context_new_container ();
   rpmostree_context_set_treefile (ctx, treefile);
 


### PR DESCRIPTION
More work towards https://github.com/coreos/rpm-ostree/issues/3364

---

treefile: Also error if derive is nonempty for client side

We don't support e.g. `override-remove` there...yet.

---

treefile: Fix naming of `assert_empty()`

The `non` part looks like a nonsequitur.

---

treefile: Add `override-replace-query`

I want to use this in `ex rebuild` to replace packages in the
container.

---

