### PR TITLE
`ex rebuild`: Drop check gating on `packages` key

### DIFF
--- a/src/libpriv/rpmostree-container.cxx
+++ b/src/libpriv/rpmostree-container.cxx
@@ -33,12 +33,6 @@ rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile,
                              GCancellable           *cancellable,
                              GError                **error)
 {
-  auto packages = treefile.get_packages();
-
-  /* for now, we only support package installs */
-  if (packages.empty())
-    return TRUE;
-
   g_autoptr(RpmOstreeContext) ctx = rpmostree_context_new_container ();
   rpmostree_context_set_treefile (ctx, treefile);
 


### PR DESCRIPTION
We added support for `repo-packages`, and it's only passing CI
because the test case *also* included `packages`.

I want to extend the declarative model to support more, so lift
this restriction.
