### PR TITLE
var: minor enhancements

### DIFF
--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -4371,7 +4371,8 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
                            &var_lib_rpm_statedir, error))
         return FALSE;
       /* We need to pre-create this dir */
-      if (!glnx_ensure_dir (tmprootfs_dfd, "var/lib/rpm-state", 0755, error))
+      if (!glnx_shutil_mkdir_p_at (tmprootfs_dfd, "var/lib/rpm-state", 0755,
+                                   cancellable, error))
         return FALSE;
 
       /* Workaround for https://github.com/projectatomic/rpm-ostree/issues/1804 */

--- a/src/libpriv/rpmostree-importer.cxx
+++ b/src/libpriv/rpmostree-importer.cxx
@@ -515,6 +515,7 @@ compose_filter_cb (OstreeRepo         *repo,
         case G_FILE_TYPE_SYMBOLIC_LINK:
           break;
         default:
+          g_debug ("Not importing spurious content at %s", path);
           return OSTREE_REPO_COMMIT_FILTER_SKIP;
         }
 


### PR DESCRIPTION
This contains two minor enhancements for the logic handling `/var`:
 * when preparing scripts environment, stop relying on an implicit `/var/lib`
 * when importing package content, log a debug message if spurious content is encountered/skipped
