### PR TITLE
Add a `Dockerfile.containerci`

### DIFF
--- a/ci/prow/Dockerfile.containerci
+++ b/ci/prow/Dockerfile.containerci
@@ -1,0 +1,19 @@
+# The main Dockerfile tests e2e via coreos-assembler and VM testing.
+# This flow just injects our binaries on top of the FCOS container image.
+FROM quay.io/coreos-assembler/fcos-buildroot:testing-devel as builder
+WORKDIR /src
+COPY . .
+RUN ./ci/build.sh && make install DESTDIR=/cosa/component-install
+RUN make -C tests/kolainst install DESTDIR=/cosa/component-tests
+# Uncomment this to fake a build to test the code below
+#RUN mkdir -p /cosa/component-install/usr/bin && echo foo > /cosa/component-install/usr/bin/foo
+
+FROM quay.io/coreos-assembler/fcos:testing-devel
+# Copy binaries from the build
+COPY --from=builder /cosa /cosa
+RUN rsync -rlv /cosa/component-install/ / && rm -rf /cosa
+# Grab all of our ci scripts
+COPY --from=builder /src/ci/ /usr/local/ci/
+RUN ln -sr /usr/local/ci/prow/test-container.sh /usr/bin/test-container
+ENTRYPOINT ["/usr/bin/test-container"]
+

--- a/ci/prow/test-container.sh
+++ b/ci/prow/test-container.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -xeuo pipefail
+
+fatal() {
+    echo "$@" 1>&2
+    exit 1
+}
+
+origindir=/etc/rpm-ostree/origin.d
+mkdir -p "${origindir}"
+cat > "${origindir}/clienterror.yaml" << 'EOF'
+base-refspec: "foo/x86_64/bar"
+EOF
+if rpm-ostree ex rebuild 2>err.txt; then
+   fatal "did rebuild with base-refspec"
+fi
+
+echo ok


### PR DESCRIPTION
This parallels our cosa build (which does a VM flow) and instead
directly overlays the production FCOS container image.

I am sure we are going to be doing more of this type of thing
as we adapt more of our CI to be really "container native".

My immediate motivation is being able to turn this on in Prow.

(That said...we do want to avoid building our binary twice, because
 it's a bit expensive.  I need to investigate
  https://docs.ci.openshift.org/docs/architecture/ci-operator/#building-artifacts
 perhaps?
