### PR TITLE
scripts: Use a tmpfs for /run

### DIFF
--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -370,12 +370,14 @@ rpmostree_run_script_in_bwrap_container (int rootfs_fd,
   /* Don't let scripts see the base rpm database by default */
   bwrap->bind_read("usr/share/empty", "usr/share/rpm");
 
-  /* Add ostree-booted API; some scriptlets may work differently on OSTree systems; e.g.
+  /* Also a tmpfs for /run.
+   * Add ostree-booted API; some scriptlets may work differently on OSTree systems; e.g.
    * akmods. Just create it manually; /run is usually tmpfs, but scriptlets shouldn't be
    * adding stuff there anyway. */
   if (!glnx_shutil_mkdir_p_at (rootfs_fd, "run", 0755, cancellable, error))
     return FALSE;
-  bwrap->bind_readwrite("./run", "/run");
+  bwrap->append_bwrap_arg("--tmpfs");
+  bwrap->append_bwrap_arg("/tmp");
 
   bwrap->take_fd(glnx_steal_fd (&devnull_fd), devnull_target_fd);
   bwrap->append_bwrap_arg("--ro-bind-data");

--- a/tests/kolainst/destructive/layering-local
+++ b/tests/kolainst/destructive/layering-local
@@ -57,6 +57,10 @@ echo "ok pkg foo added locally"
 
 booted_commit=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
 
+if ostree ls "${booted_commit}" /run/ostree-booted 2>/dev/null; then
+  fatal "Found /run/ostree-booted committed in tree"
+fi
+
 ostree show --print-metadata-key=ostree.bootable ${booted_commit} >out.txt
 assert_file_has_content_literal out.txt 'true'
 echo "ok bootable metadata"


### PR DESCRIPTION
This is an ugly bug; I noticed while doing an `ostree diff`
between two commits that `/run/ostree-booted` had been added.

This was because bwrap `--ro-bind-data` writes a persistent file,
and we weren't mounting `/run` as a tmpfs.

In general we've been potentially leaking state from any scripts
into the persistent commit!

We should change ostree to perhaps error out on this if `--bootable`
is specified or so.
