### PR TITLE
treefile: Skip serializing `container-cmd` if None

### DIFF
--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1352,6 +1352,7 @@ pub(crate) struct BaseComposeConfigFields {
     pub(crate) rpmdb_normalize: Option<bool>,
 
     // Container related bits
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) container_cmd: Option<Vec<String>>,
 
     #[serde(flatten)]


### PR DESCRIPTION
Just like all the other options in the tree.
Otherwise this throws off the `error_if_base` check.