### PR TITLE
composepost: Remove /usr/lib/sysimage/rpm dir before symlinking

### DIFF
--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -981,6 +981,8 @@ fn hardlink_rpmdb_base_location(
 
     // And write a symlink from the proposed standard /usr/lib/sysimage/rpm
     // to our /usr/share/rpm - eventually we will invert this.
+    // Temporarily remove the directory if it exists until then.
+    rootfs.remove_dir_optional(RPMOSTREE_SYSIMAGE_RPMDB)?;
     rootfs.symlink(RPMOSTREE_SYSIMAGE_RPMDB, "../../share/rpm")?;
 
     Ok(true)


### PR DESCRIPTION
Rawhide has moved the rpmdb to `/usr/lib/sysimage/rpm`, which is great!
FCOS composes started breaking because rpm now creates that directory:

https://github.com/coreos/rpm-ostree/issues/3397

We should be able to eventually flip our `_dbpath` macro with this (and
eventually much later once it hits RHEL, stop overriding the macro at
all). This will require some careful changes and testing.

But anyway we probably don't want to do this yet on f35 to match Fedora,
so we will want a transition mechanism; e.g. a `rpmdb-in-sysimage`
treefile knob.

For now just to unblock rawhide changes, let's remove the empty dir so
we can symlink and keep `/usr/share/rpm` as canonical. We'll rework once
we have the permanent solution.
