### PR TITLE
treefile: Add `container-cmd`

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -87,6 +87,10 @@ It supports the following parameters:
     files present in packages and prior layers will be silently overriden.
     This is useful for development builds to replace parts of the base tree.
 
+ * `container-cmd`: array of strings, optional: This maps to the `CMD` Dockerfile
+   instruction, and is currently only meaningful when encapsulating/exporting
+   an ostree commit as a Docker/OCI container.
+
  * `bootstrap_packages`: Array of strings, optional: Deprecated; you should
     now just include this set in the main `packages` array.
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -415,6 +415,7 @@ pub mod ffi {
         fn get_lockfile_repos(&self) -> Vec<String>;
         fn get_ref(&self) -> &str;
         fn get_cliwrap(&self) -> bool;
+        fn get_container_cmd(&self) -> Vec<String>;
         fn get_readonly_executables(&self) -> bool;
         fn get_documentation(&self) -> bool;
         fn get_recommends(&self) -> bool;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -380,6 +380,7 @@ fn treefile_merge(dest: &mut TreeComposeConfig, src: &mut TreeComposeConfig) {
         container,
         recommends,
         readonly_executables,
+        container_cmd,
         documentation,
         boot_location,
         tmp_is_dir,
@@ -755,6 +756,10 @@ impl Treefile {
 
     pub(crate) fn get_releasever(&self) -> &str {
         self.parsed.base.releasever.as_deref().unwrap_or_default()
+    }
+
+    pub(crate) fn get_container_cmd(&self) -> Vec<String> {
+        self.parsed.base.container_cmd.clone().unwrap_or_default()
     }
 
     /// Returns true if the database backend must be regenerated using the target system.
@@ -1381,6 +1386,9 @@ pub(crate) struct BaseComposeConfigFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "rpmdb-normalize")]
     pub(crate) rpmdb_normalize: Option<bool>,
+
+    // Container related bits
+    pub(crate) container_cmd: Option<Vec<String>>,
 
     #[serde(flatten)]
     pub(crate) legacy_fields: LegacyTreeComposeConfigFields,

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -761,6 +761,18 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
         return FALSE;
     }
 
+  auto cmd = (*self->treefile_rs)->get_container_cmd();
+  if (cmd.size() > 0)
+    {
+      g_auto(GVariantBuilder) builder;
+      g_variant_builder_init (&builder, G_VARIANT_TYPE ("as"));
+      for (auto s: cmd)
+        {
+          g_variant_builder_add (&builder, "s", s.c_str());
+        }
+      g_hash_table_insert (self->metadata, g_strdup ("ostree.container-cmd"), g_variant_ref_sink (g_variant_builder_end (&builder)));
+    }
+
   auto layers = (*self->treefile_rs)->get_all_ostree_layers();
   if (layers.size() > 0 && !opt_unified_core)
     return glnx_throw (error, "ostree-layers requires unified-core mode");

--- a/tests/compose/test-misc-tweaks.sh
+++ b/tests/compose/test-misc-tweaks.sh
@@ -35,6 +35,8 @@ EOF
 cat > config/other.yaml <<'EOF'
 recommends: true
 readonly-executables: true
+container-cmd:
+  - /usr/bin/bash
 EOF
 treefile_append "include" '["documentation.yaml", "other.yaml"]'
 for x in 'recommends' 'documentation' 'readonly-executables'; do


### PR DESCRIPTION
Builds on https://github.com/ostreedev/ostree-rs-ext/pull/235

Part of https://github.com/coreos/coreos-assembler/issues/2685

Note making use of this will require bumping ostree-ext here.
