### PR TITLE
Bump to cap-std-ext 0.24.1 && cliwrap: Port to cap-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std-ext"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ae6a293d08473437dd15c64e53fd7166b7689455c0d10eb2dc0319691cbdc3"
+checksum = "374e427554ef23d91b535e4cb15a75e9323c6f2ce22923ea792b06621442316b"
 dependencies = [
  "cap-std",
  "rustix",


### PR DESCRIPTION
Bump to cap-std-ext 0.24.1

Has the `O_TMPFILE` fallback we need.

---

cliwrap: Port to cap-std

Ongoing cleanup that helps me at least get a PR or two out
per day so I signal my continued existence.

---

