### PR TITLE
scripts: Fix tmpfs for `/run`

### DIFF
--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -377,7 +377,7 @@ rpmostree_run_script_in_bwrap_container (int rootfs_fd,
   if (!glnx_shutil_mkdir_p_at (rootfs_fd, "run", 0755, cancellable, error))
     return FALSE;
   bwrap->append_bwrap_arg("--tmpfs");
-  bwrap->append_bwrap_arg("/tmp");
+  bwrap->append_bwrap_arg("/run");
 
   bwrap->take_fd(glnx_steal_fd (&devnull_fd), devnull_target_fd);
   bwrap->append_bwrap_arg("--ro-bind-data");

--- a/tests/kolainst/kolainst-build.sh
+++ b/tests/kolainst/kolainst-build.sh
@@ -57,6 +57,8 @@ build_rpm testdaemon \
 # Will be useful for testing cancellation
 build_rpm testpkg-post-infinite-loop \
              post "echo entering testpkg-post-infinite-loop 1>&2; while true; do sleep 1h; done"
+build_rpm testpkg-touch-run \
+             post "touch /{run,tmp,var/tmp}/should-not-persist"
 # Test module
 build_rpm foomodular
 build_module foomodular \


### PR DESCRIPTION
The previous commit was not correct.  While we're here, add
a much stronger test that explicitly verifies the non-persistence
for `/run`, `/tmp`, and `/var/tmp`.
