### PR TITLE
Bump to cap-std-ext 0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,15 +155,34 @@ checksum = "6a443c65e406bcce3edd5023bc37a6e2eade7ff65f21f1a9fc71b58824f47e13"
 dependencies = [
  "ambient-authority",
  "errno",
- "fs-set-times",
- "io-extras",
- "io-lifetimes",
+ "fs-set-times 0.14.2",
+ "io-extras 0.12.2",
+ "io-lifetimes 0.4.4",
  "ipnet",
  "maybe-owned",
- "rustix",
+ "rustix 0.32.1",
  "winapi",
  "winapi-util",
- "winx",
+ "winx 0.30.0",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc128b736b17903e7cdfa753073bdf27e0c6fce26bc098205128550bfc2eac"
+dependencies = [
+ "ambient-authority",
+ "errno",
+ "fs-set-times 0.15.0",
+ "io-extras 0.13.0",
+ "io-lifetimes 0.5.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix 0.33.0",
+ "winapi",
+ "winapi-util",
+ "winx 0.31.0",
 ]
 
 [[package]]
@@ -172,31 +191,55 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a73f60ac353e0f593708a8cc069e4412ac31b644a403c90d3c77888a484d8bd"
 dependencies = [
- "cap-primitives",
- "io-extras",
- "io-lifetimes",
+ "cap-primitives 0.23.1",
+ "io-extras 0.12.2",
+ "io-lifetimes 0.4.4",
  "ipnet",
- "rustix",
+ "rustix 0.32.1",
+]
+
+[[package]]
+name = "cap-std"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b8c96d0db4735e144eeb51e04fb4d6cb2477c47d023822e84a98e5cdf77881"
+dependencies = [
+ "cap-primitives 0.24.0",
+ "io-extras 0.13.0",
+ "io-lifetimes 0.5.1",
+ "ipnet",
+ "rustix 0.33.0",
 ]
 
 [[package]]
 name = "cap-std-ext"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a112ff00b6dc34598e32fb0e956b419f005e8d74c43ffa704b07ca4311298f"
+checksum = "78bee7523666a0075f6fe798ac54539813d935ef4dc00df68b69bdca9f6abc11"
 dependencies = [
- "cap-std",
- "rustix",
+ "cap-std 0.23.1",
+ "rustix 0.32.1",
+ "uuid",
+]
+
+[[package]]
+name = "cap-std-ext"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ae6a293d08473437dd15c64e53fd7166b7689455c0d10eb2dc0319691cbdc3"
+dependencies = [
+ "cap-std 0.24.0",
+ "rustix 0.33.0",
  "uuid",
 ]
 
 [[package]]
 name = "cap-tempfile"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c426e0191f9964890296f592181ab26a5713bfb9794569225edd2d49958c3ca"
+checksum = "8b2cc4af777567ad4932df16056906a0bc0c7a7b1e6d7b94e5f7e6cfc648758a"
 dependencies = [
- "cap-std",
+ "cap-std 0.24.0",
  "rand",
  "uuid",
 ]
@@ -752,8 +795,19 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c496df0e588acbc672c912b4eb48ca7912164e89498ffad89969492f8e958f"
 dependencies = [
- "io-lifetimes",
- "rustix",
+ "io-lifetimes 0.4.4",
+ "rustix 0.32.1",
+ "winapi",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df62ee66ee2d532ea8d567b5a3f0d03ecd64636b98bad5be1e93dcc918b92aa"
+dependencies = [
+ "io-lifetimes 0.5.1",
+ "rustix 0.33.0",
  "winapi",
 ]
 
@@ -1166,7 +1220,17 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9132d2d6504f4e348b8e16787f01613b4d0e587458641a40e727304416ac8d"
 dependencies = [
- "io-lifetimes",
+ "io-lifetimes 0.4.4",
+ "winapi",
+]
+
+[[package]]
+name = "io-extras"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c57cc6cb4d343d7062b67afde154c7839c649f460b04500f0c73fc82dc960621"
+dependencies = [
+ "io-lifetimes 0.5.1",
  "winapi",
 ]
 
@@ -1179,6 +1243,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "io-lifetimes"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "768dbad422f45f69c8f5ce59c0802e2681aa3e751c5db8217901607bb2bc24dd"
 
 [[package]]
 name = "ipnet"
@@ -1616,7 +1686,7 @@ dependencies = [
  "async-compression",
  "bitflags",
  "camino",
- "cap-std-ext",
+ "cap-std-ext 0.23.1",
  "cjson",
  "containers-image-proxy",
  "flate2",
@@ -1625,7 +1695,7 @@ dependencies = [
  "gvariant",
  "hex",
  "indicatif",
- "io-lifetimes",
+ "io-lifetimes 0.4.4",
  "libc",
  "oci-spec",
  "once_cell",
@@ -2031,7 +2101,7 @@ dependencies = [
  "binread",
  "c_utf8",
  "camino",
- "cap-std",
+ "cap-std-ext 0.24.0",
  "cap-tempfile",
  "chrono",
  "clap",
@@ -2063,7 +2133,6 @@ dependencies = [
  "regex",
  "rpmostree-client",
  "rust-ini",
- "rustix",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2098,7 +2167,23 @@ checksum = "7cee647393af53c750e15dcbf7781cdd2e550b246bde76e46c326e7ea3c73773"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes",
+ "io-lifetimes 0.4.4",
+ "itoa 1.0.1",
+ "libc",
+ "linux-raw-sys",
+ "once_cell",
+ "winapi",
+]
+
+[[package]]
+name = "rustix"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "817cc66bf0c10bfaf7d5291ad6cf9ff7b3428bc76472a6521fce328f6d6c041b"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 0.5.1",
  "itoa 1.0.1",
  "libc",
  "linux-raw-sys",
@@ -2881,7 +2966,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54de2ce52a3e5839e129c7859e2b1f581769bbef57c0a2a09a12a5a3a5b3c2a"
 dependencies = [
  "bitflags",
- "io-lifetimes",
+ "io-lifetimes 0.4.4",
+ "winapi",
+]
+
+[[package]]
+name = "winx"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d5973cb8cd94a77d03ad7e23bbe14889cb29805da1cec0e4aff75e21aebded"
+dependencies = [
+ "bitflags",
+ "io-lifetimes 0.5.1",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ anyhow = "1.0.52"
 binread = "2.2.0"
 c_utf8 = "0.1.0"
 camino = "1.0.7"
-cap-std = "0.23.0"
-cap-tempfile = "0.23.0"
+cap-std-ext = "0.24.0"
+cap-tempfile = "0.24.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = "2.34.0"
 curl = "0.4.42"
@@ -64,7 +64,6 @@ rayon = "1.5.1"
 regex = "1.5"
 rpmostree-client = { path = "rust/rpmostree-client", version = "0.1.0" }
 rust-ini = "0.17.0"
-rustix = "0.32.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_derive = "1.0.118"
 serde_json = "1.0.78"

--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -6,6 +6,7 @@ use crate::cxxrsutil::*;
 use crate::ffi::BubblewrapMutability;
 use crate::normalization;
 use anyhow::{Context, Result};
+use cap_std_ext::rustix;
 use fn_error_context::context;
 use openat_ext::OpenatDirExt;
 use ostree_ext::{gio, glib};

--- a/rust/src/capstdext.rs
+++ b/rust/src/capstdext.rs
@@ -3,42 +3,12 @@
 //! [`cap-std` crate]: https://crates.io/crates/cap-std
 //  SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use std::io::Result;
-use std::os::unix::fs::DirBuilderExt;
-use std::os::unix::prelude::PermissionsExt;
-use std::path::Path;
-
 use cap_std::fs::DirBuilder;
-
-pub(crate) trait CapStdDirExt {
-    /// Create the target directory, but do nothing if it already exists.
-    fn ensure_dir_with(
-        &self,
-        p: impl AsRef<Path>,
-        builder: &cap_std::fs::DirBuilder,
-    ) -> Result<bool>;
-}
-
-impl CapStdDirExt for cap_std::fs::Dir {
-    fn ensure_dir_with(
-        &self,
-        p: impl AsRef<Path>,
-        builder: &cap_std::fs::DirBuilder,
-    ) -> Result<bool> {
-        match self.create_dir_with(p, builder) {
-            Ok(()) => Ok(false),
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(true),
-            Err(e) => Err(e),
-        }
-    }
-}
+use cap_std_ext::cap_std;
+use std::os::unix::fs::DirBuilderExt;
 
 pub(crate) fn dirbuilder_from_mode(m: u32) -> DirBuilder {
     let mut r = DirBuilder::new();
     r.mode(m);
     r
-}
-
-pub(crate) fn perms_from_mode(m: u32) -> cap_std::fs::Permissions {
-    cap_std::fs::Permissions::from_std(std::fs::Permissions::from_mode(m))
 }

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -5,6 +5,7 @@
 use crate::cxxrsutil::*;
 use crate::utils;
 use anyhow::{anyhow, Result};
+use cap_std_ext::rustix;
 use gio::prelude::*;
 use ostree_ext::{gio, glib};
 use std::os::unix::io::IntoRawFd;

--- a/rust/src/cliwrap/cliutil.rs
+++ b/rust/src/cliwrap/cliutil.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use anyhow::Result;
+use cap_std_ext::rustix;
 use nix::sys::statvfs;
 use std::os::unix::process::CommandExt;
 use std::{path, thread, time};

--- a/rust/src/countme.rs
+++ b/rust/src/countme.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use anyhow::{bail, Context, Result};
+use cap_std_ext::rustix;
 use curl::easy::Easy;
 use os_release::OsRelease;
 use std::path;

--- a/rust/src/ffiutil.rs
+++ b/rust/src/ffiutil.rs
@@ -32,6 +32,7 @@
 //! outlive the function call.
 
 use c_utf8::CUtf8;
+use cap_std_ext::{cap_std, rustix};
 use ostree_ext::{gio, glib};
 use std::ffi::CString;
 use std::fmt::Display;

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -10,6 +10,7 @@
 use crate::cxxrsutil::*;
 use crate::variant_utils;
 use anyhow::{bail, Context, Result};
+use cap_std_ext::cap_std;
 use glib::translate::ToGlibPtr;
 use glib::Variant;
 use lazy_static::lazy_static;


### PR DESCRIPTION
And cap-std 0.24 and rustix 0.33.  Both of those are now
consistently imported via the re-export from cap-std-ext to
avoid version duplication/tearing.
