### PR TITLE
var: enhance workarounds for 'vagrant' and 'alternatives'

### DIFF
--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -788,29 +788,46 @@ fn convert_path_to_tmpfiles_d_recurse(
 ///
 /// For example:
 ///  - Symlink /usr/local -> /var/usrlocal
-///  - Symlink /var/lib/alternatives -> /usr/lib/alternatives
-///  - Symlink /var/lib/vagrant -> /usr/lib/vagrant
+///  - If present, symlink /var/lib/alternatives -> /usr/lib/alternatives
+///  - If present, symlink /var/lib/vagrant -> /usr/lib/vagrant
 #[context("Preparing symlinks in rootfs")]
 pub fn rootfs_prepare_links(rootfs_dfd: i32) -> CxxResult<()> {
     let rootfs = crate::ffiutil::ffi_view_openat_dir(rootfs_dfd);
 
+    // Unconditionally drop /usr/local and replace it with a symlink.
     rootfs
         .remove_all("usr/local")
         .context("Removing /usr/local")?;
-    let state_paths = &["usr/lib/alternatives", "usr/lib/vagrant"];
-    for entry in state_paths {
-        rootfs
-            .ensure_dir_all(*entry, 0o0755)
-            .with_context(|| format!("Creating '/{}'", entry))?;
-    }
+    ensure_symlink(&rootfs, "../var/usrlocal", "usr/local")
+        .context("Creating /usr/local symlink")?;
 
-    let symlinks = &[
-        ("../var/usrlocal", "usr/local"),
-        ("../../usr/lib/alternatives", "var/lib/alternatives"),
-        ("../../usr/lib/vagrant", "var/lib/vagrant"),
-    ];
-    for (target, linkpath) in symlinks {
-        ensure_symlink(&rootfs, target, linkpath)?;
+    // Move existing content to /usr/lib, then put a symlink in its
+    // place under /var/lib.
+    rootfs
+        .ensure_dir_all("usr/lib", 0o0755)
+        .context("Creating /usr/lib")?;
+    let content_dirs = &["alternatives", "vagrant"];
+    for entry in content_dirs {
+        let varlib_path = format!("var/lib/{}", entry);
+        let is_var_dir = rootfs
+            .metadata_optional(&varlib_path)?
+            .map(|m| m.is_dir())
+            .unwrap_or(false);
+        if !is_var_dir {
+            continue;
+        }
+
+        let usrlib_path = format!("usr/lib/{}", entry);
+        rootfs
+            .remove_all(&usrlib_path)
+            .with_context(|| format!("Removing /{}", &usrlib_path))?;
+        rootfs
+            .local_rename(&varlib_path, &usrlib_path)
+            .with_context(|| format!("Moving /{} to /{}", &varlib_path, &usrlib_path))?;
+
+        let target = format!("../../{}", &usrlib_path);
+        ensure_symlink(&rootfs, &target, &varlib_path)
+            .with_context(|| format!("Creating /{} symlink", &varlib_path))?;
     }
 
     Ok(())
@@ -1310,6 +1327,10 @@ OSTREE_VERSION='33.4'
         let temp_rootfs = tempfile::tempdir().unwrap();
         let rootfs = openat::Dir::open(temp_rootfs.path()).unwrap();
         rootfs.ensure_dir_all("usr/local", 0o755).unwrap();
+        rootfs
+            .ensure_dir_all("var/lib/alternatives", 0o755)
+            .unwrap();
+        rootfs.ensure_dir_all("var/lib/vagrant", 0o755).unwrap();
 
         rootfs_prepare_links(rootfs.as_raw_fd()).unwrap();
         {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -127,7 +127,7 @@ pub mod ffi {
 
         fn bind_read(&mut self, src: &str, dest: &str);
         fn bind_readwrite(&mut self, src: &str, dest: &str);
-        fn var_tmp_tmpfs(&mut self);
+        fn setup_compat_var(&mut self) -> Result<()>;
 
         fn run(&mut self, cancellable: Pin<&mut GCancellable>) -> Result<()>;
     }

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -467,9 +467,9 @@ rpmostree_postprocess_final (int            rootfs_dfd,
         return glnx_prefix_error (error, "SELinux postprocess");
     }
 
-  CXX_TRY(convert_var_to_tmpfiles_d (rootfs_dfd, *cancellable), error);
-
   CXX_TRY(rootfs_prepare_links(rootfs_dfd), error);
+
+  CXX_TRY(convert_var_to_tmpfiles_d (rootfs_dfd, *cancellable), error);
 
   if (!rpmostree_rootfs_postprocess_common (rootfs_dfd, cancellable, error))
     return FALSE;

--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -357,7 +357,11 @@ rpmostree_run_script_in_bwrap_container (int rootfs_fd,
     (is_glibc_locales || !enable_fuse) ? rpmostreecxx::BubblewrapMutability::MutateFreely : rpmostreecxx::BubblewrapMutability::RoFiles;
   auto bwrap = CXX_TRY_VAL(bubblewrap_new_with_mutability (rootfs_fd, mutability), error);
   /* Scripts can see a /var with compat links like alternatives */
-  bwrap->var_tmp_tmpfs();
+  try {
+    bwrap->setup_compat_var();
+  } catch (std::exception&e) {
+    return glnx_throw (error, "%s", e.what());
+  }
 
   struct stat stbuf;
   if (glnx_fstatat (rootfs_fd, "usr/lib/opt", &stbuf, AT_SYMLINK_NOFOLLOW, NULL) && S_ISDIR(stbuf.st_mode))

--- a/src/libpriv/rpmostree-util.cxx
+++ b/src/libpriv/rpmostree-util.cxx
@@ -141,6 +141,11 @@ rpmostree_translate_path_for_ostree (const char *path)
     return g_strconcat ("usr/etc/selinux/targeted/", path + strlen (VAR_SELINUX_TARGETED_PATH), NULL);
   else if (g_str_has_prefix (path, "opt/"))
     return g_strconcat ("usr/lib/", path, NULL);
+  else if ((strcmp (path, "var/lib/alternatives/") == 0) ||
+           g_str_has_prefix (path, "var/lib/alternatives") ||
+           (strcmp (path, "var/lib/vagrant/") == 0) ||
+           g_str_has_prefix (path, "var/lib/vagrant"))
+    return g_strconcat ("usr/", path + strlen ("var/"), NULL);
 
   return NULL;
 }

--- a/tests/compose/libbasic-test.sh
+++ b/tests/compose/libbasic-test.sh
@@ -124,13 +124,10 @@ assert_file_has_content parent.txt 01ba4719c80b6fe911b091a7c05124b64eeece964e09c
 echo "ok --parent"
 
 # Check symlinks injected into the rootfs.
-ostree --repo="${repo}" ls "${treeref}" /usr/lib/alternatives /usr/lib/vagrant | grep '^d00755'> symlinks.txt
-assert_file_has_content_literal symlinks.txt '/usr/lib/alternatives'
-assert_file_has_content_literal symlinks.txt '/usr/lib/vagrant'
-ostree --repo="${repo}" ls "${treeref}" /var/lib/alternatives /var/lib/vagrant /usr/local | grep '^l00777' > symlinks.txt
+ostree --repo="${repo}" ls "${treeref}" /usr/lib/alternatives | grep '^d00755'> dirs.txt
+assert_file_has_content_literal dirs.txt '/usr/lib/alternatives'
+ostree --repo="${repo}" ls "${treeref}" /usr/local | grep '^l00777' > symlinks.txt
 assert_file_has_content_literal symlinks.txt '/usr/local -> ../var/usrlocal'
-assert_file_has_content_literal symlinks.txt '/var/lib/alternatives -> ../../usr/lib/alternatives'
-assert_file_has_content_literal symlinks.txt '/var/lib/vagrant -> ../../usr/lib/vagrant'
 echo "ok symlinks"
 }
 


### PR DESCRIPTION
This reworks the exsisting workarounds for '/var/lib/alternatives'
and '/var/lib/vagrant', making the symlink generation conditional.

The 'alternatives' and 'vagrant' packages currently ship
some content under /var.
A proper ostree commit should come with a basically empty /var,
thus rpm-ostree needs to apply some ad-hoc tweaks here.

For these specific cases, workarounds are performed in two steps:
 * their '/var/lib/foo' path-prefixes are translated to
   '/usr/lib/foo'.
 * '/var/lib/foo -> /usr/lib/foo' symlink entries are put in place
   for compatibility purposes.