### PR TITLE
treefile: Add conditional includes

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -201,10 +201,14 @@ It supports the following parameters:
 
    Example: `ignore-removed-groups: ["avahi"]`
 
- * `releasever`: String, optional: Used to set the librepo `$releasever` variable,
-   commonly used in yum repo files.
+ * `releasever`: String or integer, optional: Used to set the librepo
+   `$releasever` variable, commonly used in yum repo files.
 
    Example: `releasever: "26"`
+   Example: `releasever: 35`
+
+   When defined, it is automatically also added to the `variable` map described
+   below. Thus, it can be used for substitutions and conditional includes.
 
  * `automatic-version-prefix` (or `automatic_version_prefix`): String, optional:
    Set the prefix for versions on the commits. The idea is that if the previous
@@ -359,6 +363,10 @@ It supports the following parameters:
  * `variables`: object (`Map<String, value>`), optional: Define new variables
    which could then be substituted into the value of various fields. Supported
    value types are booleans, numbers, and strings.
+
+   The `releasever` variable is reserved and automatically populated to the same
+   value as the `releasever` key. The `basearch` variable is reserved and
+   automatically populated to the base architecture of the compose.
 
    Example:
 

--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -312,6 +312,53 @@ It supports the following parameters:
        - tweaks-s390x.yaml
     ```
 
+ * `conditional-include`: array of objects, optional: This is like `include`,
+    but supports conditions based on variables defined in `variables`. The
+    syntax is:
+
+    ```yaml
+    conditional-include:
+      - if: <var> <op> <value>
+        include: <include>
+    ```
+
+    `<var>` is a variable name previously defined via `variables`. `<op>` must
+    be one of `==`, `!=`, `<`, `<=`, `>`, `>=`. `<value>` has the same sematics
+    as variable values: it can be a boolean, number, or string (in quotes).
+    `<include>` functions the same as the `include` key above - it can be either
+    a string or an array of strings.
+
+    Multiple conditions may be provided:
+
+    ```yaml
+    conditional-include:
+      - if:
+        - <var> <op> <value>
+        - <var> <op> <value>
+        - <var> <op> <value>
+        include: <include>
+    ```
+
+    In that case, *all* conditions must be met for the inclusion to happen.
+
+    Example:
+
+    ```yaml
+   variables:
+     devpackages: true
+     stream: "development"
+   releasever: 35
+   conditional-include:
+     - if: devpackages == true
+       include: dev-packages.yaml
+   conditional-include:
+     - if: stream != "development"
+       include: delete-dev-files.yaml
+   conditional-include:
+     - if: releasever >= 35
+       include: f35-selinux-workaround.yaml
+    ```
+
  * `container`: boolean, optional: Defaults to `false`.  If `true`, then
    rpm-ostree will not do any special handling of kernel, initrd or the
    /boot directory. This is useful if the target for the tree is some kind
@@ -361,8 +408,9 @@ It supports the following parameters:
    field supports variable substitution.
 
  * `variables`: object (`Map<String, value>`), optional: Define new variables
-   which could then be substituted into the value of various fields. Supported
-   value types are booleans, numbers, and strings.
+   which could then be substituted into the value of various fields and used in
+   conditional includes described above. Supported value types are booleans,
+   numbers, and strings.
 
    The `releasever` variable is reserved and automatically populated to the same
    value as the `releasever` key. The `basearch` variable is reserved and
@@ -376,6 +424,9 @@ It supports the following parameters:
      stream: "development"
    releasever: 35
    ref: "cool-os/${releasever}/${stream}"
+   conditional-include:
+     - if: devpackages == true
+       include: dev-packages.yaml
    ```
 
 ## Experimental options

--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -17,7 +17,7 @@ It supports the following parameters:
  * `ref`: string, mandatory: Holds a string which will be the name of
    the branch for the content. This field supports variable substitution.
 
-   Example: `ref: "cool-os/${releasever}"`
+   Example: `ref: "cool-os/${releasever}/${stream}"`
 
  * `gpg-key` (or `gpg_key`): string, optional: Key ID for GPG signing; the
    secret key must be in the home directory of the building user.  Defaults to
@@ -251,7 +251,7 @@ It supports the following parameters:
    ```yaml
    add-commit-metadata:
      cool-os.is-production: false
-     cool-os.git-snapshot: "${releasever}"
+     cool-os.git-snapshot: "${git_snapshot}"
    ```
 
  * `postprocess-script`: String, optional: Full filesystem path to a script
@@ -353,7 +353,22 @@ It supports the following parameters:
    order.  If the first mechanism fails and we are running a compose, we will not
    have the necessary files to allow the fall back to work.  If you find yourself
    in this situation you can provide the platform module name yourself using this
-   option. You can also use this to override the platform module if needed.
+   option. You can also use this to override the platform module if needed. This
+   field supports variable substitution.
+
+ * `variables`: object (`Map<String, value>`), optional: Define new variables
+   which could then be substituted into the value of various fields. Supported
+   value types are booleans, numbers, and strings.
+
+   Example:
+
+   ```yaml
+   variables:
+     devpackages: true
+     stream: "development"
+   releasever: 35
+   ref: "cool-os/${releasever}/${stream}"
+   ```
 
 ## Experimental options
 

