### PR TITLE
scripts: add replacements scripts for /sbin/ldconfig calls in glibc-common

### DIFF
--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -163,6 +163,17 @@ static const RpmOstreeLuaReplacement lua_replacements[] = {
     "/usr/bin/sh",
     glibc_langpacks_script
   },
+  /* See https://src.fedoraproject.org/rpms/glibc/pull-request/54, which converts this to
+   * Lua as part of https://bugzilla.redhat.com/show_bug.cgi?id=2018913.
+   */
+  { "glibc-common.transfiletriggerin",
+    "/usr/bin/sh",
+    "/sbin/ldconfig"
+  },
+  { "glibc-common.transfiletriggerpostun",
+    "/usr/bin/sh",
+    "/sbin/ldconfig"
+  },
   /* See https://src.fedoraproject.org/rpms/glibc/pull-request/12
    * Code originally introduced in https://src.fedoraproject.org/rpms/glibc/c/34927af202deb7d97dbb211a3cb13b1c53b496d3?branch=master
    * Most of that script is about working around bugs from a traditional RPM in-place update,


### PR DESCRIPTION
The scriptlet in glibc adds a dependency on bash to glibc-common, which
is required by glibc, so effectively the whole world depends on bash.
I want to rewrite the script in lua to drop this dependency.

Quoting https://bugzilla.redhat.com/show_bug.cgi?id=2018913#c34:

```
warning: SCC #1: 5 members (5 external dependencies)
warning: 	glibc-2.35-2.fc37.x86_64
warning: 		-> glibc-minimal-langpack-2.35-2.fc37.x86_64
warning: 		-> glibc-common-2.35-2.fc37.x86_64
warning: 	ncurses-libs-6.2-9.20210508.fc36.x86_64
warning: 		-> glibc-2.35-2.fc37.x86_64
warning: 	bash-5.1.16-2.fc36.x86_64
warning: 		-> ncurses-libs-6.2-9.20210508.fc36.x86_64
warning: 		-> glibc-2.35-2.fc37.x86_64
warning: 	glibc-common-2.35-2.fc37.x86_64
warning: 		-> glibc-2.35-2.fc37.x86_64
warning: 		-> bash-5.1.16-2.fc36.x86_64
warning: 	glibc-minimal-langpack-2.35-2.fc37.x86_64
warning: 		-> glibc-common-2.35-2.fc37.x86_64
warning: 		-> glibc-2.35-2.fc37.x86_64
```

If we look into SCC #1, bash obviously requires glibc because it links
to it. The loop is created by glibc → glibc-common → bash, because
glibc-common has %transfiletriggerin and %transfiletriggerpostun using
bash to call /sbin/ldconfig.
