### PR TITLE
DNM: ci: Test composes with latest stable rpm-ostree

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -86,7 +86,6 @@ compose: {
         stage("Install Deps") {
           shwrap("""
             ci/install-test-deps.sh
-            dnf install -y *.rpm  # install our built rpm-ostree
           """)
         }
         stage("Run") {


### PR DESCRIPTION
Part of debugging
https://github.com/coreos/rpm-ostree/pull/3406#issuecomment-1036330466.