### PR TITLE
composepost: Do replace `altfiles` in `/etc/authselect/nsswitch.conf`

### DIFF
--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -151,6 +151,12 @@ mod err {
         }
     }
 
+    impl From<String> for CxxError {
+        fn from(v: String) -> Self {
+            Self(v)
+        }
+    }
+
     impl From<cxx::Exception> for CxxError {
         fn from(v: cxx::Exception) -> Self {
             Self(format!("{:#}", v))


### PR DESCRIPTION
This is a followup to https://bugzilla.redhat.com/show_bug.cgi?id=2034360

The existing code that checks for `OSTREE_VERSION` has (I believe)
never actually worked at `compose tree` time because the version
mutation happens after the altfiles bits.

We recently started adding `/run/ostree-booted` in the legacy
compose path to try to aid this too.

But the code in the authselect `%post` for this is not really
less ugly or more maintanable than us doing the mutation too.

I think it *would* be cleaner if authselect's upstream code base
handled this by default.  But that seems like a more invasive
fix that requires some design changes.
