### PR TITLE
A few minor patches

### DIFF
--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -202,7 +202,7 @@ pub fn decompose_sha256_nevra(v: &str) -> Result<(&str, &str)> {
 /// not possible to have a literal `${` in the string.
 fn varsubst(instr: &str, vars: &HashMap<String, String>) -> Result<String> {
     let mut buf = instr;
-    let mut s = "".to_string();
+    let mut s = String::with_capacity(instr.len());
     while !buf.is_empty() {
         if let Some(start) = buf.find("${") {
             let (prefix, rest) = buf.split_at(start);


### PR DESCRIPTION
utils: varsubst: Allocate initial string to around expected capacity

Just a drive by minor commit.

---

live: A bit of porting to cap-std

There's more here, just trying to keep up momentum.

---

countme: Port to cap-std

Keeping up porting momentum.

---

