### PR TITLE
`db version`: Switch to using SHA-256

### DIFF
--- a/src/libpriv/rpmostree-rpm-util.cxx
+++ b/src/libpriv/rpmostree-rpm-util.cxx
@@ -431,11 +431,8 @@ rpmhdrs_rpmdbv (struct RpmHeaders *l1,
                 GCancellable   *cancellable,
                 GError        **error)
 {
-  GChecksum *checksum = g_checksum_new (G_CHECKSUM_SHA1);
-  g_autofree char *checksum_cstr = NULL;
-  char *ret = NULL;
+  g_autoptr(GChecksum) checksum = g_checksum_new (G_CHECKSUM_SHA256);
   int num = 0;
-
   while (num < l1->hs->len)
     {
       auto pkg = static_cast<Header>(l1->hs->pdata[num++]);
@@ -444,13 +441,7 @@ rpmhdrs_rpmdbv (struct RpmHeaders *l1,
       g_checksum_update (checksum, (guint8*)envra, strlen(envra));
     }
 
-  checksum_cstr = g_strdup (g_checksum_get_string (checksum));
-
-  ret = g_strdup_printf ("%u:%s", num, checksum_cstr);
-
-  g_checksum_free (checksum);
-
-  return ret;
+  return g_strdup_printf ("%u:%s", num, g_checksum_get_string (checksum));
 }
 
 /* glib? */


### PR DESCRIPTION
`db version`: Switch to using SHA-256

Motivated by a RHEL-initiated effort to change or drop code using
SHA-1.

This code is old, has no unit tests, and I am not aware of anything
actually using it.  We could probably just delete it.

That said, let's take a middle ground of changing it to use SHA-256.

I believe the higher level logic here duplicates that of libdnf;
xref https://github.com/rpm-software-management/libdnf/issues/1373
We should be using that API anyways; but that's a larger change,
I'm just trying to get SHA-1 out for now.