--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -15,7 +15,9 @@ Jenkins to operate on them as it changes.
 It supports the following parameters:
 
  * `ref`: string, mandatory: Holds a string which will be the name of
-   the branch for the content.
+   the branch for the content. This field supports variable substitution.
+
+   Example: `ref: "cool-os/${releasever}"`
 
  * `gpg-key` (or `gpg_key`): string, optional: Key ID for GPG signing; the
    secret key must be in the home directory of the building user.  Defaults to
@@ -52,7 +54,9 @@ It supports the following parameters:
     version, and adds a specific `OSTREE_VERSION` key that can be easier
     for processes to query than looking via ostree. The actual value of
     this key represents the baked string that gets substituted out for
-    the final OSTree version.
+    the final OSTree version. This field supports variable substitution.
+
+    Example: `mutate-os-release: "${releasever}"`
 
  * `documentation`: boolean, optional. If this is set to false it sets the RPM
    transaction flag "nodocs" which makes yum/rpm not install files marked as
@@ -228,7 +232,10 @@ It supports the following parameters:
    | `22.<date:%Y>`             | 22.2019.0, 22.2019.1, 22.2020.0, ...       |
    | `22.<date:%Y>.1`           | 22.2019.1.0, 22.2019.1.1, 22.2020.1.0, ... |
 
+   This field supports variable substitution.
+
    Example: `automatic-version-prefix: "22.0"`
+   Example: `automatic-version-prefix: "${releasever}.<date:%Y%m%d>.dev"`
 
  * `automatic-version-suffix`: String, optional: This must be a single ASCII
    character.  The default value is `.`.  Used by `automatic-version-prefix`.
@@ -236,7 +243,16 @@ It supports the following parameters:
 
  * `add-commit-metadata`: Map<String, Object>, optional: Metadata to inject as
    part of composed commits. Keys inserted here can still be overridden at the
-   command line with `--add-metadata-string` or `--add-metadata-from-json`.
+   command line with `--add-metadata-string` or `--add-metadata-from-json`. All
+   objects of type string support variable substitution.
+
+   Example:
+
+   ```yaml
+   add-commit-metadata:
+     cool-os.is-production: false
+     cool-os.git-snapshot: "${releasever}"
+   ```
 
  * `postprocess-script`: String, optional: Full filesystem path to a script
    that will be executed in the context of the target tree.  The script

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -428,7 +428,7 @@ pub mod ffi {
         fn get_documentation(&self) -> bool;
         fn get_recommends(&self) -> bool;
         fn get_selinux(&self) -> bool;
-        fn get_releasever(&self) -> &str;
+        fn get_releasever(&self) -> String;
         fn rpmdb_backend_is_target(&self) -> bool;
         fn should_normalize_rpmdb(&self) -> bool;
         fn get_files_remove_regex(&self, package: &str) -> Vec<String>;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -754,8 +754,13 @@ impl Treefile {
         self.parsed.base.selinux.unwrap_or(true)
     }
 
-    pub(crate) fn get_releasever(&self) -> &str {
-        self.parsed.base.releasever.as_deref().unwrap_or_default()
+    pub(crate) fn get_releasever(&self) -> String {
+        self.parsed
+            .base
+            .releasever
+            .as_ref()
+            .map(|rv| rv.clone())
+            .unwrap_or_else(|| "".to_string())
     }
 
     pub(crate) fn get_container_cmd(&self) -> Vec<String> {

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -613,7 +613,7 @@ rpmostree_context_setup (RpmOstreeContext    *self,
       self->treefile_rs = &**self->treefile_owned;
     }
 
-  auto releasever = std::string(self->treefile_rs->get_releasever());
+  auto releasever = self->treefile_rs->get_releasever();
 
   if (!install_root)
     install_root = emptydir_path;

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -106,7 +106,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     arch=$(arch)
     # TODO close race here around webserver readiness
     (cd ${KOLA_EXT_DATA}/rpm-repos/0 && ~core/kolet httpd) &
-    while !curl -q http://127.0.0.1; do sleep 1; done
+    while ! curl -q http://127.0.0.1; do sleep 1; done
     cat >local.repo << 'EOF'
 [local]
 gpgcheck=0


### PR DESCRIPTION
The way we use manifests in FCOS and RHCOS really pushes the limits of
rpm-ostree's include system.

In FCOS for example, we often need to have some tweaks applied based on
the version of Fedora being targeted by the stream (especially around
rebase preparations time, and of course rawhide).

Currently, we do this by adding such tweaks in the `manifest.yaml`,
which is unique per stream. But if there are multiple streams that need
this change (e.g. `rawhide`, `branched`, `next-devel`, `next`), it
becomes cumbersome and error-prone to modify all their manifest files.

We could add a conditional include based on `releasever` similar to what
was done with `arch-include`, but this only hints at a need for more
customizable include logic.

Now with the introduction of arbitrary variables, let's add basic
support for a conditional include syntax which should make more
sophisticated schemes possible.

There is a complexity cost here, but overall I think it's well worth it
for the flexibility it affords us in Fedora CoreOS at least.

There's more that could be done after this, such as supporting nested
`TreeComposeConfig` objects instead of having to have a separate file,
but we can leave that as a follow-up.