### PR TITLE
Add internal API to expose package variant list to Rust

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -668,6 +668,16 @@ pub mod ffi {
         fn nevra_to_cache_branch(nevra: &CxxString) -> Result<String>;
         fn get_repodata_chksum_repr(pkg: &mut DnfPackage) -> Result<String>;
     }
+
+    // rpmostree-package-variants.h
+    unsafe extern "C++" {
+        include!("rpmostree-package-variants.h");
+        fn package_variant_list_for_commit(
+            repo: Pin<&mut OstreeRepo>,
+            rev: &str,
+            cancellable: Pin<&mut GCancellable>,
+        ) -> Result<*mut GVariant>;
+    }
 }
 
 mod builtins;

--- a/src/daemon/rpmostree-package-variants.cxx
+++ b/src/daemon/rpmostree-package-variants.cxx
@@ -22,6 +22,8 @@
 
 #include <rpmostree.h>
 #include "rpmostree-package-variants.h"
+#include "rpmostree-package-priv.h"
+#include "rpmostree-util.h"
 #include <libglnx.h>
 
 /**
@@ -197,4 +199,17 @@ rpm_ostree_db_diff_variant (OstreeRepo *repo,
   *out_variant = g_variant_builder_end (&builder);
   g_variant_ref_sink (*out_variant);
   return TRUE;
+}
+
+namespace rpmostreecxx {
+GVariant *
+package_variant_list_for_commit (OstreeRepo &repo, rust::Str rev, GCancellable &cancellable)
+{
+  g_autoptr(GError) local_error = NULL;
+  auto rev_c = std::string(rev);
+  g_autoptr(GVariant) ret_v = NULL;
+  if (!_rpm_ostree_package_variant_list_for_commit (&repo, rev_c.c_str(), FALSE, &ret_v, &cancellable, &local_error))
+    util::throw_gerror (local_error);
+  return util::move_nullify(ret_v);
+}
 }

--- a/src/daemon/rpmostree-package-variants.h
+++ b/src/daemon/rpmostree-package-variants.h
@@ -44,3 +44,10 @@ rpm_ostree_db_diff_variant (OstreeRepo *repo,
                             GError **error);
 
 G_END_DECLS
+
+#ifdef __cplusplus
+#include "rust/cxx.h"
+namespace rpmostreecxx {
+   GVariant *package_variant_list_for_commit (OstreeRepo &repo, rust::Str rev, GCancellable &cancellable);
+}
+#endif

--- a/src/lib/rpmostree-package-priv.h
+++ b/src/lib/rpmostree-package-priv.h
@@ -29,6 +29,14 @@ G_BEGIN_DECLS
 RpmOstreePackage * _rpm_ostree_package_new_from_variant (GVariant *gv_nevra);
 
 gboolean
+_rpm_ostree_package_variant_list_for_commit (OstreeRepo   *repo,
+                                     const char   *rev,
+                                     gboolean      allow_noent,
+                                     GVariant    **out_pkglist,
+                                     GCancellable *cancellable,
+                                     GError      **error);
+
+gboolean
 _rpm_ostree_package_list_for_commit (OstreeRepo   *repo,
                                      const char   *rev,
                                      gboolean      allow_noent,

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -30,8 +30,10 @@ assert_jq status.json \
   '.deployments[0]["layered-commit-meta"]|not' \
   '.deployments[0]["staged"]|not'
 rm status.json
-rpm-ostree testutils validate-parse-status
 echo "ok empty pkg arrays, and commit meta correct in status json"
+
+# All tests which require a booted system, but are nondestructive
+rpm-ostree testutils integration-read-only
 
 # Ensure we return an error when passing a wrong option.
 rpm-ostree --help | awk '/^$/ {in_commands=0} {if(in_commands==1){print $0}} /^Builtin Commands:/ {in_commands=1}' > commands.txt


### PR DESCRIPTION
Prep for using this for ostree layer splitting work.
