### PR TITLE
treefile: Two small patches

### DIFF
--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1025,7 +1025,8 @@ impl TreefileExternals {
         Ok(())
     }
 
-    fn assert_nonempty(&self) {
+    // Panic if there is externally referenced data.
+    fn assert_empty(&self) {
         // can't use the Default trick here because we can't auto-derive Eq because of `File`
         assert!(self.postprocess_script.is_none());
         assert!(self.add_files.is_empty());
@@ -2330,7 +2331,7 @@ pub(crate) fn treefile_new_client_from_etc(basearch: &str) -> CxxResult<Box<Tree
         let new_cfg = treefile_parse_and_process(tf, basearch)?;
         new_cfg.config.base.error_if_nonempty()?;
         new_cfg.config.derive.error_if_nonempty()?;
-        new_cfg.externals.assert_nonempty();
+        new_cfg.externals.assert_empty();
         let mut new_cfg = new_cfg.config;
         treefile_merge(&mut new_cfg, &mut cfg);
         cfg = new_cfg;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -2329,6 +2329,7 @@ pub(crate) fn treefile_new_client_from_etc(basearch: &str) -> CxxResult<Box<Tree
     for tf in tfs {
         let new_cfg = treefile_parse_and_process(tf, basearch)?;
         new_cfg.config.base.error_if_nonempty()?;
+        new_cfg.config.derive.error_if_nonempty()?;
         new_cfg.externals.assert_nonempty();
         let mut new_cfg = new_cfg.config;
         treefile_merge(&mut new_cfg, &mut cfg);


### PR DESCRIPTION
treefile: Also error if derive is nonempty for client side

We don't support e.g. `override-remove` there...yet.

---

treefile: Fix naming of `assert_empty()`

The `non` part looks like a nonsequitur.

---

