### PR TITLE
var: minor cleanup and basic checks for iptables alternatives 

### DIFF
--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -374,8 +374,9 @@ impl Bubblewrap {
     /// Set /var to be read-only, but with a transient writable /var/tmp
     /// and compat symlinks for scripts.
     pub(crate) fn setup_compat_var(&mut self) -> CxxResult<()> {
-        let content_dirs = &["alternatives", "vagrant"];
-        for entry in content_dirs {
+        use crate::composepost::COMPAT_VARLIB_SYMLINKS;
+
+        for entry in COMPAT_VARLIB_SYMLINKS {
             let varlib_path = format!("var/lib/{}", &entry);
             if !self.rootfs_fd.exists(&varlib_path)? {
                 let target = format!("../../usr/lib/{}", &entry);

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -37,6 +37,10 @@ use std::path::Path;
 use std::pin::Pin;
 use std::process::Stdio;
 
+/// Directories that are moved out and symlinked from their `/var/lib/<entry>`
+/// location to `/usr/lib/<entry>`.
+pub(crate) static COMPAT_VARLIB_SYMLINKS: &[&str] = &["alternatives", "vagrant"];
+
 /* See rpmostree-core.h */
 const RPMOSTREE_BASE_RPMDB: &str = "usr/lib/sysimage/rpm-ostree-base-db";
 const RPMOSTREE_RPMDB_LOCATION: &str = "usr/share/rpm";
@@ -806,8 +810,7 @@ pub fn rootfs_prepare_links(rootfs_dfd: i32) -> CxxResult<()> {
     rootfs
         .ensure_dir_all("usr/lib", 0o0755)
         .context("Creating /usr/lib")?;
-    let content_dirs = &["alternatives", "vagrant"];
-    for entry in content_dirs {
+    for entry in COMPAT_VARLIB_SYMLINKS {
         let varlib_path = format!("var/lib/{}", entry);
         let is_var_dir = rootfs
             .metadata_optional(&varlib_path)?

--- a/tests/compose/libbasic-test.sh
+++ b/tests/compose/libbasic-test.sh
@@ -129,5 +129,13 @@ assert_file_has_content_literal dirs.txt '/usr/lib/alternatives'
 ostree --repo="${repo}" ls "${treeref}" /usr/local | grep '^l00777' > symlinks.txt
 assert_file_has_content_literal symlinks.txt '/usr/local -> ../var/usrlocal'
 echo "ok symlinks"
+
+# Check iptables setup through alternatives.
+ostree --repo="${repo}" ls "${treeref}" '/usr/lib/alternatives/iptables' | grep '^-' > alternatives.txt
+assert_file_has_content_literal alternatives.txt '/usr/lib/alternatives/iptables'
+ostree --repo="${repo}" ls "${treeref}" '/usr/etc/alternatives/iptables' | grep '^l00777' > symlinks.txt
+# NOTE: this does not check the whole symlink target, but only a reasonably-stable leading portion of it.
+assert_file_has_content_literal symlinks.txt '/usr/etc/alternatives/iptables -> /usr/sbin/ip'
+echo "ok alternatives"
 }
 


### PR DESCRIPTION
Minor followup to https://github.com/coreos/rpm-ostree/pull/3387.
