### PR TITLE
Run all C/C++ code under `src` through `clang-format` and add ongoing enforcement

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+---
+Language: Cpp
+BasedOnStyle: GNU
+ColumnLimit: 100

--- a/ci/codestyle.sh
+++ b/ci/codestyle.sh
@@ -6,11 +6,26 @@ set -euo pipefail
 echo -n "checking for tabs... "
 (git grep -E '^	+' -- '*.[ch]' || true) > tabdamage.txt
 if test -s tabdamage.txt; then
-    echo "Error: tabs in .[ch] files:"
-    cat tabdamage.txt
+    echo "Error: tabs in .[ch] files:" 1>&2
+    cat tabdamage.txt 1>&2
     exit 1
 fi
 rm tabdamage.txt
+echo "ok"
+
+echo -n "checking clang-format... "
+rm -f clang-unformatted.txt
+git ls-files 'src/**.c' 'src/**.cxx' 'src/**.h' 'src/**.hpp' | while read f; do
+    if ! clang-format --Werror --ferror-limit=1 --dry-run "$f" > /dev/null 2>&1; then
+        echo "$f" >> clang-unformatted.txt
+    fi
+done
+if test -s clang-unformatted.txt; then
+    echo "Error: clang-format needed on these files:" 1>&2
+    cat clang-unformatted.txt 1>&2
+    exit 1
+fi
+rm -f clang-unformatted.txt
 echo "ok"
 
 echo -n "checking rustfmt... "

--- a/src/app/rpmostree-builtin-applylive.cxx
+++ b/src/app/rpmostree-builtin-applylive.cxx
@@ -20,26 +20,23 @@
 
 #include "config.h"
 
-#include <string.h>
 #include <glib-unix.h>
+#include <string.h>
 
-#include "rpmostree-ex-builtins.h"
-#include "rpmostree-libbuiltin.h"
 #include "rpmostree-clientlib.h"
 #include "rpmostree-cxxrs.h"
+#include "rpmostree-ex-builtins.h"
+#include "rpmostree-libbuiltin.h"
 
 #include <libglnx.h>
 
 gboolean
-rpmostree_ex_builtin_apply_live (int             argc,
-                                 char          **argv,
-                                 RpmOstreeCommandInvocation *invocation,
-                                 GCancellable   *cancellable,
-                                 GError        **error)
+rpmostree_ex_builtin_apply_live (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+                                 GCancellable *cancellable, GError **error)
 {
   rust::Vec<rust::String> rustargv;
   for (int i = 0; i < argc; i++)
-    rustargv.push_back(std::string(argv[i]));
-  CXX_TRY(applylive_entrypoint(rustargv), error);
+    rustargv.push_back (std::string (argv[i]));
+  CXX_TRY (applylive_entrypoint (rustargv), error);
   return TRUE;
 }

--- a/src/app/rpmostree-builtin-compose.cxx
+++ b/src/app/rpmostree-builtin-compose.cxx
@@ -20,38 +20,40 @@
 
 #include "config.h"
 
-#include "rpmostree-compose-builtins.h"
 #include "rpmostree-builtins.h"
+#include "rpmostree-compose-builtins.h"
 
-#include <ostree.h>
 #include "libglnx.h"
+#include <ostree.h>
 
 #include <glib/gi18n.h>
 
-static RpmOstreeCommand compose_subcommands[] = {
-  { "tree", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    "Process a \"treefile\"; install packages and commit the result to an OSTree repository",
-    rpmostree_compose_builtin_tree },
-  { "install", (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT),
-    "Install packages into a target path",
-    rpmostree_compose_builtin_install },
-  { "postprocess", (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT),
-    "Perform final postprocessing on an installation root",
-    rpmostree_compose_builtin_postprocess },
-  { "commit", (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT),
-    "Commit a target path to an OSTree repository",
-    rpmostree_compose_builtin_commit },
-  { "extensions", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    "Download RPM packages guaranteed to depsolve with a base OSTree",
-    rpmostree_compose_builtin_extensions },
-  { NULL, (RpmOstreeBuiltinFlags)0, NULL, NULL }
-};
+static RpmOstreeCommand compose_subcommands[]
+    = { { "tree", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+          "Process a \"treefile\"; install packages and commit the result to an OSTree repository",
+          rpmostree_compose_builtin_tree },
+        { "install",
+          (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD
+                                  | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT),
+          "Install packages into a target path", rpmostree_compose_builtin_install },
+        { "postprocess",
+          (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD
+                                  | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT),
+          "Perform final postprocessing on an installation root",
+          rpmostree_compose_builtin_postprocess },
+        { "commit",
+          (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD
+                                  | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT),
+          "Commit a target path to an OSTree repository", rpmostree_compose_builtin_commit },
+        { "extensions", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+          "Download RPM packages guaranteed to depsolve with a base OSTree",
+          rpmostree_compose_builtin_extensions },
+        { NULL, (RpmOstreeBuiltinFlags)0, NULL, NULL } };
 
 gboolean
-rpmostree_builtin_compose (int argc, char **argv,
-                           RpmOstreeCommandInvocation *invocation,
+rpmostree_builtin_compose (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
                            GCancellable *cancellable, GError **error)
 {
-  return rpmostree_handle_subcommand (argc, argv, compose_subcommands,
-                                      invocation, cancellable, error);
+  return rpmostree_handle_subcommand (argc, argv, compose_subcommands, invocation, cancellable,
+                                      error);
 }

--- a/src/app/rpmostree-builtin-db.cxx
+++ b/src/app/rpmostree-builtin-db.cxx
@@ -23,52 +23,40 @@
 #include "rpmostree-db-builtins.h"
 #include "rpmostree-rpm-util.h"
 
-static RpmOstreeCommand rpm_subcommands[] = {
-  { "diff", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    "Show package changes between two commits",
-    rpmostree_db_builtin_diff },
-  { "list", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    "List packages within commits",
-    rpmostree_db_builtin_list },
-  { "version", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    "Show rpmdb version of packages within the commits",
-    rpmostree_db_builtin_version },
-  { NULL, (RpmOstreeBuiltinFlags)0, NULL, NULL }
-};
+static RpmOstreeCommand rpm_subcommands[]
+    = { { "diff", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD, "Show package changes between two commits",
+          rpmostree_db_builtin_diff },
+        { "list", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD, "List packages within commits",
+          rpmostree_db_builtin_list },
+        { "version", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+          "Show rpmdb version of packages within the commits", rpmostree_db_builtin_version },
+        { NULL, (RpmOstreeBuiltinFlags)0, NULL, NULL } };
 
 static char *opt_repo;
 
-static GOptionEntry global_entries[] = {
-  { "repo", 'r', 0, G_OPTION_ARG_STRING, &opt_repo, "Path to OSTree repository (defaults to /sysroot/ostree/repo)", "PATH" },
-  { NULL }
-};
+static GOptionEntry global_entries[]
+    = { { "repo", 'r', 0, G_OPTION_ARG_STRING, &opt_repo,
+          "Path to OSTree repository (defaults to /sysroot/ostree/repo)", "PATH" },
+        { NULL } };
 
 gboolean
-rpmostree_db_option_context_parse (GOptionContext *context,
-                                   const GOptionEntry *main_entries,
-                                   int *argc, char ***argv,
-                                   RpmOstreeCommandInvocation *invocation,
-                                   OstreeRepo **out_repo,
-                                   GCancellable *cancellable, GError **error)
+rpmostree_db_option_context_parse (GOptionContext *context, const GOptionEntry *main_entries,
+                                   int *argc, char ***argv, RpmOstreeCommandInvocation *invocation,
+                                   OstreeRepo **out_repo, GCancellable *cancellable, GError **error)
 {
   /* Entries are listed in --help output in the order added.  We add the
    * main entries ourselves so that we can add the --repo entry first. */
 
   g_option_context_add_main_entries (context, global_entries, NULL);
 
-  if (!rpmostree_option_context_parse (context,
-                                       main_entries,
-                                       argc, argv,
-                                       invocation,
-                                       cancellable,
-                                       NULL, NULL, NULL,
-                                       error))
+  if (!rpmostree_option_context_parse (context, main_entries, argc, argv, invocation, cancellable,
+                                       NULL, NULL, NULL, error))
     return FALSE;
 
-  g_autoptr(OstreeRepo) repo = NULL;
+  g_autoptr (OstreeRepo) repo = NULL;
   if (opt_repo == NULL)
     {
-      g_autoptr(OstreeSysroot) sysroot = ostree_sysroot_new_default ();
+      g_autoptr (OstreeSysroot) sysroot = ostree_sysroot_new_default ();
 
       if (!ostree_sysroot_load (sysroot, cancellable, error))
         return FALSE;
@@ -91,11 +79,8 @@ rpmostree_db_option_context_parse (GOptionContext *context,
 }
 
 gboolean
-rpmostree_builtin_db (int argc, char **argv,
-                      RpmOstreeCommandInvocation *invocation,
+rpmostree_builtin_db (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
                       GCancellable *cancellable, GError **error)
 {
-  return rpmostree_handle_subcommand (argc, argv, rpm_subcommands,
-                                      invocation, cancellable, error);
+  return rpmostree_handle_subcommand (argc, argv, rpm_subcommands, invocation, cancellable, error);
 }
-

--- a/src/app/rpmostree-builtin-deploy.cxx
+++ b/src/app/rpmostree-builtin-deploy.cxx
@@ -21,9 +21,9 @@
 #include "config.h"
 
 #include "rpmostree-builtins.h"
+#include "rpmostree-clientlib.h"
 #include "rpmostree-libbuiltin.h"
 #include "rpmostree-rpm-util.h"
-#include "rpmostree-clientlib.h"
 
 #include <libglnx.h>
 
@@ -40,52 +40,55 @@ static gboolean opt_bypass_driver;
 static gboolean opt_skip_branch_check;
 static char *opt_ex_cliwrap;
 
-static GOptionEntry option_entries[] = {
-  { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
-  { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot, "Initiate a reboot after operation is complete", NULL },
-  /* XXX As much as I dislike the inconsistency with "rpm-ostree upgrade",
-   *     calling this option --check-diff doesn't really make sense here.
-   *     A --preview option would work for both commands if we wanted to
-   *     deprecate --check-diff. */
-  { "preview", 0, 0, G_OPTION_ARG_NONE, &opt_preview, "Just preview package differences", NULL },
-  { "cache-only", 'C', 0, G_OPTION_ARG_NONE, &opt_cache_only, "Do not download latest ostree and RPM data", NULL },
-  { "download-only", 0, 0, G_OPTION_ARG_NONE, &opt_download_only, "Just download latest ostree and RPM data, don't deploy", NULL },
-  { "skip-branch-check", 0, 0, G_OPTION_ARG_NONE, &opt_skip_branch_check, "Do not check if commit belongs on the same branch", NULL },
-  { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization, "Prevent automatic deployment finalization on shutdown", NULL },
-  { "disallow-downgrade", 0, 0, G_OPTION_ARG_NONE, &opt_disallow_downgrade, "Forbid deployment of chronologically older trees", NULL },
-  { "unchanged-exit-77", 0, 0, G_OPTION_ARG_NONE, &opt_unchanged_exit_77, "If no new deployment made, exit 77", NULL },
-  { "register-driver", 0, 0, G_OPTION_ARG_STRING, &opt_register_driver, "Register the calling agent as the driver for updates; if REVISION is an empty string, register driver without deploying", "DRIVERNAME" },
-  { "bypass-driver", 0, 0, G_OPTION_ARG_NONE, &opt_bypass_driver, "Force a deploy even if an updates driver is registered", NULL},
-  { "ex-cliwrap", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_ex_cliwrap, "Enable or disable wrapping binaries like /usr/bin/rpm", NULL},
-  { NULL }
-};
+static GOptionEntry option_entries[]
+    = { { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+        { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot,
+          "Initiate a reboot after operation is complete", NULL },
+        /* XXX As much as I dislike the inconsistency with "rpm-ostree upgrade",
+         *     calling this option --check-diff doesn't really make sense here.
+         *     A --preview option would work for both commands if we wanted to
+         *     deprecate --check-diff. */
+        { "preview", 0, 0, G_OPTION_ARG_NONE, &opt_preview, "Just preview package differences",
+          NULL },
+        { "cache-only", 'C', 0, G_OPTION_ARG_NONE, &opt_cache_only,
+          "Do not download latest ostree and RPM data", NULL },
+        { "download-only", 0, 0, G_OPTION_ARG_NONE, &opt_download_only,
+          "Just download latest ostree and RPM data, don't deploy", NULL },
+        { "skip-branch-check", 0, 0, G_OPTION_ARG_NONE, &opt_skip_branch_check,
+          "Do not check if commit belongs on the same branch", NULL },
+        { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization,
+          "Prevent automatic deployment finalization on shutdown", NULL },
+        { "disallow-downgrade", 0, 0, G_OPTION_ARG_NONE, &opt_disallow_downgrade,
+          "Forbid deployment of chronologically older trees", NULL },
+        { "unchanged-exit-77", 0, 0, G_OPTION_ARG_NONE, &opt_unchanged_exit_77,
+          "If no new deployment made, exit 77", NULL },
+        { "register-driver", 0, 0, G_OPTION_ARG_STRING, &opt_register_driver,
+          "Register the calling agent as the driver for updates; if REVISION is an empty string, "
+          "register driver without deploying",
+          "DRIVERNAME" },
+        { "bypass-driver", 0, 0, G_OPTION_ARG_NONE, &opt_bypass_driver,
+          "Force a deploy even if an updates driver is registered", NULL },
+        { "ex-cliwrap", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_ex_cliwrap,
+          "Enable or disable wrapping binaries like /usr/bin/rpm", NULL },
+        { NULL } };
 
 gboolean
-rpmostree_builtin_deploy (int            argc,
-                          char         **argv,
-                          RpmOstreeCommandInvocation *invocation,
-                          GCancellable  *cancellable,
-                          GError       **error)
+rpmostree_builtin_deploy (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+                          GCancellable *cancellable, GError **error)
 {
-  g_autoptr(GOptionContext) context = NULL;
+  g_autoptr (GOptionContext) context = NULL;
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   g_autofree char *transaction_address = NULL;
-  const char * const packages[] = { NULL };
+  const char *const packages[] = { NULL };
   const char *revision;
   const char *const *install_pkgs = NULL;
   const char *const *uninstall_pkgs = NULL;
 
   context = g_option_context_new ("REVISION");
 
-  if (!rpmostree_option_context_parse (context,
-                                       option_entries,
-                                       &argc, &argv,
-                                       invocation,
-                                       cancellable,
-                                       &install_pkgs,
-                                       &uninstall_pkgs,
-                                       &sysroot_proxy,
+  if (!rpmostree_option_context_parse (context, option_entries, &argc, &argv, invocation,
+                                       cancellable, &install_pkgs, &uninstall_pkgs, &sysroot_proxy,
                                        error))
     return FALSE;
 
@@ -111,20 +114,15 @@ rpmostree_builtin_deploy (int            argc,
   else
     revision = NULL;
 
-  if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname,
-                                cancellable, &os_proxy, error))
+  if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname, cancellable, &os_proxy, error))
     return FALSE;
 
-  g_autoptr(GVariant) previous_deployment = rpmostree_os_dup_default_deployment (os_proxy);
+  g_autoptr (GVariant) previous_deployment = rpmostree_os_dup_default_deployment (os_proxy);
 
   if (opt_preview)
     {
-      if (!rpmostree_os_call_download_deploy_rpm_diff_sync (os_proxy,
-                                                            revision,
-                                                            packages,
-                                                            &transaction_address,
-                                                            cancellable,
-                                                            error))
+      if (!rpmostree_os_call_download_deploy_rpm_diff_sync (
+              os_proxy, revision, packages, &transaction_address, cancellable, error))
         return FALSE;
     }
   else
@@ -158,62 +156,44 @@ rpmostree_builtin_deploy (int            argc,
           if (g_str_equal (opt_ex_cliwrap, "true"))
             cliwrap_enabled = TRUE;
           else if (!g_str_equal (opt_ex_cliwrap, "false"))
-            return glnx_throw (error, "Expecting --ex-cli-wrap=true/false but found %s", opt_ex_cliwrap);
+            return glnx_throw (error, "Expecting --ex-cli-wrap=true/false but found %s",
+                               opt_ex_cliwrap);
           g_variant_dict_insert (&dict, "ex-cliwrap", "b", cliwrap_enabled);
         }
-      g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
+      g_autoptr (GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
       /* Use newer D-Bus API only if we have to so we maintain coverage. */
       if (install_pkgs || uninstall_pkgs || opt_ex_cliwrap)
         {
-          if (!rpmostree_update_deployment (os_proxy,
-                                            NULL, /* refspec */
-                                            revision,
-                                            install_pkgs,
-                                            NULL, /* install_fileoverride_pkgs */
-                                            uninstall_pkgs,
-                                            NULL, /* override replace */
-                                            NULL, /* override remove */
-                                            NULL, /* override reset */
-                                            NULL, /* local_repo_remote */
-                                            options,
-                                            &transaction_address,
-                                            cancellable,
-                                            error))
+          if (!rpmostree_update_deployment (os_proxy, NULL, /* refspec */
+                                            revision, install_pkgs,
+                                            NULL,                 /* install_fileoverride_pkgs */
+                                            uninstall_pkgs, NULL, /* override replace */
+                                            NULL,                 /* override remove */
+                                            NULL,                 /* override reset */
+                                            NULL,                 /* local_repo_remote */
+                                            options, &transaction_address, cancellable, error))
             return FALSE;
         }
       else
         {
-          if (!rpmostree_os_call_deploy_sync (os_proxy,
-                                              revision,
-                                              options,
-                                              NULL,
-                                              &transaction_address,
-                                              NULL,
-                                              cancellable,
-                                              error))
+          if (!rpmostree_os_call_deploy_sync (os_proxy, revision, options, NULL,
+                                              &transaction_address, NULL, cancellable, error))
             return FALSE;
         }
     }
 
-  if (!rpmostree_transaction_get_response_sync (sysroot_proxy,
-                                                transaction_address,
-                                                cancellable,
+  if (!rpmostree_transaction_get_response_sync (sysroot_proxy, transaction_address, cancellable,
                                                 error))
     return FALSE;
 
   if (opt_preview)
     {
-      g_autoptr(GVariant) result = NULL;
-      g_autoptr(GVariant) details = NULL;
+      g_autoptr (GVariant) result = NULL;
+      g_autoptr (GVariant) details = NULL;
 
-      if (!rpmostree_os_call_get_cached_deploy_rpm_diff_sync (os_proxy,
-                                                              revision,
-                                                              packages,
-                                                              &result,
-                                                              &details,
-                                                              cancellable,
-                                                              error))
+      if (!rpmostree_os_call_get_cached_deploy_rpm_diff_sync (os_proxy, revision, packages, &result,
+                                                              &details, cancellable, error))
         return FALSE;
 
       if (g_variant_n_children (result) == 0)
@@ -236,8 +216,10 @@ rpmostree_builtin_deploy (int            argc,
 
       /* do diff without dbus: https://github.com/projectatomic/rpm-ostree/pull/116 */
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
-      CXX_TRY(print_treepkg_diff_from_sysroot_path (rust::Str(sysroot_path),
-            RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0, cancellable), error);
+      CXX_TRY (print_treepkg_diff_from_sysroot_path (rust::Str (sysroot_path),
+                                                     RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0,
+                                                     cancellable),
+               error);
 
       g_print ("Run \"systemctl reboot\" to start a reboot\n");
     }

--- a/src/app/rpmostree-builtin-ex.cxx
+++ b/src/app/rpmostree-builtin-ex.cxx
@@ -24,23 +24,21 @@
 
 static RpmOstreeCommand ex_subcommands[] = {
   { "livefs", (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_HIDDEN),
-    "Apply pending deployment changes to booted deployment",
-    rpmostree_ex_builtin_apply_live },
-  { "apply-live", (RpmOstreeBuiltinFlags)0,
-    "Apply pending deployment changes to booted deployment",
+    "Apply pending deployment changes to booted deployment", rpmostree_ex_builtin_apply_live },
+  { "apply-live", (RpmOstreeBuiltinFlags)0, "Apply pending deployment changes to booted deployment",
     rpmostree_ex_builtin_apply_live },
   { "history", (RpmOstreeBuiltinFlags)RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
     "Inspect rpm-ostree history of the system", rpmostree_ex_builtin_history },
-  { "initramfs-etc", (RpmOstreeBuiltinFlags)0,
-    "Track initramfs configuration files", rpmostree_ex_builtin_initramfs_etc },
+  { "initramfs-etc", (RpmOstreeBuiltinFlags)0, "Track initramfs configuration files",
+    rpmostree_ex_builtin_initramfs_etc },
   /* This is currently only for CoreOS layering; so hide it to not confuse
    * users. */
   { "rebuild", (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_HIDDEN),
     "Rebuild system based on configuration", rpmostree_ex_builtin_rebuild },
   /* To graduate out of experimental, simply revert:
    * https://github.com/coreos/rpm-ostree/pull/3078 */
-  { "module", static_cast<RpmOstreeBuiltinFlags>(0),
-    "Commands to install/uninstall modules", rpmostree_ex_builtin_module },
+  { "module", static_cast<RpmOstreeBuiltinFlags> (0), "Commands to install/uninstall modules",
+    rpmostree_ex_builtin_module },
   { NULL, (RpmOstreeBuiltinFlags)0, NULL, NULL }
 };
 
@@ -51,25 +49,22 @@ static GOptionEntry global_entries[] = {
 */
 
 gboolean
-rpmostree_builtin_ex (int argc, char **argv,
-                      RpmOstreeCommandInvocation *invocation,
+rpmostree_builtin_ex (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
                       GCancellable *cancellable, GError **error)
 {
   g_printerr ("NOTICE: Experimental commands are subject to change.\n");
-  return rpmostree_handle_subcommand (argc, argv, ex_subcommands,
-                                      invocation, cancellable, error);
+  return rpmostree_handle_subcommand (argc, argv, ex_subcommands, invocation, cancellable, error);
 }
 
 /* Commands that are pure Rust are proxied here. */
 
 gboolean
-rpmostree_ex_builtin_module (int argc, char **argv,
-                             RpmOstreeCommandInvocation *invocation,
+rpmostree_ex_builtin_module (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
                              GCancellable *cancellable, GError **error)
 {
   rust::Vec<rust::String> rustargv;
   for (int i = 0; i < argc; i++)
-    rustargv.push_back(std::string(argv[i]));
-  CXX_TRY(modularity_entrypoint(rustargv), error);
+    rustargv.push_back (std::string (argv[i]));
+  CXX_TRY (modularity_entrypoint (rustargv), error);
   return TRUE;
 }

--- a/src/app/rpmostree-builtin-finalize-deployment.cxx
+++ b/src/app/rpmostree-builtin-finalize-deployment.cxx
@@ -31,24 +31,23 @@ static GOptionEntry option_entries[] = {
   /* though there can only be one staged deployment at a time, this could still
    * be useful to assert a specific osname */
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
-  { "allow-missing-checksum", 0, 0, G_OPTION_ARG_NONE, &opt_allow_missing, "Don't error out if no expected checksum is provided", NULL },
-  { "allow-unlocked", 0, 0, G_OPTION_ARG_NONE, &opt_allow_unlocked, "Don't error out if staged deployment wasn't locked", NULL },
+  { "allow-missing-checksum", 0, 0, G_OPTION_ARG_NONE, &opt_allow_missing,
+    "Don't error out if no expected checksum is provided", NULL },
+  { "allow-unlocked", 0, 0, G_OPTION_ARG_NONE, &opt_allow_unlocked,
+    "Don't error out if staged deployment wasn't locked", NULL },
   { NULL }
 };
 
 gboolean
-rpmostree_builtin_finalize_deployment (int             argc,
-                                       char          **argv,
+rpmostree_builtin_finalize_deployment (int argc, char **argv,
                                        RpmOstreeCommandInvocation *invocation,
-                                       GCancellable   *cancellable,
-                                       GError        **error)
+                                       GCancellable *cancellable, GError **error)
 {
-  g_autoptr(GOptionContext) context = g_option_context_new ("CHECKSUM");
+  g_autoptr (GOptionContext) context = g_option_context_new ("CHECKSUM");
 
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
-  if (!rpmostree_option_context_parse (context, option_entries, &argc, &argv,
-                                       invocation, cancellable, NULL, NULL,
-                                       &sysroot_proxy, error))
+  if (!rpmostree_option_context_parse (context, option_entries, &argc, &argv, invocation,
+                                       cancellable, NULL, NULL, &sysroot_proxy, error))
     return FALSE;
 
   const char *checksum = NULL;
@@ -59,20 +58,21 @@ rpmostree_builtin_finalize_deployment (int             argc,
     }
   else if (argc < 2 && !opt_allow_missing)
     {
-      rpmostree_usage_error (context, "Must provide expected CHECKSUM or --allow-missing-checksum", error);
+      rpmostree_usage_error (context, "Must provide expected CHECKSUM or --allow-missing-checksum",
+                             error);
       return FALSE;
     }
   else if (argc == 2 && opt_allow_missing)
     {
-      rpmostree_usage_error (context, "Cannot specify both CHECKSUM and --allow-missing-checksum", error);
+      rpmostree_usage_error (context, "Cannot specify both CHECKSUM and --allow-missing-checksum",
+                             error);
       return FALSE;
     }
   else if (!opt_allow_missing)
     checksum = argv[1];
 
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
-  if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname,
-                                cancellable, &os_proxy, error))
+  if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname, cancellable, &os_proxy, error))
     return FALSE;
 
   GVariantDict dict;
@@ -82,19 +82,14 @@ rpmostree_builtin_finalize_deployment (int             argc,
   g_variant_dict_insert (&dict, "allow-missing-checksum", "b", opt_allow_missing);
   g_variant_dict_insert (&dict, "allow-unlocked", "b", opt_allow_unlocked);
   g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
-  g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
+  g_autoptr (GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
   g_autofree char *transaction_address = NULL;
-  if (!rpmostree_os_call_finalize_deployment_sync (os_proxy,
-                                                   options,
-                                                   &transaction_address,
-                                                   cancellable,
-                                                   error))
+  if (!rpmostree_os_call_finalize_deployment_sync (os_proxy, options, &transaction_address,
+                                                   cancellable, error))
     return FALSE;
 
-  if (!rpmostree_transaction_get_response_sync (sysroot_proxy,
-                                                transaction_address,
-                                                cancellable,
+  if (!rpmostree_transaction_get_response_sync (sysroot_proxy, transaction_address, cancellable,
                                                 error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-override.cxx
+++ b/src/app/rpmostree-builtin-override.cxx
@@ -23,25 +23,19 @@
 #include "rpmostree-builtins.h"
 #include "rpmostree-override-builtins.h"
 
-static RpmOstreeCommand override_subcommands[] = {
-  { "replace", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
-    "Replace packages in the base layer",
-    rpmostree_override_builtin_replace },
-  { "remove", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
-    "Remove packages from the base layer",
-    rpmostree_override_builtin_remove },
-  { "reset", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
-    "Reset currently active package overrides",
-    rpmostree_override_builtin_reset },
-  { NULL, (RpmOstreeBuiltinFlags)0, NULL, NULL }
-};
+static RpmOstreeCommand override_subcommands[]
+    = { { "replace", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
+          "Replace packages in the base layer", rpmostree_override_builtin_replace },
+        { "remove", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
+          "Remove packages from the base layer", rpmostree_override_builtin_remove },
+        { "reset", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
+          "Reset currently active package overrides", rpmostree_override_builtin_reset },
+        { NULL, (RpmOstreeBuiltinFlags)0, NULL, NULL } };
 
 gboolean
-rpmostree_builtin_override (int argc, char **argv,
-                            RpmOstreeCommandInvocation *invocation,
+rpmostree_builtin_override (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
                             GCancellable *cancellable, GError **error)
 {
-  return rpmostree_handle_subcommand (argc, argv, override_subcommands,
-                                      invocation, cancellable, error);
+  return rpmostree_handle_subcommand (argc, argv, override_subcommands, invocation, cancellable,
+                                      error);
 }
-

--- a/src/app/rpmostree-builtin-rebase.cxx
+++ b/src/app/rpmostree-builtin-rebase.cxx
@@ -20,24 +20,24 @@
 
 #include "config.h"
 
-#include <string.h>
 #include <glib-unix.h>
+#include <string.h>
 
 #include "rpmostree-builtins.h"
-#include "rpmostree-util.h"
+#include "rpmostree-clientlib.h"
 #include "rpmostree-core.h"
 #include "rpmostree-libbuiltin.h"
-#include "rpmostree-clientlib.h"
+#include "rpmostree-util.h"
 
 #include <libglnx.h>
 
 static char *opt_osname;
 static gboolean opt_reboot;
 static gboolean opt_skip_purge;
-static char * opt_branch;
-static char * opt_remote;
-static char * opt_custom_origin_url;
-static char * opt_custom_origin_description;
+static char *opt_branch;
+static char *opt_remote;
+static char *opt_custom_origin_url;
+static char *opt_custom_origin_description;
 static gboolean opt_cache_only;
 static gboolean opt_download_only;
 static gboolean opt_experimental;
@@ -45,29 +45,38 @@ static gboolean opt_disallow_downgrade;
 static gboolean opt_lock_finalization;
 static gboolean opt_bypass_driver;
 
-static GOptionEntry option_entries[] = {
-  { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
-  { "branch", 'b', 0, G_OPTION_ARG_STRING, &opt_branch, "Rebase to branch BRANCH; use --remote to change remote as well", "BRANCH" },
-  { "remote", 'm', 0, G_OPTION_ARG_STRING, &opt_remote, "Rebase to current branch name using REMOTE; may also be combined with --branch", "REMOTE" },
-  { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot, "Initiate a reboot after operation is complete", NULL },
-  { "skip-purge", 0, 0, G_OPTION_ARG_NONE, &opt_skip_purge, "Keep previous refspec after rebase", NULL },
-  { "cache-only", 'C', 0, G_OPTION_ARG_NONE, &opt_cache_only, "Do not download latest ostree and RPM data", NULL },
-  { "download-only", 0, 0, G_OPTION_ARG_NONE, &opt_download_only, "Just download latest ostree and RPM data, don't deploy", NULL },
-  { "custom-origin-description", 0, 0, G_OPTION_ARG_STRING, &opt_custom_origin_description, "Human-readable description of custom origin", NULL },
-  { "custom-origin-url", 0, 0, G_OPTION_ARG_STRING, &opt_custom_origin_url, "Machine-readable description of custom origin", NULL },
-  { "experimental", 0, 0, G_OPTION_ARG_NONE, &opt_experimental, "Enable experimental features", NULL },
-  { "disallow-downgrade", 0, 0, G_OPTION_ARG_NONE, &opt_disallow_downgrade, "Forbid deployment of chronologically older trees", NULL },
-  { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization, "Prevent automatic deployment finalization on shutdown", NULL },
-  { "bypass-driver", 0, 0, G_OPTION_ARG_NONE, &opt_bypass_driver, "Force a rebase even if an updates driver is registered", NULL},
-  { NULL }
-};
+static GOptionEntry option_entries[]
+    = { { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+        { "branch", 'b', 0, G_OPTION_ARG_STRING, &opt_branch,
+          "Rebase to branch BRANCH; use --remote to change remote as well", "BRANCH" },
+        { "remote", 'm', 0, G_OPTION_ARG_STRING, &opt_remote,
+          "Rebase to current branch name using REMOTE; may also be combined with --branch",
+          "REMOTE" },
+        { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot,
+          "Initiate a reboot after operation is complete", NULL },
+        { "skip-purge", 0, 0, G_OPTION_ARG_NONE, &opt_skip_purge,
+          "Keep previous refspec after rebase", NULL },
+        { "cache-only", 'C', 0, G_OPTION_ARG_NONE, &opt_cache_only,
+          "Do not download latest ostree and RPM data", NULL },
+        { "download-only", 0, 0, G_OPTION_ARG_NONE, &opt_download_only,
+          "Just download latest ostree and RPM data, don't deploy", NULL },
+        { "custom-origin-description", 0, 0, G_OPTION_ARG_STRING, &opt_custom_origin_description,
+          "Human-readable description of custom origin", NULL },
+        { "custom-origin-url", 0, 0, G_OPTION_ARG_STRING, &opt_custom_origin_url,
+          "Machine-readable description of custom origin", NULL },
+        { "experimental", 0, 0, G_OPTION_ARG_NONE, &opt_experimental,
+          "Enable experimental features", NULL },
+        { "disallow-downgrade", 0, 0, G_OPTION_ARG_NONE, &opt_disallow_downgrade,
+          "Forbid deployment of chronologically older trees", NULL },
+        { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization,
+          "Prevent automatic deployment finalization on shutdown", NULL },
+        { "bypass-driver", 0, 0, G_OPTION_ARG_NONE, &opt_bypass_driver,
+          "Force a rebase even if an updates driver is registered", NULL },
+        { NULL } };
 
 gboolean
-rpmostree_builtin_rebase (int             argc,
-                          char          **argv,
-                          RpmOstreeCommandInvocation *invocation,
-                          GCancellable   *cancellable,
-                          GError        **error)
+rpmostree_builtin_rebase (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+                          GCancellable *cancellable, GError **error)
 {
   const char *new_provided_refspec;
   g_autofree char *new_refspec_owned = NULL;
@@ -76,21 +85,15 @@ rpmostree_builtin_rebase (int             argc,
   /* forced blank for now */
   const char *packages[] = { NULL };
 
-  g_autoptr(GOptionContext) context = g_option_context_new ("REFSPEC [REVISION]");
+  g_autoptr (GOptionContext) context = g_option_context_new ("REFSPEC [REVISION]");
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   g_autofree char *transaction_address = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   const char *const *install_pkgs = NULL;
   const char *const *uninstall_pkgs = NULL;
 
-  if (!rpmostree_option_context_parse (context,
-                                       option_entries,
-                                       &argc, &argv,
-                                       invocation,
-                                       cancellable,
-                                       &install_pkgs,
-                                       &uninstall_pkgs,
-                                       &sysroot_proxy,
+  if (!rpmostree_option_context_parse (context, option_entries, &argc, &argv, invocation,
+                                       cancellable, &install_pkgs, &uninstall_pkgs, &sysroot_proxy,
                                        error))
     return FALSE;
 
@@ -99,18 +102,19 @@ rpmostree_builtin_rebase (int             argc,
       rpmostree_usage_error (context, "Too many arguments", error);
       return FALSE;
     }
-  
+
   if (!opt_bypass_driver)
     if (!error_if_driver_registered (sysroot_proxy, cancellable, error))
       return FALSE;
 
-  if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname,
-                                cancellable, &os_proxy, error))
+  if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname, cancellable, &os_proxy, error))
     return FALSE;
 
   if (argc < 2 && !(opt_branch || opt_remote))
     {
-      return rpmostree_usage_error (context, "Must specify refspec, or -b branch or -r remote", error), FALSE;
+      return rpmostree_usage_error (context, "Must specify refspec, or -b branch or -r remote",
+                                    error),
+             FALSE;
     }
   else if (argc >= 2)
     {
@@ -124,8 +128,8 @@ rpmostree_builtin_rebase (int             argc,
     {
       if (opt_remote)
         {
-          new_provided_refspec = new_refspec_owned =
-            g_strconcat (opt_remote, ":", opt_branch ?: "", NULL);
+          new_provided_refspec = new_refspec_owned
+              = g_strconcat (opt_remote, ":", opt_branch ?: "", NULL);
         }
       else
         new_provided_refspec = opt_branch;
@@ -143,17 +147,17 @@ rpmostree_builtin_rebase (int             argc,
   if (refspectype == RPMOSTREE_REFSPEC_TYPE_CONTAINER)
     {
       if (!opt_experimental)
-        return glnx_throw (error, "Rebasing to a container image reference requires --experimental");
+        return glnx_throw (error,
+                           "Rebasing to a container image reference requires --experimental");
       /* When using the container refspec type, if rebasing to a specific commit, we expect a
-      * specific digest tag in the refspec, not in a separate argument */
+       * specific digest tag in the refspec, not in a separate argument */
       if (revision)
         return glnx_throw (error, "Unexpected ostree revision alongside container refspec type");
     }
 
   /* Check if remote refers to a local repo */
   g_autofree char *local_repo_remote = NULL;
-  if (G_IN_SET (refspectype, RPMOSTREE_REFSPEC_TYPE_OSTREE,
-                             RPMOSTREE_REFSPEC_TYPE_CHECKSUM))
+  if (G_IN_SET (refspectype, RPMOSTREE_REFSPEC_TYPE_OSTREE, RPMOSTREE_REFSPEC_TYPE_CHECKSUM))
     {
       if (*new_provided_refspec == '/')
         {
@@ -168,7 +172,7 @@ rpmostree_builtin_rebase (int             argc,
         }
     }
 
-  g_autoptr(GVariant) previous_deployment = rpmostree_os_dup_default_deployment (os_proxy);
+  g_autoptr (GVariant) previous_deployment = rpmostree_os_dup_default_deployment (os_proxy);
 
   GVariantDict dict;
   g_variant_dict_init (&dict, NULL);
@@ -182,30 +186,23 @@ rpmostree_builtin_rebase (int             argc,
   if (opt_custom_origin_url)
     {
       if (!opt_custom_origin_description)
-        return glnx_throw (error, "--custom-origin-description must be supplied with --custom-origin-url");
-      g_variant_dict_insert (&dict, "custom-origin", "(ss)",
-                             opt_custom_origin_url,
+        return glnx_throw (error,
+                           "--custom-origin-description must be supplied with --custom-origin-url");
+      g_variant_dict_insert (&dict, "custom-origin", "(ss)", opt_custom_origin_url,
                              opt_custom_origin_description);
     }
-  g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
+  g_autoptr (GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
   /* Use newer D-Bus API only if we have to. */
   if (install_pkgs || uninstall_pkgs || local_repo_remote)
     {
-      if (!rpmostree_update_deployment (os_proxy,
-                                        new_provided_refspec,
-                                        revision,
-                                        install_pkgs,
-                                        NULL, /* install_fileoverride_pkgs */
-                                        uninstall_pkgs,
-                                        NULL, /* override replace */
-                                        NULL, /* override remove */
-                                        NULL, /* override reset */
-                                        local_repo_remote,
-                                        options,
-                                        &transaction_address,
-                                        cancellable,
-                                        error))
+      if (!rpmostree_update_deployment (os_proxy, new_provided_refspec, revision, install_pkgs,
+                                        NULL,                 /* install_fileoverride_pkgs */
+                                        uninstall_pkgs, NULL, /* override replace */
+                                        NULL,                 /* override remove */
+                                        NULL,                 /* override reset */
+                                        local_repo_remote, options, &transaction_address,
+                                        cancellable, error))
         return FALSE;
     }
   else
@@ -213,28 +210,19 @@ rpmostree_builtin_rebase (int             argc,
       /* the original Rebase() call takes the revision through the options */
       if (revision)
         {
-          g_autoptr(GVariant) old_options = options;
-          g_auto(GVariantDict) dict;
+          g_autoptr (GVariant) old_options = options;
+          g_auto (GVariantDict) dict;
           g_variant_dict_init (&dict, old_options);
           g_variant_dict_insert (&dict, "revision", "s", revision);
           options = g_variant_ref_sink (g_variant_dict_end (&dict));
         }
 
-      if (!rpmostree_os_call_rebase_sync (os_proxy,
-                                          options,
-                                          new_provided_refspec,
-                                          packages,
-                                          NULL,
-                                          &transaction_address,
-                                          NULL,
-                                          cancellable,
-                                          error))
+      if (!rpmostree_os_call_rebase_sync (os_proxy, options, new_provided_refspec, packages, NULL,
+                                          &transaction_address, NULL, cancellable, error))
         return FALSE;
     }
 
-  return rpmostree_transaction_client_run (invocation, sysroot_proxy, os_proxy,
-                                           options, FALSE,
-                                           transaction_address,
-                                           previous_deployment,
-                                           cancellable, error);
+  return rpmostree_transaction_client_run (invocation, sysroot_proxy, os_proxy, options, FALSE,
+                                           transaction_address, previous_deployment, cancellable,
+                                           error);
 }

--- a/src/app/rpmostree-builtin-rebuild.cxx
+++ b/src/app/rpmostree-builtin-rebuild.cxx
@@ -25,6 +25,7 @@
 
 #include "rpmostree-ex-builtins.h"
 #include "rpmostree-libbuiltin.h"
+
 #include "rpmostree-clientlib.h"
 #include "rpmostree-container.h"
 

--- a/src/app/rpmostree-builtin-rebuild.cxx
+++ b/src/app/rpmostree-builtin-rebuild.cxx
@@ -20,8 +20,8 @@
 
 #include "config.h"
 
-#include <string.h>
 #include <glib-unix.h>
+#include <string.h>
 
 #include "rpmostree-ex-builtins.h"
 #include "rpmostree-libbuiltin.h"
@@ -32,34 +32,26 @@
 #include <libglnx.h>
 
 gboolean
-rpmostree_ex_builtin_rebuild (int             argc,
-                              char          **argv,
-                              RpmOstreeCommandInvocation *invocation,
-                              GCancellable   *cancellable,
-                              GError        **error)
+rpmostree_ex_builtin_rebuild (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+                              GCancellable *cancellable, GError **error)
 {
-  g_autoptr(GOptionContext) context = g_option_context_new ("");
+  g_autoptr (GOptionContext) context = g_option_context_new ("");
 
-  if (!rpmostree_option_context_parse (context,
-                                       NULL,
-                                       &argc, &argv,
-                                       invocation,
-                                       cancellable,
-                                       NULL, NULL, NULL,
-                                       error))
+  if (!rpmostree_option_context_parse (context, NULL, &argc, &argv, invocation, cancellable, NULL,
+                                       NULL, NULL, error))
     return FALSE;
 
   bool in_container = false;
-  if (rpmostreecxx::running_in_container())
+  if (rpmostreecxx::running_in_container ())
     {
-      auto is_ostree_container = CXX_TRY_VAL(is_ostree_container(), error);
+      auto is_ostree_container = CXX_TRY_VAL (is_ostree_container (), error);
       if (!is_ostree_container)
         return glnx_throw (error, "This command can only run in an OSTree container.");
       in_container = true;
     }
 
-  auto basearch = rpmostreecxx::get_rpm_basearch();
-  auto treefile = CXX_TRY_VAL(treefile_new_client_from_etc (basearch), error);
+  auto basearch = rpmostreecxx::get_rpm_basearch ();
+  auto treefile = CXX_TRY_VAL (treefile_new_client_from_etc (basearch), error);
 
   /* This is the big switch: we support running this command in two modes:
    * "client containers", where the effect takes place in the active rootfs, and
@@ -72,7 +64,7 @@ rpmostree_ex_builtin_rebuild (int             argc,
 
       /* In the container flow, we effectively "consume" the treefiles after
        * modifying the rootfs. */
-      auto n = CXX_TRY_VAL(treefile_delete_client_etc (), error);
+      auto n = CXX_TRY_VAL (treefile_delete_client_etc (), error);
       if (n == 0)
         {
           g_print ("No changes to apply.\n");

--- a/src/app/rpmostree-builtin-refresh-md.cxx
+++ b/src/app/rpmostree-builtin-refresh-md.cxx
@@ -18,24 +18,23 @@
 
 #include "config.h"
 
-#include <string.h>
 #include <glib-unix.h>
+#include <string.h>
 
 #include "rpmostree-builtins.h"
-#include "rpmostree-util.h"
-#include "rpmostree-libbuiltin.h"
 #include "rpmostree-clientlib.h"
+#include "rpmostree-libbuiltin.h"
+#include "rpmostree-util.h"
 
 #include <libglnx.h>
 
 static char *opt_osname;
 static char *opt_force;
 
-static GOptionEntry option_entries[] = {
-  { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
-  { "force", 'f', 0, G_OPTION_ARG_NONE, &opt_force, "Expire current cache", NULL },
-  { NULL }
-};
+static GOptionEntry option_entries[]
+    = { { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+        { "force", 'f', 0, G_OPTION_ARG_NONE, &opt_force, "Expire current cache", NULL },
+        { NULL } };
 
 static GVariant *
 get_args_variant (void)
@@ -47,25 +46,16 @@ get_args_variant (void)
 }
 
 gboolean
-rpmostree_builtin_refresh_md (int             argc,
-                              char          **argv,
-                              RpmOstreeCommandInvocation *invocation,
-                              GCancellable   *cancellable,
-                              GError        **error)
+rpmostree_builtin_refresh_md (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+                              GCancellable *cancellable, GError **error)
 {
-  g_autoptr(GOptionContext) context = g_option_context_new ("");
+  g_autoptr (GOptionContext) context = g_option_context_new ("");
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   g_autofree char *transaction_address = NULL;
 
-  if (!rpmostree_option_context_parse (context,
-                                       option_entries,
-                                       &argc, &argv,
-                                       invocation,
-                                       cancellable,
-                                       NULL, NULL,
-                                       &sysroot_proxy,
-                                       error))
+  if (!rpmostree_option_context_parse (context, option_entries, &argc, &argv, invocation,
+                                       cancellable, NULL, NULL, &sysroot_proxy, error))
     return FALSE;
 
   if (argc < 1 || argc > 2)
@@ -74,20 +64,14 @@ rpmostree_builtin_refresh_md (int             argc,
       return FALSE;
     }
 
-  if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname,
-                                cancellable, &os_proxy, error))
+  if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname, cancellable, &os_proxy, error))
     return FALSE;
 
-  if (!rpmostree_os_call_refresh_md_sync (os_proxy,
-                                          get_args_variant (),
-                                          &transaction_address,
-                                          cancellable,
-                                          error))
+  if (!rpmostree_os_call_refresh_md_sync (os_proxy, get_args_variant (), &transaction_address,
+                                          cancellable, error))
     return FALSE;
 
-  if (!rpmostree_transaction_get_response_sync (sysroot_proxy,
-                                                transaction_address,
-                                                cancellable,
+  if (!rpmostree_transaction_get_response_sync (sysroot_proxy, transaction_address, cancellable,
                                                 error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-reload.cxx
+++ b/src/app/rpmostree-builtin-reload.cxx
@@ -20,37 +20,26 @@
 
 #include "config.h"
 
-#include <string.h>
-#include <glib-unix.h>
 #include <gio/gio.h>
+#include <glib-unix.h>
+#include <string.h>
 
 #include "rpmostree-builtins.h"
 #include "rpmostree-libbuiltin.h"
 
 #include <libglnx.h>
 
-static GOptionEntry option_entries[] = {
-  { NULL }
-};
+static GOptionEntry option_entries[] = { { NULL } };
 
 gboolean
-rpmostree_builtin_reload (int             argc,
-                          char          **argv,
-                          RpmOstreeCommandInvocation *invocation,
-                          GCancellable   *cancellable,
-                          GError        **error)
+rpmostree_builtin_reload (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+                          GCancellable *cancellable, GError **error)
 {
-  g_autoptr(GOptionContext) context = g_option_context_new ("");
+  g_autoptr (GOptionContext) context = g_option_context_new ("");
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
 
-  if (!rpmostree_option_context_parse (context,
-                                       option_entries,
-                                       &argc, &argv,
-                                       invocation,
-                                       cancellable,
-                                       NULL, NULL,
-                                       &sysroot_proxy,
-                                       error))
+  if (!rpmostree_option_context_parse (context, option_entries, &argc, &argv, invocation,
+                                       cancellable, NULL, NULL, &sysroot_proxy, error))
     return FALSE;
 
   if (!rpmostree_sysroot_call_reload_config_sync (sysroot_proxy, cancellable, error))

--- a/src/app/rpmostree-builtin-start-daemon.cxx
+++ b/src/app/rpmostree-builtin-start-daemon.cxx
@@ -20,38 +20,38 @@
 
 #include "config.h"
 
-#include <string.h>
-#include <glib-unix.h>
-#include <gio/gunixoutputstream.h>
-#include <systemd/sd-journal.h>
-#include <systemd/sd-daemon.h>
-#include <stdio.h>
-#include <libglnx.h>
-#include <glib/gi18n.h>
-#include <syslog.h>
 #include "libglnx.h"
+#include <gio/gunixoutputstream.h>
+#include <glib-unix.h>
+#include <glib/gi18n.h>
+#include <libglnx.h>
+#include <stdio.h>
+#include <string.h>
+#include <syslog.h>
+#include <systemd/sd-daemon.h>
+#include <systemd/sd-journal.h>
 
 #include "rpmostree-builtins.h"
+#include "rpmostree-libbuiltin.h"
 #include "rpmostree-util.h"
 #include "rpmostreed-daemon.h"
-#include "rpmostree-libbuiltin.h"
 
-typedef enum {
+typedef enum
+{
   APPSTATE_STARTING, /* Before the ♫♫♫ maaaain event ♫♫♫ */
-  APPSTATE_RUNNING, /* Main event loop */
+  APPSTATE_RUNNING,  /* Main event loop */
   APPSTATE_FLUSHING, /* We should release our bus name, and wait for it to be released */
-  APPSTATE_EXITING, /* About to exit() */
+  APPSTATE_EXITING,  /* About to exit() */
 } AppState;
 
 static AppState appstate = APPSTATE_STARTING;
 static gboolean opt_debug = FALSE;
 static char *opt_sysroot = NULL;
-static GOptionEntry opt_entries[] =
-{
-  { "debug", 'd', 0, G_OPTION_ARG_NONE, &opt_debug, "Print debug information on stderr", NULL },
-  { "sysroot", 0, 0, G_OPTION_ARG_STRING, &opt_sysroot, "Use system root SYSROOT (default: /)", "SYSROOT" },
-  { NULL }
-};
+static GOptionEntry opt_entries[] = { { "debug", 'd', 0, G_OPTION_ARG_NONE, &opt_debug,
+                                        "Print debug information on stderr", NULL },
+                                      { "sysroot", 0, 0, G_OPTION_ARG_STRING, &opt_sysroot,
+                                        "Use system root SYSROOT (default: /)", "SYSROOT" },
+                                      { NULL } };
 
 static RpmostreedDaemon *rpm_ostree_daemon = NULL;
 
@@ -66,26 +66,21 @@ state_transition (AppState state)
 }
 
 static gboolean
-start_daemon (GDBusConnection *connection,
-              GError         **error)
+start_daemon (GDBusConnection *connection, GError **error)
 {
   GLNX_AUTO_PREFIX_ERROR ("Couldn't start daemon", error);
-  rpm_ostree_daemon = (RpmostreedDaemon*)g_initable_new (RPMOSTREED_TYPE_DAEMON,
-                                      NULL, error,
-                                      "connection", connection,
-                                      "sysroot-path", opt_sysroot ?: "/",
-                                      NULL);
+  rpm_ostree_daemon
+      = (RpmostreedDaemon *)g_initable_new (RPMOSTREED_TYPE_DAEMON, NULL, error, "connection",
+                                            connection, "sysroot-path", opt_sysroot ?: "/", NULL);
   if (rpm_ostree_daemon == NULL)
     return FALSE;
-  (void) g_bus_own_name_on_connection (connection, DBUS_NAME, G_BUS_NAME_OWNER_FLAGS_NONE,
-                                       NULL, NULL, NULL, NULL);
+  (void)g_bus_own_name_on_connection (connection, DBUS_NAME, G_BUS_NAME_OWNER_FLAGS_NONE, NULL,
+                                      NULL, NULL, NULL);
   return TRUE;
 }
 
 static void
-on_bus_name_released (GDBusConnection     *connection,
-                      GAsyncResult        *result,
-                      void                *user_data)
+on_bus_name_released (GDBusConnection *connection, GAsyncResult *result, void *user_data)
 {
   state_transition (APPSTATE_EXITING);
 }
@@ -99,9 +94,7 @@ on_sigint (gpointer user_data)
 }
 
 static gboolean
-on_stdin_close (GIOChannel *channel,
-                GIOCondition condition,
-                gpointer data)
+on_stdin_close (GIOChannel *channel, GIOCondition condition, gpointer data)
 {
   /* Nowhere to log */
   sd_journal_print (LOG_INFO, "%s", "output closed");
@@ -109,31 +102,27 @@ on_stdin_close (GIOChannel *channel,
   return FALSE;
 }
 
-
 static void
-on_log_debug (const gchar *log_domain,
-             GLogLevelFlags log_level,
-             const gchar *message,
-             gpointer user_data)
+on_log_debug (const gchar *log_domain, GLogLevelFlags log_level, const gchar *message,
+              gpointer user_data)
 {
-  g_autoptr(GString) string = NULL;
+  g_autoptr (GString) string = NULL;
   const gchar *progname;
   const gchar *level;
 
   string = g_string_new (NULL);
   switch (log_level & G_LOG_LEVEL_MASK)
     {
-      case G_LOG_LEVEL_DEBUG:
-        level = "DEBUG";
-        break;
-      case G_LOG_LEVEL_INFO:
-        level = "INFO";
-        break;
-      default:
-        level = "";
-        break;
+    case G_LOG_LEVEL_DEBUG:
+      level = "DEBUG";
+      break;
+    case G_LOG_LEVEL_INFO:
+      level = "INFO";
+      break;
+    default:
+      level = "";
+      break;
     }
-
 
   progname = g_get_prgname ();
   if (progname == NULL)
@@ -142,7 +131,7 @@ on_log_debug (const gchar *log_domain,
   if (message == NULL)
     message = "(NULL) message";
 
-  g_string_append_printf (string, "(%s:%lu): ", progname, (gulong) getpid ());
+  g_string_append_printf (string, "(%s:%lu): ", progname, (gulong)getpid ());
 
   if (log_domain != NULL)
     g_string_append_printf (string, "%s-", log_domain);
@@ -152,55 +141,52 @@ on_log_debug (const gchar *log_domain,
   g_printerr ("%s\n", string->str);
 }
 
-
 static void
-on_log_handler (const gchar *log_domain,
-                GLogLevelFlags log_level,
-                const gchar *message,
+on_log_handler (const gchar *log_domain, GLogLevelFlags log_level, const gchar *message,
                 gpointer user_data)
 {
   const gchar *domains;
   int priority;
 
   /*
-  * Note: we should not call GLib fucntions here.
-  *
-  * Mapping glib log levels to syslog priorities
-  * is not at all obvious.
-  */
+   * Note: we should not call GLib fucntions here.
+   *
+   * Mapping glib log levels to syslog priorities
+   * is not at all obvious.
+   */
   switch (log_level & G_LOG_LEVEL_MASK)
     {
-    /*
-    * In GLib this is always fatal, caller of this
-    * function aborts()
-    */
+      /*
+       * In GLib this is always fatal, caller of this
+       * function aborts()
+       */
 
     case G_LOG_LEVEL_ERROR:
       priority = LOG_CRIT;
       break;
 
     /*
-    * By convention in GLib applications, critical warnings
-    * are usually internal programmer error (ie: precondition
-    * failures). This maps well to LOG_CRIT.
-    */
+     * By convention in GLib applications, critical warnings
+     * are usually internal programmer error (ie: precondition
+     * failures). This maps well to LOG_CRIT.
+     */
     case G_LOG_LEVEL_CRITICAL:
       priority = LOG_CRIT;
       break;
 
     /*
-    * By convention in GLib apps, g_warning() is used for
-    * non-fatal problems, but ones that should be corrected
-    * or not be encountered in normal system behavior.
-    */
+     * By convention in GLib apps, g_warning() is used for
+     * non-fatal problems, but ones that should be corrected
+     * or not be encountered in normal system behavior.
+     */
     case G_LOG_LEVEL_WARNING:
       priority = LOG_WARNING;
       break;
 
     /*
-    * These are related to bad input, or other hosts behaving
-    * badly. Map well to syslog warnings.
-    */
+     * These are related to bad input, or other hosts behaving
+     * badly. Map well to syslog warnings.
+     */
     case G_LOG_LEVEL_MESSAGE:
     default:
       priority = LOG_WARNING;
@@ -214,8 +200,8 @@ on_log_handler (const gchar *log_domain,
     /* Debug messages. */
     case G_LOG_LEVEL_DEBUG:
       domains = g_getenv ("G_MESSAGES_DEBUG");
-      if (domains == NULL ||
-          (strcmp (domains, "all") != 0 && (!log_domain || !strstr (domains, log_domain))))
+      if (domains == NULL
+          || (strcmp (domains, "all") != 0 && (!log_domain || !strstr (domains, log_domain))))
         return;
 
       priority = LOG_INFO;
@@ -226,13 +212,10 @@ on_log_handler (const gchar *log_domain,
 }
 
 gboolean
-rpmostree_builtin_start_daemon (int             argc,
-                                char          **argv,
-                                RpmOstreeCommandInvocation *invocation,
-                                GCancellable   *cancellable,
-                                GError        **error)
+rpmostree_builtin_start_daemon (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+                                GCancellable *cancellable, GError **error)
 {
-  g_autoptr(GOptionContext) opt_context = g_option_context_new (" - start the daemon process");
+  g_autoptr (GOptionContext) opt_context = g_option_context_new (" - start the daemon process");
   g_option_context_add_main_entries (opt_context, opt_entries, NULL);
 
   if (!g_option_context_parse (opt_context, &argc, &argv, error))
@@ -240,9 +223,11 @@ rpmostree_builtin_start_daemon (int             argc,
 
   if (opt_debug)
     {
-      g_autoptr(GIOChannel) channel = NULL;
-      g_log_set_handler (G_LOG_DOMAIN, (GLogLevelFlags)(G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO), on_log_debug, NULL);
-      g_log_set_always_fatal ((GLogLevelFlags)(G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL | G_LOG_LEVEL_WARNING));
+      g_autoptr (GIOChannel) channel = NULL;
+      g_log_set_handler (G_LOG_DOMAIN, (GLogLevelFlags)(G_LOG_LEVEL_DEBUG | G_LOG_LEVEL_INFO),
+                         on_log_debug, NULL);
+      g_log_set_always_fatal (
+          (GLogLevelFlags)(G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL | G_LOG_LEVEL_WARNING));
 
       /* When in debug mode (often testing) we exit when stdin closes */
       channel = g_io_channel_unix_new (0);
@@ -258,14 +243,15 @@ rpmostree_builtin_start_daemon (int             argc,
   g_unix_signal_add (SIGTERM, on_sigint, NULL);
 
   /* Get an explicit ref to the bus so we can use it later */
-  g_autoptr(GDBusConnection) bus = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, error);
+  g_autoptr (GDBusConnection) bus = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, error);
   if (!bus)
     return FALSE;
-  if (!start_daemon (bus, error)) {
-    if (*error)
-      sd_notifyf (0, "STATUS=error: %s", (*error)->message);
-    return FALSE;
-  }
+  if (!start_daemon (bus, error))
+    {
+      if (*error)
+        sd_notifyf (0, "STATUS=error: %s", (*error)->message);
+      return FALSE;
+    }
 
   state_transition (APPSTATE_RUNNING);
 
@@ -289,18 +275,14 @@ rpmostree_builtin_start_daemon (int             argc,
        */
       if (appstate < APPSTATE_FLUSHING)
         state_transition (APPSTATE_FLUSHING);
-      g_dbus_connection_call (bus,
-                              "org.freedesktop.DBus", "/org/freedesktop/DBus",
-                              "org.freedesktop.DBus", "ReleaseName",
-                              g_variant_new ("(s)", DBUS_NAME),
-                              G_VARIANT_TYPE ("(u)"),
-                              G_DBUS_CALL_FLAGS_NONE,
-                              -1, NULL,
-                              (GAsyncReadyCallback)on_bus_name_released, NULL);
+      g_dbus_connection_call (
+          bus, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+          "ReleaseName", g_variant_new ("(s)", DBUS_NAME), G_VARIANT_TYPE ("(u)"),
+          G_DBUS_CALL_FLAGS_NONE, -1, NULL, (GAsyncReadyCallback)on_bus_name_released, NULL);
     }
 
   /* Waiting 🛌 for the name to be released */
-  g_autoptr(GMainContext) mainctx = g_main_context_default ();
+  g_autoptr (GMainContext) mainctx = g_main_context_default ();
   while (appstate == APPSTATE_FLUSHING)
     g_main_context_iteration (mainctx, TRUE);
 

--- a/src/app/rpmostree-builtin-testutils.cxx
+++ b/src/app/rpmostree-builtin-testutils.cxx
@@ -25,47 +25,44 @@
 #include "config.h"
 
 #include "rpmostree-builtins.h"
-#include "rpmostree-rpm-util.h"
 #include "rpmostree-cxxrs.h"
+#include "rpmostree-rpm-util.h"
 #include "rpmostree-scripts.h"
 
-#define BUILTIN(n) \
-  gboolean \
-  rpmostree_testutils_builtin_ ## n (int argc, char **argv, \
-                                     RpmOstreeCommandInvocation *invocation, \
-                                     GCancellable *cancellable, GError **error);
-BUILTIN(inject_pkglist)
-BUILTIN(script_shell)
+#define BUILTIN(n)                                                                                 \
+  gboolean rpmostree_testutils_builtin_##n (int argc, char **argv,                                 \
+                                            RpmOstreeCommandInvocation *invocation,                \
+                                            GCancellable *cancellable, GError **error);
+BUILTIN (inject_pkglist)
+BUILTIN (script_shell)
 #undef BUILTIN
 
-static RpmOstreeCommand testutils_subcommands[] = {
-  { "inject-pkglist", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    NULL, rpmostree_testutils_builtin_inject_pkglist },
-  { "script-shell", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    NULL, rpmostree_testutils_builtin_script_shell },
-  // Avoid adding other commands here - write them in Rust in testutils.rs
-  { NULL, (RpmOstreeBuiltinFlags)0, NULL, NULL }
-};
+static RpmOstreeCommand testutils_subcommands[]
+    = { { "inject-pkglist", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD, NULL,
+          rpmostree_testutils_builtin_inject_pkglist },
+        { "script-shell", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD, NULL,
+          rpmostree_testutils_builtin_script_shell },
+        // Avoid adding other commands here - write them in Rust in testutils.rs
+        { NULL, (RpmOstreeBuiltinFlags)0, NULL, NULL } };
 
 gboolean
-rpmostree_builtin_testutils (int argc, char **argv,
-                             RpmOstreeCommandInvocation *invocation,
+rpmostree_builtin_testutils (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
                              GCancellable *cancellable, GError **error)
 {
   // See above; avoid adding other commands here - write them in Rust in testutils.rs
   if (argc >= 2)
     {
       if (g_str_equal (argv[1], "inject-pkglist"))
-        return rpmostree_handle_subcommand (argc, argv, testutils_subcommands,
-                                            invocation, cancellable, error);
+        return rpmostree_handle_subcommand (argc, argv, testutils_subcommands, invocation,
+                                            cancellable, error);
       else if (g_str_equal (argv[1], "script-shell"))
-        return rpmostree_handle_subcommand (argc, argv, testutils_subcommands,
-                                            invocation, cancellable, error);
+        return rpmostree_handle_subcommand (argc, argv, testutils_subcommands, invocation,
+                                            cancellable, error);
     }
   rust::Vec<rust::String> rustargv;
   for (int i = 0; i < argc; i++)
-    rustargv.push_back(std::string(argv[i]));
-  CXX_TRY(testutils_entrypoint (rustargv), error);
+    rustargv.push_back (std::string (argv[i]));
+  CXX_TRY (testutils_entrypoint (rustargv), error);
   return TRUE;
 }
 
@@ -95,7 +92,7 @@ rpmostree_testutils_builtin_inject_pkglist (int argc, char **argv,
   if (!ostree_parse_refspec (refspec, &remote, &ref, error))
     return FALSE;
 
-  g_autoptr(OstreeRepo) repo = ostree_repo_open_at (AT_FDCWD, repo_path, NULL, error);
+  g_autoptr (OstreeRepo) repo = ostree_repo_open_at (AT_FDCWD, repo_path, NULL, error);
   if (!repo)
     return FALSE;
 
@@ -103,12 +100,12 @@ rpmostree_testutils_builtin_inject_pkglist (int argc, char **argv,
   if (!ostree_repo_resolve_rev (repo, refspec, FALSE, &checksum, error))
     return FALSE;
 
-  g_autoptr(GVariant) commit = NULL;
+  g_autoptr (GVariant) commit = NULL;
   if (!ostree_repo_load_commit (repo, checksum, &commit, NULL, error))
     return FALSE;
 
-  g_autoptr(GVariant) meta = g_variant_get_child_value (commit, 0);
-  g_autoptr(GVariantDict) meta_dict = g_variant_dict_new (meta);
+  g_autoptr (GVariant) meta = g_variant_get_child_value (commit, 0);
+  g_autoptr (GVariantDict) meta_dict = g_variant_dict_new (meta);
   if (g_variant_dict_contains (meta_dict, "rpmostree.rpmdb.pkglist"))
     {
       g_print ("Refspec '%s' already has pkglist metadata; exiting.\n", refspec);
@@ -116,21 +113,21 @@ rpmostree_testutils_builtin_inject_pkglist (int argc, char **argv,
     }
 
   /* just an easy way to checkout the rpmdb */
-  g_autoptr(RpmOstreeRefSack) rsack =
-    rpmostree_get_refsack_for_commit (repo, checksum, NULL, error);
+  g_autoptr (RpmOstreeRefSack) rsack
+      = rpmostree_get_refsack_for_commit (repo, checksum, NULL, error);
   if (!rsack)
     return FALSE;
   g_assert (rsack->tmpdir.initialized);
 
-  g_autoptr(GVariant) pkglist = NULL;
+  g_autoptr (GVariant) pkglist = NULL;
   if (!rpmostree_create_rpmdb_pkglist_variant (rsack->tmpdir.fd, ".", &pkglist, NULL, error))
     return FALSE;
 
   g_variant_dict_insert_value (meta_dict, "rpmostree.rpmdb.pkglist", pkglist);
-  g_autoptr(GVariant) new_meta = g_variant_ref_sink (g_variant_dict_end (meta_dict));
+  g_autoptr (GVariant) new_meta = g_variant_ref_sink (g_variant_dict_end (meta_dict));
 
-  g_autoptr(GFile) root = NULL;
-  if (!ostree_repo_read_commit (repo,  checksum, &root, NULL, NULL, error))
+  g_autoptr (GFile) root = NULL;
+  if (!ostree_repo_read_commit (repo, checksum, &root, NULL, NULL, error))
     return FALSE;
 
   g_autofree char *new_checksum = NULL;
@@ -142,7 +139,7 @@ rpmostree_testutils_builtin_inject_pkglist (int argc, char **argv,
   if (!ostree_repo_set_ref_immediate (repo, remote, ref, new_checksum, NULL, error))
     return FALSE;
 
-  g_print("%s => %s\n", refspec, new_checksum);
+  g_print ("%s => %s\n", refspec, new_checksum);
   return TRUE;
 }
 
@@ -158,7 +155,6 @@ rpmostree_testutils_builtin_script_shell (int argc, char **argv,
   if (!glnx_opendirat (AT_FDCWD, rootpath, TRUE, &rootfs_dfd, error))
     return FALSE;
 
-  return rpmostree_run_script_in_bwrap_container (rootfs_dfd, NULL, TRUE, "testscript",
-                                                  NULL, NULL, NULL, NULL, 
-                                                  STDIN_FILENO, cancellable, error);
+  return rpmostree_run_script_in_bwrap_container (rootfs_dfd, NULL, TRUE, "testscript", NULL, NULL,
+                                                  NULL, NULL, STDIN_FILENO, cancellable, error);
 }

--- a/src/app/rpmostree-builtin-types.h
+++ b/src/app/rpmostree-builtin-types.h
@@ -26,12 +26,13 @@ G_BEGIN_DECLS
 
 /* Exit code for no change after pulling commits.
  * Use alongside EXIT_SUCCESS and EXIT_FAILURE. */
-#define RPM_OSTREE_EXIT_UNCHANGED  (77)
+#define RPM_OSTREE_EXIT_UNCHANGED (77)
 
 /* Exit code for when a pending deployment can be rebooted into. */
-#define RPM_OSTREE_EXIT_PENDING  (77)
+#define RPM_OSTREE_EXIT_PENDING (77)
 
-typedef enum {
+typedef enum
+{
   RPM_OSTREE_BUILTIN_FLAG_NONE = 0,
   RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD = 1 << 0,
   RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT = 1 << 1,
@@ -42,20 +43,22 @@ typedef enum {
 typedef struct RpmOstreeCommand RpmOstreeCommand;
 typedef struct RpmOstreeCommandInvocation RpmOstreeCommandInvocation;
 
-struct RpmOstreeCommand {
+struct RpmOstreeCommand
+{
   const char *name;
   RpmOstreeBuiltinFlags flags;
   const char *description; /* a short decription to describe the functionality */
-  int (*fn) (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
+  int (*fn) (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+             GCancellable *cancellable, GError **error);
 };
 
 /* @command: Passed from core cmdline parsing to cmds
  * @exit_code: Set by commands; default -1 meaning "if GError is set exit 1, otherwise 0"
  */
-struct RpmOstreeCommandInvocation {
+struct RpmOstreeCommandInvocation
+{
   RpmOstreeCommand *command;
   const char *command_line;
   int exit_code;
 };
 G_END_DECLS
-

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -27,57 +27,51 @@
 
 G_BEGIN_DECLS
 
-#define BUILTINPROTO(name) gboolean rpmostree_builtin_ ## name (int argc, char **argv, \
-                                                                RpmOstreeCommandInvocation *invocation, \
-                                                                GCancellable *cancellable, GError **error)
+#define BUILTINPROTO(name)                                                                         \
+  gboolean rpmostree_builtin_##name (int argc, char **argv,                                        \
+                                     RpmOstreeCommandInvocation *invocation,                       \
+                                     GCancellable *cancellable, GError **error)
 
-BUILTINPROTO(compose);
-BUILTINPROTO(countme);
-BUILTINPROTO(upgrade);
-BUILTINPROTO(reload);
-BUILTINPROTO(deploy);
-BUILTINPROTO(rebase);
-BUILTINPROTO(cancel);
-BUILTINPROTO(cleanup);
-BUILTINPROTO(rollback);
-BUILTINPROTO(initramfs);
-BUILTINPROTO(status);
-BUILTINPROTO(refresh_md);
-BUILTINPROTO(db);
-BUILTINPROTO(internals);
-BUILTINPROTO(container);
-BUILTINPROTO(install);
-BUILTINPROTO(uninstall);
-BUILTINPROTO(override);
-BUILTINPROTO(kargs);
-BUILTINPROTO(reset);
-BUILTINPROTO(start_daemon);
-BUILTINPROTO(shlib_backend);
-BUILTINPROTO(coreos_rootfs);
-BUILTINPROTO(testutils);
-BUILTINPROTO(ex);
-BUILTINPROTO(finalize_deployment);
-BUILTINPROTO(initramfs_etc);
+BUILTINPROTO (compose);
+BUILTINPROTO (countme);
+BUILTINPROTO (upgrade);
+BUILTINPROTO (reload);
+BUILTINPROTO (deploy);
+BUILTINPROTO (rebase);
+BUILTINPROTO (cancel);
+BUILTINPROTO (cleanup);
+BUILTINPROTO (rollback);
+BUILTINPROTO (initramfs);
+BUILTINPROTO (status);
+BUILTINPROTO (refresh_md);
+BUILTINPROTO (db);
+BUILTINPROTO (internals);
+BUILTINPROTO (container);
+BUILTINPROTO (install);
+BUILTINPROTO (uninstall);
+BUILTINPROTO (override);
+BUILTINPROTO (kargs);
+BUILTINPROTO (reset);
+BUILTINPROTO (start_daemon);
+BUILTINPROTO (shlib_backend);
+BUILTINPROTO (coreos_rootfs);
+BUILTINPROTO (testutils);
+BUILTINPROTO (ex);
+BUILTINPROTO (finalize_deployment);
+BUILTINPROTO (initramfs_etc);
 
 #undef BUILTINPROTO
 
-gboolean
-rpmostree_option_context_parse (GOptionContext *context,
-                                const GOptionEntry *main_entries,
-                                int *argc,
-                                char ***argv,
-                                RpmOstreeCommandInvocation *invocation,
-                                GCancellable *cancellable,
-                                const char *const* *out_install_pkgs,
-                                const char *const* *out_uninstall_pkgs,
-                                RPMOSTreeSysroot **out_sysroot_proxy,
-                                GError **error);
+gboolean rpmostree_option_context_parse (GOptionContext *context, const GOptionEntry *main_entries,
+                                         int *argc, char ***argv,
+                                         RpmOstreeCommandInvocation *invocation,
+                                         GCancellable *cancellable,
+                                         const char *const **out_install_pkgs,
+                                         const char *const **out_uninstall_pkgs,
+                                         RPMOSTreeSysroot **out_sysroot_proxy, GError **error);
 
-int
-rpmostree_handle_subcommand (int argc, char **argv,
-                             RpmOstreeCommand *subcommands,
-                             RpmOstreeCommandInvocation *invocation,
-                             GCancellable *cancellable, GError **error);
+int rpmostree_handle_subcommand (int argc, char **argv, RpmOstreeCommand *subcommands,
+                                 RpmOstreeCommandInvocation *invocation, GCancellable *cancellable,
+                                 GError **error);
 
 G_END_DECLS
-

--- a/src/app/rpmostree-clientlib.h
+++ b/src/app/rpmostree-clientlib.h
@@ -18,41 +18,44 @@
 
 #pragma once
 
-#include <glib-unix.h>
 #include <gio/gio.h>
 #include <gio/gunixfdlist.h>
+#include <glib-unix.h>
 
 #include "rpm-ostreed-generated.h"
 #include "rpmostree-builtin-types.h"
 
+#include <ostree.h>
 #include <stdint.h>
 #include <string.h>
-#include <ostree.h>
 
-#include <memory>
 #include "rust/cxx.h"
+#include <memory>
 
-namespace rpmostreecxx {
+namespace rpmostreecxx
+{
 
-class ClientConnection final {
+class ClientConnection final
+{
 private:
-    GDBusConnection *conn;
+  GDBusConnection *conn;
+
 public:
-    ClientConnection(GDBusConnection *connp) : conn(connp) {}
-    ~ClientConnection() {
-        g_clear_object(&conn);
-    }
+  ClientConnection (GDBusConnection *connp) : conn (connp) {}
+  ~ClientConnection () { g_clear_object (&conn); }
 
-    GDBusConnection &get_connection() {
-        return *conn;
-    }
+  GDBusConnection &
+  get_connection ()
+  {
+    return *conn;
+  }
 
-    void transaction_connect_progress_sync(const rust::Str address) const;
+  void transaction_connect_progress_sync (const rust::Str address) const;
 };
 
-void client_require_root();
+void client_require_root ();
 
-std::unique_ptr<ClientConnection> new_client_connection();
+std::unique_ptr<ClientConnection> new_client_connection ();
 
 } // namespace
 
@@ -60,113 +63,64 @@ G_BEGIN_DECLS
 
 #define BUS_NAME "org.projectatomic.rpmostree1"
 
-gboolean
-rpmostree_load_sysroot                       (const char        *sysroot,
-                                              GCancellable      *cancellable,
-                                              RPMOSTreeSysroot **out_sysroot_proxy,
-                                              GError **error);
+gboolean rpmostree_load_sysroot (const char *sysroot, GCancellable *cancellable,
+                                 RPMOSTreeSysroot **out_sysroot_proxy, GError **error);
 
-gboolean
-rpmostree_load_os_proxy                      (RPMOSTreeSysroot *sysroot_proxy,
-                                              gchar *opt_osname,
-                                              GCancellable *cancellable,
-                                              RPMOSTreeOS **out_os_proxy,
-                                              GError **error);
+gboolean rpmostree_load_os_proxy (RPMOSTreeSysroot *sysroot_proxy, gchar *opt_osname,
+                                  GCancellable *cancellable, RPMOSTreeOS **out_os_proxy,
+                                  GError **error);
 
-gboolean
-rpmostree_load_os_proxies                    (RPMOSTreeSysroot *sysroot_proxy,
-                                              const char *opt_osname,
-                                              GCancellable *cancellable,
-                                              RPMOSTreeOS **out_os_proxy,
-                                              RPMOSTreeOSExperimental **out_osexperimental_proxy,
-                                              GError **error);
+gboolean rpmostree_load_os_proxies (RPMOSTreeSysroot *sysroot_proxy, const char *opt_osname,
+                                    GCancellable *cancellable, RPMOSTreeOS **out_os_proxy,
+                                    RPMOSTreeOSExperimental **out_osexperimental_proxy,
+                                    GError **error);
 
-gboolean
-rpmostree_transaction_connect_active         (RPMOSTreeSysroot *sysroot_proxy,
-                                              char                 **out_path,
-                                              RPMOSTreeTransaction **out_txn,
-                                              GCancellable *cancellable,
-                                              GError      **error);
+gboolean rpmostree_transaction_connect_active (RPMOSTreeSysroot *sysroot_proxy, char **out_path,
+                                               RPMOSTreeTransaction **out_txn,
+                                               GCancellable *cancellable, GError **error);
 
-gboolean
-rpmostree_transaction_get_response_sync      (RPMOSTreeSysroot *sysroot_proxy,
-                                              const char *transaction_address,
-                                              GCancellable *cancellable,
-                                              GError **error);
+gboolean rpmostree_transaction_get_response_sync (RPMOSTreeSysroot *sysroot_proxy,
+                                                  const char *transaction_address,
+                                                  GCancellable *cancellable, GError **error);
 
-gboolean
-rpmostree_transaction_client_run             (RpmOstreeCommandInvocation *invocation,
-                                              RPMOSTreeSysroot *sysroot_proxy,
-                                              RPMOSTreeOS      *os_proxy,
-                                              GVariant         *options,
-                                              gboolean          exit_unchanged_77,
-                                              const char *transaction_address,
-                                              GVariant         *previous_deployment,
-                                              GCancellable *cancellable,
-                                              GError **error);
+gboolean rpmostree_transaction_client_run (RpmOstreeCommandInvocation *invocation,
+                                           RPMOSTreeSysroot *sysroot_proxy, RPMOSTreeOS *os_proxy,
+                                           GVariant *options, gboolean exit_unchanged_77,
+                                           const char *transaction_address,
+                                           GVariant *previous_deployment, GCancellable *cancellable,
+                                           GError **error);
 
-void
-rpmostree_print_gpg_info (GVariant  *signatures,
-                          gboolean   verbose,
-                          guint      max_key_len);
+void rpmostree_print_gpg_info (GVariant *signatures, gboolean verbose, guint max_key_len);
 
-void
-rpmostree_print_package_diffs                (GVariant *variant);
+void rpmostree_print_package_diffs (GVariant *variant);
 
-gboolean
-rpmostree_sort_pkgs_strv (const char *const* pkgs,
-                          GUnixFDList  *fd_list,
-                          GPtrArray   **out_repo_pkgs,
-                          GVariant    **out_fd_idxs,
-                          GError      **error);
+gboolean rpmostree_sort_pkgs_strv (const char *const *pkgs, GUnixFDList *fd_list,
+                                   GPtrArray **out_repo_pkgs, GVariant **out_fd_idxs,
+                                   GError **error);
 
-gboolean
-rpmostree_update_deployment (RPMOSTreeOS  *os_proxy,
-                             const char   *set_refspec,
-                             const char   *set_revision,
-                             const char *const* install_pkgs,
-                             const char *const* install_fileoverride_pkgs,
-                             const char *const* uninstall_pkgs,
-                             const char *const* override_replace_pkgs,
-                             const char *const* override_remove_pkgs,
-                             const char *const* override_reset_pkgs,
-                             const char   *local_repo_remote,
-                             GVariant     *options,
-                             char        **out_transaction_address,
-                             GCancellable *cancellable,
-                             GError      **error);
+gboolean rpmostree_update_deployment (
+    RPMOSTreeOS *os_proxy, const char *set_refspec, const char *set_revision,
+    const char *const *install_pkgs, const char *const *install_fileoverride_pkgs,
+    const char *const *uninstall_pkgs, const char *const *override_replace_pkgs,
+    const char *const *override_remove_pkgs, const char *const *override_reset_pkgs,
+    const char *local_repo_remote, GVariant *options, char **out_transaction_address,
+    GCancellable *cancellable, GError **error);
 
-gboolean
-rpmostree_print_diff_advisories (GVariant         *rpm_diff,
-                                 GVariant         *advisories,
-                                 gboolean          verbose,
-                                 gboolean          verbose_advisories,
-                                 guint             max_key_len,
-                                 GError          **error);
+gboolean rpmostree_print_diff_advisories (GVariant *rpm_diff, GVariant *advisories,
+                                          gboolean verbose, gboolean verbose_advisories,
+                                          guint max_key_len, GError **error);
 
-gboolean
-rpmostree_print_cached_update (GVariant         *cached_update,
-                               gboolean          verbose,
-                               gboolean          verbose_advisories,
-                               GCancellable     *cancellable,
-                               GError          **error);
+gboolean rpmostree_print_cached_update (GVariant *cached_update, gboolean verbose,
+                                        gboolean verbose_advisories, GCancellable *cancellable,
+                                        GError **error);
 
-void
-rpmostree_print_advisories (GVariant *advisories,
-                            gboolean  verbose,
-                            guint     max_key_len);
+void rpmostree_print_advisories (GVariant *advisories, gboolean verbose, guint max_key_len);
 
-gboolean
-get_sd_unit_objpath (GDBusConnection  *connection,
-                     const char       *method_name,
-                     GVariant         *parameters,
-                     const char      **unit_objpath,
-                     GCancellable     *cancellable,
-                     GError          **error);
+gboolean get_sd_unit_objpath (GDBusConnection *connection, const char *method_name,
+                              GVariant *parameters, const char **unit_objpath,
+                              GCancellable *cancellable, GError **error);
 
-gboolean
-error_if_driver_registered (RPMOSTreeSysroot *sysroot_proxy,
-                            GCancellable     *cancellable,
-                            GError          **error);
+gboolean error_if_driver_registered (RPMOSTreeSysroot *sysroot_proxy, GCancellable *cancellable,
+                                     GError **error);
 
 G_END_DECLS

--- a/src/app/rpmostree-compose-builtins.h
+++ b/src/app/rpmostree-compose-builtins.h
@@ -26,11 +26,20 @@
 
 G_BEGIN_DECLS
 
-gboolean rpmostree_compose_builtin_tree (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
-gboolean rpmostree_compose_builtin_install (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
-gboolean rpmostree_compose_builtin_postprocess (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
-gboolean rpmostree_compose_builtin_commit (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
-gboolean rpmostree_compose_builtin_extensions (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
+gboolean rpmostree_compose_builtin_tree (int argc, char **argv,
+                                         RpmOstreeCommandInvocation *invocation,
+                                         GCancellable *cancellable, GError **error);
+gboolean rpmostree_compose_builtin_install (int argc, char **argv,
+                                            RpmOstreeCommandInvocation *invocation,
+                                            GCancellable *cancellable, GError **error);
+gboolean rpmostree_compose_builtin_postprocess (int argc, char **argv,
+                                                RpmOstreeCommandInvocation *invocation,
+                                                GCancellable *cancellable, GError **error);
+gboolean rpmostree_compose_builtin_commit (int argc, char **argv,
+                                           RpmOstreeCommandInvocation *invocation,
+                                           GCancellable *cancellable, GError **error);
+gboolean rpmostree_compose_builtin_extensions (int argc, char **argv,
+                                               RpmOstreeCommandInvocation *invocation,
+                                               GCancellable *cancellable, GError **error);
 
 G_END_DECLS
-

--- a/src/app/rpmostree-composeutil.cxx
+++ b/src/app/rpmostree-composeutil.cxx
@@ -20,45 +20,41 @@
 
 #include "config.h"
 
-#include <string.h>
-#include <glib-unix.h>
-#include <json-glib/json-glib.h>
 #include <gio/gunixinputstream.h>
 #include <gio/gunixoutputstream.h>
-#include <libdnf/libdnf.h>
+#include <glib-unix.h>
+#include <json-glib/json-glib.h>
 #include <libdnf/dnf-repo.h>
-#include <sys/mount.h>
-#include <stdio.h>
+#include <libdnf/libdnf.h>
+#include <libglnx.h>
 #include <linux/magic.h>
+#include <rpm/rpmmacro.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mount.h>
 #include <sys/statvfs.h>
 #include <sys/vfs.h>
-#include <libglnx.h>
-#include <rpm/rpmmacro.h>
 
+#include "libglnx.h"
 #include "rpmostree-composeutil.h"
-#include "rpmostree-util.h"
 #include "rpmostree-core.h"
 #include "rpmostree-json-parsing.h"
-#include "rpmostree-package-variants.h"
 #include "rpmostree-libbuiltin.h"
+#include "rpmostree-package-variants.h"
 #include "rpmostree-rpm-util.h"
-#include "libglnx.h"
+#include "rpmostree-util.h"
 
 gboolean
-rpmostree_composeutil_checksum (HyGoal             goal,
-                                OstreeRepo        *repo,
-                                const rpmostreecxx::Treefile &tf,
-                                JsonObject        *treefile,
-                                char             **out_checksum,
-                                GError           **error)
+rpmostree_composeutil_checksum (HyGoal goal, OstreeRepo *repo, const rpmostreecxx::Treefile &tf,
+                                JsonObject *treefile, char **out_checksum, GError **error)
 {
   GLNX_AUTO_PREFIX_ERROR ("Computing compose checksum", error);
-  g_autoptr(GChecksum) checksum = g_checksum_new (G_CHECKSUM_SHA256);
+  g_autoptr (GChecksum) checksum = g_checksum_new (G_CHECKSUM_SHA256);
 
   /* Hash in the treefile inputs (this includes all externals like postprocess, add-files,
    * etc... and the final flattened treefile -- see treefile.rs for more details). */
-  auto tf_checksum = tf.get_checksum(*repo);
-  g_checksum_update (checksum, (const guint8*)tf_checksum.data(), tf_checksum.size());
+  auto tf_checksum = tf.get_checksum (*repo);
+  g_checksum_update (checksum, (const guint8 *)tf_checksum.data (), tf_checksum.size ());
 
   /* Hash in each package */
   if (!rpmostree_dnf_add_checksum_goal (checksum, goal, NULL, error))
@@ -69,17 +65,16 @@ rpmostree_composeutil_checksum (HyGoal             goal,
 }
 
 gboolean
-rpmostree_composeutil_read_json_metadata (JsonNode    *root,
-                                          GHashTable  *metadata,
-                                          GError     **error)
+rpmostree_composeutil_read_json_metadata (JsonNode *root, GHashTable *metadata, GError **error)
 {
-  g_autoptr(GVariant) jsonmetav = json_gvariant_deserialize (root, "a{sv}", error);
+  g_autoptr (GVariant) jsonmetav = json_gvariant_deserialize (root, "a{sv}", error);
   if (!jsonmetav)
     return FALSE;
 
   GVariantIter viter;
   g_variant_iter_init (&viter, jsonmetav);
-  { char *key;
+  {
+    char *key;
     GVariant *value;
     while (g_variant_iter_loop (&viter, "{sv}", &key, &value))
       g_hash_table_replace (metadata, g_strdup (key), g_variant_ref (value));
@@ -92,9 +87,8 @@ rpmostree_composeutil_read_json_metadata (JsonNode    *root,
  * to a hash table of a{sv}; suitable for further extension.
  */
 gboolean
-rpmostree_composeutil_read_json_metadata_from_file (const char *path,
-                                                    GHashTable *metadata,
-                                                    GError    **error)
+rpmostree_composeutil_read_json_metadata_from_file (const char *path, GHashTable *metadata,
+                                                    GError **error)
 {
   const char *errprefix = glnx_strjoina ("While parsing JSON file ", path);
   GLNX_AUTO_PREFIX_ERROR (errprefix, error);
@@ -108,20 +102,20 @@ rpmostree_composeutil_read_json_metadata_from_file (const char *path,
 }
 
 static GVariantBuilder *
-metadata_conversion_start(GHashTable *metadata)
+metadata_conversion_start (GHashTable *metadata)
 {
   GVariantBuilder *builder = g_variant_builder_new (G_VARIANT_TYPE ("a{sv}"));
 
-  GLNX_HASH_TABLE_FOREACH_KV (metadata, const char*, strkey, GVariant*, v)
-    g_variant_builder_add (builder, "{sv}", strkey, v);
+  GLNX_HASH_TABLE_FOREACH_KV (metadata, const char *, strkey, GVariant *, v)
+  g_variant_builder_add (builder, "{sv}", strkey, v);
 
   return builder;
 }
 
 static GVariant *
-metadata_conversion_end(GVariantBuilder *builder)
+metadata_conversion_end (GVariantBuilder *builder)
 {
-  g_autoptr(GVariant) ret = g_variant_ref_sink (g_variant_builder_end (builder));
+  g_autoptr (GVariant) ret = g_variant_ref_sink (g_variant_builder_end (builder));
   /* Canonicalize to big endian, like OSTree does. Without this, any numbers
    * we place in the metadata will be unreadable since clients won't know
    * their endianness.
@@ -133,18 +127,15 @@ metadata_conversion_end(GVariantBuilder *builder)
 
 /* Convert hash table of metadata into finalized GVariant */
 GVariant *
-rpmostree_composeutil_finalize_metadata (GHashTable *metadata,
-                                         int         rootfs_dfd,
-                                         GError    **error)
+rpmostree_composeutil_finalize_metadata (GHashTable *metadata, int rootfs_dfd, GError **error)
 {
-  g_autoptr(GVariantBuilder) builder = metadata_conversion_start(metadata);
+  g_autoptr (GVariantBuilder) builder = metadata_conversion_start (metadata);
 
   /* include list of packages in rpmdb; this is used client-side for easily previewing
    * pending updates. once we only support unified core composes, this can easily be much
    * more readily injected during assembly */
-  g_autoptr(GVariant) rpmdb_v = NULL;
-  if (!rpmostree_create_rpmdb_pkglist_variant (rootfs_dfd, ".", &rpmdb_v,
-                                               NULL, error))
+  g_autoptr (GVariant) rpmdb_v = NULL;
+  if (!rpmostree_create_rpmdb_pkglist_variant (rootfs_dfd, ".", &rpmdb_v, NULL, error))
     return FALSE;
   g_variant_builder_add (builder, "{sv}", "rpmostree.rpmdb.pkglist", rpmdb_v);
 
@@ -159,27 +150,23 @@ rpmostree_composeutil_finalize_detached_metadata (GHashTable *detached_metadata)
   if (g_hash_table_size (detached_metadata) == 0)
     return NULL;
 
-  g_autoptr(GVariantBuilder) builder = metadata_conversion_start(detached_metadata);
+  g_autoptr (GVariantBuilder) builder = metadata_conversion_start (detached_metadata);
   return metadata_conversion_end (builder);
 }
-
 
 /* Implements --write-composejson-to, and also prints values.
  * If `path` is NULL, we'll just print some data.
  */
 gboolean
-rpmostree_composeutil_write_composejson (OstreeRepo  *repo,
-                                         const char *path,
+rpmostree_composeutil_write_composejson (OstreeRepo *repo, const char *path,
                                          const OstreeRepoTransactionStats *stats,
-                                         const char *new_revision,
-                                         GVariant   *new_commit,
-                                         const char *new_ref,
-                                         GCancellable *cancellable,
-                                         GError    **error)
+                                         const char *new_revision, GVariant *new_commit,
+                                         const char *new_ref, GCancellable *cancellable,
+                                         GError **error)
 {
-  g_autoptr(GVariant) new_commit_inline_meta = g_variant_get_child_value (new_commit, 0);
+  g_autoptr (GVariant) new_commit_inline_meta = g_variant_get_child_value (new_commit, 0);
 
-  g_auto(GVariantBuilder) builder;
+  g_auto (GVariantBuilder) builder;
   g_variant_builder_init (&builder, G_VARIANT_TYPE ("a{sv}"));
 
   if (new_ref != NULL)
@@ -205,42 +192,48 @@ rpmostree_composeutil_write_composejson (OstreeRepo  *repo,
   g_variant_builder_add (&builder, "{sv}", "ostree-commit", g_variant_new_string (new_revision));
 
   g_autofree char *content_checksum = ostree_commit_get_content_checksum (new_commit);
-  g_variant_builder_add (&builder, "{sv}", "ostree-content-checksum", g_variant_new_string (content_checksum));
+  g_variant_builder_add (&builder, "{sv}", "ostree-content-checksum",
+                         g_variant_new_string (content_checksum));
 
   const char *commit_version = NULL;
-  (void)g_variant_lookup (new_commit_inline_meta, OSTREE_COMMIT_META_KEY_VERSION, "&s", &commit_version);
+  (void)g_variant_lookup (new_commit_inline_meta, OSTREE_COMMIT_META_KEY_VERSION, "&s",
+                          &commit_version);
   if (commit_version)
-    g_variant_builder_add (&builder, "{sv}", "ostree-version", g_variant_new_string (commit_version));
+    g_variant_builder_add (&builder, "{sv}", "ostree-version",
+                           g_variant_new_string (commit_version));
 
   /* Since JavaScript doesn't have 64 bit integers and hence neither does JSON,
    * store this as a string:
    * https://stackoverflow.com/questions/10286204/the-right-json-date-format
    * */
-  { guint64 commit_ts = ostree_commit_get_timestamp (new_commit);
+  {
+    guint64 commit_ts = ostree_commit_get_timestamp (new_commit);
     g_autofree char *commit_ts_iso_8601 = rpmostree_timestamp_str_from_unix_utc (commit_ts);
-    g_variant_builder_add (&builder, "{sv}", "ostree-timestamp", g_variant_new_string (commit_ts_iso_8601));
+    g_variant_builder_add (&builder, "{sv}", "ostree-timestamp",
+                           g_variant_new_string (commit_ts_iso_8601));
   }
 
   const char *inputhash = NULL;
   (void)g_variant_lookup (new_commit_inline_meta, "rpmostree.inputhash", "&s", &inputhash);
   /* We may not have the inputhash in the split-up installroot case */
   if (inputhash)
-    g_variant_builder_add (&builder, "{sv}", "rpm-ostree-inputhash", g_variant_new_string (inputhash));
+    g_variant_builder_add (&builder, "{sv}", "rpm-ostree-inputhash",
+                           g_variant_new_string (inputhash));
 
   g_autofree char *parent_revision = ostree_commit_get_parent (new_commit);
   if (path && parent_revision)
     {
       /* don't error if the parent doesn't exist */
       gboolean parent_exists;
-      if (!ostree_repo_has_object (repo, OSTREE_OBJECT_TYPE_COMMIT, parent_revision,
-                                   &parent_exists, cancellable, error))
+      if (!ostree_repo_has_object (repo, OSTREE_OBJECT_TYPE_COMMIT, parent_revision, &parent_exists,
+                                   cancellable, error))
         return FALSE;
 
       if (parent_exists)
         {
-          g_autoptr(GVariant) diffv = NULL;
-          if (!rpm_ostree_db_diff_variant (repo, parent_revision, new_revision,
-                                           TRUE, &diffv, cancellable, error))
+          g_autoptr (GVariant) diffv = NULL;
+          if (!rpm_ostree_db_diff_variant (repo, parent_revision, new_revision, TRUE, &diffv,
+                                           cancellable, error))
             return FALSE;
           g_variant_builder_add (&builder, "{sv}", "pkgdiff", diffv);
         }
@@ -248,18 +241,19 @@ rpmostree_composeutil_write_composejson (OstreeRepo  *repo,
 
   if (path)
     {
-      g_autoptr(GVariant) composemeta_v = g_variant_builder_end (&builder);
+      g_autoptr (GVariant) composemeta_v = g_variant_builder_end (&builder);
       JsonNode *composemeta_node = json_gvariant_serialize (composemeta_v);
       glnx_unref_object JsonGenerator *generator = json_generator_new ();
       json_generator_set_root (generator, composemeta_node);
 
       char *dnbuf = strdupa (path);
       const char *dn = dirname (dnbuf);
-      g_auto(GLnxTmpfile) tmpf = { 0, };
-      if (!glnx_open_tmpfile_linkable_at (AT_FDCWD, dn, O_WRONLY | O_CLOEXEC,
-                                          &tmpf, error))
+      g_auto (GLnxTmpfile) tmpf = {
+        0,
+      };
+      if (!glnx_open_tmpfile_linkable_at (AT_FDCWD, dn, O_WRONLY | O_CLOEXEC, &tmpf, error))
         return FALSE;
-      g_autoptr(GOutputStream) out = g_unix_output_stream_new (tmpf.fd, FALSE);
+      g_autoptr (GOutputStream) out = g_unix_output_stream_new (tmpf.fd, FALSE);
       /* See also similar code in status.c */
       if (json_generator_to_stream (generator, out, cancellable, error) <= 0
           || (error != NULL && *error != NULL))
@@ -269,8 +263,7 @@ rpmostree_composeutil_write_composejson (OstreeRepo  *repo,
       if (!glnx_fchmod (tmpf.fd, 0644, error))
         return FALSE;
 
-      if (!glnx_link_tmpfile_at (&tmpf, GLNX_LINK_TMPFILE_REPLACE,
-                                 AT_FDCWD, path, error))
+      if (!glnx_link_tmpfile_at (&tmpf, GLNX_LINK_TMPFILE_REPLACE, AT_FDCWD, path, error))
         return FALSE;
     }
 

--- a/src/app/rpmostree-composeutil.h
+++ b/src/app/rpmostree-composeutil.h
@@ -27,39 +27,24 @@
 
 G_BEGIN_DECLS
 
-gboolean
-rpmostree_composeutil_checksum (HyGoal             goal,
-                                OstreeRepo        *repo,
-                                const rpmostreecxx::Treefile &tf,
-                                JsonObject        *treefile,
-                                char             **out_checksum,
-                                GError           **error);
+gboolean rpmostree_composeutil_checksum (HyGoal goal, OstreeRepo *repo,
+                                         const rpmostreecxx::Treefile &tf, JsonObject *treefile,
+                                         char **out_checksum, GError **error);
 
-gboolean
-rpmostree_composeutil_read_json_metadata (JsonNode    *root,
-                                          GHashTable  *metadata,
-                                          GError     **error);
-gboolean
-rpmostree_composeutil_read_json_metadata_from_file (const char *path,
-                                                    GHashTable *metadata,
-                                                    GError    **error);
+gboolean rpmostree_composeutil_read_json_metadata (JsonNode *root, GHashTable *metadata,
+                                                   GError **error);
+gboolean rpmostree_composeutil_read_json_metadata_from_file (const char *path, GHashTable *metadata,
+                                                             GError **error);
 
-GVariant *
-rpmostree_composeutil_finalize_metadata (GHashTable *metadata,
-                                         int         rootfs_dfd,
-                                         GError    **error);
+GVariant *rpmostree_composeutil_finalize_metadata (GHashTable *metadata, int rootfs_dfd,
+                                                   GError **error);
 
-GVariant *
-rpmostree_composeutil_finalize_detached_metadata (GHashTable *detached_metadata);
+GVariant *rpmostree_composeutil_finalize_detached_metadata (GHashTable *detached_metadata);
 
-gboolean
-rpmostree_composeutil_write_composejson (OstreeRepo  *repo,
-                                         const char *path,
-                                         const OstreeRepoTransactionStats *stats,
-                                         const char *new_revision,
-                                         GVariant   *new_commit,
-                                         const char *new_ref,
-                                         GCancellable *cancellable,
-                                         GError    **error);
+gboolean rpmostree_composeutil_write_composejson (OstreeRepo *repo, const char *path,
+                                                  const OstreeRepoTransactionStats *stats,
+                                                  const char *new_revision, GVariant *new_commit,
+                                                  const char *new_ref, GCancellable *cancellable,
+                                                  GError **error);
 
 G_END_DECLS

--- a/src/app/rpmostree-db-builtin-list.cxx
+++ b/src/app/rpmostree-db-builtin-list.cxx
@@ -25,21 +25,17 @@
 
 static gboolean opt_advisories;
 
-static GOptionEntry option_entries[] = {
-  { "advisories", 'a', 0, G_OPTION_ARG_NONE, &opt_advisories, "Also list advisories", NULL },
-  { NULL }
-};
+static GOptionEntry option_entries[]
+    = { { "advisories", 'a', 0, G_OPTION_ARG_NONE, &opt_advisories, "Also list advisories", NULL },
+        { NULL } };
 
 static gboolean
-_builtin_db_list (OstreeRepo      *repo,
-                  GPtrArray       *revs,
-                  const GPtrArray *patterns,
-                  GCancellable    *cancellable,
-                  GError         **error)
+_builtin_db_list (OstreeRepo *repo, GPtrArray *revs, const GPtrArray *patterns,
+                  GCancellable *cancellable, GError **error)
 {
   for (guint num = 0; num < revs->len; num++)
     {
-      auto rev = static_cast<const char *>(revs->pdata[num]);
+      auto rev = static_cast<const char *> (revs->pdata[num]);
 
       g_autofree char *checksum = NULL;
       if (!ostree_repo_resolve_rev (repo, rev, FALSE, &checksum, error))
@@ -53,20 +49,20 @@ _builtin_db_list (OstreeRepo      *repo,
       /* in the common case where no patterns are provided, use the smarter db_query API */
       if (!patterns)
         {
-          g_autoptr(GPtrArray) packages =
-            rpm_ostree_db_query_all (repo, checksum, cancellable, error);
+          g_autoptr (GPtrArray) packages
+              = rpm_ostree_db_query_all (repo, checksum, cancellable, error);
           if (!packages)
             return FALSE;
 
           for (guint i = 0; i < packages->len; i++)
             {
-              auto package = static_cast<RpmOstreePackage *>(g_ptr_array_index (packages, i));
+              auto package = static_cast<RpmOstreePackage *> (g_ptr_array_index (packages, i));
               g_print (" %s\n", rpm_ostree_package_get_nevra (package));
             }
         }
       else
         {
-          g_autoptr(RpmRevisionData) rpmrev = NULL;
+          g_autoptr (RpmRevisionData) rpmrev = NULL;
           rpmrev = rpmrev_new (repo, checksum, patterns, cancellable, error);
           if (!rpmrev)
             return FALSE;
@@ -76,16 +72,16 @@ _builtin_db_list (OstreeRepo      *repo,
 
       if (opt_advisories)
         {
-          g_autoptr(GVariant) commit = NULL;
+          g_autoptr (GVariant) commit = NULL;
           if (!ostree_repo_load_commit (repo, checksum, &commit, NULL, error))
             return FALSE;
 
-          g_autoptr(GVariant) meta = g_variant_get_child_value (commit, 0);
+          g_autoptr (GVariant) meta = g_variant_get_child_value (commit, 0);
           rpmostree_variant_be_to_native (&meta);
-          g_autoptr(GVariantDict) dict = g_variant_dict_new (meta);
+          g_autoptr (GVariantDict) dict = g_variant_dict_new (meta);
 
-          g_autoptr(GVariant) advisories =
-            g_variant_dict_lookup_value (dict, "rpmostree.advisories", RPMOSTREE_UPDATE_ADVISORY_GVARIANT_FORMAT);
+          g_autoptr (GVariant) advisories = g_variant_dict_lookup_value (
+              dict, "rpmostree.advisories", RPMOSTREE_UPDATE_ADVISORY_GVARIANT_FORMAT);
           if (advisories)
             {
               g_print ("\n");
@@ -98,24 +94,22 @@ _builtin_db_list (OstreeRepo      *repo,
 }
 
 gboolean
-rpmostree_db_builtin_list (int argc, char **argv,
-                           RpmOstreeCommandInvocation *invocation,
+rpmostree_db_builtin_list (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
                            GCancellable *cancellable, GError **error)
 {
-  g_autoptr(GOptionContext) context =
-    g_option_context_new ("REV... [PREFIX-PKGNAME...]");
+  g_autoptr (GOptionContext) context = g_option_context_new ("REV... [PREFIX-PKGNAME...]");
 
-  g_autoptr(OstreeRepo) repo = NULL;
-  if (!rpmostree_db_option_context_parse (context, option_entries, &argc, &argv,
-                                          invocation, &repo, cancellable, error))
+  g_autoptr (OstreeRepo) repo = NULL;
+  if (!rpmostree_db_option_context_parse (context, option_entries, &argc, &argv, invocation, &repo,
+                                          cancellable, error))
     return FALSE;
 
   /* Iterate over all arguments. When we see the first argument which
    * appears to be an OSTree commit, take all other arguments to be
    * patterns.
    */
-  g_autoptr(GPtrArray) revs = g_ptr_array_new ();
-  g_autoptr(GPtrArray) patterns = NULL;
+  g_autoptr (GPtrArray) revs = g_ptr_array_new ();
+  g_autoptr (GPtrArray) patterns = NULL;
 
   for (int ii = 1; ii < argc; ii++)
     {

--- a/src/app/rpmostree-db-builtin-version.cxx
+++ b/src/app/rpmostree-db-builtin-version.cxx
@@ -23,25 +23,20 @@
 #include "rpmostree-db-builtins.h"
 #include "rpmostree-rpm-util.h"
 
-static GOptionEntry db_version_entries[] = {
-  { NULL }
-};
+static GOptionEntry db_version_entries[] = { { NULL } };
 
 static gboolean
-_builtin_db_version (OstreeRepo *repo, GPtrArray *revs,
-                     GCancellable   *cancellable,
-                     GError        **error)
+_builtin_db_version (OstreeRepo *repo, GPtrArray *revs, GCancellable *cancellable, GError **error)
 {
   for (guint num = 0; num < revs->len; num++)
     {
-      auto rev = static_cast<const char *>(revs->pdata[num]);
+      auto rev = static_cast<const char *> (revs->pdata[num]);
 
-      g_autoptr(RpmRevisionData) rpmrev = rpmrev_new (repo, rev, NULL, cancellable, error);
+      g_autoptr (RpmRevisionData) rpmrev = rpmrev_new (repo, rev, NULL, cancellable, error);
       if (!rpmrev)
         return FALSE;
 
-      g_autofree char *rpmdbv =
-        rpmhdrs_rpmdbv (rpmrev_get_headers (rpmrev), cancellable, error);
+      g_autofree char *rpmdbv = rpmhdrs_rpmdbv (rpmrev_get_headers (rpmrev), cancellable, error);
       if (rpmdbv == NULL)
         return FALSE;
 
@@ -57,20 +52,17 @@ _builtin_db_version (OstreeRepo *repo, GPtrArray *revs,
 }
 
 gboolean
-rpmostree_db_builtin_version (int argc, char **argv,
-                              RpmOstreeCommandInvocation *invocation,
+rpmostree_db_builtin_version (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
                               GCancellable *cancellable, GError **error)
 {
-  g_autoptr(GOptionContext) context =
-    g_option_context_new ("COMMIT...");
+  g_autoptr (GOptionContext) context = g_option_context_new ("COMMIT...");
 
-  g_autoptr(OstreeRepo) repo = NULL;
-  if (!rpmostree_db_option_context_parse (context, db_version_entries, &argc,
-                                          &argv, invocation, &repo, cancellable,
-                                          error))
+  g_autoptr (OstreeRepo) repo = NULL;
+  if (!rpmostree_db_option_context_parse (context, db_version_entries, &argc, &argv, invocation,
+                                          &repo, cancellable, error))
     return FALSE;
 
-  g_autoptr(GPtrArray) revs = g_ptr_array_new ();
+  g_autoptr (GPtrArray) revs = g_ptr_array_new ();
 
   for (int ii = 1; ii < argc; ii++)
     g_ptr_array_add (revs, argv[ii]);
@@ -80,4 +72,3 @@ rpmostree_db_builtin_version (int argc, char **argv,
 
   return TRUE;
 }
-

--- a/src/app/rpmostree-db-builtins.h
+++ b/src/app/rpmostree-db-builtins.h
@@ -26,16 +26,18 @@
 
 G_BEGIN_DECLS
 
-gboolean rpmostree_db_builtin_diff (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
-gboolean rpmostree_db_builtin_list (int argc, char **argv, RpmOstreeCommandInvocation *invocation,  GCancellable *cancellable, GError **error);
-gboolean rpmostree_db_builtin_version (int argc, char **argv, RpmOstreeCommandInvocation *invocation,  GCancellable *cancellable, GError **error);
+gboolean rpmostree_db_builtin_diff (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+                                    GCancellable *cancellable, GError **error);
+gboolean rpmostree_db_builtin_list (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+                                    GCancellable *cancellable, GError **error);
+gboolean rpmostree_db_builtin_version (int argc, char **argv,
+                                       RpmOstreeCommandInvocation *invocation,
+                                       GCancellable *cancellable, GError **error);
 
 gboolean rpmostree_db_option_context_parse (GOptionContext *context,
-                                            const GOptionEntry *main_entries,
-                                            int *argc, char ***argv,
-                                            RpmOstreeCommandInvocation *invocation,
-                                            OstreeRepo **out_repo,
-                                            GCancellable *cancellable,
+                                            const GOptionEntry *main_entries, int *argc,
+                                            char ***argv, RpmOstreeCommandInvocation *invocation,
+                                            OstreeRepo **out_repo, GCancellable *cancellable,
                                             GError **error);
 
 G_END_DECLS

--- a/src/app/rpmostree-ex-builtins.h
+++ b/src/app/rpmostree-ex-builtins.h
@@ -26,18 +26,18 @@
 
 G_BEGIN_DECLS
 
-#define BUILTINPROTO(name) gboolean rpmostree_ex_builtin_ ## name (int argc, char **argv, \
-                                                                   RpmOstreeCommandInvocation *invocation, \
-                                                                   GCancellable *cancellable, GError **error)
+#define BUILTINPROTO(name)                                                                         \
+  gboolean rpmostree_ex_builtin_##name (int argc, char **argv,                                     \
+                                        RpmOstreeCommandInvocation *invocation,                    \
+                                        GCancellable *cancellable, GError **error)
 
-BUILTINPROTO(unpack);
-BUILTINPROTO(apply_live);
-BUILTINPROTO(history);
-BUILTINPROTO(initramfs_etc);
-BUILTINPROTO(module);
-BUILTINPROTO(rebuild);
+BUILTINPROTO (unpack);
+BUILTINPROTO (apply_live);
+BUILTINPROTO (history);
+BUILTINPROTO (initramfs_etc);
+BUILTINPROTO (module);
+BUILTINPROTO (rebuild);
 
 #undef BUILTINPROTO
 
 G_END_DECLS
-

--- a/src/app/rpmostree-libbuiltin.cxx
+++ b/src/app/rpmostree-libbuiltin.cxx
@@ -23,32 +23,26 @@
 #include "string.h"
 
 #include "rpmostree-libbuiltin.h"
-#include "rpmostree.h"
 #include "rpmostree-util.h"
+#include "rpmostree.h"
 
 #include "libglnx.h"
 
 void
-rpmostree_print_kv_no_newline (const char *key,
-                               guint       maxkeylen,
-                               const char *value)
+rpmostree_print_kv_no_newline (const char *key, guint maxkeylen, const char *value)
 {
   printf ("  %*s%s %s", maxkeylen, key, strlen (key) ? ":" : " ", value);
 }
 
 void
-rpmostree_print_kv (const char *key,
-                    guint       maxkeylen,
-                    const char *value)
+rpmostree_print_kv (const char *key, guint maxkeylen, const char *value)
 {
   rpmostree_print_kv_no_newline (key, maxkeylen, value);
   putc ('\n', stdout);
 }
 
 void
-rpmostree_usage_error (GOptionContext  *context,
-                       const char      *message,
-                       GError         **error)
+rpmostree_usage_error (GOptionContext *context, const char *message, GError **error)
 {
   g_assert (context != NULL);
   g_assert (message != NULL);
@@ -56,23 +50,22 @@ rpmostree_usage_error (GOptionContext  *context,
   g_autofree char *help = g_option_context_get_help (context, TRUE, NULL);
   g_printerr ("%s\n", help);
 
-  (void) glnx_throw (error, "usage error: %s", message);
+  (void)glnx_throw (error, "usage error: %s", message);
 }
 
-static const char*
+static const char *
 get_id_from_deployment_variant (GVariant *deployment)
 {
-  g_autoptr(GVariantDict) dict = g_variant_dict_new (deployment);
+  g_autoptr (GVariantDict) dict = g_variant_dict_new (deployment);
   const char *id;
   g_assert (g_variant_dict_lookup (dict, "id", "&s", &id));
   return id;
 }
 
 gboolean
-rpmostree_has_new_default_deployment (RPMOSTreeOS *os_proxy,
-                                      GVariant    *previous_deployment)
+rpmostree_has_new_default_deployment (RPMOSTreeOS *os_proxy, GVariant *previous_deployment)
 {
-  g_autoptr(GVariant) new_deployment = rpmostree_os_dup_default_deployment (os_proxy);
+  g_autoptr (GVariant) new_deployment = rpmostree_os_dup_default_deployment (os_proxy);
 
   /* trivial case */
   if (g_variant_equal (previous_deployment, new_deployment))
@@ -83,65 +76,61 @@ rpmostree_has_new_default_deployment (RPMOSTreeOS *os_proxy,
   return !g_str_equal (previous_id, new_id);
 }
 
-namespace rpmostreecxx {
+namespace rpmostreecxx
+{
 
 /* Print the diff between the booted and pending deployments */
 void
-print_treepkg_diff_from_sysroot_path (rust::Str      sysroot_path,
-                                      RpmOstreeDiffPrintFormat format,
-                                      guint32        max_key_len,
-                                      GCancellable  *cancellable)
+print_treepkg_diff_from_sysroot_path (rust::Str sysroot_path, RpmOstreeDiffPrintFormat format,
+                                      guint32 max_key_len, GCancellable *cancellable)
 {
-  g_autoptr(GError) local_error = NULL;
-  g_autofree char *sysroot_cpath = g_strndup (sysroot_path.data(), sysroot_path.length());
-  g_autoptr(GFile) sysroot_file = g_file_new_for_path (sysroot_cpath);
-  g_autoptr(OstreeSysroot) sysroot = ostree_sysroot_new (sysroot_file);
+  g_autoptr (GError) local_error = NULL;
+  g_autofree char *sysroot_cpath = g_strndup (sysroot_path.data (), sysroot_path.length ());
+  g_autoptr (GFile) sysroot_file = g_file_new_for_path (sysroot_cpath);
+  g_autoptr (OstreeSysroot) sysroot = ostree_sysroot_new (sysroot_file);
   if (!ostree_sysroot_load (sysroot, cancellable, &local_error))
-    util::throw_gerror(local_error);
+    util::throw_gerror (local_error);
 
-  g_autoptr(GPtrArray) deployments = ostree_sysroot_get_deployments (sysroot);
+  g_autoptr (GPtrArray) deployments = ostree_sysroot_get_deployments (sysroot);
   g_assert_cmpuint (deployments->len, >, 1);
 
-  auto new_deployment = static_cast<OstreeDeployment *>(deployments->pdata[0]);
+  auto new_deployment = static_cast<OstreeDeployment *> (deployments->pdata[0]);
   OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment (sysroot);
 
   if (!booted_deployment || ostree_deployment_equal (booted_deployment, new_deployment))
     return;
 
-  g_autoptr(OstreeRepo) repo = NULL;
+  g_autoptr (OstreeRepo) repo = NULL;
   if (!ostree_sysroot_get_repo (sysroot, &repo, cancellable, &local_error))
-    util::throw_gerror(local_error);
+    util::throw_gerror (local_error);
 
   const char *from_rev = ostree_deployment_get_csum (booted_deployment);
   const char *to_rev = ostree_deployment_get_csum (new_deployment);
 
-  g_autoptr(GPtrArray) removed = NULL;
-  g_autoptr(GPtrArray) added = NULL;
-  g_autoptr(GPtrArray) modified_old = NULL;
-  g_autoptr(GPtrArray) modified_new = NULL;
-  if (!rpm_ostree_db_diff (repo, from_rev, to_rev,
-                           &removed, &added, &modified_old, &modified_new,
+  g_autoptr (GPtrArray) removed = NULL;
+  g_autoptr (GPtrArray) added = NULL;
+  g_autoptr (GPtrArray) modified_old = NULL;
+  g_autoptr (GPtrArray) modified_new = NULL;
+  if (!rpm_ostree_db_diff (repo, from_rev, to_rev, &removed, &added, &modified_old, &modified_new,
                            cancellable, &local_error))
-    util::throw_gerror(local_error);
+    util::throw_gerror (local_error);
 
-  rpmostree_diff_print_formatted (format, NULL, max_key_len,
-                                  removed, added, modified_old, modified_new);
+  rpmostree_diff_print_formatted (format, NULL, max_key_len, removed, added, modified_old,
+                                  modified_new);
 }
 
 } /* namespace */
 
 void
-rpmostree_print_timestamp_version (const char  *version_string,
-                                   const char  *timestamp_string,
-                                   guint        max_key_len)
+rpmostree_print_timestamp_version (const char *version_string, const char *timestamp_string,
+                                   guint max_key_len)
 {
   if (!version_string)
     rpmostree_print_kv ("Timestamp", max_key_len, timestamp_string);
   else
     {
-      g_autofree char *version_time
-        = g_strdup_printf ("%s%s%s (%s)", get_bold_start (), version_string,
-                           get_bold_end (), timestamp_string);
+      g_autofree char *version_time = g_strdup_printf (
+          "%s%s%s (%s)", get_bold_start (), version_string, get_bold_end (), timestamp_string);
       rpmostree_print_kv ("Version", max_key_len, version_time);
     }
 }

--- a/src/app/rpmostree-libbuiltin.h
+++ b/src/app/rpmostree-libbuiltin.h
@@ -30,51 +30,38 @@
 
 G_BEGIN_DECLS
 
-#define TERM_ESCAPE_SEQUENCE(type,seq)                   \
-    static inline const char* get_##type (void) {        \
-      if (glnx_stdout_is_tty ())                         \
-        return seq;                                      \
-      return "";                                         \
-    }
+#define TERM_ESCAPE_SEQUENCE(type, seq)                                                            \
+  static inline const char *get_##type (void)                                                      \
+  {                                                                                                \
+    if (glnx_stdout_is_tty ())                                                                     \
+      return seq;                                                                                  \
+    return "";                                                                                     \
+  }
 
-TERM_ESCAPE_SEQUENCE(red_start,  "\x1b[31m")
-TERM_ESCAPE_SEQUENCE(red_end,    "\x1b[22m")
-TERM_ESCAPE_SEQUENCE(bold_start, "\x1b[1m")
-TERM_ESCAPE_SEQUENCE(bold_end,   "\x1b[0m")
+TERM_ESCAPE_SEQUENCE (red_start, "\x1b[31m")
+TERM_ESCAPE_SEQUENCE (red_end, "\x1b[22m")
+TERM_ESCAPE_SEQUENCE (bold_start, "\x1b[1m")
+TERM_ESCAPE_SEQUENCE (bold_end, "\x1b[0m")
 
 #undef TERM_ESCAPE_SEQUENCE
 
-void
-rpmostree_print_kv_no_newline (const char *key,
-                               guint       maxkeylen,
-                               const char *value);
+void rpmostree_print_kv_no_newline (const char *key, guint maxkeylen, const char *value);
 
-void
-rpmostree_print_kv (const char *key,
-                    guint       maxkeylen,
-                    const char *value);
+void rpmostree_print_kv (const char *key, guint maxkeylen, const char *value);
 
-void
-rpmostree_usage_error (GOptionContext  *context,
-                       const char      *message,
-                       GError         **error);
+void rpmostree_usage_error (GOptionContext *context, const char *message, GError **error);
 
-gboolean
-rpmostree_has_new_default_deployment (RPMOSTreeOS *os_proxy,
-                                      GVariant    *previous_deployment);
+gboolean rpmostree_has_new_default_deployment (RPMOSTreeOS *os_proxy,
+                                               GVariant *previous_deployment);
 
-namespace rpmostreecxx {
+namespace rpmostreecxx
+{
 
-void
-print_treepkg_diff_from_sysroot_path (rust::Str      sysroot_path,
-                                      RpmOstreeDiffPrintFormat format,
-                                      guint32        max_key_len,
-                                      GCancellable  *cancellable);
+void print_treepkg_diff_from_sysroot_path (rust::Str sysroot_path, RpmOstreeDiffPrintFormat format,
+                                           guint32 max_key_len, GCancellable *cancellable);
 }
 
-void
-rpmostree_print_timestamp_version (const char  *version_string,
-                                   const char  *timestamp_string,
-                                   guint        max_key_len);
+void rpmostree_print_timestamp_version (const char *version_string, const char *timestamp_string,
+                                        guint max_key_len);
 
 G_END_DECLS

--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -20,8 +20,8 @@
 
 #include "config.h"
 
-#include "rpmostree-override-builtins.h"
 #include "rpmostree-libbuiltin.h"
+#include "rpmostree-override-builtins.h"
 
 #include <libglnx.h>
 
@@ -39,47 +39,46 @@ static gboolean opt_lock_finalization;
 static gboolean opt_experimental;
 static gboolean opt_freeze;
 
-static GOptionEntry option_entries[] = {
-  { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
-  { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot, "Initiate a reboot after operation is complete", NULL },
-  { "dry-run", 'n', 0, G_OPTION_ARG_NONE, &opt_dry_run, "Exit after printing the transaction", NULL },
-  { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization, "Prevent automatic deployment finalization on shutdown", NULL },
-  { "cache-only", 'C', 0, G_OPTION_ARG_NONE, &opt_cache_only, "Only operate on cached data", NULL },
-  { NULL }
-};
+static GOptionEntry option_entries[]
+    = { { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+        { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot,
+          "Initiate a reboot after operation is complete", NULL },
+        { "dry-run", 'n', 0, G_OPTION_ARG_NONE, &opt_dry_run, "Exit after printing the transaction",
+          NULL },
+        { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization,
+          "Prevent automatic deployment finalization on shutdown", NULL },
+        { "cache-only", 'C', 0, G_OPTION_ARG_NONE, &opt_cache_only, "Only operate on cached data",
+          NULL },
+        { NULL } };
 
-static GOptionEntry reset_option_entries[] = {
-  { "all", 'a', 0, G_OPTION_ARG_NONE, &opt_reset_all, "Reset all active overrides", NULL },
-  { NULL }
-};
+static GOptionEntry reset_option_entries[]
+    = { { "all", 'a', 0, G_OPTION_ARG_NONE, &opt_reset_all, "Reset all active overrides", NULL },
+        { NULL } };
 
-static GOptionEntry replace_option_entries[] = {
-  { "remove", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_remove_pkgs, "Remove a package", "PKG" },
-  { "experimental", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_experimental, "Allow experimental options such as --from or --freeze", NULL},
-  { "freeze", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_freeze, "Pin packages to versions found", NULL},
-  { "from", 'r', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_from, "Source of override", "KIND=NAME" },
-  { NULL }
-};
+static GOptionEntry replace_option_entries[]
+    = { { "remove", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_remove_pkgs, "Remove a package", "PKG" },
+        { "experimental", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_experimental,
+          "Allow experimental options such as --from or --freeze", NULL },
+        { "freeze", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_freeze,
+          "Pin packages to versions found", NULL },
+        { "from", 'r', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_from, "Source of override",
+          "KIND=NAME" },
+        { NULL } };
 
-static GOptionEntry remove_option_entries[] = {
-  { "replace", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_replace_pkgs, "Replace a package", "RPM" },
-  { NULL }
-};
+static GOptionEntry remove_option_entries[] = { { "replace", 0, 0, G_OPTION_ARG_STRING_ARRAY,
+                                                  &opt_replace_pkgs, "Replace a package", "RPM" },
+                                                { NULL } };
 
 static gboolean
-handle_override (RPMOSTreeSysroot  *sysroot_proxy,
-                 RpmOstreeCommandInvocation *invocation,
-                 const char *const *override_remove,
-                 const char *const *override_replace,
-                 const char *const *override_reset,
-                 GCancellable      *cancellable,
-                 GError           **error)
+handle_override (RPMOSTreeSysroot *sysroot_proxy, RpmOstreeCommandInvocation *invocation,
+                 const char *const *override_remove, const char *const *override_replace,
+                 const char *const *override_reset, GCancellable *cancellable, GError **error)
 {
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   RPMOSTreeOSExperimental *osexperimental_proxy = NULL;
 
-  if (!rpmostree_load_os_proxies (sysroot_proxy, opt_osname, cancellable,
-                                  &os_proxy, &osexperimental_proxy, error))
+  if (!rpmostree_load_os_proxies (sysroot_proxy, opt_osname, cancellable, &os_proxy,
+                                  &osexperimental_proxy, error))
     return FALSE;
 
   /* Perform uninstalls offline; users don't expect the "auto-update" behaviour here. But
@@ -96,11 +95,11 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
   g_variant_dict_insert (&dict, "no-overrides", "b", opt_reset_all);
   g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
   g_variant_dict_insert (&dict, "lock-finalization", "b", opt_lock_finalization);
-  g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
+  g_autoptr (GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
-  g_autoptr(GVariant) previous_deployment = rpmostree_os_dup_default_deployment (os_proxy);
-  g_autoptr(GUnixFDList) fetched_rpms_fds = NULL;
-  g_autoptr(GPtrArray) override_replace_final = NULL; 
+  g_autoptr (GVariant) previous_deployment = rpmostree_os_dup_default_deployment (os_proxy);
+  g_autoptr (GUnixFDList) fetched_rpms_fds = NULL;
+  g_autoptr (GPtrArray) override_replace_final = NULL;
 
   if (!opt_experimental && (opt_freeze || opt_from))
     return glnx_throw (error, "Must specify --experimental to use --freeze or --from");
@@ -108,9 +107,9 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
   if (override_replace && opt_experimental && opt_freeze && opt_from)
     {
       override_replace_final = g_ptr_array_new_with_free_func (free);
-      g_autoptr(GPtrArray) queries = g_ptr_array_new ();
+      g_autoptr (GPtrArray) queries = g_ptr_array_new ();
 
-      for (const char *const* it = override_replace; it && *it; it++)
+      for (const char *const *it = override_replace; it && *it; it++)
         {
           auto pkg = *it;
 
@@ -132,13 +131,12 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
           if (!rpmostree_os_call_refresh_md_sync (os_proxy, options, &refresh_transaction_address,
                                                   cancellable, error))
             return FALSE;
-          if (!rpmostree_transaction_get_response_sync (sysroot_proxy, (const char*)refresh_transaction_address,
-                                                       cancellable, error))
+          if (!rpmostree_transaction_get_response_sync (
+                  sysroot_proxy, (const char *)refresh_transaction_address, cancellable, error))
             return FALSE;
-          if (!rpmostree_osexperimental_call_download_packages_sync (osexperimental_proxy,
-                                                                     (const char *const*)queries->pdata,
-                                                                     opt_from, NULL, &fetched_rpms_fds,
-                                                                     cancellable, error))
+          if (!rpmostree_osexperimental_call_download_packages_sync (
+                  osexperimental_proxy, (const char *const *)queries->pdata, opt_from, NULL,
+                  &fetched_rpms_fds, cancellable, error))
             return FALSE;
 
           const int nfds = fetched_rpms_fds ? g_unix_fd_list_get_length (fetched_rpms_fds) : 0;
@@ -149,32 +147,23 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
               gint fd = g_unix_fd_list_get (fetched_rpms_fds, i, error);
               if (fd < 0)
                 return FALSE;
-              g_ptr_array_add (override_replace_final, g_strdup_printf ("file:///proc/self/fd/%d", fd));
+              g_ptr_array_add (override_replace_final,
+                               g_strdup_printf ("file:///proc/self/fd/%d", fd));
             }
           g_ptr_array_add (override_replace_final, NULL);
-          override_replace = (const char *const*)override_replace_final->pdata;
+          override_replace = (const char *const *)override_replace_final->pdata;
         }
     }
   g_autofree char *transaction_address = NULL;
-  if (!rpmostree_update_deployment (os_proxy,
-                                    NULL, /* set-refspec */
-                                    NULL, /* set-revision */
-                                    install_pkgs,
-                                    NULL, /* install_fileoverride_pkgs */
-                                    uninstall_pkgs,
-                                    override_replace,
-                                    override_remove,
-                                    override_reset,
-                                    NULL,
-                                    options,
-                                    &transaction_address,
-                                    cancellable,
-                                    error))
+  if (!rpmostree_update_deployment (os_proxy, NULL,     /* set-refspec */
+                                    NULL,               /* set-revision */
+                                    install_pkgs, NULL, /* install_fileoverride_pkgs */
+                                    uninstall_pkgs, override_replace, override_remove,
+                                    override_reset, NULL, options, &transaction_address,
+                                    cancellable, error))
     return FALSE;
 
-  if (!rpmostree_transaction_get_response_sync (sysroot_proxy,
-                                                transaction_address,
-                                                cancellable,
+  if (!rpmostree_transaction_get_response_sync (sysroot_proxy, transaction_address, cancellable,
                                                 error))
     return FALSE;
 
@@ -189,8 +178,10 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
         return TRUE;
 
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
-      CXX_TRY(print_treepkg_diff_from_sysroot_path (rust::Str(sysroot_path),
-            RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0, cancellable), error);
+      CXX_TRY (print_treepkg_diff_from_sysroot_path (rust::Str (sysroot_path),
+                                                     RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0,
+                                                     cancellable),
+               error);
 
       if (override_replace || override_remove)
         g_print ("Use \"rpm-ostree override reset\" to undo overrides\n");
@@ -202,10 +193,8 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
 }
 
 gboolean
-rpmostree_override_builtin_replace (int argc, char **argv,
-                                    RpmOstreeCommandInvocation *invocation,
-                                    GCancellable *cancellable,
-                                    GError **error)
+rpmostree_override_builtin_replace (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+                                    GCancellable *cancellable, GError **error)
 {
   GOptionContext *context;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
@@ -214,39 +203,30 @@ rpmostree_override_builtin_replace (int argc, char **argv,
 
   g_option_context_add_main_entries (context, replace_option_entries, NULL);
 
-  if (!rpmostree_option_context_parse (context,
-                                       option_entries,
-                                       &argc, &argv,
-                                       invocation,
-                                       cancellable,
-                                       &install_pkgs,
-                                       &uninstall_pkgs,
-                                       &sysroot_proxy,
+  if (!rpmostree_option_context_parse (context, option_entries, &argc, &argv, invocation,
+                                       cancellable, &install_pkgs, &uninstall_pkgs, &sysroot_proxy,
                                        error))
     return FALSE;
 
   if (argc < 2)
     {
-      rpmostree_usage_error (context, "At least one PACKAGE must be specified",
-                             error);
+      rpmostree_usage_error (context, "At least one PACKAGE must be specified", error);
       return FALSE;
     }
 
   /* shift to first pkgspec and ensure it's a proper strv (previous parsing
    * might have moved args around) */
-  argv++; argc--;
+  argv++;
+  argc--;
   argv[argc] = NULL;
 
-  return handle_override (sysroot_proxy, invocation,
-                          opt_remove_pkgs, (const char *const*)argv, NULL,
-                          cancellable, error);
+  return handle_override (sysroot_proxy, invocation, opt_remove_pkgs, (const char *const *)argv,
+                          NULL, cancellable, error);
 }
 
 gboolean
-rpmostree_override_builtin_remove (int argc, char **argv,
-                                   RpmOstreeCommandInvocation *invocation,
-                                   GCancellable *cancellable,
-                                   GError **error)
+rpmostree_override_builtin_remove (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+                                   GCancellable *cancellable, GError **error)
 {
   GOptionContext *context;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
@@ -255,39 +235,30 @@ rpmostree_override_builtin_remove (int argc, char **argv,
 
   g_option_context_add_main_entries (context, remove_option_entries, NULL);
 
-  if (!rpmostree_option_context_parse (context,
-                                       option_entries,
-                                       &argc, &argv,
-                                       invocation,
-                                       cancellable,
-                                       &install_pkgs,
-                                       &uninstall_pkgs,
-                                       &sysroot_proxy,
+  if (!rpmostree_option_context_parse (context, option_entries, &argc, &argv, invocation,
+                                       cancellable, &install_pkgs, &uninstall_pkgs, &sysroot_proxy,
                                        error))
     return FALSE;
 
   if (argc < 2)
     {
-      rpmostree_usage_error (context, "At least one PACKAGE must be specified",
-                             error);
+      rpmostree_usage_error (context, "At least one PACKAGE must be specified", error);
       return FALSE;
     }
 
   /* shift to first pkgspec and ensure it's a proper strv (previous parsing
    * might have moved args around) */
-  argv++; argc--;
+  argv++;
+  argc--;
   argv[argc] = NULL;
 
-  return handle_override (sysroot_proxy, invocation,
-                          (const char *const*)argv, opt_replace_pkgs, NULL,
-                          cancellable, error);
+  return handle_override (sysroot_proxy, invocation, (const char *const *)argv, opt_replace_pkgs,
+                          NULL, cancellable, error);
 }
 
 gboolean
-rpmostree_override_builtin_reset (int argc, char **argv,
-                                  RpmOstreeCommandInvocation *invocation,
-                                  GCancellable *cancellable,
-                                  GError **error)
+rpmostree_override_builtin_reset (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+                                  GCancellable *cancellable, GError **error)
 {
   GOptionContext *context;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
@@ -296,36 +267,28 @@ rpmostree_override_builtin_reset (int argc, char **argv,
 
   g_option_context_add_main_entries (context, reset_option_entries, NULL);
 
-  if (!rpmostree_option_context_parse (context,
-                                       option_entries,
-                                       &argc, &argv,
-                                       invocation,
-                                       cancellable,
-                                       &install_pkgs,
-                                       &uninstall_pkgs,
-                                       &sysroot_proxy,
+  if (!rpmostree_option_context_parse (context, option_entries, &argc, &argv, invocation,
+                                       cancellable, &install_pkgs, &uninstall_pkgs, &sysroot_proxy,
                                        error))
     return FALSE;
 
   if (argc < 2 && !opt_reset_all)
     {
-      rpmostree_usage_error (context, "At least one PACKAGE must be specified",
-                             error);
+      rpmostree_usage_error (context, "At least one PACKAGE must be specified", error);
       return FALSE;
     }
   else if (opt_reset_all && argc >= 2)
     {
-      rpmostree_usage_error (context, "Cannot specify PACKAGEs with --all",
-                             error);
+      rpmostree_usage_error (context, "Cannot specify PACKAGEs with --all", error);
       return FALSE;
     }
 
   /* shift to first pkgspec and ensure it's a proper strv (previous parsing
    * might have moved args around) */
-  argv++; argc--;
+  argv++;
+  argc--;
   argv[argc] = NULL;
 
-  return handle_override (sysroot_proxy, invocation,
-                          NULL, NULL, (const char *const*)argv,
+  return handle_override (sysroot_proxy, invocation, NULL, NULL, (const char *const *)argv,
                           cancellable, error);
 }

--- a/src/app/rpmostree-override-builtins.h
+++ b/src/app/rpmostree-override-builtins.h
@@ -26,21 +26,14 @@
 
 G_BEGIN_DECLS
 
-gboolean
-rpmostree_override_builtin_replace (int argc, char **argv,
-                                    RpmOstreeCommandInvocation *invocation,
-                                    GCancellable *cancellable,
-                                    GError **error);
-gboolean
-rpmostree_override_builtin_remove (int argc, char **argv,
-                                   RpmOstreeCommandInvocation *invocation,
-                                   GCancellable *cancellable,
-                                   GError **error);
-gboolean
-rpmostree_override_builtin_reset (int argc, char **argv,
-                                  RpmOstreeCommandInvocation *invocation,
-                                  GCancellable *cancellable,
-                                  GError **error);
+gboolean rpmostree_override_builtin_replace (int argc, char **argv,
+                                             RpmOstreeCommandInvocation *invocation,
+                                             GCancellable *cancellable, GError **error);
+gboolean rpmostree_override_builtin_remove (int argc, char **argv,
+                                            RpmOstreeCommandInvocation *invocation,
+                                            GCancellable *cancellable, GError **error);
+gboolean rpmostree_override_builtin_reset (int argc, char **argv,
+                                           RpmOstreeCommandInvocation *invocation,
+                                           GCancellable *cancellable, GError **error);
 
 G_END_DECLS
-

--- a/src/app/rpmostree-polkit-agent.cxx
+++ b/src/app/rpmostree-polkit-agent.cxx
@@ -21,26 +21,26 @@
 
 /* snipped from PackageKit/systemd */
 
-#include <stdio.h>
-#include <sys/types.h>
-#include <sys/prctl.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
 #include <dirent.h>
-#include <signal.h>
-#include <fcntl.h>
-#include <errno.h>
 #include <err.h>
-#include <inttypes.h>
-#include <sys/poll.h>
-#include <sys/wait.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <glib.h>
+#include <inttypes.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/poll.h>
+#include <sys/prctl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include "rpmostree-polkit-agent.h"
 
-#define memzero(x,l) (memset((x), 0, (l)))
-#define zero(x) (memzero(&(x), sizeof(x)))
+#define memzero(x, l) (memset ((x), 0, (l)))
+#define zero(x) (memzero (&(x), sizeof (x)))
 
 #define POLKIT_TTY_AGENT_BINARY_PATH "/usr/bin/pkttyagent"
 
@@ -99,33 +99,33 @@ fork_agent (pid_t *pid, const char *path, ...)
        * read EOF we actually do generate EOF and
        * not delay this indefinitely by because we
        * keep an unused copy of stdin around. */
-      fd = open("/dev/tty", O_WRONLY);
+      fd = open ("/dev/tty", O_WRONLY);
       if (fd < 0)
         err (EXIT_FAILURE, "Failed to open /dev/tty");
 
       if (!stdout_is_tty)
-        dup2(fd, STDOUT_FILENO);
+        dup2 (fd, STDOUT_FILENO);
 
       if (!stderr_is_tty)
-        dup2(fd, STDERR_FILENO);
+        dup2 (fd, STDERR_FILENO);
 
       if (fd > 2)
-        close(fd);
+        close (fd);
     }
 
   /* Count arguments */
   va_start (ap, path);
-  for (n = 0; va_arg(ap, char*); n++)
+  for (n = 0; va_arg (ap, char *); n++)
     ;
-  va_end(ap);
+  va_end (ap);
 
   /* Allocate strv */
-  l = (char**)alloca (sizeof(char *) * (n + 1));
+  l = (char **)alloca (sizeof (char *) * (n + 1));
 
   /* Fill in arguments */
   va_start (ap, path);
   for (i = 0; i <= n; i++)
-    l[i] = va_arg (ap, char*);
+    l[i] = va_arg (ap, char *);
   va_end (ap);
 
   execv (path, l);
@@ -168,11 +168,11 @@ fd_wait_for_event (int fd, int event, uint64_t t)
   struct pollfd pollfd;
   int r;
 
-  zero(pollfd);
+  zero (pollfd);
   pollfd.fd = fd;
   pollfd.events = event;
 
-  r = poll(&pollfd, 1, t == (uint64_t) -1 ? -1 : (int) (t / 1000));
+  r = poll (&pollfd, 1, t == (uint64_t)-1 ? -1 : (int)(t / 1000));
   if (r < 0)
     return -errno;
 
@@ -190,11 +190,12 @@ wait_for_terminate (pid_t pid)
 
   for (;;)
     {
-      if (waitpid(pid, &status, 0) < 0) {
-        if (errno == EINTR)
-          continue;
-        return -errno;
-      }
+      if (waitpid (pid, &status, 0) < 0)
+        {
+          if (errno == EINTR)
+            continue;
+          return -errno;
+        }
       return 0;
     }
 }
@@ -218,13 +219,10 @@ rpmostree_polkit_agent_open (void)
     return -errno;
 
   snprintf (notify_fd, sizeof (notify_fd), "%i", pipe_fd[1]);
-  notify_fd[sizeof (notify_fd) -1] = 0;
+  notify_fd[sizeof (notify_fd) - 1] = 0;
 
-  r = fork_agent (&agent_pid,
-                  POLKIT_TTY_AGENT_BINARY_PATH,
-                  POLKIT_TTY_AGENT_BINARY_PATH,
-                  "--notify-fd", notify_fd,
-                  "--fallback", NULL);
+  r = fork_agent (&agent_pid, POLKIT_TTY_AGENT_BINARY_PATH, POLKIT_TTY_AGENT_BINARY_PATH,
+                  "--notify-fd", notify_fd, "--fallback", NULL);
 
   /* Close the writing side, because that's the one for the agent */
   close_nointr_nofail (pipe_fd[1]);
@@ -233,7 +231,7 @@ rpmostree_polkit_agent_open (void)
     g_warning ("Failed to fork TTY ask password agent: %s", strerror (-r));
   else
     /* Wait until the agent closes the fd */
-    fd_wait_for_event (pipe_fd[0], POLLHUP, (uint64_t) -1);
+    fd_wait_for_event (pipe_fd[0], POLLHUP, (uint64_t)-1);
 
   close_nointr_nofail (pipe_fd[0]);
 

--- a/src/app/rpmostree-polkit-agent.h
+++ b/src/app/rpmostree-polkit-agent.h
@@ -23,7 +23,7 @@
 
 G_BEGIN_DECLS
 
-int rpmostree_polkit_agent_open(void);
-void rpmostree_polkit_agent_close(void);
+int rpmostree_polkit_agent_open (void);
+void rpmostree_polkit_agent_close (void);
 
 G_END_DECLS

--- a/src/app/rpmostreemain.h
+++ b/src/app/rpmostreemain.h
@@ -2,7 +2,8 @@
 
 #include "rust/cxx.h"
 
-namespace rpmostreecxx {
+namespace rpmostreecxx
+{
 
 void early_main ();
 void rpmostree_process_global_teardown ();

--- a/src/daemon/rpmostree-package-variants.h
+++ b/src/daemon/rpmostree-package-variants.h
@@ -27,27 +27,25 @@ G_BEGIN_DECLS
 
 #define RPMOSTREE_DB_DIFF_VARIANT_FORMAT G_VARIANT_TYPE ("a(sua{sv})")
 
-typedef enum {
+typedef enum
+{
   RPM_OSTREE_PACKAGE_ADDED,
   RPM_OSTREE_PACKAGE_REMOVED,
   RPM_OSTREE_PACKAGE_UPGRADED,
   RPM_OSTREE_PACKAGE_DOWNGRADED
 } RpmOstreePackageDiffTypes;
 
-gboolean
-rpm_ostree_db_diff_variant (OstreeRepo *repo,
-                            const char *from_rev,
-                            const char *to_rev,
-                            gboolean    allow_noent,
-                            GVariant  **out_variant,
-                            GCancellable *cancellable,
-                            GError **error);
+gboolean rpm_ostree_db_diff_variant (OstreeRepo *repo, const char *from_rev, const char *to_rev,
+                                     gboolean allow_noent, GVariant **out_variant,
+                                     GCancellable *cancellable, GError **error);
 
 G_END_DECLS
 
 #ifdef __cplusplus
 #include "rust/cxx.h"
-namespace rpmostreecxx {
-   GVariant *package_variant_list_for_commit (OstreeRepo &repo, rust::Str rev, GCancellable &cancellable);
+namespace rpmostreecxx
+{
+GVariant *package_variant_list_for_commit (OstreeRepo &repo, rust::Str rev,
+                                           GCancellable &cancellable);
 }
 #endif

--- a/src/daemon/rpmostree-sysroot-core.cxx
+++ b/src/daemon/rpmostree-sysroot-core.cxx
@@ -20,22 +20,22 @@
 
 #include "config.h"
 
-#include <memory>
-#include <libglnx.h>
-#include <systemd/sd-journal.h>
-#include "rpmostreed-utils.h"
 #include "rpmostree-util.h"
+#include "rpmostreed-utils.h"
+#include <libglnx.h>
+#include <memory>
 #include <string>
+#include <systemd/sd-journal.h>
 
-#include "rpmostree-sysroot-upgrader.h"
-#include "rpmostree-sysroot-core.h"
 #include "rpmostree-core.h"
-#include "rpmostree-origin.h"
-#include "rpmostree-kernel.h"
-#include "rpmostree-rpm-util.h"
-#include "rpmostree-postprocess.h"
-#include "rpmostree-output.h"
 #include "rpmostree-cxxrs.h"
+#include "rpmostree-kernel.h"
+#include "rpmostree-origin.h"
+#include "rpmostree-output.h"
+#include "rpmostree-postprocess.h"
+#include "rpmostree-rpm-util.h"
+#include "rpmostree-sysroot-core.h"
+#include "rpmostree-sysroot-upgrader.h"
 
 #include "ostree-repo.h"
 
@@ -55,33 +55,29 @@
  * let's try to be nice).
  **/
 static gboolean
-generate_baselayer_refs (OstreeSysroot            *sysroot,
-                         OstreeRepo               *repo,
-                         GCancellable             *cancellable,
-                         GError                  **error)
+generate_baselayer_refs (OstreeSysroot *sysroot, OstreeRepo *repo, GCancellable *cancellable,
+                         GError **error)
 {
   GLNX_AUTO_PREFIX_ERROR ("baselayer refs", error);
-  g_autoptr(GHashTable) refs = NULL;
-  if (!ostree_repo_list_refs_ext (repo, "rpmostree/base", &refs,
-                                  OSTREE_REPO_LIST_REFS_EXT_NONE,
+  g_autoptr (GHashTable) refs = NULL;
+  if (!ostree_repo_list_refs_ext (repo, "rpmostree/base", &refs, OSTREE_REPO_LIST_REFS_EXT_NONE,
                                   cancellable, error))
     return FALSE;
 
   /* delete all the refs */
-  GLNX_HASH_TABLE_FOREACH (refs, const char*, ref)
-    ostree_repo_transaction_set_refspec (repo, ref, NULL);
+  GLNX_HASH_TABLE_FOREACH (refs, const char *, ref)
+  ostree_repo_transaction_set_refspec (repo, ref, NULL);
 
-  g_autoptr(GHashTable) bases =
-    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+  g_autoptr (GHashTable) bases = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
   /* collect the csums */
-  { guint i = 0;
-    g_autoptr(GPtrArray) deployments =
-      ostree_sysroot_get_deployments (sysroot);
+  {
+    guint i = 0;
+    g_autoptr (GPtrArray) deployments = ostree_sysroot_get_deployments (sysroot);
 
     /* existing deployments */
     for (; i < deployments->len; i++)
       {
-        auto deployment = static_cast<OstreeDeployment*>(deployments->pdata[i]);
+        auto deployment = static_cast<OstreeDeployment *> (deployments->pdata[i]);
         g_autofree char *base_rev = NULL;
         if (!rpmostree_deployment_get_base_layer (repo, deployment, &base_rev, error))
           return FALSE;
@@ -92,12 +88,13 @@ generate_baselayer_refs (OstreeSysroot            *sysroot,
   }
 
   /* create the new refs */
-  { guint i = 0;
-    GLNX_HASH_TABLE_FOREACH (bases, const char*, base)
-      {
-        g_autofree char *ref = g_strdup_printf ("rpmostree/base/%u", i++);
-        ostree_repo_transaction_set_refspec (repo, ref, base);
-      }
+  {
+    guint i = 0;
+    GLNX_HASH_TABLE_FOREACH (bases, const char *, base)
+    {
+      g_autofree char *ref = g_strdup_printf ("rpmostree/base/%u", i++);
+      ostree_repo_transaction_set_refspec (repo, ref, base);
+    }
   }
 
   return TRUE;
@@ -108,12 +105,10 @@ generate_baselayer_refs (OstreeSysroot            *sysroot,
  * collection of layered package refs.
  */
 static gboolean
-add_package_refs_to_set (RpmOstreeRefSack *rsack,
-                         GHashTable *referenced_pkgs,
-                         GCancellable *cancellable,
-                         GError **error)
+add_package_refs_to_set (RpmOstreeRefSack *rsack, GHashTable *referenced_pkgs,
+                         GCancellable *cancellable, GError **error)
 {
-  g_autoptr(GPtrArray) pkglist = NULL;
+  g_autoptr (GPtrArray) pkglist = NULL;
   hy_autoquery HyQuery query = hy_query_create (rsack->sack);
   hy_query_filter (query, HY_PKG_REPONAME, HY_EQ, HY_SYSTEM_REPO_NAME);
   pkglist = hy_query_run (query);
@@ -126,7 +121,7 @@ add_package_refs_to_set (RpmOstreeRefSack *rsack,
     {
       for (guint i = 0; i < pkglist->len; i++)
         {
-          auto pkg = static_cast<DnfPackage *>(pkglist->pdata[i]);
+          auto pkg = static_cast<DnfPackage *> (pkglist->pdata[i]);
           g_autofree char *pkgref = rpmostree_get_cache_branch_pkg (pkg);
           g_hash_table_add (referenced_pkgs, util::move_nullify (pkgref));
         }
@@ -140,26 +135,23 @@ add_package_refs_to_set (RpmOstreeRefSack *rsack,
  * that set.
  */
 static gboolean
-generate_pkgcache_refs (OstreeSysroot            *sysroot,
-                        OstreeRepo               *repo,
-                        guint                    *out_n_freed,
-                        GCancellable             *cancellable,
-                        GError                  **error)
+generate_pkgcache_refs (OstreeSysroot *sysroot, OstreeRepo *repo, guint *out_n_freed,
+                        GCancellable *cancellable, GError **error)
 {
   GLNX_AUTO_PREFIX_ERROR ("pkgcache cleanup", error);
-  g_autoptr(GHashTable) referenced_pkgs = /* cache refs of packages we want to keep */
-    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+  g_autoptr (GHashTable) referenced_pkgs = /* cache refs of packages we want to keep */
+      g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 
-  g_autoptr(GPtrArray) deployments = ostree_sysroot_get_deployments (sysroot);
+  g_autoptr (GPtrArray) deployments = ostree_sysroot_get_deployments (sysroot);
   for (guint i = 0; i < deployments->len; i++)
     {
-      auto deployment = static_cast<OstreeDeployment *>(deployments->pdata[i]);
+      auto deployment = static_cast<OstreeDeployment *> (deployments->pdata[i]);
 
       g_autofree char *base_commit = NULL;
       if (!rpmostree_deployment_get_base_layer (repo, deployment, &base_commit, error))
         return FALSE;
 
-      g_autoptr(RpmOstreeOrigin) origin = rpmostree_origin_parse_deployment (deployment, error);
+      g_autoptr (RpmOstreeOrigin) origin = rpmostree_origin_parse_deployment (deployment, error);
       if (!origin)
         return FALSE;
 
@@ -170,15 +162,14 @@ generate_pkgcache_refs (OstreeSysroot            *sysroot,
        */
       if (base_commit)
         {
-          g_autofree char *deployment_dirpath =
-            ostree_sysroot_get_deployment_dirpath (sysroot, deployment);
+          g_autofree char *deployment_dirpath
+              = ostree_sysroot_get_deployment_dirpath (sysroot, deployment);
 
           /* We could do this via the commit object, but it's faster
            * to reuse the existing rpmdb checkout.
            */
-          g_autoptr(RpmOstreeRefSack) rsack =
-            rpmostree_get_refsack_for_root (ostree_sysroot_get_fd (sysroot),
-                                            deployment_dirpath, error);
+          g_autoptr (RpmOstreeRefSack) rsack = rpmostree_get_refsack_for_root (
+              ostree_sysroot_get_fd (sysroot), deployment_dirpath, error);
           if (rsack == NULL)
             return FALSE;
 
@@ -188,27 +179,27 @@ generate_pkgcache_refs (OstreeSysroot            *sysroot,
 
       /* also add any inactive local replacements */
       GHashTable *local_replace = rpmostree_origin_get_overrides_local_replace (origin);
-      GLNX_HASH_TABLE_FOREACH (local_replace, const char*, nevra)
-        {
-          auto cachebranch = CXX_TRY_VAL(nevra_to_cache_branch (std::string(nevra)), error);
-          g_hash_table_add (referenced_pkgs, g_strdup (cachebranch.c_str()));
-        }
+      GLNX_HASH_TABLE_FOREACH (local_replace, const char *, nevra)
+      {
+        auto cachebranch = CXX_TRY_VAL (nevra_to_cache_branch (std::string (nevra)), error);
+        g_hash_table_add (referenced_pkgs, g_strdup (cachebranch.c_str ()));
+      }
     }
 
   guint n_freed = 0;
   /* Loop over layered refs */
-  g_autoptr(GHashTable) pkg_refs = NULL;
-  if (!ostree_repo_list_refs_ext (repo, "rpmostree/pkg", &pkg_refs,
-                                  OSTREE_REPO_LIST_REFS_EXT_NONE, cancellable, error))
+  g_autoptr (GHashTable) pkg_refs = NULL;
+  if (!ostree_repo_list_refs_ext (repo, "rpmostree/pkg", &pkg_refs, OSTREE_REPO_LIST_REFS_EXT_NONE,
+                                  cancellable, error))
     return FALSE;
-  GLNX_HASH_TABLE_FOREACH (pkg_refs, const char*, ref)
-    {
-      if (g_hash_table_contains (referenced_pkgs, ref))
-        continue;
+  GLNX_HASH_TABLE_FOREACH (pkg_refs, const char *, ref)
+  {
+    if (g_hash_table_contains (referenced_pkgs, ref))
+      continue;
 
-      ostree_repo_transaction_set_ref (repo, NULL, ref, NULL);
-      n_freed++;
-    }
+    ostree_repo_transaction_set_ref (repo, NULL, ref, NULL);
+    n_freed++;
+  }
 
   *out_n_freed = n_freed;
   return TRUE;
@@ -216,15 +207,14 @@ generate_pkgcache_refs (OstreeSysroot            *sysroot,
 
 /* Regenerate base and pkgcache refs */
 static gboolean
-syscore_regenerate_refs (OstreeSysroot            *sysroot,
-                         OstreeRepo               *repo,
-                         guint                    *out_n_pkgcache_freed,
-                         GCancellable             *cancellable,
-                         GError                  **error)
+syscore_regenerate_refs (OstreeSysroot *sysroot, OstreeRepo *repo, guint *out_n_pkgcache_freed,
+                         GCancellable *cancellable, GError **error)
 {
   GLNX_AUTO_PREFIX_ERROR ("regenerating refs", error);
 
-  g_auto(RpmOstreeRepoAutoTransaction) txn = { 0, };
+  g_auto (RpmOstreeRepoAutoTransaction) txn = {
+    0,
+  };
   if (!rpmostree_repo_auto_transaction_start (&txn, repo, FALSE, cancellable, error))
     return FALSE;
 
@@ -250,10 +240,8 @@ syscore_regenerate_refs (OstreeSysroot            *sysroot,
  * but is now used by the cleanup txn.
  */
 gboolean
-rpmostree_syscore_cleanup (OstreeSysroot            *sysroot,
-                           OstreeRepo               *repo,
-                           GCancellable             *cancellable,
-                           GError                  **error)
+rpmostree_syscore_cleanup (OstreeSysroot *sysroot, OstreeRepo *repo, GCancellable *cancellable,
+                           GError **error)
 {
   GLNX_AUTO_PREFIX_ERROR ("syscore cleanup", error);
   int repo_dfd = ostree_repo_get_dfd (repo); /* borrowed */
@@ -263,37 +251,35 @@ rpmostree_syscore_cleanup (OstreeSysroot            *sysroot,
     return FALSE;
   /* delete our checkout dir in case a previous run didn't finish
      successfully */
-  if (!glnx_shutil_rm_rf_at (repo_dfd, RPMOSTREE_TMP_ROOTFS_DIR,
-                             cancellable, error))
+  if (!glnx_shutil_rm_rf_at (repo_dfd, RPMOSTREE_TMP_ROOTFS_DIR, cancellable, error))
     return glnx_prefix_error (error, "cleaning tmp rootfs");
   /* also delete extra history entries */
-  CXX_TRY(history_prune(), error);
+  CXX_TRY (history_prune (), error);
 
   /* Regenerate all refs */
   guint n_pkgcache_freed = 0;
-  if (!syscore_regenerate_refs (sysroot, repo, &n_pkgcache_freed,
-                                cancellable, error))
+  if (!syscore_regenerate_refs (sysroot, repo, &n_pkgcache_freed, cancellable, error))
     return FALSE;
 
   /* Refs for the live state */
-  CXX_TRY(applylive_sync_ref(*sysroot), error);
+  CXX_TRY (applylive_sync_ref (*sysroot), error);
 
   /* And do a prune */
   guint64 freed_space;
   gint n_objects_total, n_objects_pruned;
-  { g_autoptr(GHashTable) reachable = ostree_repo_traverse_new_reachable ();
+  {
+    g_autoptr (GHashTable) reachable = ostree_repo_traverse_new_reachable ();
     OstreeRepoPruneOptions opts = { OSTREE_REPO_PRUNE_FLAGS_REFS_ONLY, reachable };
-    if (!ostree_sysroot_cleanup_prune_repo (sysroot, &opts, &n_objects_total,
-                                            &n_objects_pruned, &freed_space,
-                                            cancellable, error))
+    if (!ostree_sysroot_cleanup_prune_repo (sysroot, &opts, &n_objects_total, &n_objects_pruned,
+                                            &freed_space, cancellable, error))
       return glnx_prefix_error (error, "pruning");
   }
 
   if (n_pkgcache_freed > 0 || freed_space > 0)
     {
       g_autofree char *freed_space_str = g_format_size_full (freed_space, G_FORMAT_SIZE_DEFAULT);
-      rpmostree_output_message ("Freed: %s (pkgcache branches: %u)",
-                                freed_space_str, n_pkgcache_freed);
+      rpmostree_output_message ("Freed: %s (pkgcache branches: %u)", freed_space_str,
+                                n_pkgcache_freed);
     }
 
   return TRUE;
@@ -306,16 +292,16 @@ rpmostree_syscore_cleanup (OstreeSysroot            *sysroot,
 OstreeDeployment *
 rpmostree_syscore_get_origin_merge_deployment (OstreeSysroot *self, const char *osname)
 {
-  g_autoptr(GPtrArray) deployments = ostree_sysroot_get_deployments (self);
+  g_autoptr (GPtrArray) deployments = ostree_sysroot_get_deployments (self);
 
   for (guint i = 0; i < deployments->len; i++)
     {
-      auto deployment = static_cast<OstreeDeployment*>(deployments->pdata[i]);
+      auto deployment = static_cast<OstreeDeployment *> (deployments->pdata[i]);
 
       if (strcmp (ostree_deployment_get_osname (deployment), osname) != 0)
         continue;
 
-      return (OstreeDeployment*)g_object_ref (deployment);
+      return (OstreeDeployment *)g_object_ref (deployment);
     }
 
   return NULL;
@@ -326,8 +312,7 @@ rpmostree_syscore_get_origin_merge_deployment (OstreeSysroot *self, const char *
  * to notify of changes to e.g. live replaced xattrs.
  */
 gboolean
-rpmostree_syscore_bump_mtime (OstreeSysroot   *sysroot,
-                              GError         **error)
+rpmostree_syscore_bump_mtime (OstreeSysroot *sysroot, GError **error)
 {
   if (utimensat (ostree_sysroot_get_fd (sysroot), "ostree/deploy", NULL, 0) < 0)
     return glnx_throw_errno_prefix (error, "futimens");
@@ -338,13 +323,11 @@ rpmostree_syscore_bump_mtime (OstreeSysroot   *sysroot,
  * just trying to remove a pending and/or rollback.
  */
 GPtrArray *
-rpmostree_syscore_filter_deployments (OstreeSysroot      *sysroot,
-                                      const char         *osname,
-                                      gboolean            cleanup_pending,
-                                      gboolean            cleanup_rollback)
+rpmostree_syscore_filter_deployments (OstreeSysroot *sysroot, const char *osname,
+                                      gboolean cleanup_pending, gboolean cleanup_rollback)
 {
-  g_autoptr(GPtrArray) deployments = ostree_sysroot_get_deployments (sysroot);
-  g_autoptr(GPtrArray) new_deployments = g_ptr_array_new_with_free_func (g_object_unref);
+  g_autoptr (GPtrArray) deployments = ostree_sysroot_get_deployments (sysroot);
+  g_autoptr (GPtrArray) new_deployments = g_ptr_array_new_with_free_func (g_object_unref);
   OstreeDeployment *booted_deployment = NULL;
   gboolean found_booted = FALSE;
 
@@ -352,20 +335,19 @@ rpmostree_syscore_filter_deployments (OstreeSysroot      *sysroot,
 
   for (guint i = 0; i < deployments->len; i++)
     {
-      auto deployment = static_cast<OstreeDeployment*>(deployments->pdata[i]);
+      auto deployment = static_cast<OstreeDeployment *> (deployments->pdata[i]);
 
       /* Is this deployment booted?  If so, note we're past the booted,
        * and ensure it's added. */
-      if (booted_deployment != NULL &&
-          ostree_deployment_equal (deployment, booted_deployment))
+      if (booted_deployment != NULL && ostree_deployment_equal (deployment, booted_deployment))
         {
           found_booted = TRUE;
           g_ptr_array_add (new_deployments, g_object_ref (deployment));
           continue;
         }
 
-      const gboolean osname_matches =
-        strcmp (ostree_deployment_get_osname (deployment), osname) == 0;
+      const gboolean osname_matches
+          = strcmp (ostree_deployment_get_osname (deployment), osname) == 0;
       /* Retain deployments for other osnames, as well as pinned ones */
       if (!osname_matches || ostree_deployment_is_pinned (deployment))
         {
@@ -392,36 +374,36 @@ rpmostree_syscore_filter_deployments (OstreeSysroot      *sysroot,
 /* A wrapper around ostree_sysroot_simple_write_deployment() that makes it easy to push
  * livefs rollbacks as well as retain them afterwards */
 gboolean
-rpmostree_syscore_write_deployment (OstreeSysroot           *sysroot,
-                                    OstreeDeployment        *new_deployment,
-                                    OstreeDeployment        *merge_deployment,
-                                    gboolean                 pushing_rollback,
-                                    GCancellable            *cancellable,
-                                    GError                 **error)
+rpmostree_syscore_write_deployment (OstreeSysroot *sysroot, OstreeDeployment *new_deployment,
+                                    OstreeDeployment *merge_deployment, gboolean pushing_rollback,
+                                    GCancellable *cancellable, GError **error)
 {
   OstreeRepo *repo = ostree_sysroot_repo (sysroot);
 
   /* we do our own cleanup afterwards */
-  auto flags = static_cast<OstreeSysrootSimpleWriteDeploymentFlags>(OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_NO_CLEAN);
+  auto flags = static_cast<OstreeSysrootSimpleWriteDeploymentFlags> (
+      OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_NO_CLEAN);
 
   if (pushing_rollback)
-    flags = static_cast<OstreeSysrootSimpleWriteDeploymentFlags>(flags | OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_NOT_DEFAULT |
-              OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_RETAIN_PENDING);
+    flags = static_cast<OstreeSysrootSimpleWriteDeploymentFlags> (
+        flags | OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_NOT_DEFAULT
+        | OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_RETAIN_PENDING);
   else
     {
       /* make sure rollbacks of live deployments aren't pruned */
       OstreeDeployment *booted = ostree_sysroot_get_booted_deployment (sysroot);
       if (booted)
         {
-          auto is_live = CXX_TRY_VAL(has_live_apply_state(*sysroot, *booted), error);
+          auto is_live = CXX_TRY_VAL (has_live_apply_state (*sysroot, *booted), error);
           if (is_live)
-            flags = static_cast<OstreeSysrootSimpleWriteDeploymentFlags>(flags | OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_RETAIN_ROLLBACK);
+            flags = static_cast<OstreeSysrootSimpleWriteDeploymentFlags> (
+                flags | OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_RETAIN_ROLLBACK);
         }
     }
 
   const char *osname = ostree_deployment_get_osname (new_deployment);
-  if (!ostree_sysroot_simple_write_deployment (sysroot, osname, new_deployment,
-                                               merge_deployment, flags, cancellable, error))
+  if (!ostree_sysroot_simple_write_deployment (sysroot, osname, new_deployment, merge_deployment,
+                                               flags, cancellable, error))
     return FALSE;
 
   if (!rpmostree_syscore_cleanup (sysroot, repo, cancellable, error))

--- a/src/daemon/rpmostree-sysroot-core.h
+++ b/src/daemon/rpmostree-sysroot-core.h
@@ -37,26 +37,21 @@ G_BEGIN_DECLS
  * /run/ostree/staged-deployment path and company. */
 #define _OSTREE_SYSROOT_RUNSTATE_STAGED_LOCKED "/run/ostree/staged-deployment-locked"
 
-gboolean
-rpmostree_syscore_cleanup (OstreeSysroot            *sysroot,
-                           OstreeRepo               *repo,
-                           GCancellable             *cancellable,
-                           GError                  **error);
+gboolean rpmostree_syscore_cleanup (OstreeSysroot *sysroot, OstreeRepo *repo,
+                                    GCancellable *cancellable, GError **error);
 
-OstreeDeployment *rpmostree_syscore_get_origin_merge_deployment (OstreeSysroot *self, const char *osname);
+OstreeDeployment *rpmostree_syscore_get_origin_merge_deployment (OstreeSysroot *self,
+                                                                 const char *osname);
 
 gboolean rpmostree_syscore_bump_mtime (OstreeSysroot *self, GError **error);
 
-GPtrArray *rpmostree_syscore_filter_deployments (OstreeSysroot      *sysroot,
-                                                 const char         *osname,
-                                                 gboolean            remove_pending,
-                                                 gboolean            remove_rollback);
+GPtrArray *rpmostree_syscore_filter_deployments (OstreeSysroot *sysroot, const char *osname,
+                                                 gboolean remove_pending, gboolean remove_rollback);
 
-gboolean rpmostree_syscore_write_deployment (OstreeSysroot           *sysroot,
-                                             OstreeDeployment        *new_deployment,
-                                             OstreeDeployment        *merge_deployment,
-                                             gboolean                 pushing_rollback,
-                                             GCancellable            *cancellable,
-                                             GError                 **error);
+gboolean rpmostree_syscore_write_deployment (OstreeSysroot *sysroot,
+                                             OstreeDeployment *new_deployment,
+                                             OstreeDeployment *merge_deployment,
+                                             gboolean pushing_rollback, GCancellable *cancellable,
+                                             GError **error);
 
 G_END_DECLS

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -19,31 +19,31 @@
  */
 
 #include "config.h"
-#include <sstream>
 #include <optional>
+#include <sstream>
 
-#include <libglnx.h>
-#include <gio/gunixoutputstream.h>
-#include <systemd/sd-journal.h>
-#include "rpmostreed-utils.h"
 #include "rpmostree-util.h"
+#include "rpmostreed-utils.h"
+#include <gio/gunixoutputstream.h>
+#include <libglnx.h>
+#include <systemd/sd-journal.h>
 
-#include "rpmostree-sysroot-upgrader.h"
 #include "rpmostree-core.h"
-#include "rpmostree-origin.h"
+#include "rpmostree-cxxrs.h"
 #include "rpmostree-kernel.h"
+#include "rpmostree-origin.h"
+#include "rpmostree-output.h"
+#include "rpmostree-postprocess.h"
+#include "rpmostree-rpm-util.h"
+#include "rpmostree-scripts.h"
+#include "rpmostree-sysroot-upgrader.h"
 #include "rpmostreed-daemon.h"
 #include "rpmostreed-deployment-utils.h"
-#include "rpmostree-kernel.h"
-#include "rpmostree-rpm-util.h"
-#include "rpmostree-postprocess.h"
-#include "rpmostree-output.h"
-#include "rpmostree-scripts.h"
-#include "rpmostree-cxxrs.h"
 
 #include "ostree-repo.h"
 
-#define RPMOSTREE_NEW_DEPLOYMENT_MSG SD_ID128_MAKE(9b,dd,bd,a1,77,cd,44,d8,91,b1,b5,61,a8,a0,ce,9e)
+#define RPMOSTREE_NEW_DEPLOYMENT_MSG                                                               \
+  SD_ID128_MAKE (9b, dd, bd, a1, 77, cd, 44, d8, 91, b1, b5, 61, a8, a0, ce, 9e)
 
 /**
  * SECTION:rpmostree-sysroot-upgrader
@@ -51,19 +51,20 @@
  * @short_description: Client side update for rpm-ostree systems
  *
  * The base libostree "upgrade" logic is ultimately very simple - a client
- * system is tracking a single ostree branch.  This appears as 
+ * system is tracking a single ostree branch.  This appears as
  * `origin/refspec` key in the origin file.
  *
  * rpm-ostree has much more logic and sophistication - optional package layering, overrides,
  * client side initramfs regeneration, etc.
  *
- * This upgrader is intended to be similar to [OstreeSysrootUpgrader](https://ostreedev.github.io/ostree/reference/ostree-Simple-upgrade-class.html).
+ * This upgrader is intended to be similar to
+ * [OstreeSysrootUpgrader](https://ostreedev.github.io/ostree/reference/ostree-Simple-upgrade-class.html).
  * If none of those features are enabled, then all we do is pull new OSTree updates.
  *
  * If extended features are enabled, rpm-ostree adds keys the base ostree "origin" file logic;
  * see also `rpmostree-origin.h`.  Most of the manipulation of the origin file is performed
  * via DBus in `rpmostree-transaction-types.cxx`.
- * 
+ *
  * One important subtlety here is optimizing the case of
  * e.g. `rpm-ostree install --allow-inactive docker` on a system that already has `docker`
  * installed.  The intended semantics here are that we just notice `docker` is installed
@@ -73,11 +74,13 @@
  * installed, then we remove it from the `computed_origin` package list.  If the final set
  * of requested packages is empty, we then know not to enable the client-side libdnf bits.
  */
-typedef struct {
+typedef struct
+{
   GObjectClass parent_class;
 } RpmOstreeSysrootUpgraderClass;
 
-struct RpmOstreeSysrootUpgrader {
+struct RpmOstreeSysrootUpgrader
+{
   GObject parent;
 
   OstreeSysroot *sysroot;
@@ -96,7 +99,7 @@ struct RpmOstreeSysrootUpgrader {
   // to e.g. avoid fetching rpm-md if all we have is "inactive requests".
   // Longer term, this functionality should be moved down into the core.
   RpmOstreeOrigin *computed_origin;
-  std::optional<rust::Box<rpmostreecxx::Treefile>> treefile;
+  std::optional<rust::Box<rpmostreecxx::Treefile> > treefile;
 
   /* Used during tree construction */
   OstreeRepoDevInoCache *devino_cache;
@@ -109,14 +112,15 @@ struct RpmOstreeSysrootUpgrader {
   gboolean layering_initialized; /* Whether layering_type is known */
   RpmOstreeSysrootUpgraderLayeringType layering_type;
   gboolean layering_changed; /* Whether changes to layering should result in a new commit */
-  gboolean pkgs_imported; /* Whether pkgs to be layered have been downloaded & imported */
-  char *base_revision; /* Non-layered replicated commit */
-  char *final_revision; /* Computed by layering; if NULL, only using base_revision */
+  gboolean pkgs_imported;    /* Whether pkgs to be layered have been downloaded & imported */
+  char *base_revision;       /* Non-layered replicated commit */
+  char *final_revision;      /* Computed by layering; if NULL, only using base_revision */
 
   char **kargs_strv; /* Kernel argument list to be written into deployment  */
 };
 
-enum {
+enum
+{
   PROP_0,
 
   PROP_SYSROOT,
@@ -127,25 +131,23 @@ enum {
 static void rpmostree_sysroot_upgrader_initable_iface_init (GInitableIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (RpmOstreeSysrootUpgrader, rpmostree_sysroot_upgrader, G_TYPE_OBJECT,
-                         G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE, rpmostree_sysroot_upgrader_initable_iface_init))
+                         G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE,
+                                                rpmostree_sysroot_upgrader_initable_iface_init))
 
 static gboolean
-parse_origin_deployment (RpmOstreeSysrootUpgrader *self,
-                         OstreeDeployment         *deployment,
-                         GCancellable           *cancellable,
-                         GError                **error)
+parse_origin_deployment (RpmOstreeSysrootUpgrader *self, OstreeDeployment *deployment,
+                         GCancellable *cancellable, GError **error)
 {
   self->original_origin = rpmostree_origin_parse_deployment (deployment, error);
   if (!self->original_origin)
     return FALSE;
   rpmostree_origin_remove_transient_state (self->original_origin);
 
-  if (rpmostree_origin_get_unconfigured_state (self->original_origin) &&
-      !(self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED))
+  if (rpmostree_origin_get_unconfigured_state (self->original_origin)
+      && !(self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED))
     {
       /* explicit action is required OS creator to upgrade, print their text as an error */
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "origin unconfigured-state: %s",
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "origin unconfigured-state: %s",
                    rpmostree_origin_get_unconfigured_state (self->original_origin));
       return FALSE;
     }
@@ -156,14 +158,12 @@ parse_origin_deployment (RpmOstreeSysrootUpgrader *self,
 }
 
 static gboolean
-rpmostree_sysroot_upgrader_initable_init (GInitable        *initable,
-                                          GCancellable     *cancellable,
-                                          GError          **error)
+rpmostree_sysroot_upgrader_initable_init (GInitable *initable, GCancellable *cancellable,
+                                          GError **error)
 {
-  RpmOstreeSysrootUpgrader *self = (RpmOstreeSysrootUpgrader*)initable;
+  RpmOstreeSysrootUpgrader *self = (RpmOstreeSysrootUpgrader *)initable;
 
-  OstreeDeployment *booted_deployment =
-    ostree_sysroot_get_booted_deployment (self->sysroot);
+  OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment (self->sysroot);
   if (booted_deployment == NULL && self->osname == NULL)
     return glnx_throw (error, "Not currently booted into an OSTree system and no OS specified");
 
@@ -178,23 +178,19 @@ rpmostree_sysroot_upgrader_initable_init (GInitable        *initable,
   if (!ostree_sysroot_get_repo (self->sysroot, &self->repo, cancellable, error))
     return FALSE;
 
-  self->cfg_merge_deployment =
-    ostree_sysroot_get_merge_deployment (self->sysroot, self->osname);
-  self->origin_merge_deployment =
-    rpmostree_syscore_get_origin_merge_deployment (self->sysroot, self->osname);
+  self->cfg_merge_deployment = ostree_sysroot_get_merge_deployment (self->sysroot, self->osname);
+  self->origin_merge_deployment
+      = rpmostree_syscore_get_origin_merge_deployment (self->sysroot, self->osname);
   if (self->cfg_merge_deployment == NULL || self->origin_merge_deployment == NULL)
-    return glnx_throw (error, "No previous deployment for OS '%s'",
-                       self->osname);
+    return glnx_throw (error, "No previous deployment for OS '%s'", self->osname);
 
   /* Should we consider requiring --discard-hotfix here?
    * See also `ostree admin upgrade` bits.
    */
-  if (!parse_origin_deployment (self, self->origin_merge_deployment,
-                                cancellable, error))
+  if (!parse_origin_deployment (self, self->origin_merge_deployment, cancellable, error))
     return FALSE;
 
-  const char *merge_deployment_csum =
-    ostree_deployment_get_csum (self->origin_merge_deployment);
+  const char *merge_deployment_csum = ostree_deployment_get_csum (self->origin_merge_deployment);
 
   /* Now, load starting base/final checksums.  We may end up changing
    * one or both if we upgrade.  But we also want to support redeploying
@@ -252,23 +248,21 @@ rpmostree_sysroot_upgrader_finalize (GObject *object)
 }
 
 static void
-rpmostree_sysroot_upgrader_set_property (GObject         *object,
-                                         guint            prop_id,
-                                         const GValue    *value,
-                                         GParamSpec      *pspec)
+rpmostree_sysroot_upgrader_set_property (GObject *object, guint prop_id, const GValue *value,
+                                         GParamSpec *pspec)
 {
   RpmOstreeSysrootUpgrader *self = RPMOSTREE_SYSROOT_UPGRADER (object);
 
   switch (prop_id)
     {
     case PROP_SYSROOT:
-      self->sysroot = (OstreeSysroot*)g_value_dup_object (value);
+      self->sysroot = (OstreeSysroot *)g_value_dup_object (value);
       break;
     case PROP_OSNAME:
       self->osname = g_value_dup_string (value);
       break;
     case PROP_FLAGS:
-      self->flags = static_cast<RpmOstreeSysrootUpgraderFlags>(g_value_get_flags (value));
+      self->flags = static_cast<RpmOstreeSysrootUpgraderFlags> (g_value_get_flags (value));
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -277,10 +271,8 @@ rpmostree_sysroot_upgrader_set_property (GObject         *object,
 }
 
 static void
-rpmostree_sysroot_upgrader_get_property (GObject         *object,
-                                         guint            prop_id,
-                                         GValue          *value,
-                                         GParamSpec      *pspec)
+rpmostree_sysroot_upgrader_get_property (GObject *object, guint prop_id, GValue *value,
+                                         GParamSpec *pspec)
 {
   RpmOstreeSysrootUpgrader *self = RPMOSTREE_SYSROOT_UPGRADER (object);
 
@@ -321,23 +313,20 @@ rpmostree_sysroot_upgrader_class_init (RpmOstreeSysrootUpgraderClass *klass)
   object_class->set_property = rpmostree_sysroot_upgrader_set_property;
   object_class->finalize = rpmostree_sysroot_upgrader_finalize;
 
-  g_object_class_install_property (object_class,
-                                   PROP_SYSROOT,
-                                   g_param_spec_object ("sysroot", "", "",
-                                                        OSTREE_TYPE_SYSROOT,
-                                                        static_cast<GParamFlags>(G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
+  g_object_class_install_property (
+      object_class, PROP_SYSROOT,
+      g_param_spec_object ("sysroot", "", "", OSTREE_TYPE_SYSROOT,
+                           static_cast<GParamFlags> (G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
 
-  g_object_class_install_property (object_class,
-                                   PROP_OSNAME,
-                                   g_param_spec_string ("osname", "", "", NULL,
-                                                        static_cast<GParamFlags>(G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
+  g_object_class_install_property (
+      object_class, PROP_OSNAME,
+      g_param_spec_string ("osname", "", "", NULL,
+                           static_cast<GParamFlags> (G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
 
-  g_object_class_install_property (object_class,
-                                   PROP_FLAGS,
-                                   g_param_spec_flags ("flags", "", "",
-                                                       rpmostree_sysroot_upgrader_flags_get_type (),
-                                                       0,
-                                                       static_cast<GParamFlags>(G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
+  g_object_class_install_property (
+      object_class, PROP_FLAGS,
+      g_param_spec_flags ("flags", "", "", rpmostree_sysroot_upgrader_flags_get_type (), 0,
+                          static_cast<GParamFlags> (G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
 }
 
 static void
@@ -355,21 +344,19 @@ rpmostree_sysroot_upgrader_init (RpmOstreeSysrootUpgrader *self)
  * Returns: (transfer full): An upgrader
  */
 RpmOstreeSysrootUpgrader *
-rpmostree_sysroot_upgrader_new (OstreeSysroot              *sysroot,
-                                const char                 *osname,
-                                RpmOstreeSysrootUpgraderFlags  flags,
-                                GCancellable               *cancellable,
-                                GError                    **error)
+rpmostree_sysroot_upgrader_new (OstreeSysroot *sysroot, const char *osname,
+                                RpmOstreeSysrootUpgraderFlags flags, GCancellable *cancellable,
+                                GError **error)
 {
-  return (RpmOstreeSysrootUpgrader*)g_initable_new (RPMOSTREE_TYPE_SYSROOT_UPGRADER, cancellable, error,
-                         "sysroot", sysroot, "osname", osname, "flags", flags, NULL);
+  return (RpmOstreeSysrootUpgrader *)g_initable_new (RPMOSTREE_TYPE_SYSROOT_UPGRADER, cancellable,
+                                                     error, "sysroot", sysroot, "osname", osname,
+                                                     "flags", flags, NULL);
 }
 
 void
-rpmostree_sysroot_upgrader_set_caller_info (RpmOstreeSysrootUpgrader *self, 
-                                            const char               *initiating_command_line, 
-                                            const char               *agent, 
-                                            const char               *sd_unit)
+rpmostree_sysroot_upgrader_set_caller_info (RpmOstreeSysrootUpgrader *self,
+                                            const char *initiating_command_line, const char *agent,
+                                            const char *sd_unit)
 {
   g_free (self->command_line);
   self->command_line = g_strdup (initiating_command_line);
@@ -386,8 +373,7 @@ rpmostree_sysroot_upgrader_dup_origin (RpmOstreeSysrootUpgrader *self)
 }
 
 void
-rpmostree_sysroot_upgrader_set_origin (RpmOstreeSysrootUpgrader *self,
-                                       RpmOstreeOrigin          *new_origin)
+rpmostree_sysroot_upgrader_set_origin (RpmOstreeSysrootUpgrader *self, RpmOstreeOrigin *new_origin)
 {
   rpmostree_origin_unref (self->original_origin);
   self->original_origin = rpmostree_origin_dup (new_origin);
@@ -401,16 +387,15 @@ rpmostree_sysroot_upgrader_get_base (RpmOstreeSysrootUpgrader *self)
   return self->base_revision;
 }
 
-OstreeDeployment*
+OstreeDeployment *
 rpmostree_sysroot_upgrader_get_merge_deployment (RpmOstreeSysrootUpgrader *self)
 {
   return self->origin_merge_deployment;
 }
 
 /* Returns DnfSack used, if any. */
-DnfSack*
-rpmostree_sysroot_upgrader_get_sack (RpmOstreeSysrootUpgrader *self,
-                                     GError                  **error)
+DnfSack *
+rpmostree_sysroot_upgrader_get_sack (RpmOstreeSysrootUpgrader *self, GError **error)
 {
   return self->rpmmd_sack;
 }
@@ -420,20 +405,15 @@ rpmostree_sysroot_upgrader_get_sack (RpmOstreeSysrootUpgrader *self,
  * use when doing layered packages.
  */
 gboolean
-rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
-                                      const char             *dir_to_pull,
-                                      OstreeRepoPullFlags     flags,
-                                      OstreeAsyncProgress    *progress,
-                                      gboolean               *out_changed,
-                                      GCancellable           *cancellable,
-                                      GError                **error)
+rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader *self, const char *dir_to_pull,
+                                      OstreeRepoPullFlags flags, OstreeAsyncProgress *progress,
+                                      gboolean *out_changed, GCancellable *cancellable,
+                                      GError **error)
 {
   g_assert (cancellable);
 
-  const gboolean allow_older =
-    (self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_ALLOW_OLDER) > 0;
-  const gboolean synthetic =
-    (self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_SYNTHETIC_PULL) > 0;
+  const gboolean allow_older = (self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_ALLOW_OLDER) > 0;
+  const gboolean synthetic = (self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_SYNTHETIC_PULL) > 0;
 
   const char *override_commit = rpmostree_origin_get_override_commit (self->computed_origin);
 
@@ -448,15 +428,17 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
     case RPMOSTREE_REFSPEC_TYPE_CONTAINER:
       {
         if (override_commit)
-          return glnx_throw (error, "Specifying commit overrides for container-image-reference type refspecs is not supported");
+          return glnx_throw (error, "Specifying commit overrides for container-image-reference "
+                                    "type refspecs is not supported");
 
-        auto refspec_s = std::string(refspec);
-        auto import = CXX_TRY_VAL(pull_container(*self->repo, *cancellable, refspec_s), error);
-        // Note this duplicates https://github.com/ostreedev/ostree-rs-ext/blob/22a663f64e733e7ba8382f11f853ce4202652254/lib/src/container/store.rs#L64
+        auto refspec_s = std::string (refspec);
+        auto import = CXX_TRY_VAL (pull_container (*self->repo, *cancellable, refspec_s), error);
+        // Note this duplicates
+        // https://github.com/ostreedev/ostree-rs-ext/blob/22a663f64e733e7ba8382f11f853ce4202652254/lib/src/container/store.rs#L64
         if (import->is_layered)
-          new_base_rev = strdup (import->merge_commit.c_str());
+          new_base_rev = strdup (import->merge_commit.c_str ());
         else
-          new_base_rev = strdup (import->base_commit.c_str());
+          new_base_rev = strdup (import->base_commit.c_str ());
         break;
       }
     case RPMOSTREE_REFSPEC_TYPE_CHECKSUM:
@@ -472,7 +454,8 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
         g_assert (self->origin_merge_deployment);
         if (origin_remote && !synthetic && !is_commit)
           {
-            g_autoptr(GVariantBuilder) optbuilder = g_variant_builder_new (G_VARIANT_TYPE ("a{sv}"));
+            g_autoptr (GVariantBuilder) optbuilder
+                = g_variant_builder_new (G_VARIANT_TYPE ("a{sv}"));
             if (dir_to_pull && *dir_to_pull)
               g_variant_builder_add (optbuilder, "{s@v}", "subdir",
                                      g_variant_new_variant (g_variant_new_string (dir_to_pull)));
@@ -489,20 +472,20 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
                  * timestamp-check is comparing against our deployment csum's timestamp, not
                  * whatever the ref is pointing to.
                  */
-                if (override_commit &&
-                    !ostree_repo_set_ref_immediate (self->repo, origin_remote, origin_ref,
-                                                    self->base_revision, cancellable, error))
+                if (override_commit
+                    && !ostree_repo_set_ref_immediate (self->repo, origin_remote, origin_ref,
+                                                       self->base_revision, cancellable, error))
                   return FALSE;
               }
-            g_variant_builder_add (optbuilder, "{s@v}", "refs",
-                                   g_variant_new_variant (g_variant_new_strv (
-                                                                              (const char *const *)&origin_ref, 1)));
+            g_variant_builder_add (
+                optbuilder, "{s@v}", "refs",
+                g_variant_new_variant (g_variant_new_strv ((const char *const *)&origin_ref, 1)));
             if (override_commit)
               g_variant_builder_add (optbuilder, "{s@v}", "override-commit-ids",
                                      g_variant_new_variant (g_variant_new_strv (
-                                                                                (const char *const *)&override_commit, 1)));
+                                         (const char *const *)&override_commit, 1)));
 
-            g_autoptr(GVariant) opts = g_variant_ref_sink (g_variant_builder_end (optbuilder));
+            g_autoptr (GVariant) opts = g_variant_ref_sink (g_variant_builder_end (optbuilder));
             if (!ostree_repo_pull_with_options (self->repo, origin_remote, opts, progress,
                                                 cancellable, error))
               return glnx_prefix_error (error, "While pulling %s", override_commit ?: origin_ref);
@@ -543,54 +526,44 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
 }
 
 static gboolean
-checkout_base_tree (RpmOstreeSysrootUpgrader *self,
-                    GCancellable          *cancellable,
-                    GError               **error)
+checkout_base_tree (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable, GError **error)
 {
   if (self->tmprootfs_dfd != -1)
     return TRUE; /* already checked out! */
 
   /* let's give the user some feedback so they don't think we're blocked */
   auto msg = g_strdup_printf ("Checking out tree %.7s", self->base_revision);
-  auto task = rpmostreecxx::progress_begin_task(msg);
+  auto task = rpmostreecxx::progress_begin_task (msg);
 
   int repo_dfd = ostree_repo_get_dfd (self->repo); /* borrowed */
   /* Always delete this */
-  if (!glnx_shutil_rm_rf_at (repo_dfd, RPMOSTREE_OLD_TMP_ROOTFS_DIR,
-                             cancellable, error))
+  if (!glnx_shutil_rm_rf_at (repo_dfd, RPMOSTREE_OLD_TMP_ROOTFS_DIR, cancellable, error))
     return FALSE;
 
   /* Make the parents with default mode */
-  if (!glnx_shutil_mkdir_p_at (repo_dfd,
-                               dirname (strdupa (RPMOSTREE_TMP_PRIVATE_DIR)),
-                               0755, cancellable, error))
+  if (!glnx_shutil_mkdir_p_at (repo_dfd, dirname (strdupa (RPMOSTREE_TMP_PRIVATE_DIR)), 0755,
+                               cancellable, error))
     return FALSE;
 
   /* And this dir should always be 0700, to ensure that when we checkout
    * world-writable dirs like /tmp it's not accessible to unprivileged users.
    */
-  if (!glnx_shutil_mkdir_p_at (repo_dfd,
-                               RPMOSTREE_TMP_PRIVATE_DIR,
-                               0700, cancellable, error))
+  if (!glnx_shutil_mkdir_p_at (repo_dfd, RPMOSTREE_TMP_PRIVATE_DIR, 0700, cancellable, error))
     return FALSE;
 
   /* delete dir in case a previous run didn't finish successfully */
-  if (!glnx_shutil_rm_rf_at (repo_dfd, RPMOSTREE_TMP_ROOTFS_DIR,
-                             cancellable, error))
+  if (!glnx_shutil_rm_rf_at (repo_dfd, RPMOSTREE_TMP_ROOTFS_DIR, cancellable, error))
     return FALSE;
 
   /* NB: we let ostree create the dir for us so that the root dir has the
    * correct xattrs (e.g. selinux label) */
   self->devino_cache = ostree_repo_devino_cache_new ();
-  OstreeRepoCheckoutAtOptions checkout_options =
-    { .devino_to_csum_cache = self->devino_cache };
-  if (!ostree_repo_checkout_at (self->repo, &checkout_options,
-                                repo_dfd, RPMOSTREE_TMP_ROOTFS_DIR,
+  OstreeRepoCheckoutAtOptions checkout_options = { .devino_to_csum_cache = self->devino_cache };
+  if (!ostree_repo_checkout_at (self->repo, &checkout_options, repo_dfd, RPMOSTREE_TMP_ROOTFS_DIR,
                                 self->base_revision, cancellable, error))
     return FALSE;
 
-  if (!glnx_opendirat (repo_dfd, RPMOSTREE_TMP_ROOTFS_DIR, FALSE,
-                       &self->tmprootfs_dfd, error))
+  if (!glnx_opendirat (repo_dfd, RPMOSTREE_TMP_ROOTFS_DIR, FALSE, &self->tmprootfs_dfd, error))
     return FALSE;
 
   return TRUE;
@@ -600,43 +573,41 @@ checkout_base_tree (RpmOstreeSysrootUpgrader *self,
  * base layer matches. Returns FALSE on error, TRUE otherwise. Check self->rsack to
  * determine if it worked. */
 static gboolean
-try_load_base_rsack_from_pending (RpmOstreeSysrootUpgrader *self,
-                                  GCancellable             *cancellable,
-                                  GError                  **error)
+try_load_base_rsack_from_pending (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable,
+                                  GError **error)
 {
-  auto is_live = CXX_TRY_VAL(has_live_apply_state(*self->sysroot, *self->origin_merge_deployment), error);
+  auto is_live
+      = CXX_TRY_VAL (has_live_apply_state (*self->sysroot, *self->origin_merge_deployment), error);
   /* livefs invalidates the deployment */
   if (is_live)
     return TRUE;
 
-  auto repo = ostree_sysroot_repo(self->sysroot);
-  auto layeredmeta = CXX_TRY_VAL(deployment_layeredmeta_load(*repo, *self->origin_merge_deployment), error);
+  auto repo = ostree_sysroot_repo (self->sysroot);
+  auto layeredmeta
+      = CXX_TRY_VAL (deployment_layeredmeta_load (*repo, *self->origin_merge_deployment), error);
   /* older client layers have a bug blocking us from using their base rpmdb:
    * https://github.com/projectatomic/rpm-ostree/pull/1560 */
   if (layeredmeta.is_layered && layeredmeta.clientlayer_version < 4)
     return TRUE;
 
-  const char *base_rev = layeredmeta.base_commit.c_str();
+  const char *base_rev = layeredmeta.base_commit.c_str ();
   /* it's no longer the base layer we're looking for (e.g. likely pulled a fresh one) */
   if (!g_str_equal (self->base_revision, base_rev))
     return TRUE;
 
   int sysroot_fd = ostree_sysroot_get_fd (self->sysroot);
-  g_autofree char *path =
-    ostree_sysroot_get_deployment_dirpath (self->sysroot, self->origin_merge_deployment);
+  g_autofree char *path
+      = ostree_sysroot_get_deployment_dirpath (self->sysroot, self->origin_merge_deployment);
 
   /* this may not actually populate the rsack if it's an old deployment */
-  if (!rpmostree_get_base_refsack_for_root (sysroot_fd, path, &self->rsack,
-                                            cancellable, error))
+  if (!rpmostree_get_base_refsack_for_root (sysroot_fd, path, &self->rsack, cancellable, error))
     return FALSE;
 
   return TRUE;
 }
 
 static gboolean
-load_base_rsack (RpmOstreeSysrootUpgrader *self,
-                 GCancellable             *cancellable,
-                 GError                  **error)
+load_base_rsack (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable, GError **error)
 {
   if (!try_load_base_rsack_from_pending (self, cancellable, error))
     return FALSE;
@@ -657,50 +628,48 @@ load_base_rsack (RpmOstreeSysrootUpgrader *self,
 }
 
 static gboolean
-initialize_metatmpdir (RpmOstreeSysrootUpgrader *self,
-                       GError                  **error)
+initialize_metatmpdir (RpmOstreeSysrootUpgrader *self, GError **error)
 {
   if (self->metatmpdir.initialized)
     return TRUE; /* already initialized; return early */
 
-  if (!glnx_mkdtemp ("rpmostree-localpkgmeta-XXXXXX", 0700,
-                     &self->metatmpdir, error))
+  if (!glnx_mkdtemp ("rpmostree-localpkgmeta-XXXXXX", 0700, &self->metatmpdir, error))
     return FALSE;
 
   return TRUE;
 }
 
 static gboolean
-finalize_removal_overrides (RpmOstreeSysrootUpgrader *self,
-                            GCancellable             *cancellable,
-                            GError                  **error)
+finalize_removal_overrides (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable,
+                            GError **error)
 {
   g_assert (self->rsack);
 
   GHashTable *removals = rpmostree_origin_get_overrides_remove (self->computed_origin);
-  g_autoptr(GPtrArray) ret_final_removals = g_ptr_array_new_with_free_func (g_free);
+  g_autoptr (GPtrArray) ret_final_removals = g_ptr_array_new_with_free_func (g_free);
 
-  g_autoptr(GPtrArray) inactive_removals = g_ptr_array_new ();
-  GLNX_HASH_TABLE_FOREACH (removals, const char*, pkgname)
-    {
-      g_autoptr(DnfPackage) pkg = NULL;
-      if (!rpmostree_sack_get_by_pkgname (self->rsack->sack, pkgname, &pkg, error))
-        return FALSE;
+  g_autoptr (GPtrArray) inactive_removals = g_ptr_array_new ();
+  GLNX_HASH_TABLE_FOREACH (removals, const char *, pkgname)
+  {
+    g_autoptr (DnfPackage) pkg = NULL;
+    if (!rpmostree_sack_get_by_pkgname (self->rsack->sack, pkgname, &pkg, error))
+      return FALSE;
 
-      if (pkg)
-        g_ptr_array_add (ret_final_removals, g_strdup (pkgname));
-      else
-        g_ptr_array_add (inactive_removals, (gpointer)pkgname);
-    }
+    if (pkg)
+      g_ptr_array_add (ret_final_removals, g_strdup (pkgname));
+    else
+      g_ptr_array_add (inactive_removals, (gpointer)pkgname);
+  }
 
   if (inactive_removals->len > 0)
     {
       rpmostree_output_message ("Inactive base removals:");
       for (guint i = 0; i < inactive_removals->len; i++)
         {
-          const char *item = (const char*)inactive_removals->pdata[i];
+          const char *item = (const char *)inactive_removals->pdata[i];
           rpmostree_output_message ("  %s", item);
-          rpmostree_origin_remove_override (self->computed_origin, item, RPMOSTREE_ORIGIN_OVERRIDE_REMOVE);
+          rpmostree_origin_remove_override (self->computed_origin, item,
+                                            RPMOSTREE_ORIGIN_OVERRIDE_REMOVE);
         }
     }
 
@@ -708,47 +677,45 @@ finalize_removal_overrides (RpmOstreeSysrootUpgrader *self,
 }
 
 static gboolean
-finalize_replacement_overrides (RpmOstreeSysrootUpgrader *self,
-                                GCancellable             *cancellable,
-                                GError                  **error)
+finalize_replacement_overrides (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable,
+                                GError **error)
 {
   g_assert (self->rsack);
 
-  GHashTable *local_replacements =
-    rpmostree_origin_get_overrides_local_replace (self->computed_origin);
-  g_autoptr(GPtrArray) ret_final_local_replacements =
-    g_ptr_array_new_with_free_func (g_free);
+  GHashTable *local_replacements
+      = rpmostree_origin_get_overrides_local_replace (self->computed_origin);
+  g_autoptr (GPtrArray) ret_final_local_replacements = g_ptr_array_new_with_free_func (g_free);
 
-  g_autoptr(GPtrArray) inactive_replacements = g_ptr_array_new ();
+  g_autoptr (GPtrArray) inactive_replacements = g_ptr_array_new ();
 
-  GLNX_HASH_TABLE_FOREACH_KV (local_replacements, const char*, nevra, const char*, sha256)
-    {
-      g_autofree char *pkgname = NULL;
-      if (!rpmostree_decompose_nevra (nevra, &pkgname, NULL, NULL, NULL, NULL, error))
-        return FALSE;
+  GLNX_HASH_TABLE_FOREACH_KV (local_replacements, const char *, nevra, const char *, sha256)
+  {
+    g_autofree char *pkgname = NULL;
+    if (!rpmostree_decompose_nevra (nevra, &pkgname, NULL, NULL, NULL, NULL, error))
+      return FALSE;
 
-      g_autoptr(DnfPackage) pkg = NULL;
-      if (!rpmostree_sack_get_by_pkgname (self->rsack->sack, pkgname, &pkg, error))
-        return FALSE;
+    g_autoptr (DnfPackage) pkg = NULL;
+    if (!rpmostree_sack_get_by_pkgname (self->rsack->sack, pkgname, &pkg, error))
+      return FALSE;
 
-      /* make inactive if it's missing or if that exact nevra is already present */
-      if (pkg && !rpmostree_sack_has_subject (self->rsack->sack, nevra))
-        {
-          g_ptr_array_add (ret_final_local_replacements,
-                           g_strconcat (sha256, ":", nevra, NULL));
-        }
-      else
-        g_ptr_array_add (inactive_replacements, (gpointer)nevra);
-    }
+    /* make inactive if it's missing or if that exact nevra is already present */
+    if (pkg && !rpmostree_sack_has_subject (self->rsack->sack, nevra))
+      {
+        g_ptr_array_add (ret_final_local_replacements, g_strconcat (sha256, ":", nevra, NULL));
+      }
+    else
+      g_ptr_array_add (inactive_replacements, (gpointer)nevra);
+  }
 
   if (inactive_replacements->len > 0)
     {
       rpmostree_output_message ("Inactive base replacements:");
       for (guint i = 0; i < inactive_replacements->len; i++)
         {
-          const char *item = (const char*)inactive_replacements->pdata[i];
+          const char *item = (const char *)inactive_replacements->pdata[i];
           rpmostree_output_message ("  %s", item);
-          rpmostree_origin_remove_override (self->computed_origin, item, RPMOSTREE_ORIGIN_OVERRIDE_REPLACE_LOCAL);
+          rpmostree_origin_remove_override (self->computed_origin, item,
+                                            RPMOSTREE_ORIGIN_OVERRIDE_REPLACE_LOCAL);
         }
     }
 
@@ -756,19 +723,15 @@ finalize_replacement_overrides (RpmOstreeSysrootUpgrader *self,
 }
 
 static gboolean
-finalize_overrides (RpmOstreeSysrootUpgrader *self,
-                    GCancellable             *cancellable,
-                    GError                  **error)
+finalize_overrides (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable, GError **error)
 {
   return finalize_removal_overrides (self, cancellable, error)
-      && finalize_replacement_overrides (self, cancellable, error);
+         && finalize_replacement_overrides (self, cancellable, error);
 }
 
 static gboolean
-add_local_pkgset_to_sack (RpmOstreeSysrootUpgrader *self,
-                          GHashTable               *pkgset,
-                          GCancellable             *cancellable,
-                          GError                  **error)
+add_local_pkgset_to_sack (RpmOstreeSysrootUpgrader *self, GHashTable *pkgset,
+                          GCancellable *cancellable, GError **error)
 {
   if (g_hash_table_size (pkgset) == 0)
     return TRUE; /* nothing to do! */
@@ -776,31 +739,28 @@ add_local_pkgset_to_sack (RpmOstreeSysrootUpgrader *self,
   if (!initialize_metatmpdir (self, error))
     return FALSE;
 
-  GLNX_HASH_TABLE_FOREACH_KV (pkgset, const char*, nevra, const char*, sha256)
-    {
-      g_autoptr(GVariant) header = NULL;
-      g_autofree char *path =
-        g_strdup_printf ("%s/%s.rpm", self->metatmpdir.path, nevra);
+  GLNX_HASH_TABLE_FOREACH_KV (pkgset, const char *, nevra, const char *, sha256)
+  {
+    g_autoptr (GVariant) header = NULL;
+    g_autofree char *path = g_strdup_printf ("%s/%s.rpm", self->metatmpdir.path, nevra);
 
-      if (!rpmostree_pkgcache_find_pkg_header (self->repo, nevra, sha256,
-                                               &header, cancellable, error))
-        return FALSE;
+    if (!rpmostree_pkgcache_find_pkg_header (self->repo, nevra, sha256, &header, cancellable,
+                                             error))
+      return FALSE;
 
-      if (!glnx_file_replace_contents_at (AT_FDCWD, path,
-                                          static_cast<const guint8*>(g_variant_get_data (header)),
-                                          g_variant_get_size (header),
-                                          GLNX_FILE_REPLACE_NODATASYNC,
-                                          cancellable, error))
-        return FALSE;
+    if (!glnx_file_replace_contents_at (
+            AT_FDCWD, path, static_cast<const guint8 *> (g_variant_get_data (header)),
+            g_variant_get_size (header), GLNX_FILE_REPLACE_NODATASYNC, cancellable, error))
+      return FALSE;
 
-      /* Also check if that exact NEVRA is already in the root (if the pkg
-       * exists, but is a different EVR, depsolve will catch that). In the
-       * future, we'll allow packages to replace base pkgs. */
-      if (rpmostree_sack_has_subject (self->rsack->sack, nevra))
-        return glnx_throw (error, "Package '%s' is already in the base", nevra);
+    /* Also check if that exact NEVRA is already in the root (if the pkg
+     * exists, but is a different EVR, depsolve will catch that). In the
+     * future, we'll allow packages to replace base pkgs. */
+    if (rpmostree_sack_has_subject (self->rsack->sack, nevra))
+      return glnx_throw (error, "Package '%s' is already in the base", nevra);
 
-      dnf_sack_add_cmdline_package (self->rsack->sack, path);
-    }
+    dnf_sack_add_cmdline_package (self->rsack->sack, path);
+  }
 
   return TRUE;
 }
@@ -815,15 +775,13 @@ add_local_pkgset_to_sack (RpmOstreeSysrootUpgrader *self,
  * libdnf after resolution).
  * */
 static gboolean
-finalize_overlays (RpmOstreeSysrootUpgrader *self,
-                   GCancellable             *cancellable,
-                   GError                  **error)
+finalize_overlays (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable, GError **error)
 {
   g_assert (self->rsack);
 
   /* request (owned by origin) --> providing nevra */
-  g_autoptr(GHashTable) inactive_requests =
-    g_hash_table_new_full (g_str_hash, g_str_equal, NULL, g_free);
+  g_autoptr (GHashTable) inactive_requests
+      = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, g_free);
 
   /* Add the local pkgs as if they were installed: since they're unconditionally
    * layered, we treat them as part of the base wrt regular requested pkgs. E.g.
@@ -833,51 +791,50 @@ finalize_overlays (RpmOstreeSysrootUpgrader *self,
   if (!add_local_pkgset_to_sack (self, local_pkgs, cancellable, error))
     return FALSE;
 
-  GHashTable *local_fileoverride_pkgs = rpmostree_origin_get_local_fileoverride_packages (self->computed_origin);
+  GHashTable *local_fileoverride_pkgs
+      = rpmostree_origin_get_local_fileoverride_packages (self->computed_origin);
   if (!add_local_pkgset_to_sack (self, local_fileoverride_pkgs, cancellable, error))
     return FALSE;
 
   GHashTable *removals = rpmostree_origin_get_overrides_remove (self->computed_origin);
 
   /* check for each package if we have a provides or a path match */
-  GLNX_HASH_TABLE_FOREACH (rpmostree_origin_get_packages (self->computed_origin),
-                           const char*, pattern)
-    {
-      g_autoptr(GPtrArray) matches =
-        rpmostree_get_matching_packages (self->rsack->sack, pattern);
+  GLNX_HASH_TABLE_FOREACH (rpmostree_origin_get_packages (self->computed_origin), const char *,
+                           pattern)
+  {
+    g_autoptr (GPtrArray) matches = rpmostree_get_matching_packages (self->rsack->sack, pattern);
 
-      if (matches->len == 0)
-        {
-          /* no matches, so we'll need to layer it (i.e. not remove it from the
-           * computed origin) */
-          continue;
-        }
+    if (matches->len == 0)
+      {
+        /* no matches, so we'll need to layer it (i.e. not remove it from the
+         * computed origin) */
+        continue;
+      }
 
-      /* Error out if it matches a base package that was also requested to be removed.
-       * Conceptually, we want users to use override replacements, not remove+overlay.
-       * Really, we could just not do this check; it'd just end up being dormant, though
-       * that might be confusing to users. */
-      for (guint i = 0; i < matches->len; i++)
-        {
-          auto pkg = static_cast<DnfPackage*>(matches->pdata[i]);
-          const char *name = dnf_package_get_name (pkg);
-          const char *repo = dnf_package_get_reponame (pkg);
+    /* Error out if it matches a base package that was also requested to be removed.
+     * Conceptually, we want users to use override replacements, not remove+overlay.
+     * Really, we could just not do this check; it'd just end up being dormant, though
+     * that might be confusing to users. */
+    for (guint i = 0; i < matches->len; i++)
+      {
+        auto pkg = static_cast<DnfPackage *> (matches->pdata[i]);
+        const char *name = dnf_package_get_name (pkg);
+        const char *repo = dnf_package_get_reponame (pkg);
 
-          if (g_strcmp0 (repo, HY_CMDLINE_REPO_NAME) == 0)
-            continue; /* local RPM added up above */
+        if (g_strcmp0 (repo, HY_CMDLINE_REPO_NAME) == 0)
+          continue; /* local RPM added up above */
 
-          if (g_hash_table_contains (removals, name))
-            return glnx_throw (error,
-                               "Cannot request '%s' provided by removed package '%s'",
-                               pattern, dnf_package_get_nevra (pkg));
-        }
+        if (g_hash_table_contains (removals, name))
+          return glnx_throw (error, "Cannot request '%s' provided by removed package '%s'", pattern,
+                             dnf_package_get_nevra (pkg));
+      }
 
-      /* Otherwise, it's an inactive request: remember them so we can print a nice notice.
-       * Just use the first package as the "providing" pkg. */
-      const char *providing_nevra = dnf_package_get_nevra (static_cast<DnfPackage*>(matches->pdata[0]));
-      g_hash_table_insert (inactive_requests, (gpointer)pattern,
-                           g_strdup (providing_nevra));
-    }
+    /* Otherwise, it's an inactive request: remember them so we can print a nice notice.
+     * Just use the first package as the "providing" pkg. */
+    const char *providing_nevra
+        = dnf_package_get_nevra (static_cast<DnfPackage *> (matches->pdata[0]));
+    g_hash_table_insert (inactive_requests, (gpointer)pattern, g_strdup (providing_nevra));
+  }
 
   /* XXX: Currently, we don't retain information about which modules were
    * installed in the commit metadata. So we can't really detect "inactive"
@@ -895,26 +852,25 @@ finalize_overlays (RpmOstreeSysrootUpgrader *self,
     {
       gboolean changed = FALSE;
       rpmostree_output_message ("Inactive requests:");
-      GLNX_HASH_TABLE_FOREACH_KV (inactive_requests, const char*, req, const char*, nevra)
-        {
-          const char *pkgs[] = { req, NULL };
-          g_autoptr(GError) local_error = NULL;
-          rpmostree_output_message ("  %s (already provided by %s)", req, nevra);
-          if (!rpmostree_origin_remove_packages (self->computed_origin, (char**)pkgs, FALSE, &changed, &local_error))
-            g_error ("%s", local_error->message);
-          g_assert (changed);
-          changed = FALSE;
-        }
+      GLNX_HASH_TABLE_FOREACH_KV (inactive_requests, const char *, req, const char *, nevra)
+      {
+        const char *pkgs[] = { req, NULL };
+        g_autoptr (GError) local_error = NULL;
+        rpmostree_output_message ("  %s (already provided by %s)", req, nevra);
+        if (!rpmostree_origin_remove_packages (self->computed_origin, (char **)pkgs, FALSE,
+                                               &changed, &local_error))
+          g_error ("%s", local_error->message);
+        g_assert (changed);
+        changed = FALSE;
+      }
     }
 
   return TRUE;
 }
 
 static gboolean
-prepare_context_for_assembly (RpmOstreeSysrootUpgrader *self,
-                              const char               *tmprootfs,
-                              GCancellable             *cancellable,
-                              GError                  **error)
+prepare_context_for_assembly (RpmOstreeSysrootUpgrader *self, const char *tmprootfs,
+                              GCancellable *cancellable, GError **error)
 {
   /* make sure yum repos and passwd used are from our cfg merge */
   rpmostree_context_configure_from_deployment (self->ctx, self->sysroot,
@@ -922,8 +878,7 @@ prepare_context_for_assembly (RpmOstreeSysrootUpgrader *self,
 
   /* load the sepolicy to use during import */
   glnx_unref_object OstreeSePolicy *sepolicy = NULL;
-  if (!rpmostree_prepare_rootfs_get_sepolicy (self->tmprootfs_dfd, &sepolicy,
-                                              cancellable, error))
+  if (!rpmostree_prepare_rootfs_get_sepolicy (self->tmprootfs_dfd, &sepolicy, cancellable, error))
     return FALSE;
 
   rpmostree_context_set_sepolicy (self->ctx, sepolicy);
@@ -936,9 +891,7 @@ prepare_context_for_assembly (RpmOstreeSysrootUpgrader *self,
 
 /* Initialize libdnf context from our configuration */
 static gboolean
-prep_local_assembly (RpmOstreeSysrootUpgrader *self,
-                     GCancellable             *cancellable,
-                     GError                  **error)
+prep_local_assembly (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable, GError **error)
 {
   g_assert (!self->ctx);
 
@@ -947,9 +900,10 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self,
   /* If initramfs regeneration is enabled, it's silly to support /etc overlays on top of
    * that. Just point users at dracut's -I instead. I guess we could auto-convert
    * ourselves? */
-  if (rpmostree_origin_get_regenerate_initramfs (self->computed_origin) &&
-      g_hash_table_size (rpmostree_origin_get_initramfs_etc_files (self->computed_origin)) > 0)
-    return glnx_throw (error, "initramfs regeneration and /etc overlay not compatible; use dracut arg -I instead");
+  if (rpmostree_origin_get_regenerate_initramfs (self->computed_origin)
+      && g_hash_table_size (rpmostree_origin_get_initramfs_etc_files (self->computed_origin)) > 0)
+    return glnx_throw (
+        error, "initramfs regeneration and /etc overlay not compatible; use dracut arg -I instead");
 
   if (!checkout_base_tree (self, cancellable, error))
     return FALSE;
@@ -962,13 +916,13 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self,
     return FALSE;
 
   {
-    g_autoptr(GKeyFile) computed_origin_kf = rpmostree_origin_dup_keyfile (self->computed_origin);
-    self->treefile = CXX_TRY_VAL(origin_to_treefile (*computed_origin_kf), error);
+    g_autoptr (GKeyFile) computed_origin_kf = rpmostree_origin_dup_keyfile (self->computed_origin);
+    self->treefile = CXX_TRY_VAL (origin_to_treefile (*computed_origin_kf), error);
   }
   rpmostree_context_set_treefile (self->ctx, **self->treefile);
 
-  if (!rpmostree_context_setup (self->ctx, tmprootfs_abspath, tmprootfs_abspath,
-                                cancellable, error))
+  if (!rpmostree_context_setup (self->ctx, tmprootfs_abspath, tmprootfs_abspath, cancellable,
+                                error))
     return FALSE;
 
   if (rpmostree_origin_has_packages (self->computed_origin))
@@ -978,8 +932,8 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self,
       self->layering_type = RPMOSTREE_SYSROOT_UPGRADER_LAYERING_RPMMD_REPOS;
 
       /* keep a ref on it in case the level higher up needs it */
-      self->rpmmd_sack =
-        (DnfSack*)g_object_ref (dnf_context_get_sack (rpmostree_context_get_dnf (self->ctx)));
+      self->rpmmd_sack
+          = (DnfSack *)g_object_ref (dnf_context_get_sack (rpmostree_context_get_dnf (self->ctx)));
     }
   else
     {
@@ -1003,17 +957,16 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self,
   /* If the current state has layering, compare the depsolved set for changes. */
   if (self->final_revision)
     {
-      g_autoptr(GVariant) prev_commit = NULL;
+      g_autoptr (GVariant) prev_commit = NULL;
 
-      if (!ostree_repo_load_variant (self->repo, OSTREE_OBJECT_TYPE_COMMIT,
-                                     self->final_revision, &prev_commit, error))
+      if (!ostree_repo_load_variant (self->repo, OSTREE_OBJECT_TYPE_COMMIT, self->final_revision,
+                                     &prev_commit, error))
         return FALSE;
 
-      g_autoptr(GVariant) metadata = g_variant_get_child_value (prev_commit, 0);
-      g_autoptr(GVariantDict) metadata_dict = g_variant_dict_new (metadata);
-      g_autoptr(GVariant) previous_sha512_v =
-        _rpmostree_vardict_lookup_value_required (metadata_dict, "rpmostree.state-sha512",
-                                                  (GVariantType*)"s", error);
+      g_autoptr (GVariant) metadata = g_variant_get_child_value (prev_commit, 0);
+      g_autoptr (GVariantDict) metadata_dict = g_variant_dict_new (metadata);
+      g_autoptr (GVariant) previous_sha512_v = _rpmostree_vardict_lookup_value_required (
+          metadata_dict, "rpmostree.state-sha512", (GVariantType *)"s", error);
       if (!previous_sha512_v)
         return FALSE;
       const char *previous_state_sha512 = g_variant_get_string (previous_sha512_v, NULL);
@@ -1033,9 +986,7 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self,
 
 /* Overlay pkgs, run scripts, and commit final rootfs to ostree */
 static gboolean
-perform_local_assembly (RpmOstreeSysrootUpgrader *self,
-                        GCancellable             *cancellable,
-                        GError                  **error)
+perform_local_assembly (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable, GError **error)
 {
   g_assert (self->layering_initialized);
   g_assert (self->pkgs_imported);
@@ -1067,11 +1018,11 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self,
   /* If either the kernel or the initramfs config changed,
    * we need to load all of the kernel state.
    */
-  const gboolean kernel_or_initramfs_changed =
-    rpmostree_context_get_kernel_changed (self->ctx) ||
-    rpmostree_origin_get_regenerate_initramfs (self->computed_origin);
-  g_autoptr(GVariant) kernel_state = NULL;
-  g_autoptr(GPtrArray) initramfs_args = g_ptr_array_new_with_free_func (g_free);
+  const gboolean kernel_or_initramfs_changed
+      = rpmostree_context_get_kernel_changed (self->ctx)
+        || rpmostree_origin_get_regenerate_initramfs (self->computed_origin);
+  g_autoptr (GVariant) kernel_state = NULL;
+  g_autoptr (GPtrArray) initramfs_args = g_ptr_array_new_with_free_func (g_free);
   const char *bootdir = NULL;
   const char *kver = NULL;
   const char *kernel_path = NULL;
@@ -1085,18 +1036,16 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self,
       /* note we extract the initramfs path here but we only use it as a fallback to use
        * with `--rebuild` if we're missing `initramfs-args` in the commit metadata -- in the
        * future, we could remove this entirely */
-      g_variant_get (kernel_state, "(&s&s&sm&s)",
-                     &kver, &bootdir,
-                     &kernel_path, &initramfs_path);
+      g_variant_get (kernel_state, "(&s&s&sm&s)", &kver, &bootdir, &kernel_path, &initramfs_path);
 
       g_assert (self->base_revision);
-      g_autoptr(GVariant) base_commit = NULL;
-      if (!ostree_repo_load_variant (self->repo, OSTREE_OBJECT_TYPE_COMMIT,
-                                     self->base_revision, &base_commit, error))
+      g_autoptr (GVariant) base_commit = NULL;
+      if (!ostree_repo_load_variant (self->repo, OSTREE_OBJECT_TYPE_COMMIT, self->base_revision,
+                                     &base_commit, error))
         return FALSE;
 
-      g_autoptr(GVariant) metadata = g_variant_get_child_value (base_commit, 0);
-      g_autoptr(GVariantDict) metadata_dict = g_variant_dict_new (metadata);
+      g_autoptr (GVariant) metadata = g_variant_get_child_value (base_commit, 0);
+      g_autoptr (GVariantDict) metadata_dict = g_variant_dict_new (metadata);
 
       g_autofree char **args = NULL;
       if (g_variant_dict_lookup (metadata_dict, "rpmostree.initramfs-args", "^a&s", &args))
@@ -1124,43 +1073,44 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self,
   if (rpmostree_context_get_kernel_changed (self->ctx))
     {
       g_assert (kernel_state && kver);
-      CXX_TRY(run_depmod(self->tmprootfs_dfd, kver, true), error);
+      CXX_TRY (run_depmod (self->tmprootfs_dfd, kver, true), error);
     }
 
   if (kernel_or_initramfs_changed)
     {
       /* append the extra args */
-      const char *const* add_dracut_argv = NULL;
+      const char *const *add_dracut_argv = NULL;
       if (rpmostree_origin_get_regenerate_initramfs (self->computed_origin))
-         add_dracut_argv = rpmostree_origin_get_initramfs_args (self->computed_origin);
-      for (char **it = (char**)add_dracut_argv; it && *it; it++)
+        add_dracut_argv = rpmostree_origin_get_initramfs_args (self->computed_origin);
+      for (char **it = (char **)add_dracut_argv; it && *it; it++)
         g_ptr_array_add (initramfs_args, g_strdup (*it));
       g_ptr_array_add (initramfs_args, NULL);
 
-      auto task = rpmostreecxx::progress_begin_task("Generating initramfs");
+      auto task = rpmostreecxx::progress_begin_task ("Generating initramfs");
 
       g_assert (kernel_state && kernel_path);
 
-      g_auto(GLnxTmpfile) initramfs_tmpf = { 0, };
+      g_auto (GLnxTmpfile) initramfs_tmpf = {
+        0,
+      };
       /* NB: We only use the real root's /etc if initramfs regeneration is explicitly
        * requested. IOW, just replacing the kernel still gets use stock settings, like the
        * server side. */
-      if (!rpmostree_run_dracut (self->tmprootfs_dfd,
-                                 (const char* const*)initramfs_args->pdata,
+      if (!rpmostree_run_dracut (self->tmprootfs_dfd, (const char *const *)initramfs_args->pdata,
                                  kver, initramfs_path,
                                  rpmostree_origin_get_regenerate_initramfs (self->computed_origin),
                                  NULL, &initramfs_tmpf, cancellable, error))
         return FALSE;
 
       if (!rpmostree_finalize_kernel (self->tmprootfs_dfd, bootdir, kver, kernel_path,
-                                      &initramfs_tmpf, RPMOSTREE_FINALIZE_KERNEL_AUTO,
-                                      cancellable, error))
+                                      &initramfs_tmpf, RPMOSTREE_FINALIZE_KERNEL_AUTO, cancellable,
+                                      error))
         return glnx_prefix_error (error, "Finalizing kernel");
     }
 
   if (!rpmostree_context_commit (self->ctx, self->base_revision,
-                                 RPMOSTREE_ASSEMBLE_TYPE_CLIENT_LAYERING,
-                                 &self->final_revision, cancellable, error))
+                                 RPMOSTREE_ASSEMBLE_TYPE_CLIENT_LAYERING, &self->final_revision,
+                                 cancellable, error))
     return glnx_prefix_error (error, "Committing");
 
   /* Ensure we aren't holding any references to the tmpdir now that we're done;
@@ -1180,9 +1130,8 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self,
 gboolean
 rpmostree_sysroot_upgrader_prep_layering (RpmOstreeSysrootUpgrader *self,
                                           RpmOstreeSysrootUpgraderLayeringType *out_layering,
-                                          gboolean                 *out_changed,
-                                          GCancellable             *cancellable,
-                                          GError                  **error)
+                                          gboolean *out_changed, GCancellable *cancellable,
+                                          GError **error)
 {
   /* Default to no assembly required, and not changed */
   self->layering_initialized = TRUE;
@@ -1230,9 +1179,8 @@ rpmostree_sysroot_upgrader_prep_layering (RpmOstreeSysrootUpgrader *self,
 }
 
 gboolean
-rpmostree_sysroot_upgrader_import_pkgs (RpmOstreeSysrootUpgrader *self,
-                                        GCancellable             *cancellable,
-                                        GError                  **error)
+rpmostree_sysroot_upgrader_import_pkgs (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable,
+                                        GError **error)
 {
   g_assert (self->layering_initialized);
   g_assert (!self->pkgs_imported);
@@ -1261,35 +1209,29 @@ rpmostree_sysroot_upgrader_import_pkgs (RpmOstreeSysrootUpgrader *self,
  * Set the active kargs to be used during deployment.
  */
 void
-rpmostree_sysroot_upgrader_set_kargs (RpmOstreeSysrootUpgrader *self,
-                                      char                    **kernel_args)
+rpmostree_sysroot_upgrader_set_kargs (RpmOstreeSysrootUpgrader *self, char **kernel_args)
 {
   g_clear_pointer (&self->kargs_strv, g_strfreev);
   self->kargs_strv = g_strdupv (kernel_args);
 }
 
 static gboolean
-write_history (RpmOstreeSysrootUpgrader *self,
-               OstreeDeployment         *new_deployment,
-               GCancellable             *cancellable,
-               GError                  **error)
+write_history (RpmOstreeSysrootUpgrader *self, OstreeDeployment *new_deployment,
+               GCancellable *cancellable, GError **error)
 {
-  g_autoptr(GVariant) deployment_variant = NULL;
-  if (!rpmostreed_deployment_generate_variant (self->sysroot, new_deployment, NULL,
-                                            self->repo, FALSE, &deployment_variant, error))
+  g_autoptr (GVariant) deployment_variant = NULL;
+  if (!rpmostreed_deployment_generate_variant (self->sysroot, new_deployment, NULL, self->repo,
+                                               FALSE, &deployment_variant, error))
     return FALSE;
 
-  g_autofree char *deployment_dirpath =
-    ostree_sysroot_get_deployment_dirpath (self->sysroot, new_deployment);
+  g_autofree char *deployment_dirpath
+      = ostree_sysroot_get_deployment_dirpath (self->sysroot, new_deployment);
   struct stat stbuf;
-  if (!glnx_fstatat (ostree_sysroot_get_fd (self->sysroot),
-                     deployment_dirpath, &stbuf, 0, error))
+  if (!glnx_fstatat (ostree_sysroot_get_fd (self->sysroot), deployment_dirpath, &stbuf, 0, error))
     return FALSE;
 
-  g_autofree char *fn =
-    g_strdup_printf ("%s/%ld", RPMOSTREE_HISTORY_DIR, stbuf.st_ctime);
-  if (!glnx_shutil_mkdir_p_at (AT_FDCWD, RPMOSTREE_HISTORY_DIR,
-                               0775, cancellable, error))
+  g_autofree char *fn = g_strdup_printf ("%s/%ld", RPMOSTREE_HISTORY_DIR, stbuf.st_ctime);
+  if (!glnx_shutil_mkdir_p_at (AT_FDCWD, RPMOSTREE_HISTORY_DIR, 0775, cancellable, error))
     return FALSE;
 
   /* Write out GVariant to a file. One obvious question here is: why not keep this in the
@@ -1300,36 +1242,32 @@ write_history (RpmOstreeSysrootUpgrader *self,
    * re-use the printing code in `status.c` as is. Note also the GVariant can be large (e.g.
    * we include the full `rpmostree.rpmdb.pkglist` in there). */
 
-  if (!glnx_file_replace_contents_at (AT_FDCWD, fn,
-                                      static_cast<const guint8*>(g_variant_get_data (deployment_variant)),
-                                      g_variant_get_size (deployment_variant),
-                                      static_cast<GLnxFileReplaceFlags>(0), cancellable, error))
+  if (!glnx_file_replace_contents_at (
+          AT_FDCWD, fn, static_cast<const guint8 *> (g_variant_get_data (deployment_variant)),
+          g_variant_get_size (deployment_variant), static_cast<GLnxFileReplaceFlags> (0),
+          cancellable, error))
     return FALSE;
 
   g_autofree char *version = NULL;
-  { g_autoptr(GVariant) commit = NULL;
-    if (!ostree_repo_load_commit (self->repo, ostree_deployment_get_csum (new_deployment),
-                                  &commit, NULL, error))
+  {
+    g_autoptr (GVariant) commit = NULL;
+    if (!ostree_repo_load_commit (self->repo, ostree_deployment_get_csum (new_deployment), &commit,
+                                  NULL, error))
       return FALSE;
     version = rpmostree_checksum_version (commit);
   }
 
-  sd_journal_send ("MESSAGE_ID=" SD_ID128_FORMAT_STR,
-                   SD_ID128_FORMAT_VAL(RPMOSTREE_NEW_DEPLOYMENT_MSG),
-                   "MESSAGE=Created new deployment /%s", deployment_dirpath,
-                   "DEPLOYMENT_PATH=/%s", deployment_dirpath,
-                   "DEPLOYMENT_TIMESTAMP=%" PRIu64, (uint64_t) stbuf.st_ctime,
-                   "DEPLOYMENT_DEVICE=%" PRIu64, (uint64_t) stbuf.st_dev,
-                   "DEPLOYMENT_INODE=%" PRIu64, (uint64_t) stbuf.st_ino,
-                   "DEPLOYMENT_CHECKSUM=%s", ostree_deployment_get_csum (new_deployment),
-                   "DEPLOYMENT_REFSPEC=%s", rpmostree_origin_get_refspec (self->computed_origin),
-                   /* we could use iovecs here and sd_journal_sendv to make these truly
-                    * conditional, but meh, empty field works fine too */
-                   "DEPLOYMENT_VERSION=%s", version ?: "",
-                   "COMMAND_LINE=%s", self->command_line ?: "",
-                   "AGENT=%s", self->agent ?: "",
-                   "AGENT_SD_UNIT=%s", self->sd_unit ?: "",
-                   NULL);
+  sd_journal_send (
+      "MESSAGE_ID=" SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL (RPMOSTREE_NEW_DEPLOYMENT_MSG),
+      "MESSAGE=Created new deployment /%s", deployment_dirpath, "DEPLOYMENT_PATH=/%s",
+      deployment_dirpath, "DEPLOYMENT_TIMESTAMP=%" PRIu64, (uint64_t)stbuf.st_ctime,
+      "DEPLOYMENT_DEVICE=%" PRIu64, (uint64_t)stbuf.st_dev, "DEPLOYMENT_INODE=%" PRIu64,
+      (uint64_t)stbuf.st_ino, "DEPLOYMENT_CHECKSUM=%s", ostree_deployment_get_csum (new_deployment),
+      "DEPLOYMENT_REFSPEC=%s", rpmostree_origin_get_refspec (self->computed_origin),
+      /* we could use iovecs here and sd_journal_sendv to make these truly
+       * conditional, but meh, empty field works fine too */
+      "DEPLOYMENT_VERSION=%s", version ?: "", "COMMAND_LINE=%s", self->command_line ?: "",
+      "AGENT=%s", self->agent ?: "", "AGENT_SD_UNIT=%s", self->sd_unit ?: "", NULL);
 
   return TRUE;
 }
@@ -1347,9 +1285,8 @@ write_history (RpmOstreeSysrootUpgrader *self,
  */
 gboolean
 rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
-                                   OstreeDeployment        **out_deployment,
-                                   GCancellable             *cancellable,
-                                   GError                  **error)
+                                   OstreeDeployment **out_deployment, GCancellable *cancellable,
+                                   GError **error)
 {
   if (self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_DRY_RUN)
     {
@@ -1382,15 +1319,15 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
   g_assert (target_revision);
 
   /* Use staging only if we're booted into the target root. */
-  const gboolean use_staging =
-    (ostree_sysroot_get_booted_deployment (self->sysroot) != NULL);
+  const gboolean use_staging = (ostree_sysroot_get_booted_deployment (self->sysroot) != NULL);
 
   /* Fix for https://github.com/projectatomic/rpm-ostree/issues/1392,
    * when kargs_strv is empty, we port those directly from pending
    * deployment if there is one */
   if (!self->kargs_strv)
     {
-      OstreeBootconfigParser *bootconfig = ostree_deployment_get_bootconfig (self->origin_merge_deployment);
+      OstreeBootconfigParser *bootconfig
+          = ostree_deployment_get_bootconfig (self->origin_merge_deployment);
       const char *options = ostree_bootconfig_parser_get (bootconfig, "options");
       self->kargs_strv = g_strsplit (options, " ", -1);
     }
@@ -1398,8 +1335,8 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
   // Note that most of the code here operates on ->computed_origin except this.
   // We want to preserve all the original requests, for cases like inactive
   // layers/overrides.
-  g_autoptr(GKeyFile) origin = rpmostree_origin_dup_keyfile (self->original_origin);
-  g_autoptr(OstreeDeployment) new_deployment = NULL;
+  g_autoptr (GKeyFile) origin = rpmostree_origin_dup_keyfile (self->original_origin);
+  g_autoptr (OstreeDeployment) new_deployment = NULL;
 
   g_autofree char *overlay_initrd_checksum = NULL;
   const char *overlay_v[] = { NULL, NULL };
@@ -1408,18 +1345,20 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
       glnx_fd_close int fd = -1;
       auto etc_files_gset = rpmostree_origin_get_initramfs_etc_files (self->computed_origin);
       rust::Vec<rust::String> etc_files;
-      GLNX_HASH_TABLE_FOREACH(etc_files_gset, const char *, key)
-        {
-          etc_files.push_back(std::string(key));
-        }
-      try {
-        fd = CXX_TRY_VAL(initramfs_overlay_generate (etc_files, *cancellable), error);
-      } catch (std::exception& e) {
-        util::rethrow_prefixed(e, "Generating initramfs overlay");
+      GLNX_HASH_TABLE_FOREACH (etc_files_gset, const char *, key)
+      {
+        etc_files.push_back (std::string (key));
       }
+      try
+        {
+          fd = CXX_TRY_VAL (initramfs_overlay_generate (etc_files, *cancellable), error);
+        }
+      catch (std::exception &e)
+        {
+          util::rethrow_prefixed (e, "Generating initramfs overlay");
+        }
 
-      if (!ostree_sysroot_stage_overlay_initrd (self->sysroot, fd,
-                                                &overlay_initrd_checksum,
+      if (!ostree_sysroot_stage_overlay_initrd (self->sysroot, fd, &overlay_initrd_checksum,
                                                 cancellable, error))
         return glnx_prefix_error (error, "Staging initramfs overlay");
 
@@ -1428,7 +1367,7 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
 
   OstreeSysrootDeployTreeOpts opts = {
     .override_kernel_argv = self->kargs_strv,
-    .overlay_initrds = (char**)overlay_v,
+    .overlay_initrds = (char **)overlay_v,
   };
 
   if (use_staging)
@@ -1448,21 +1387,17 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
                                             _OSTREE_SYSROOT_RUNSTATE_STAGED_LOCKED);
         }
 
-      auto task = rpmostreecxx::progress_begin_task("Staging deployment");
-      if (!ostree_sysroot_stage_tree_with_options (self->sysroot, self->osname,
-                                                   target_revision, origin,
-                                                   self->cfg_merge_deployment,
-                                                   &opts, &new_deployment,
-                                                   cancellable, error))
+      auto task = rpmostreecxx::progress_begin_task ("Staging deployment");
+      if (!ostree_sysroot_stage_tree_with_options (self->sysroot, self->osname, target_revision,
+                                                   origin, self->cfg_merge_deployment, &opts,
+                                                   &new_deployment, cancellable, error))
         return FALSE;
     }
   else
     {
-      if (!ostree_sysroot_deploy_tree_with_options (self->sysroot, self->osname,
-                                                    target_revision, origin,
-                                                    self->cfg_merge_deployment,
-                                                    &opts, &new_deployment,
-                                                    cancellable, error))
+      if (!ostree_sysroot_deploy_tree_with_options (self->sysroot, self->osname, target_revision,
+                                                    origin, self->cfg_merge_deployment, &opts,
+                                                    &new_deployment, cancellable, error))
         return FALSE;
     }
 
@@ -1478,8 +1413,8 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
    */
   if (!self->final_revision)
     {
-      g_autofree char *deployment_path =
-        ostree_sysroot_get_deployment_dirpath (self->sysroot, new_deployment);
+      g_autofree char *deployment_path
+          = ostree_sysroot_get_deployment_dirpath (self->sysroot, new_deployment);
       glnx_autofd int deployment_dfd = -1;
       if (!glnx_opendirat (ostree_sysroot_get_fd (self->sysroot), deployment_path, TRUE,
                            &deployment_dfd, error))
@@ -1494,8 +1429,7 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
        * interrupted; the base layer refs generation isn't transactional.
        */
       if (!ostree_repo_set_ref_immediate (self->repo, NULL, RPMOSTREE_TMP_BASE_REF,
-                                          self->base_revision,
-                                          cancellable, error))
+                                          self->base_revision, cancellable, error))
         return FALSE;
     }
 
@@ -1510,9 +1444,8 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
     }
   else
     {
-      if (!rpmostree_syscore_write_deployment (self->sysroot, new_deployment,
-                                               self->cfg_merge_deployment, FALSE,
-                                               cancellable, error))
+      if (!rpmostree_syscore_write_deployment (
+              self->sysroot, new_deployment, self->cfg_merge_deployment, FALSE, cancellable, error))
         return FALSE;
     }
 
@@ -1530,26 +1463,20 @@ rpmostree_sysroot_upgrader_flags_get_type (void)
     {
       static const GFlagsValue values[] = {
         { RPMOSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED,
-          "RPMOSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED",
-          "ignore-unconfigured" },
+          "RPMOSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED", "ignore-unconfigured" },
         { RPMOSTREE_SYSROOT_UPGRADER_FLAGS_ALLOW_OLDER,
-          "RPMOSTREE_SYSROOT_UPGRADER_FLAGS_ALLOW_OLDER",
-          "allow-older" },
-        { RPMOSTREE_SYSROOT_UPGRADER_FLAGS_DRY_RUN,
-          "RPMOSTREE_SYSROOT_UPGRADER_FLAGS_DRY_RUN",
+          "RPMOSTREE_SYSROOT_UPGRADER_FLAGS_ALLOW_OLDER", "allow-older" },
+        { RPMOSTREE_SYSROOT_UPGRADER_FLAGS_DRY_RUN, "RPMOSTREE_SYSROOT_UPGRADER_FLAGS_DRY_RUN",
           "dry-run" },
         { RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGCACHE_ONLY,
-          "RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGCACHE_ONLY",
-          "pkgcache-only" },
+          "RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGCACHE_ONLY", "pkgcache-only" },
         { RPMOSTREE_SYSROOT_UPGRADER_FLAGS_SYNTHETIC_PULL,
-          "RPMOSTREE_SYSROOT_UPGRADER_FLAGS_SYNTHETIC_PULL",
-          "synthetic-pull" },
+          "RPMOSTREE_SYSROOT_UPGRADER_FLAGS_SYNTHETIC_PULL", "synthetic-pull" },
         { RPMOSTREE_SYSROOT_UPGRADER_FLAGS_LOCK_FINALIZATION,
-          "RPMOSTREE_SYSROOT_UPGRADER_FLAGS_LOCK_FINALIZATION",
-          "lock-finalization" },
+          "RPMOSTREE_SYSROOT_UPGRADER_FLAGS_LOCK_FINALIZATION", "lock-finalization" },
       };
-      GType g_define_type_id =
-        g_flags_register_static (g_intern_static_string ("RpmOstreeSysrootUpgraderFlags"), values);
+      GType g_define_type_id = g_flags_register_static (
+          g_intern_static_string ("RpmOstreeSysrootUpgraderFlags"), values);
       g_once_init_leave (&static_g_define_type_id, g_define_type_id);
     }
 

--- a/src/daemon/rpmostree-sysroot-upgrader.h
+++ b/src/daemon/rpmostree-sysroot-upgrader.h
@@ -20,16 +20,16 @@
 
 #pragma once
 
-#include <ostree.h>
 #include "rpmostree-origin.h"
 #include "rpmostree-sysroot-core.h"
+#include <ostree.h>
 
 G_BEGIN_DECLS
 
-#define RPMOSTREE_TYPE_SYSROOT_UPGRADER rpmostree_sysroot_upgrader_get_type()
-#define RPMOSTREE_SYSROOT_UPGRADER(obj) \
+#define RPMOSTREE_TYPE_SYSROOT_UPGRADER rpmostree_sysroot_upgrader_get_type ()
+#define RPMOSTREE_SYSROOT_UPGRADER(obj)                                                            \
   (G_TYPE_CHECK_INSTANCE_CAST ((obj), RPMOSTREE_TYPE_SYSROOT_UPGRADER, RpmOstreeSysrootUpgrader))
-#define RPMOSTREE_IS_SYSROOT_UPGRADER(obj) \
+#define RPMOSTREE_IS_SYSROOT_UPGRADER(obj)                                                         \
   (G_TYPE_CHECK_INSTANCE_TYPE ((obj), RPMOSTREE_TYPE_SYSROOT_UPGRADER))
 
 typedef struct RpmOstreeSysrootUpgrader RpmOstreeSysrootUpgrader;
@@ -38,31 +38,37 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (RpmOstreeSysrootUpgrader, g_object_unref)
 /**
  * RpmOstreeSysrootUpgraderFlags:
  * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_NONE: No options
- * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED: Do not error if the origin has an unconfigured-state key
- * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_ALLOW_OLDER: Do not error if the new deployment was composed earlier than the current deployment
- * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_DRY_RUN: Don't deploy new base. If layering packages, only print the transaction
+ * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED: Do not error if the origin has an
+ * unconfigured-state key
+ * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_ALLOW_OLDER: Do not error if the new deployment was composed
+ * earlier than the current deployment
+ * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_DRY_RUN: Don't deploy new base. If layering packages, only
+ * print the transaction
  * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGCACHE_ONLY: Don't try to update cached packages.
- * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_SYNTHETIC_PULL: Don't actually pull, just resolve ref and timestamp check
+ * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_SYNTHETIC_PULL: Don't actually pull, just resolve ref and
+ * timestamp check
  * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_LOCK_FINALIZATION: Prevent deployment finalization on shutdown
  *
  * Flags controlling operation of an #RpmOstreeSysrootUpgrader.
  */
-typedef enum {
+typedef enum
+{
   /* NB: When changing here, also change rpmostree_sysroot_upgrader_flags_get_type(). */
-  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_NONE                 = (1 << 0),
-  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED  = (1 << 1),
-  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_ALLOW_OLDER          = (1 << 2),
-  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_DRY_RUN              = (1 << 3),
-  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGCACHE_ONLY        = (1 << 4),
-  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_SYNTHETIC_PULL       = (1 << 5),
-  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_LOCK_FINALIZATION    = (1 << 6),
+  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_NONE = (1 << 0),
+  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED = (1 << 1),
+  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_ALLOW_OLDER = (1 << 2),
+  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_DRY_RUN = (1 << 3),
+  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGCACHE_ONLY = (1 << 4),
+  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_SYNTHETIC_PULL = (1 << 5),
+  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_LOCK_FINALIZATION = (1 << 6),
 } RpmOstreeSysrootUpgraderFlags;
 
 /* _NONE means we're doing pure ostree, no client-side computation.
  * _LOCAL is just e.g. rpm-ostree initramfs
  * _RPMMD_REPOS is where we're downloading data from /etc/yum.repos.d
  */
-typedef enum {
+typedef enum
+{
   RPMOSTREE_SYSROOT_UPGRADER_LAYERING_NONE = 0,
   RPMOSTREE_SYSROOT_UPGRADER_LAYERING_LOCAL = 1,
   RPMOSTREE_SYSROOT_UPGRADER_LAYERING_RPMMD_REPOS = 2,
@@ -72,71 +78,47 @@ GType rpmostree_sysroot_upgrader_get_type (void);
 
 GType rpmostree_sysroot_upgrader_flags_get_type (void);
 
-RpmOstreeSysrootUpgrader *rpmostree_sysroot_upgrader_new (OstreeSysroot              *sysroot,
-                                                          const char                 *osname,
-                                                          RpmOstreeSysrootUpgraderFlags  flags,
-                                                          GCancellable               *cancellable,
-                                                          GError                    **error);
+RpmOstreeSysrootUpgrader *rpmostree_sysroot_upgrader_new (OstreeSysroot *sysroot,
+                                                          const char *osname,
+                                                          RpmOstreeSysrootUpgraderFlags flags,
+                                                          GCancellable *cancellable,
+                                                          GError **error);
 
-void rpmostree_sysroot_upgrader_set_caller_info (RpmOstreeSysrootUpgrader *self, 
-                                                 const char               *initiating_command_line, 
-                                                 const char               *agent,
-                                                 const char               *sd_unit);
+void rpmostree_sysroot_upgrader_set_caller_info (RpmOstreeSysrootUpgrader *self,
+                                                 const char *initiating_command_line,
+                                                 const char *agent, const char *sd_unit);
 
-OstreeDeployment* rpmostree_sysroot_upgrader_get_merge_deployment (RpmOstreeSysrootUpgrader *self);
+OstreeDeployment *rpmostree_sysroot_upgrader_get_merge_deployment (RpmOstreeSysrootUpgrader *self);
 
-RpmOstreeOrigin *
-rpmostree_sysroot_upgrader_dup_origin (RpmOstreeSysrootUpgrader *self);
+RpmOstreeOrigin *rpmostree_sysroot_upgrader_dup_origin (RpmOstreeSysrootUpgrader *self);
 
-void
-rpmostree_sysroot_upgrader_set_origin (RpmOstreeSysrootUpgrader *self,
-                                       RpmOstreeOrigin *origin);
-const char *
-rpmostree_sysroot_upgrader_get_base (RpmOstreeSysrootUpgrader *self);
+void rpmostree_sysroot_upgrader_set_origin (RpmOstreeSysrootUpgrader *self,
+                                            RpmOstreeOrigin *origin);
+const char *rpmostree_sysroot_upgrader_get_base (RpmOstreeSysrootUpgrader *self);
 
-DnfSack*
-rpmostree_sysroot_upgrader_get_sack (RpmOstreeSysrootUpgrader *self,
-                                     GError                  **error);
+DnfSack *rpmostree_sysroot_upgrader_get_sack (RpmOstreeSysrootUpgrader *self, GError **error);
 
-gboolean
-rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
-                                      const char             *dir_to_pull,
-                                      OstreeRepoPullFlags     flags,
-                                      OstreeAsyncProgress    *progress,
-                                      gboolean               *out_changed,
-                                      GCancellable           *cancellable,
-                                      GError                **error);
+gboolean rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader *self,
+                                               const char *dir_to_pull, OstreeRepoPullFlags flags,
+                                               OstreeAsyncProgress *progress, gboolean *out_changed,
+                                               GCancellable *cancellable, GError **error);
 
-gboolean
-rpmostree_sysroot_upgrader_prep_layering (RpmOstreeSysrootUpgrader *self,
-                                          RpmOstreeSysrootUpgraderLayeringType *out_layering,
-                                          gboolean                 *out_changed,
-                                          GCancellable             *cancellable,
-                                          GError                  **error);
+gboolean rpmostree_sysroot_upgrader_prep_layering (
+    RpmOstreeSysrootUpgrader *self, RpmOstreeSysrootUpgraderLayeringType *out_layering,
+    gboolean *out_changed, GCancellable *cancellable, GError **error);
 
-gboolean
-rpmostree_sysroot_upgrader_import_pkgs (RpmOstreeSysrootUpgrader *self,
-                                        GCancellable             *cancellable,
-                                        GError                  **error);
+gboolean rpmostree_sysroot_upgrader_import_pkgs (RpmOstreeSysrootUpgrader *self,
+                                                 GCancellable *cancellable, GError **error);
 
-gboolean
-rpmostree_sysroot_upgrader_pull_repos (RpmOstreeSysrootUpgrader  *self,
-                                       const char             *dir_to_pull,
-                                       OstreeRepoPullFlags     flags,
-                                       OstreeAsyncProgress    *progress,
-                                       gboolean               *out_changed,
-                                       GCancellable           *cancellable,
-                                       GError                **error);
+gboolean rpmostree_sysroot_upgrader_pull_repos (RpmOstreeSysrootUpgrader *self,
+                                                const char *dir_to_pull, OstreeRepoPullFlags flags,
+                                                OstreeAsyncProgress *progress,
+                                                gboolean *out_changed, GCancellable *cancellable,
+                                                GError **error);
 
+gboolean rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
+                                            OstreeDeployment **out_deployment,
+                                            GCancellable *cancellable, GError **error);
 
-
-gboolean
-rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
-                                   OstreeDeployment        **out_deployment,
-                                   GCancellable             *cancellable,
-                                   GError                  **error);
-
-void
-rpmostree_sysroot_upgrader_set_kargs (RpmOstreeSysrootUpgrader *self,
-                                      char                    **kernel_args);
+void rpmostree_sysroot_upgrader_set_kargs (RpmOstreeSysrootUpgrader *self, char **kernel_args);
 G_END_DECLS

--- a/src/daemon/rpmostreed-daemon.h
+++ b/src/daemon/rpmostreed-daemon.h
@@ -1,31 +1,32 @@
 /*
-* Copyright (C) 2015 Red Hat, Inc.
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program; if not, write to the Free Software
-* Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
-*/
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 #pragma once
 
-#include "rpmostreed-types.h"
 #include "rpmostree-util.h"
+#include "rpmostreed-types.h"
 
 G_BEGIN_DECLS
 
-#define RPMOSTREED_TYPE_DAEMON   (rpmostreed_daemon_get_type ())
-#define RPMOSTREED_DAEMON(o)     (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_DAEMON, RpmostreedDaemon))
-#define RPMOSTREED_IS_DAEMON(o)  (G_TYPE_CHECK_INSTANCE_TYPE ((o), RPMOSTREED_TYPE_DAEMON))
+#define RPMOSTREED_TYPE_DAEMON (rpmostreed_daemon_get_type ())
+#define RPMOSTREED_DAEMON(o)                                                                       \
+  (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_DAEMON, RpmostreedDaemon))
+#define RPMOSTREED_IS_DAEMON(o) (G_TYPE_CHECK_INSTANCE_TYPE ((o), RPMOSTREED_TYPE_DAEMON))
 
 #define DBUS_NAME "org.projectatomic.rpmostree1"
 #define BASE_DBUS_PATH "/org/projectatomic/rpmostree1"
@@ -36,41 +37,28 @@ G_BEGIN_DECLS
 #define RPMOSTREE_DRIVER_SD_UNIT "driver-sd-unit"
 #define RPMOSTREE_DRIVER_NAME "driver-name"
 
-GType              rpmostreed_daemon_get_type       (void) G_GNUC_CONST;
-RpmostreedDaemon * rpmostreed_daemon_get            (void);
-GDBusConnection  * rpmostreed_daemon_connection     (void);
-gboolean           rpmostreed_get_client_uid        (RpmostreedDaemon *self,
-                                                     const char       *client,
-                                                     uid_t            *out_uid);
-void               rpmostreed_daemon_add_client     (RpmostreedDaemon *self,
-                                                     const char *client,
-                                                     const char *client_id);
-void               rpmostreed_daemon_remove_client  (RpmostreedDaemon *self,
-                                                     const char *client);
-char *             rpmostreed_daemon_client_get_string (RpmostreedDaemon *self,
-                                                        const char *client);
-char *             rpmostreed_daemon_client_get_agent_id (RpmostreedDaemon *self,
-                                                        const char *client);
-char *             rpmostreed_daemon_client_get_sd_unit (RpmostreedDaemon *self,
-                                                         const char *client);
-void               rpmostreed_daemon_exit_now       (RpmostreedDaemon *self);
-void               rpmostreed_daemon_reboot         (RpmostreedDaemon *self);
-gboolean           rpmostreed_daemon_is_rebooting   (RpmostreedDaemon *self);
-void               rpmostreed_daemon_run_until_idle_exit (RpmostreedDaemon *self);
-void               rpmostreed_daemon_publish        (RpmostreedDaemon *self,
-                                                     const gchar *path,
-                                                     gboolean uniquely,
-                                                     gpointer thing);
-void               rpmostreed_daemon_unpublish      (RpmostreedDaemon *self,
-                                                     const gchar *path,
-                                                     gpointer thing);
-gboolean           rpmostreed_daemon_reload_config  (RpmostreedDaemon *self,
-                                                     gboolean         *out_changed,
-                                                     GError          **error);
+GType rpmostreed_daemon_get_type (void) G_GNUC_CONST;
+RpmostreedDaemon *rpmostreed_daemon_get (void);
+GDBusConnection *rpmostreed_daemon_connection (void);
+gboolean rpmostreed_get_client_uid (RpmostreedDaemon *self, const char *client, uid_t *out_uid);
+void rpmostreed_daemon_add_client (RpmostreedDaemon *self, const char *client,
+                                   const char *client_id);
+void rpmostreed_daemon_remove_client (RpmostreedDaemon *self, const char *client);
+char *rpmostreed_daemon_client_get_string (RpmostreedDaemon *self, const char *client);
+char *rpmostreed_daemon_client_get_agent_id (RpmostreedDaemon *self, const char *client);
+char *rpmostreed_daemon_client_get_sd_unit (RpmostreedDaemon *self, const char *client);
+void rpmostreed_daemon_exit_now (RpmostreedDaemon *self);
+void rpmostreed_daemon_reboot (RpmostreedDaemon *self);
+gboolean rpmostreed_daemon_is_rebooting (RpmostreedDaemon *self);
+void rpmostreed_daemon_run_until_idle_exit (RpmostreedDaemon *self);
+void rpmostreed_daemon_publish (RpmostreedDaemon *self, const gchar *path, gboolean uniquely,
+                                gpointer thing);
+void rpmostreed_daemon_unpublish (RpmostreedDaemon *self, const gchar *path, gpointer thing);
+gboolean rpmostreed_daemon_reload_config (RpmostreedDaemon *self, gboolean *out_changed,
+                                          GError **error);
 
 gboolean rpmostreed_authorize_method_for_uid0 (GDBusMethodInvocation *invocation);
 
-RpmostreedAutomaticUpdatePolicy
-rpmostreed_get_automatic_update_policy (RpmostreedDaemon *self);
+RpmostreedAutomaticUpdatePolicy rpmostreed_get_automatic_update_policy (RpmostreedDaemon *self);
 
 G_END_DECLS

--- a/src/daemon/rpmostreed-deployment-utils.h
+++ b/src/daemon/rpmostreed-deployment-utils.h
@@ -18,48 +18,36 @@
 
 #pragma once
 
-#include <ostree.h>
 #include <libdnf/libdnf.h>
+#include <ostree.h>
 
 #include "rpmostreed-types.h"
 
 G_BEGIN_DECLS
 
-char *          rpmostreed_deployment_generate_id (OstreeDeployment *deployment);
+char *rpmostreed_deployment_generate_id (OstreeDeployment *deployment);
 
-gboolean
-rpmostreed_deployment_get_for_id (OstreeSysroot     *sysroot,
-                                  const gchar       *deploy_id,
-                                  OstreeDeployment **out_deployment,
-                                  GError           **error);
+gboolean rpmostreed_deployment_get_for_id (OstreeSysroot *sysroot, const gchar *deploy_id,
+                                           OstreeDeployment **out_deployment, GError **error);
 
-OstreeDeployment *
-                rpmostreed_deployment_get_for_index (OstreeSysroot *sysroot,
-                                                     const gchar   *index,
-                                                     GError       **error);
+OstreeDeployment *rpmostreed_deployment_get_for_index (OstreeSysroot *sysroot, const gchar *index,
+                                                       GError **error);
 
-GVariant *      rpmostreed_deployment_generate_blank_variant (void);
+GVariant *rpmostreed_deployment_generate_blank_variant (void);
 
-gboolean        rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroot,
-                                                        OstreeDeployment *deployment,
-                                                        const char       *booted_id,
-                                                        OstreeRepo       *repo,
-                                                        gboolean          filter,
-                                                        GVariant        **out_variant,
-                                                        GError          **error);
+gboolean rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot,
+                                                 OstreeDeployment *deployment,
+                                                 const char *booted_id, OstreeRepo *repo,
+                                                 gboolean filter, GVariant **out_variant,
+                                                 GError **error);
 
-GVariant *      rpmostreed_commit_generate_cached_details_variant (OstreeDeployment *deployment,
-                                                                   OstreeRepo       *repo,
-                                                                   const char       *refspec,
-                                                                   const char       *checksum,
-                                                                   GError          **error);
+GVariant *rpmostreed_commit_generate_cached_details_variant (OstreeDeployment *deployment,
+                                                             OstreeRepo *repo, const char *refspec,
+                                                             const char *checksum, GError **error);
 
-gboolean        rpmostreed_update_generate_variant (OstreeDeployment  *booted_deployment,
-                                                    OstreeDeployment  *staged_deployment,
-                                                    OstreeRepo        *repo,
-                                                    DnfSack           *sack,
-                                                    GVariant         **out_update,
-                                                    GCancellable      *cancellable,
-                                                    GError           **error);
+gboolean rpmostreed_update_generate_variant (OstreeDeployment *booted_deployment,
+                                             OstreeDeployment *staged_deployment, OstreeRepo *repo,
+                                             DnfSack *sack, GVariant **out_update,
+                                             GCancellable *cancellable, GError **error);
 
 G_END_DECLS

--- a/src/daemon/rpmostreed-errors.cxx
+++ b/src/daemon/rpmostreed-errors.cxx
@@ -1,38 +1,32 @@
 /*
-* Copyright (C) 2015 Red Hat, Inc.
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program; if not, write to the Free Software
-* Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
-*/
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 #include "config.h"
 
 #include "rpmostreed-errors.h"
 #include "rpmostreed-types.h"
 
-static const GDBusErrorEntry dbus_error_entries[] =
-{
-  {RPM_OSTREED_ERROR_FAILED,
-   "org.projectatomic.rpmostreed.Error.Failed"},
-  {RPM_OSTREED_ERROR_INVALID_SYSROOT,
-   "org.projectatomic.rpmostreed.Error.InvalidSysroot"},
-  {RPM_OSTREED_ERROR_NOT_AUTHORIZED,
-   "org.projectatomic.rpmostreed.Error.NotAuthorized"},
-  {RPM_OSTREED_ERROR_UPDATE_IN_PROGRESS,
-   "org.projectatomic.rpmostreed.Error.UpdateInProgress"},
-  {RPM_OSTREED_ERROR_INVALID_REFSPEC,
-   "org.projectatomic.rpmostreed.Error.InvalidRefspec"},
+static const GDBusErrorEntry dbus_error_entries[] = {
+  { RPM_OSTREED_ERROR_FAILED, "org.projectatomic.rpmostreed.Error.Failed" },
+  { RPM_OSTREED_ERROR_INVALID_SYSROOT, "org.projectatomic.rpmostreed.Error.InvalidSysroot" },
+  { RPM_OSTREED_ERROR_NOT_AUTHORIZED, "org.projectatomic.rpmostreed.Error.NotAuthorized" },
+  { RPM_OSTREED_ERROR_UPDATE_IN_PROGRESS, "org.projectatomic.rpmostreed.Error.UpdateInProgress" },
+  { RPM_OSTREED_ERROR_INVALID_REFSPEC, "org.projectatomic.rpmostreed.Error.InvalidRefspec" },
 };
 
 GQuark
@@ -40,9 +34,7 @@ rpmostreed_error_quark (void)
 {
   G_STATIC_ASSERT (G_N_ELEMENTS (dbus_error_entries) == RPM_OSTREED_ERROR_NUM_ENTRIES);
   static gsize quark = 0;
-  g_dbus_error_register_error_domain ("rpmostreed-error-quark",
-                                      &quark,
-                                      dbus_error_entries,
+  g_dbus_error_register_error_domain ("rpmostreed-error-quark", &quark, dbus_error_entries,
                                       G_N_ELEMENTS (dbus_error_entries));
-  return (GQuark) quark;
+  return (GQuark)quark;
 }

--- a/src/daemon/rpmostreed-errors.h
+++ b/src/daemon/rpmostreed-errors.h
@@ -1,20 +1,20 @@
 /*
-* Copyright (C) 2015 Red Hat, Inc.
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program; if not, write to the Free Software
-* Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
-*/
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 #pragma once
 
@@ -24,7 +24,8 @@ G_BEGIN_DECLS
 
 #define RPM_OSTREED_ERROR (rpmostreed_error_quark ())
 
-typedef enum {
+typedef enum
+{
   RPM_OSTREED_ERROR_FAILED,
   RPM_OSTREED_ERROR_INVALID_SYSROOT,
   RPM_OSTREED_ERROR_NOT_AUTHORIZED,

--- a/src/daemon/rpmostreed-os-experimental.h
+++ b/src/daemon/rpmostreed-os-experimental.h
@@ -1,20 +1,20 @@
 /*
-* Copyright (C) 2015 Red Hat, Inc.
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program; if not, write to the Free Software
-* Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
-*/
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 #pragma once
 
@@ -22,12 +22,13 @@
 
 G_BEGIN_DECLS
 
-#define RPMOSTREED_TYPE_OSEXPERIMENTAL   (rpmostreed_osexperimental_get_type ())
-#define RPMOSTREED_OSEXPERIMENTAL(o)     (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_OSEXPERIMENTAL, RpmostreedOSExperimental))
-#define RPMOSTREED_IS_OSEXPERIMENTAL(o)  (G_TYPE_CHECK_INSTANCE_TYPE ((o), RPMOSTREED_TYPE_OSEXPERIMENTAL))
+#define RPMOSTREED_TYPE_OSEXPERIMENTAL (rpmostreed_osexperimental_get_type ())
+#define RPMOSTREED_OSEXPERIMENTAL(o)                                                               \
+  (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_OSEXPERIMENTAL, RpmostreedOSExperimental))
+#define RPMOSTREED_IS_OSEXPERIMENTAL(o)                                                            \
+  (G_TYPE_CHECK_INSTANCE_TYPE ((o), RPMOSTREED_TYPE_OSEXPERIMENTAL))
 
-GType             rpmostreed_osexperimental_get_type           (void) G_GNUC_CONST;
-RPMOSTreeOSExperimental *     rpmostreed_osexperimental_new                (OstreeSysroot *sysroot,
-                                                                OstreeRepo *repo,
-                                                                            const char *name);
+GType rpmostreed_osexperimental_get_type (void) G_GNUC_CONST;
+RPMOSTreeOSExperimental *rpmostreed_osexperimental_new (OstreeSysroot *sysroot, OstreeRepo *repo,
+                                                        const char *name);
 G_END_DECLS

--- a/src/daemon/rpmostreed-os.cxx
+++ b/src/daemon/rpmostreed-os.cxx
@@ -1,20 +1,20 @@
 /*
-* Copyright (C) 2015 Red Hat, Inc.
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program; if not, write to the Free Software
-* Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
-*/
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 #include "config.h"
 #include "ostree.h"
@@ -22,19 +22,19 @@
 #include <libglnx.h>
 #include <systemd/sd-journal.h>
 
-#include "rpmostreed-sysroot.h"
+#include "rpmostree-core.h"
+#include "rpmostree-origin.h"
+#include "rpmostree-package-variants.h"
+#include "rpmostree-sysroot-core.h"
+#include "rpmostree-util.h"
 #include "rpmostreed-daemon.h"
 #include "rpmostreed-deployment-utils.h"
-#include "rpmostree-package-variants.h"
 #include "rpmostreed-errors.h"
-#include "rpmostree-origin.h"
-#include "rpmostree-core.h"
-#include "rpmostree-sysroot-core.h"
 #include "rpmostreed-os.h"
-#include "rpmostreed-utils.h"
-#include "rpmostree-util.h"
-#include "rpmostreed-transaction.h"
+#include "rpmostreed-sysroot.h"
 #include "rpmostreed-transaction-types.h"
+#include "rpmostreed-transaction.h"
+#include "rpmostreed-utils.h"
 
 typedef struct _RpmostreedOSClass RpmostreedOSClass;
 
@@ -59,40 +59,36 @@ static inline char **vardict_lookup_strv (GVariantDict *dict, const char *key);
 
 static gboolean vardict_lookup_bool (GVariantDict *dict, const char *key, gboolean dfault);
 
-G_DEFINE_TYPE_WITH_CODE (RpmostreedOS,
-                         rpmostreed_os,
-                         RPMOSTREE_TYPE_OS_SKELETON,
-                         G_IMPLEMENT_INTERFACE (RPMOSTREE_TYPE_OS,
-                                                rpmostreed_os_iface_init));
+G_DEFINE_TYPE_WITH_CODE (RpmostreedOS, rpmostreed_os, RPMOSTREE_TYPE_OS_SKELETON,
+                         G_IMPLEMENT_INTERFACE (RPMOSTREE_TYPE_OS, rpmostreed_os_iface_init));
 
-/* ---------------------------------------------------------------------------------------------------- */
+/* ----------------------------------------------------------------------------------------------------
+ */
 
 static void
-sysroot_changed (RpmostreedSysroot *sysroot,
-                 gpointer user_data)
+sysroot_changed (RpmostreedSysroot *sysroot, gpointer user_data)
 {
   RpmostreedOS *self = RPMOSTREED_OS (user_data);
-  g_autoptr(GError) local_error = NULL;
+  g_autoptr (GError) local_error = NULL;
   GError **error = &local_error;
 
   if (!rpmostreed_os_load_internals (self, error))
-      goto out;
+    goto out;
 
- out:
+out:
   if (local_error)
     g_warning ("%s", local_error->message);
 }
 
 static gboolean
-os_authorize_method (GDBusInterfaceSkeleton *interface,
-                     GDBusMethodInvocation  *invocation)
+os_authorize_method (GDBusInterfaceSkeleton *interface, GDBusMethodInvocation *invocation)
 {
   RpmostreedSysroot *sysroot = rpmostreed_sysroot_get ();
   PolkitAuthority *authority = rpmostreed_sysroot_get_polkit_authority (sysroot);
   const gchar *method_name = g_dbus_method_invocation_get_method_name (invocation);
   const gchar *sender = g_dbus_method_invocation_get_sender (invocation);
   GVariant *parameters = g_dbus_method_invocation_get_parameters (invocation);
-  g_autoptr(GPtrArray) actions = g_ptr_array_new ();
+  g_autoptr (GPtrArray) actions = g_ptr_array_new ();
   gboolean authorized = FALSE;
 
   if (rpmostreed_sysroot_is_on_session_bus (sysroot))
@@ -101,35 +97,35 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
       return TRUE;
     }
 
-  if (g_strcmp0 (method_name, "GetDeploymentsRpmDiff") == 0 ||
-           g_strcmp0 (method_name, "GetCachedDeployRpmDiff") == 0 ||
-           g_strcmp0 (method_name, "DownloadDeployRpmDiff") == 0 ||
-           g_strcmp0 (method_name, "GetCachedUpdateRpmDiff") == 0 ||
-           g_strcmp0 (method_name, "DownloadUpdateRpmDiff") == 0 ||
-           g_strcmp0 (method_name, "GetCachedRebaseRpmDiff") == 0 ||
-           g_strcmp0 (method_name, "DownloadRebaseRpmDiff") == 0 ||
-           g_strcmp0 (method_name, "RefreshMd") == 0)
+  if (g_strcmp0 (method_name, "GetDeploymentsRpmDiff") == 0
+      || g_strcmp0 (method_name, "GetCachedDeployRpmDiff") == 0
+      || g_strcmp0 (method_name, "DownloadDeployRpmDiff") == 0
+      || g_strcmp0 (method_name, "GetCachedUpdateRpmDiff") == 0
+      || g_strcmp0 (method_name, "DownloadUpdateRpmDiff") == 0
+      || g_strcmp0 (method_name, "GetCachedRebaseRpmDiff") == 0
+      || g_strcmp0 (method_name, "DownloadRebaseRpmDiff") == 0
+      || g_strcmp0 (method_name, "RefreshMd") == 0)
 
     {
-      g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.repo-refresh");
+      g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.repo-refresh");
     }
   else if (g_strcmp0 (method_name, "ModifyYumRepo") == 0)
     {
-      g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.repo-modify");
+      g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.repo-modify");
     }
   else if (g_strcmp0 (method_name, "Deploy") == 0)
     {
-      g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.deploy");
+      g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.deploy");
     }
   /* unite these for now; it could make sense at least to make "check" its own action */
-  else if (g_strcmp0 (method_name, "Upgrade") == 0 ||
-           g_strcmp0 (method_name, "AutomaticUpdateTrigger") == 0)
+  else if (g_strcmp0 (method_name, "Upgrade") == 0
+           || g_strcmp0 (method_name, "AutomaticUpdateTrigger") == 0)
     {
-      g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.upgrade");
+      g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.upgrade");
     }
   else if (g_strcmp0 (method_name, "Rebase") == 0)
     {
-      g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.rebase");
+      g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.rebase");
     }
   else if (g_strcmp0 (method_name, "GetDeploymentBootConfig") == 0)
     {
@@ -138,104 +134,97 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
        */
       return TRUE;
     }
-  else if (g_strcmp0 (method_name, "SetInitramfsState") == 0 ||
-           g_strcmp0 (method_name, "KernelArgs") == 0 ||
-           g_strcmp0 (method_name, "InitramfsEtc") == 0)
+  else if (g_strcmp0 (method_name, "SetInitramfsState") == 0
+           || g_strcmp0 (method_name, "KernelArgs") == 0
+           || g_strcmp0 (method_name, "InitramfsEtc") == 0)
     {
-      g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.bootconfig");
+      g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.bootconfig");
     }
   else if (g_strcmp0 (method_name, "Cleanup") == 0)
     {
-      g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.cleanup");
+      g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.cleanup");
     }
-  else if (g_strcmp0 (method_name, "Rollback") == 0 ||
-           g_strcmp0 (method_name, "ClearRollbackTarget") == 0)
+  else if (g_strcmp0 (method_name, "Rollback") == 0
+           || g_strcmp0 (method_name, "ClearRollbackTarget") == 0)
     {
-      g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.rollback");
+      g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.rollback");
     }
   else if (g_strcmp0 (method_name, "PkgChange") == 0)
     {
-      g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.install-uninstall-packages");
+      g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.install-uninstall-packages");
     }
   else if (g_strcmp0 (method_name, "UpdateDeployment") == 0)
     {
-      g_autoptr(GVariant) modifiers = g_variant_get_child_value (parameters, 0);
-      g_autoptr(GVariant) options = g_variant_get_child_value (parameters, 1);
-      g_auto(GVariantDict) modifiers_dict;
-      g_auto(GVariantDict) options_dict;
+      g_autoptr (GVariant) modifiers = g_variant_get_child_value (parameters, 0);
+      g_autoptr (GVariant) options = g_variant_get_child_value (parameters, 1);
+      g_auto (GVariantDict) modifiers_dict;
+      g_auto (GVariantDict) options_dict;
       g_variant_dict_init (&modifiers_dict, modifiers);
       g_variant_dict_init (&options_dict, options);
-      auto refspec =
-        static_cast<const char*>(vardict_lookup_ptr (&modifiers_dict, "set-refspec", "&s"));
-      auto revision =
-        static_cast<const char *>(vardict_lookup_ptr (&modifiers_dict, "set-revision", "&s"));
-      g_autofree char **install_pkgs =
-        vardict_lookup_strv (&modifiers_dict, "install-packages");
-      g_autofree char **uninstall_pkgs =
-        vardict_lookup_strv (&modifiers_dict, "uninstall-packages");
-      g_autofree char **enable_modules =
-        vardict_lookup_strv (&modifiers_dict, "enable-modules");
-      g_autofree char **disable_modules =
-        vardict_lookup_strv (&modifiers_dict, "disable-modules");
-      g_autofree char **install_modules =
-        vardict_lookup_strv (&modifiers_dict, "install-modules");
-      g_autofree char **uninstall_modules =
-        vardict_lookup_strv (&modifiers_dict, "uninstall-modules");
-      g_autofree const char *const *override_replace_pkgs =
-        vardict_lookup_strv (&modifiers_dict, "override-replace-packages");
-      g_autofree const char *const *override_remove_pkgs =
-        vardict_lookup_strv (&modifiers_dict, "override-remove-packages");
-      g_autofree const char *const *override_reset_pkgs =
-        vardict_lookup_strv (&modifiers_dict, "override-reset-packages");
-      g_autoptr(GVariant) install_local_pkgs =
-        g_variant_dict_lookup_value (&modifiers_dict, "install-local-packages",
-                                     G_VARIANT_TYPE("ah"));
-      g_autoptr(GVariant) install_local_fileoverride_pkgs =
-        g_variant_dict_lookup_value (&modifiers_dict, "install-local-fileoverride-packages",
-                                     G_VARIANT_TYPE("ah"));
-      g_autoptr(GVariant) override_replace_local_pkgs =
-        g_variant_dict_lookup_value (&modifiers_dict, "override-replace-local-packages",
-                                     G_VARIANT_TYPE("ah"));
-      gboolean no_pull_base =
-        vardict_lookup_bool (&options_dict, "no-pull-base", FALSE);
-      gboolean no_overrides =
-        vardict_lookup_bool (&options_dict, "no-overrides", FALSE);
-      gboolean no_layering =
-        vardict_lookup_bool (&options_dict, "no-layering", FALSE);
+      auto refspec
+          = static_cast<const char *> (vardict_lookup_ptr (&modifiers_dict, "set-refspec", "&s"));
+      auto revision
+          = static_cast<const char *> (vardict_lookup_ptr (&modifiers_dict, "set-revision", "&s"));
+      g_autofree char **install_pkgs = vardict_lookup_strv (&modifiers_dict, "install-packages");
+      g_autofree char **uninstall_pkgs
+          = vardict_lookup_strv (&modifiers_dict, "uninstall-packages");
+      g_autofree char **enable_modules = vardict_lookup_strv (&modifiers_dict, "enable-modules");
+      g_autofree char **disable_modules = vardict_lookup_strv (&modifiers_dict, "disable-modules");
+      g_autofree char **install_modules = vardict_lookup_strv (&modifiers_dict, "install-modules");
+      g_autofree char **uninstall_modules
+          = vardict_lookup_strv (&modifiers_dict, "uninstall-modules");
+      g_autofree const char *const *override_replace_pkgs
+          = vardict_lookup_strv (&modifiers_dict, "override-replace-packages");
+      g_autofree const char *const *override_remove_pkgs
+          = vardict_lookup_strv (&modifiers_dict, "override-remove-packages");
+      g_autofree const char *const *override_reset_pkgs
+          = vardict_lookup_strv (&modifiers_dict, "override-reset-packages");
+      g_autoptr (GVariant) install_local_pkgs = g_variant_dict_lookup_value (
+          &modifiers_dict, "install-local-packages", G_VARIANT_TYPE ("ah"));
+      g_autoptr (GVariant) install_local_fileoverride_pkgs = g_variant_dict_lookup_value (
+          &modifiers_dict, "install-local-fileoverride-packages", G_VARIANT_TYPE ("ah"));
+      g_autoptr (GVariant) override_replace_local_pkgs = g_variant_dict_lookup_value (
+          &modifiers_dict, "override-replace-local-packages", G_VARIANT_TYPE ("ah"));
+      gboolean no_pull_base = vardict_lookup_bool (&options_dict, "no-pull-base", FALSE);
+      gboolean no_overrides = vardict_lookup_bool (&options_dict, "no-overrides", FALSE);
+      gboolean no_layering = vardict_lookup_bool (&options_dict, "no-layering", FALSE);
 
       if (vardict_lookup_bool (&options_dict, "no-initramfs", FALSE))
-        g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.bootconfig");
+        g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.bootconfig");
 
       if (refspec != NULL)
-        g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.rebase");
+        g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.rebase");
       else if (revision != NULL)
-        g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.deploy");
+        g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.deploy");
       else if (!no_pull_base)
-        g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.upgrade");
+        g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.upgrade");
 
-      if (install_pkgs != NULL || uninstall_pkgs != NULL ||
-          enable_modules != NULL || disable_modules != NULL ||
-          install_modules != NULL || uninstall_modules != NULL ||
-          no_layering)
-        g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.install-uninstall-packages");
+      if (install_pkgs != NULL || uninstall_pkgs != NULL || enable_modules != NULL
+          || disable_modules != NULL || install_modules != NULL || uninstall_modules != NULL
+          || no_layering)
+        g_ptr_array_add (actions,
+                         (void *)"org.projectatomic.rpmostree1.install-uninstall-packages");
 
       if ((install_local_pkgs != NULL && g_variant_n_children (install_local_pkgs) > 0)
-          || (install_local_fileoverride_pkgs != NULL && g_variant_n_children (install_local_fileoverride_pkgs) > 0))
-        g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.install-local-packages");
+          || (install_local_fileoverride_pkgs != NULL
+              && g_variant_n_children (install_local_fileoverride_pkgs) > 0))
+        g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.install-local-packages");
 
-      if (override_replace_pkgs != NULL || override_remove_pkgs != NULL || override_reset_pkgs != NULL ||
-          (override_replace_local_pkgs != NULL && g_variant_n_children (override_replace_local_pkgs) > 0) ||
-          no_overrides)
-        g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.override");
+      if (override_replace_pkgs != NULL || override_remove_pkgs != NULL
+          || override_reset_pkgs != NULL
+          || (override_replace_local_pkgs != NULL
+              && g_variant_n_children (override_replace_local_pkgs) > 0)
+          || no_overrides)
+        g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.override");
       /* If we couldn't figure out what's going on, count it as an override.  This occurs
        * right now with `deploy --ex-cliwrap=true`.
        */
       if (actions->len == 0)
-        g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.override");
+        g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.override");
     }
   else if (g_strcmp0 (method_name, "FinalizeDeployment") == 0)
     {
-      g_ptr_array_add (actions, (void*)"org.projectatomic.rpmostree1.finalize-deployment");
+      g_ptr_array_add (actions, (void *)"org.projectatomic.rpmostree1.finalize-deployment");
     }
   else
     {
@@ -244,15 +233,14 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
 
   for (guint i = 0; i < actions->len; i++)
     {
-      auto action = static_cast<const gchar *>(g_ptr_array_index (actions, i));
+      auto action = static_cast<const gchar *> (g_ptr_array_index (actions, i));
       glnx_unref_object PolkitSubject *subject = polkit_system_bus_name_new (sender);
       glnx_unref_object PolkitAuthorizationResult *result = NULL;
-      g_autoptr(GError) error = NULL;
+      g_autoptr (GError) error = NULL;
 
-      result = polkit_authority_check_authorization_sync (authority, subject,
-                                                          action, NULL,
-                                                          POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
-                                                          NULL, &error);
+      result = polkit_authority_check_authorization_sync (
+          authority, subject, action, NULL, POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+          NULL, &error);
       if (result == NULL)
         {
           g_assert (error);
@@ -276,10 +264,9 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
 
   if (!authorized)
     {
-      g_dbus_method_invocation_return_error (invocation,
-                                             G_DBUS_ERROR,
-                                             G_DBUS_ERROR_ACCESS_DENIED,
-                                             "rpmostreed OS operation %s not allowed for user", method_name);
+      g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_ACCESS_DENIED,
+                                             "rpmostreed OS operation %s not allowed for user",
+                                             method_name);
     }
 
   return authorized;
@@ -291,15 +278,14 @@ os_dispose (GObject *object)
   RpmostreedOS *self = RPMOSTREED_OS (object);
   const gchar *object_path;
 
-  object_path = g_dbus_interface_skeleton_get_object_path (G_DBUS_INTERFACE_SKELETON(self));
+  object_path = g_dbus_interface_skeleton_get_object_path (G_DBUS_INTERFACE_SKELETON (self));
   if (object_path != NULL)
     {
-      rpmostreed_daemon_unpublish (rpmostreed_daemon_get (),
-                                   object_path, object);
+      rpmostreed_daemon_unpublish (rpmostreed_daemon_get (), object_path, object);
     }
 
   if (self->signal_id > 0)
-      g_signal_handler_disconnect (rpmostreed_sysroot_get (), self->signal_id);
+    g_signal_handler_disconnect (rpmostreed_sysroot_get (), self->signal_id);
 
   self->signal_id = 0;
 
@@ -311,9 +297,8 @@ os_constructed (GObject *object)
 {
   RpmostreedOS *self = RPMOSTREED_OS (object);
 
-  self->signal_id = g_signal_connect (rpmostreed_sysroot_get (),
-                                      "updated",
-                                      G_CALLBACK (sysroot_changed), self);
+  self->signal_id
+      = g_signal_connect (rpmostreed_sysroot_get (), "updated", G_CALLBACK (sysroot_changed), self);
   G_OBJECT_CLASS (rpmostreed_os_parent_class)->constructed (object);
 }
 
@@ -325,7 +310,7 @@ rpmostreed_os_class_init (RpmostreedOSClass *klass)
 
   gobject_class = G_OBJECT_CLASS (klass);
   gobject_class->dispose = os_dispose;
-  gobject_class->constructed  = os_constructed;
+  gobject_class->constructed = os_constructed;
 
   gdbus_interface_skeleton_class = G_DBUS_INTERFACE_SKELETON_CLASS (klass);
   gdbus_interface_skeleton_class->g_authorize_method = os_authorize_method;
@@ -336,30 +321,29 @@ rpmostreed_os_init (RpmostreedOS *self)
 {
 }
 
-/* ---------------------------------------------------------------------------------------------------- */
+/* ----------------------------------------------------------------------------------------------------
+ */
 
 static GVariant *
-new_variant_diff_result (GVariant *diff,
-                         GVariant *details)
+new_variant_diff_result (GVariant *diff, GVariant *details)
 {
   return g_variant_new ("(@a(sua{sv})@a{sv})", diff, details);
 }
 
-/* ---------------------------------------------------------------------------------------------------- */
+/* ----------------------------------------------------------------------------------------------------
+ */
 
 static gboolean
-os_handle_get_deployments_rpm_diff (RPMOSTreeOS *interface,
-                                    GDBusMethodInvocation *invocation,
-                                    const char *arg_deployid0,
-                                    const char *arg_deployid1)
+os_handle_get_deployments_rpm_diff (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
+                                    const char *arg_deployid0, const char *arg_deployid1)
 {
-  g_autoptr(GCancellable) cancellable = NULL;
+  g_autoptr (GCancellable) cancellable = NULL;
   RpmostreedSysroot *global_sysroot;
   glnx_unref_object OstreeDeployment *deployment0 = NULL;
   glnx_unref_object OstreeDeployment *deployment1 = NULL;
   OstreeSysroot *ot_sysroot = NULL;
   OstreeRepo *ot_repo = NULL;
-  g_autoptr(GVariant) value = NULL;
+  g_autoptr (GVariant) value = NULL;
   GError *local_error = NULL;
   const gchar *ref0;
   const gchar *ref1;
@@ -377,8 +361,7 @@ os_handle_get_deployments_rpm_diff (RPMOSTreeOS *interface,
     goto out;
   ref1 = ostree_deployment_get_csum (deployment1);
 
-  if (!rpm_ostree_db_diff_variant (ot_repo, ref0, ref1, FALSE, &value,
-                                   cancellable, &local_error))
+  if (!rpm_ostree_db_diff_variant (ot_repo, ref0, ref1, FALSE, &value, cancellable, &local_error))
     goto out;
 
 out:
@@ -388,27 +371,25 @@ out:
     }
   else
     {
-      g_dbus_method_invocation_return_value (invocation,
-                                             g_variant_new ("(@a(sua{sv}))", value));
+      g_dbus_method_invocation_return_value (invocation, g_variant_new ("(@a(sua{sv}))", value));
     }
 
   return TRUE;
 }
 
 static gboolean
-os_handle_get_cached_update_rpm_diff (RPMOSTreeOS *interface,
-                                      GDBusMethodInvocation *invocation,
+os_handle_get_cached_update_rpm_diff (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
                                       const char *arg_deployid)
 {
   RpmostreedSysroot *global_sysroot;
   const gchar *name;
-  g_autoptr(RpmOstreeOrigin) origin = NULL;
+  g_autoptr (RpmOstreeOrigin) origin = NULL;
   OstreeSysroot *ot_sysroot = NULL;
   OstreeRepo *ot_repo = NULL;
   glnx_unref_object OstreeDeployment *base_deployment = NULL;
   GCancellable *cancellable = NULL;
-  g_autoptr(GVariant) value = NULL;
-  g_autoptr(GVariant) details = NULL;
+  g_autoptr (GVariant) value = NULL;
+  g_autoptr (GVariant) details = NULL;
   GError *local_error = NULL;
 
   global_sysroot = rpmostreed_sysroot_get ();
@@ -422,14 +403,15 @@ os_handle_get_cached_update_rpm_diff (RPMOSTreeOS *interface,
       base_deployment = ostree_sysroot_get_merge_deployment (ot_sysroot, name);
       if (base_deployment == NULL)
         {
-          local_error = g_error_new (G_IO_ERROR, G_IO_ERROR_FAILED,
-                                     "No deployments found for os %s", name);
+          local_error
+              = g_error_new (G_IO_ERROR, G_IO_ERROR_FAILED, "No deployments found for os %s", name);
           goto out;
         }
     }
   else
     {
-      if (!rpmostreed_deployment_get_for_id (ot_sysroot, arg_deployid, &base_deployment, &local_error))
+      if (!rpmostreed_deployment_get_for_id (ot_sysroot, arg_deployid, &base_deployment,
+                                             &local_error))
         goto out;
     }
 
@@ -442,10 +424,8 @@ os_handle_get_cached_update_rpm_diff (RPMOSTreeOS *interface,
                                    cancellable, &local_error))
     goto out;
 
-  details = rpmostreed_commit_generate_cached_details_variant (base_deployment, ot_repo,
-                                                               rpmostree_origin_get_refspec (origin),
-                                                               NULL,
-                                                               &local_error);
+  details = rpmostreed_commit_generate_cached_details_variant (
+      base_deployment, ot_repo, rpmostree_origin_get_refspec (origin), NULL, &local_error);
   if (!details)
     goto out;
 
@@ -456,20 +436,18 @@ out:
     }
   else
     {
-      g_dbus_method_invocation_return_value (invocation,
-                                             new_variant_diff_result (value, details));
+      g_dbus_method_invocation_return_value (invocation, new_variant_diff_result (value, details));
     }
 
   return TRUE;
 }
 
-static gboolean
-refresh_cached_update (RpmostreedOS*, GError **error);
+static gboolean refresh_cached_update (RpmostreedOS *, GError **error);
 
 static void
 on_auto_update_done (RpmostreedTransaction *transaction, RpmostreedOS *self)
 {
-  g_autoptr(GError) local_error = NULL;
+  g_autoptr (GError) local_error = NULL;
   if (!refresh_cached_update (self, &local_error))
     {
       sd_journal_print (LOG_WARNING, "Failed to refresh CachedUpdate property: %s",
@@ -478,12 +456,11 @@ on_auto_update_done (RpmostreedTransaction *transaction, RpmostreedOS *self)
 }
 
 static gboolean
-os_handle_download_update_rpm_diff (RPMOSTreeOS *interface,
-                                    GDBusMethodInvocation *invocation)
+os_handle_download_update_rpm_diff (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation)
 {
   RpmostreedOS *self = RPMOSTREED_OS (interface);
   glnx_unref_object OstreeSysroot *ot_sysroot = NULL;
-  g_autoptr(GCancellable) cancellable = g_cancellable_new ();
+  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
   const char *osname;
   GError *local_error = NULL;
 
@@ -495,22 +472,16 @@ os_handle_download_update_rpm_diff (RPMOSTreeOS *interface,
   if (transaction)
     goto out;
 
-  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (),
-                                      cancellable,
-                                      &ot_sysroot,
-                                      NULL,
+  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (), cancellable, &ot_sysroot, NULL,
                                       &local_error))
     goto out;
 
   osname = rpmostree_os_get_name (interface);
 
-  transaction = rpmostreed_transaction_new_package_diff (invocation,
-                                                         ot_sysroot,
-                                                         osname,
-                                                         NULL,  /* refspec */
-                                                         NULL,  /* revision */
-                                                         cancellable,
-                                                         &local_error);
+  transaction
+      = rpmostreed_transaction_new_package_diff (invocation, ot_sysroot, osname, NULL, /* refspec */
+                                                 NULL, /* revision */
+                                                 cancellable, &local_error);
 
   if (transaction == NULL)
     goto out;
@@ -537,10 +508,8 @@ out:
   return TRUE;
 }
 
-static inline void*
-vardict_lookup_ptr (GVariantDict  *dict,
-                    const char    *key,
-                    const char    *fmt)
+static inline void *
+vardict_lookup_ptr (GVariantDict *dict, const char *key, const char *fmt)
 {
   void *val;
   if (g_variant_dict_lookup (dict, key, fmt, &val))
@@ -549,16 +518,13 @@ vardict_lookup_ptr (GVariantDict  *dict,
 }
 
 static inline char **
-vardict_lookup_strv (GVariantDict  *dict,
-                     const char    *key)
+vardict_lookup_strv (GVariantDict *dict, const char *key)
 {
-  return static_cast<char**>(vardict_lookup_ptr (dict, key, "^a&s"));
+  return static_cast<char **> (vardict_lookup_ptr (dict, key, "^a&s"));
 }
 
 static gboolean
-vardict_lookup_bool (GVariantDict *dict,
-                     const char   *key,
-                     gboolean      dfault)
+vardict_lookup_bool (GVariantDict *dict, const char *key, gboolean dfault)
 {
   gboolean val;
   if (g_variant_dict_lookup (dict, key, "b", &val))
@@ -566,22 +532,17 @@ vardict_lookup_bool (GVariantDict *dict,
   return dfault;
 }
 
-typedef void (*InvocationCompleter)(RPMOSTreeOS*,
-                                    GDBusMethodInvocation*,
-                                    GUnixFDList*,
-                                    const gchar*);
+typedef void (*InvocationCompleter) (RPMOSTreeOS *, GDBusMethodInvocation *, GUnixFDList *,
+                                     const gchar *);
 
 static gboolean
-os_merge_or_start_deployment_txn (RPMOSTreeOS            *interface,
-                                  GDBusMethodInvocation  *invocation,
-                                  RpmOstreeTransactionDeployFlags default_flags,
-                                  GVariant               *options,
+os_merge_or_start_deployment_txn (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
+                                  RpmOstreeTransactionDeployFlags default_flags, GVariant *options,
                                   RpmOstreeUpdateDeploymentModifiers *modifiers,
-                                  GUnixFDList            *fd_list,
-                                  InvocationCompleter     completer)
+                                  GUnixFDList *fd_list, InvocationCompleter completer)
 {
   RpmostreedOS *self = RPMOSTREED_OS (interface);
-  g_autoptr(GError) local_error = NULL;
+  g_autoptr (GError) local_error = NULL;
   const char *client_address = NULL;
 
   /* try to merge with an existing transaction, otherwise start a new one */
@@ -593,15 +554,14 @@ os_merge_or_start_deployment_txn (RPMOSTreeOS            *interface,
   if (!transaction)
     {
       glnx_unref_object OstreeSysroot *ot_sysroot = NULL;
-      g_autoptr(GCancellable) cancellable = g_cancellable_new ();
-      if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (), cancellable,
-                                          &ot_sysroot, NULL, &local_error))
+      g_autoptr (GCancellable) cancellable = g_cancellable_new ();
+      if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (), cancellable, &ot_sysroot, NULL,
+                                          &local_error))
         goto err;
 
-      transaction = rpmostreed_transaction_new_deploy (invocation, ot_sysroot,
-                                                       rpmostree_os_get_name (interface),
-                                                       default_flags, options, modifiers, fd_list,
-                                                       cancellable, &local_error);
+      transaction = rpmostreed_transaction_new_deploy (
+          invocation, ot_sysroot, rpmostree_os_get_name (interface), default_flags, options,
+          modifiers, fd_list, cancellable, &local_error);
       if (!transaction)
         goto err;
 
@@ -616,129 +576,107 @@ os_merge_or_start_deployment_txn (RPMOSTreeOS            *interface,
       /* For the AutomaticUpdateTrigger "check" case, we want to make sure we refresh
        * the CachedUpdate property; "stage" will do this through sysroot_changed */
       const char *method_name = g_dbus_method_invocation_get_method_name (invocation);
-      if (g_str_equal (method_name, "AutomaticUpdateTrigger") &&
-          (default_flags & (RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_ONLY |
-                            RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_METADATA_ONLY)))
+      if (g_str_equal (method_name, "AutomaticUpdateTrigger")
+          && (default_flags
+              & (RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_ONLY
+                 | RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_METADATA_ONLY)))
         g_signal_connect (transaction, "closed", G_CALLBACK (on_auto_update_done), self);
     }
 
   client_address = rpmostreed_transaction_get_client_address (transaction);
   completer (interface, invocation, NULL, client_address);
   return TRUE;
- err:
+err:
   if (!local_error) /* we should've gotten an error, but let's be safe */
     glnx_throw (&local_error, "Failed to start the transaction");
-  g_dbus_method_invocation_take_error (invocation,
-                                       util::move_nullify (local_error));
+  g_dbus_method_invocation_take_error (invocation, util::move_nullify (local_error));
   /* We always return TRUE to signal that we handled the invocation. */
   return TRUE;
 }
 
 static gboolean
-os_handle_deploy (RPMOSTreeOS *interface,
-                  GDBusMethodInvocation *invocation,
-                  GUnixFDList *fd_list,
-                  const char *arg_revision,
-                  GVariant *arg_options)
+os_handle_deploy (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation, GUnixFDList *fd_list,
+                  const char *arg_revision, GVariant *arg_options)
 {
-  g_autoptr(GVariantBuilder) vbuilder = g_variant_builder_new (G_VARIANT_TYPE_VARDICT);
+  g_autoptr (GVariantBuilder) vbuilder = g_variant_builder_new (G_VARIANT_TYPE_VARDICT);
   if (arg_revision)
-    g_variant_builder_add (vbuilder, "{sv}", "set-revision",
-                           g_variant_new_string (arg_revision));
-  g_autoptr(RpmOstreeUpdateDeploymentModifiers) modifiers =
-    g_variant_ref_sink (g_variant_builder_end (vbuilder));
-  return os_merge_or_start_deployment_txn (interface, invocation,
-                                           RPMOSTREE_TRANSACTION_DEPLOY_FLAG_ALLOW_DOWNGRADE,
-                                           arg_options, modifiers, fd_list,
-                                           rpmostree_os_complete_deploy);
+    g_variant_builder_add (vbuilder, "{sv}", "set-revision", g_variant_new_string (arg_revision));
+  g_autoptr (RpmOstreeUpdateDeploymentModifiers) modifiers
+      = g_variant_ref_sink (g_variant_builder_end (vbuilder));
+  return os_merge_or_start_deployment_txn (
+      interface, invocation, RPMOSTREE_TRANSACTION_DEPLOY_FLAG_ALLOW_DOWNGRADE, arg_options,
+      modifiers, fd_list, rpmostree_os_complete_deploy);
 }
 
 static gboolean
-os_handle_upgrade (RPMOSTreeOS *interface,
-                   GDBusMethodInvocation *invocation,
-                   GUnixFDList *fd_list,
+os_handle_upgrade (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation, GUnixFDList *fd_list,
                    GVariant *arg_options)
 {
-  g_autoptr(GVariantBuilder) vbuilder = g_variant_builder_new (G_VARIANT_TYPE_VARDICT);
-  g_autoptr(RpmOstreeUpdateDeploymentModifiers) modifiers =
-    g_variant_ref_sink (g_variant_builder_end (vbuilder));
-  return os_merge_or_start_deployment_txn (interface, invocation, static_cast<RpmOstreeTransactionDeployFlags>(0),
-                                           arg_options, modifiers, fd_list,
-                                           rpmostree_os_complete_upgrade);
+  g_autoptr (GVariantBuilder) vbuilder = g_variant_builder_new (G_VARIANT_TYPE_VARDICT);
+  g_autoptr (RpmOstreeUpdateDeploymentModifiers) modifiers
+      = g_variant_ref_sink (g_variant_builder_end (vbuilder));
+  return os_merge_or_start_deployment_txn (
+      interface, invocation, static_cast<RpmOstreeTransactionDeployFlags> (0), arg_options,
+      modifiers, fd_list, rpmostree_os_complete_upgrade);
 }
 
 static gboolean
-os_handle_rebase (RPMOSTreeOS *interface,
-                  GDBusMethodInvocation *invocation,
-                  GUnixFDList *fd_list,
-                  GVariant *arg_options,
-                  const char *arg_refspec,
-                  const char * const *arg_packages)
+os_handle_rebase (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation, GUnixFDList *fd_list,
+                  GVariant *arg_options, const char *arg_refspec, const char *const *arg_packages)
 {
   /* back-compat -- the revision is specified in the options variant; take it
    * out of there and make it a proper argument */
-  g_auto(GVariantDict) options_dict;
+  g_auto (GVariantDict) options_dict;
   g_variant_dict_init (&options_dict, arg_options);
   const char *opt_revision = NULL;
   g_variant_dict_lookup (&options_dict, "revision", "&s", &opt_revision);
 
-  g_autoptr(GVariantBuilder) vbuilder = g_variant_builder_new (G_VARIANT_TYPE_VARDICT);
+  g_autoptr (GVariantBuilder) vbuilder = g_variant_builder_new (G_VARIANT_TYPE_VARDICT);
   if (arg_refspec)
-    g_variant_builder_add (vbuilder, "{sv}", "set-refspec",
-                           g_variant_new_string (arg_refspec));
+    g_variant_builder_add (vbuilder, "{sv}", "set-refspec", g_variant_new_string (arg_refspec));
   if (opt_revision)
-    g_variant_builder_add (vbuilder, "{sv}", "set-revision",
-                           g_variant_new_string (opt_revision));
-  g_autoptr(RpmOstreeUpdateDeploymentModifiers) modifiers =
-    g_variant_ref_sink (g_variant_builder_end (vbuilder));
+    g_variant_builder_add (vbuilder, "{sv}", "set-revision", g_variant_new_string (opt_revision));
+  g_autoptr (RpmOstreeUpdateDeploymentModifiers) modifiers
+      = g_variant_ref_sink (g_variant_builder_end (vbuilder));
 
-  return os_merge_or_start_deployment_txn (interface, invocation,
-                                           RPMOSTREE_TRANSACTION_DEPLOY_FLAG_ALLOW_DOWNGRADE,
-                                           arg_options, modifiers, fd_list,
-                                           rpmostree_os_complete_rebase);
+  return os_merge_or_start_deployment_txn (
+      interface, invocation, RPMOSTREE_TRANSACTION_DEPLOY_FLAG_ALLOW_DOWNGRADE, arg_options,
+      modifiers, fd_list, rpmostree_os_complete_rebase);
 }
 
 static gboolean
-os_handle_pkg_change (RPMOSTreeOS *interface,
-                      GDBusMethodInvocation *invocation,
-                      GUnixFDList *fd_list,
-                      GVariant *arg_options,
-                      const char * const *arg_packages_added,
-                      const char * const *arg_packages_removed)
+os_handle_pkg_change (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
+                      GUnixFDList *fd_list, GVariant *arg_options,
+                      const char *const *arg_packages_added,
+                      const char *const *arg_packages_removed)
 {
-  g_autoptr(GVariantBuilder) vbuilder = g_variant_builder_new (G_VARIANT_TYPE_VARDICT);
+  g_autoptr (GVariantBuilder) vbuilder = g_variant_builder_new (G_VARIANT_TYPE_VARDICT);
   g_variant_builder_add (vbuilder, "{sv}", "install-packages",
                          g_variant_new_strv (arg_packages_added, -1));
   g_variant_builder_add (vbuilder, "{sv}", "uninstall-packages",
                          g_variant_new_strv (arg_packages_removed, -1));
-  g_autoptr(RpmOstreeUpdateDeploymentModifiers) modifiers =
-    g_variant_ref_sink (g_variant_builder_end (vbuilder));
-  return os_merge_or_start_deployment_txn (interface, invocation,
-                                           RPMOSTREE_TRANSACTION_DEPLOY_FLAG_NO_PULL_BASE,
-                                           arg_options, modifiers, NULL,
-                                           rpmostree_os_complete_pkg_change);
+  g_autoptr (RpmOstreeUpdateDeploymentModifiers) modifiers
+      = g_variant_ref_sink (g_variant_builder_end (vbuilder));
+  return os_merge_or_start_deployment_txn (
+      interface, invocation, RPMOSTREE_TRANSACTION_DEPLOY_FLAG_NO_PULL_BASE, arg_options, modifiers,
+      NULL, rpmostree_os_complete_pkg_change);
 }
 
 static gboolean
-os_handle_update_deployment (RPMOSTreeOS *interface,
-                             GDBusMethodInvocation *invocation,
-                             GUnixFDList *fd_list,
-                             GVariant *arg_modifiers,
-                             GVariant *arg_options)
+os_handle_update_deployment (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
+                             GUnixFDList *fd_list, GVariant *arg_modifiers, GVariant *arg_options)
 {
   RpmOstreeUpdateDeploymentModifiers *modifiers = arg_modifiers;
-  return os_merge_or_start_deployment_txn (interface, invocation,
-                                           static_cast<RpmOstreeTransactionDeployFlags>(0), arg_options, modifiers, fd_list,
-                                           rpmostree_os_complete_update_deployment);
+  return os_merge_or_start_deployment_txn (
+      interface, invocation, static_cast<RpmOstreeTransactionDeployFlags> (0), arg_options,
+      modifiers, fd_list, rpmostree_os_complete_update_deployment);
 }
 
 /* compat shim for call completer */
 static void
-automatic_update_trigger_completer (RPMOSTreeOS            *os,
-                                    GDBusMethodInvocation  *invocation,
-                                    GUnixFDList            *dummy,
-                                    const gchar            *address)
-{                                                              /* enabled */
+automatic_update_trigger_completer (RPMOSTreeOS *os, GDBusMethodInvocation *invocation,
+                                    GUnixFDList *dummy, const gchar *address)
+{ /* enabled */
   rpmostree_os_complete_automatic_update_trigger (os, invocation, TRUE, address);
 }
 
@@ -747,11 +685,10 @@ automatic_update_trigger_completer (RPMOSTreeOS            *os,
  */
 
 static gboolean
-os_handle_automatic_update_trigger (RPMOSTreeOS *interface,
-                                    GDBusMethodInvocation *invocation,
+os_handle_automatic_update_trigger (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
                                     GVariant *arg_options)
 {
-  g_autoptr(GError) local_error = NULL;
+  g_autoptr (GError) local_error = NULL;
   GError **error = &local_error;
 
   const char *osname = rpmostree_os_get_name (interface);
@@ -768,9 +705,9 @@ os_handle_automatic_update_trigger (RPMOSTreeOS *interface,
       return TRUE;
     }
 
-  g_auto(GVariantDict) dict;
+  g_auto (GVariantDict) dict;
   g_variant_dict_init (&dict, arg_options);
-  auto mode = static_cast<const char *>(vardict_lookup_ptr (&dict, "mode", "&s") ?: "auto");
+  auto mode = static_cast<const char *> (vardict_lookup_ptr (&dict, "mode", "&s") ?: "auto");
 
   RpmostreedAutomaticUpdatePolicy autoupdate_policy;
   if (g_str_equal (mode, "auto"))
@@ -788,7 +725,7 @@ os_handle_automatic_update_trigger (RPMOSTreeOS *interface,
    * starting it at all if we're not even on. The benefit of this approach is that we keep
    * the Deploy transaction simpler. */
 
-  auto dfault = static_cast<RpmOstreeTransactionDeployFlags>(0);
+  auto dfault = static_cast<RpmOstreeTransactionDeployFlags> (0);
   switch (autoupdate_policy)
     {
     case RPMOSTREED_AUTOMATIC_UPDATE_POLICY_NONE:
@@ -808,32 +745,24 @@ os_handle_automatic_update_trigger (RPMOSTreeOS *interface,
     }
 
   /* if output-to-self is not explicitly set, default to TRUE */
-  g_autoptr(GVariant) arg_options_owned = NULL;
+  g_autoptr (GVariant) arg_options_owned = NULL;
   if (!g_variant_dict_contains (&dict, "output-to-self"))
     {
       g_variant_dict_insert (&dict, "output-to-self", "b", TRUE);
       arg_options = arg_options_owned = g_variant_ref_sink (g_variant_dict_end (&dict));
     }
-  (void) arg_options_owned; /* Pacify static analysis */
+  (void)arg_options_owned; /* Pacify static analysis */
 
-  return os_merge_or_start_deployment_txn (
-      interface,
-      invocation,
-      dfault,
-      arg_options,
-      NULL,
-      NULL,
-      automatic_update_trigger_completer);
+  return os_merge_or_start_deployment_txn (interface, invocation, dfault, arg_options, NULL, NULL,
+                                           automatic_update_trigger_completer);
 }
 
-
 static gboolean
-os_handle_rollback (RPMOSTreeOS *interface,
-                    GDBusMethodInvocation *invocation,
+os_handle_rollback (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
                     GVariant *arg_options)
 {
   glnx_unref_object OstreeSysroot *ot_sysroot = NULL;
-  g_autoptr(GCancellable) cancellable = g_cancellable_new ();
+  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
   const char *osname;
   gboolean opt_reboot = FALSE;
   GVariantDict options_dict;
@@ -847,10 +776,7 @@ os_handle_rollback (RPMOSTreeOS *interface,
   if (transaction)
     goto out;
 
-  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (),
-                                      cancellable,
-                                      &ot_sysroot,
-                                      NULL,
+  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (), cancellable, &ot_sysroot, NULL,
                                       &local_error))
     goto out;
 
@@ -858,18 +784,12 @@ os_handle_rollback (RPMOSTreeOS *interface,
 
   g_variant_dict_init (&options_dict, arg_options);
 
-  g_variant_dict_lookup (&options_dict,
-                         "reboot", "b",
-                         &opt_reboot);
+  g_variant_dict_lookup (&options_dict, "reboot", "b", &opt_reboot);
 
   g_variant_dict_clear (&options_dict);
 
-  transaction = rpmostreed_transaction_new_rollback (invocation,
-                                                     ot_sysroot,
-                                                     osname,
-                                                     opt_reboot,
-                                                     cancellable,
-                                                     &local_error);
+  transaction = rpmostreed_transaction_new_rollback (invocation, ot_sysroot, osname, opt_reboot,
+                                                     cancellable, &local_error);
 
   if (transaction == NULL)
     goto out;
@@ -892,18 +812,17 @@ out:
 }
 
 static gboolean
-os_handle_refresh_md (RPMOSTreeOS *interface,
-                      GDBusMethodInvocation *invocation,
+os_handle_refresh_md (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
                       GVariant *arg_options)
 {
-  g_autoptr(OstreeSysroot) ot_sysroot = NULL;
-  g_autoptr(GCancellable) cancellable = g_cancellable_new ();
+  g_autoptr (OstreeSysroot) ot_sysroot = NULL;
+  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
   const char *osname;
   GError *local_error = NULL;
   int flags = 0;
   gboolean force = FALSE;
-  g_autoptr(GString) title = g_string_new ("refresh-md");
-  g_auto(GVariantDict) dict;
+  g_autoptr (GString) title = g_string_new ("refresh-md");
+  g_auto (GVariantDict) dict;
   g_variant_dict_init (&dict, arg_options);
 
   /* try to merge with an existing transaction, otherwise start a new one */
@@ -914,15 +833,11 @@ os_handle_refresh_md (RPMOSTreeOS *interface,
   if (transaction)
     goto out;
 
-  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (),
-                                      cancellable,
-                                      &ot_sysroot,
-                                      NULL,
+  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (), cancellable, &ot_sysroot, NULL,
                                       &local_error))
     goto out;
 
   osname = rpmostree_os_get_name (interface);
-
 
   if (vardict_lookup_bool (&dict, "force", FALSE))
     {
@@ -930,12 +845,9 @@ os_handle_refresh_md (RPMOSTreeOS *interface,
       force = TRUE;
     }
 
-  transaction = rpmostreed_transaction_new_refresh_md (invocation,
-                                                       ot_sysroot,
-                                                       static_cast<RpmOstreeTransactionRefreshMdFlags>(flags),
-                                                       osname,
-                                                       cancellable,
-                                                       &local_error);
+  transaction = rpmostreed_transaction_new_refresh_md (
+      invocation, ot_sysroot, static_cast<RpmOstreeTransactionRefreshMdFlags> (flags), osname,
+      cancellable, &local_error);
   if (transaction == NULL)
     goto out;
 
@@ -958,13 +870,11 @@ out:
 }
 
 static gboolean
-os_handle_modify_yum_repo (RPMOSTreeOS *interface,
-                           GDBusMethodInvocation *invocation,
-                           const char *arg_repo_id,
-                           GVariant *arg_settings)
+os_handle_modify_yum_repo (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
+                           const char *arg_repo_id, GVariant *arg_settings)
 {
   glnx_unref_object OstreeSysroot *ot_sysroot = NULL;
-  g_autoptr(GCancellable) cancellable = g_cancellable_new ();
+  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
   const char *osname;
   GError *local_error = NULL;
 
@@ -976,22 +886,14 @@ os_handle_modify_yum_repo (RPMOSTreeOS *interface,
   if (transaction)
     goto out;
 
-  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (),
-                                      cancellable,
-                                      &ot_sysroot,
-                                      NULL,
+  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (), cancellable, &ot_sysroot, NULL,
                                       &local_error))
     goto out;
 
   osname = rpmostree_os_get_name (interface);
 
-  transaction = rpmostreed_transaction_new_modify_yum_repo (invocation,
-                                                            ot_sysroot,
-                                                            osname,
-                                                            arg_repo_id,
-                                                            arg_settings,
-                                                            cancellable,
-                                                            &local_error);
+  transaction = rpmostreed_transaction_new_modify_yum_repo (
+      invocation, ot_sysroot, osname, arg_repo_id, arg_settings, cancellable, &local_error);
   if (transaction == NULL)
     goto out;
 
@@ -1012,13 +914,12 @@ out:
 }
 
 static gboolean
-os_handle_finalize_deployment (RPMOSTreeOS *interface,
-                               GDBusMethodInvocation *invocation,
+os_handle_finalize_deployment (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
                                GVariant *arg_options)
 {
-  g_autoptr(GCancellable) cancellable = g_cancellable_new ();
+  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
   glnx_unref_object RpmostreedTransaction *transaction = NULL;
-  g_autoptr(OstreeSysroot) sysroot = NULL;
+  g_autoptr (OstreeSysroot) sysroot = NULL;
   const char *osname;
   GError *local_error = NULL;
   const char *command_line;
@@ -1036,15 +937,16 @@ os_handle_finalize_deployment (RPMOSTreeOS *interface,
 
   osname = rpmostree_os_get_name (interface);
 
-  transaction = rpmostreed_transaction_new_finalize_deployment (invocation, sysroot, osname,
-                                                                arg_options, cancellable,
-                                                                &local_error);
+  transaction = rpmostreed_transaction_new_finalize_deployment (
+      invocation, sysroot, osname, arg_options, cancellable, &local_error);
   if (transaction == NULL)
     goto out;
 
-  rpmostreed_sysroot_set_txn_and_title (rsysroot, transaction, 
-                                        g_variant_lookup (arg_options, "initiating-command-line", "&s", &command_line) ?
-                                        command_line : "finalize-deployment");
+  rpmostreed_sysroot_set_txn_and_title (
+      rsysroot, transaction,
+      g_variant_lookup (arg_options, "initiating-command-line", "&s", &command_line)
+          ? command_line
+          : "finalize-deployment");
 
 out:
   if (local_error != NULL)
@@ -1062,13 +964,12 @@ out:
 
 /* This is an older variant of Cleanup, kept for backcompat */
 static gboolean
-os_handle_clear_rollback_target (RPMOSTreeOS *interface,
-                                 GDBusMethodInvocation *invocation,
+os_handle_clear_rollback_target (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
                                  GVariant *arg_options)
 {
   glnx_unref_object OstreeSysroot *ot_sysroot = NULL;
-  g_autoptr(GCancellable) cancellable = g_cancellable_new ();
-  auto flags = static_cast<RpmOstreeTransactionCleanupFlags>(0);
+  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
+  auto flags = static_cast<RpmOstreeTransactionCleanupFlags> (0);
   const char *osname;
   GError *local_error = NULL;
 
@@ -1080,8 +981,8 @@ os_handle_clear_rollback_target (RPMOSTreeOS *interface,
   if (transaction)
     goto out;
 
-  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (),
-                                      cancellable, &ot_sysroot, NULL, &local_error))
+  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (), cancellable, &ot_sysroot, NULL,
+                                      &local_error))
     goto out;
 
   osname = rpmostree_os_get_name (interface);
@@ -1091,8 +992,7 @@ os_handle_clear_rollback_target (RPMOSTreeOS *interface,
    */
 
   flags = RPMOSTREE_TRANSACTION_CLEANUP_ROLLBACK_DEPLOY;
-  transaction = rpmostreed_transaction_new_cleanup (invocation, ot_sysroot,
-                                                    osname, flags,
+  transaction = rpmostreed_transaction_new_cleanup (invocation, ot_sysroot, osname, flags,
                                                     cancellable, &local_error);
   if (transaction == NULL)
     goto out;
@@ -1114,16 +1014,12 @@ out:
 }
 
 static gboolean
-os_handle_initramfs_etc (RPMOSTreeOS *interface,
-                         GDBusMethodInvocation *invocation,
-                         const char *const* track,
-                         const char *const* untrack,
-                         gboolean untrack_all,
-                         gboolean force_sync,
-                         GVariant *options)
+os_handle_initramfs_etc (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
+                         const char *const *track, const char *const *untrack, gboolean untrack_all,
+                         gboolean force_sync, GVariant *options)
 {
   glnx_unref_object OstreeSysroot *ot_sysroot = NULL;
-  g_autoptr(GCancellable) cancellable = g_cancellable_new ();
+  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
   const char *osname;
   GError *local_error = NULL;
   const char *command_line = NULL;
@@ -1136,31 +1032,22 @@ os_handle_initramfs_etc (RPMOSTreeOS *interface,
   if (transaction)
     goto out;
 
-  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (),
-                                      cancellable,
-                                      &ot_sysroot,
-                                      NULL,
+  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (), cancellable, &ot_sysroot, NULL,
                                       &local_error))
     goto out;
 
   osname = rpmostree_os_get_name (interface);
 
-  transaction = rpmostreed_transaction_new_initramfs_etc (invocation,
-                                                          ot_sysroot,
-                                                          osname,
-                                                          (char**)track,
-                                                          (char**)untrack,
-                                                          untrack_all,
-                                                          force_sync,
-                                                          options,
-                                                          cancellable,
-                                                          &local_error);
+  transaction = rpmostreed_transaction_new_initramfs_etc (
+      invocation, ot_sysroot, osname, (char **)track, (char **)untrack, untrack_all, force_sync,
+      options, cancellable, &local_error);
   if (transaction == NULL)
     goto out;
 
-  rpmostreed_sysroot_set_txn_and_title (rsysroot, transaction,
-                                        g_variant_lookup (options, "initiating-command-line", "&s", &command_line) ?
-                                        command_line : "initramfs-etc");
+  rpmostreed_sysroot_set_txn_and_title (
+      rsysroot, transaction,
+      g_variant_lookup (options, "initiating-command-line", "&s", &command_line) ? command_line
+                                                                                 : "initramfs-etc");
 
 out:
   if (local_error != NULL)
@@ -1178,14 +1065,11 @@ out:
 }
 
 static gboolean
-os_handle_set_initramfs_state (RPMOSTreeOS *interface,
-                               GDBusMethodInvocation *invocation,
-                               gboolean regenerate,
-                               const char *const*args,
-                               GVariant *arg_options)
+os_handle_set_initramfs_state (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
+                               gboolean regenerate, const char *const *args, GVariant *arg_options)
 {
   glnx_unref_object OstreeSysroot *ot_sysroot = NULL;
-  g_autoptr(GCancellable) cancellable = g_cancellable_new ();
+  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
   const char *osname;
   GError *local_error = NULL;
   const char *command_line = NULL;
@@ -1198,29 +1082,22 @@ os_handle_set_initramfs_state (RPMOSTreeOS *interface,
   if (transaction)
     goto out;
 
-  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (),
-                                      cancellable,
-                                      &ot_sysroot,
-                                      NULL,
+  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (), cancellable, &ot_sysroot, NULL,
                                       &local_error))
     goto out;
 
   osname = rpmostree_os_get_name (interface);
 
-  transaction = rpmostreed_transaction_new_initramfs_state (invocation,
-                                                            ot_sysroot,
-                                                            osname,
-                                                            regenerate,
-                                                            (char**)args,
-                                                            arg_options,
-                                                            cancellable,
-                                                            &local_error);
+  transaction = rpmostreed_transaction_new_initramfs_state (invocation, ot_sysroot, osname,
+                                                            regenerate, (char **)args, arg_options,
+                                                            cancellable, &local_error);
   if (transaction == NULL)
     goto out;
 
-  rpmostreed_sysroot_set_txn_and_title (rsysroot, transaction,
-                                        g_variant_lookup (arg_options, "initiating-command-line", "&s", &command_line) ?
-                                        command_line : "initramfs");
+  rpmostreed_sysroot_set_txn_and_title (
+      rsysroot, transaction,
+      g_variant_lookup (arg_options, "initiating-command-line", "&s", &command_line) ? command_line
+                                                                                     : "initramfs");
 
 out:
   if (local_error != NULL)
@@ -1238,16 +1115,13 @@ out:
 }
 
 static gboolean
-os_handle_kernel_args (RPMOSTreeOS *interface,
-                       GDBusMethodInvocation *invocation,
-                       const char * existing_kernel_args,
-                       const char * const *kernel_args_added,
-                       const char * const *kernel_args_replaced,
-                       const char * const *kernel_args_deleted,
-                       GVariant *arg_options)
+os_handle_kernel_args (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
+                       const char *existing_kernel_args, const char *const *kernel_args_added,
+                       const char *const *kernel_args_replaced,
+                       const char *const *kernel_args_deleted, GVariant *arg_options)
 {
   glnx_unref_object OstreeSysroot *ot_sysroot = NULL;
-  g_autoptr(GCancellable) cancellable = g_cancellable_new ();
+  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
   GError *local_error = NULL;
   const char *osname = NULL;
   const char *command_line = NULL;
@@ -1260,30 +1134,21 @@ os_handle_kernel_args (RPMOSTreeOS *interface,
   if (transaction)
     goto out;
 
-  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (),
-                                      cancellable,
-                                      &ot_sysroot,
-                                      NULL,
+  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (), cancellable, &ot_sysroot, NULL,
                                       &local_error))
     goto out;
   osname = rpmostree_os_get_name (interface);
 
-  transaction = rpmostreed_transaction_new_kernel_arg (invocation,
-                                                       ot_sysroot,
-                                                       osname,
-                                                       existing_kernel_args,
-                                                       kernel_args_added,
-                                                       kernel_args_replaced,
-                                                       kernel_args_deleted,
-                                                       arg_options,
-                                                       cancellable,
-                                                       &local_error);
+  transaction = rpmostreed_transaction_new_kernel_arg (
+      invocation, ot_sysroot, osname, existing_kernel_args, kernel_args_added, kernel_args_replaced,
+      kernel_args_deleted, arg_options, cancellable, &local_error);
   if (transaction == NULL)
     goto out;
 
-  rpmostreed_sysroot_set_txn_and_title (rsysroot, transaction,
-                                        g_variant_lookup (arg_options, "initiating-command-line", "&s", &command_line) ?
-                                        command_line : "kargs");
+  rpmostreed_sysroot_set_txn_and_title (
+      rsysroot, transaction,
+      g_variant_lookup (arg_options, "initiating-command-line", "&s", &command_line) ? command_line
+                                                                                     : "kargs");
 
 out:
   if (local_error != NULL)
@@ -1298,36 +1163,25 @@ out:
 }
 
 static gboolean
-os_handle_get_deployment_boot_config (RPMOSTreeOS *interface,
-                                      GDBusMethodInvocation *invocation,
-                                      const char *arg_deploy_index,
-                                      gboolean is_pending)
+os_handle_get_deployment_boot_config (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
+                                      const char *arg_deploy_index, gboolean is_pending)
 {
   glnx_unref_object OstreeSysroot *ot_sysroot = NULL;
   GError *local_error = NULL;
-  g_autoptr(GCancellable) cancellable = NULL;
-  glnx_unref_object OstreeDeployment *target_deployment  = NULL;
+  g_autoptr (GCancellable) cancellable = NULL;
+  glnx_unref_object OstreeDeployment *target_deployment = NULL;
   GVariantDict boot_config_dict;
   GVariant *boot_config_result = NULL;
   OstreeBootconfigParser *bootconfig = NULL;
-  const char* osname = NULL;
+  const char *osname = NULL;
   /* Note because boot config is a private structure.. currently I have no good way
    * other than specifying all the content directly */
-  const char *bootconfig_keys[] = {
-    "title",
-    "linux",
-    "initrd",
-    "options",
-    OSTREE_COMMIT_META_KEY_VERSION,
-    NULL
-  };
+  const char *bootconfig_keys[]
+      = { "title", "linux", "initrd", "options", OSTREE_COMMIT_META_KEY_VERSION, NULL };
   gboolean staged = FALSE;
 
   /* Load the sysroot */
-  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (),
-                                      cancellable,
-                                      &ot_sysroot,
-                                      NULL,
+  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (), cancellable, &ot_sysroot, NULL,
                                       &local_error))
     goto out;
   osname = rpmostree_os_get_name (interface);
@@ -1337,7 +1191,7 @@ os_handle_get_deployment_boot_config (RPMOSTreeOS *interface,
         target_deployment = rpmostree_syscore_get_origin_merge_deployment (ot_sysroot, osname);
       else
         target_deployment = ostree_sysroot_get_merge_deployment (ot_sysroot, osname);
-      if (target_deployment  == NULL)
+      if (target_deployment == NULL)
         {
           local_error = g_error_new (G_IO_ERROR, G_IO_ERROR_FAILED,
                                      "No deployments found for os %s", osname);
@@ -1347,13 +1201,12 @@ os_handle_get_deployment_boot_config (RPMOSTreeOS *interface,
   else
     {
       /* If the deploy_index is specified, we ignore the pending option */
-      target_deployment = rpmostreed_deployment_get_for_index (ot_sysroot, arg_deploy_index,
-                                                               &local_error);
+      target_deployment
+          = rpmostreed_deployment_get_for_index (ot_sysroot, arg_deploy_index, &local_error);
       if (target_deployment == NULL)
         goto out;
     }
   bootconfig = ostree_deployment_get_bootconfig (target_deployment);
-
 
   /* We initalize a dictionary and put key/value pair in bootconfig into it */
   g_variant_dict_init (&boot_config_dict, NULL);
@@ -1387,12 +1240,11 @@ out:
 }
 
 static gboolean
-os_handle_cleanup (RPMOSTreeOS *interface,
-                   GDBusMethodInvocation *invocation,
-                   const char *const*args)
+os_handle_cleanup (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
+                   const char *const *args)
 {
   glnx_unref_object OstreeSysroot *ot_sysroot = NULL;
-  g_autoptr(GCancellable) cancellable = g_cancellable_new ();
+  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
   const char *osname = NULL;
   GError *local_error = NULL;
   const char *client_address = NULL;
@@ -1406,16 +1258,13 @@ os_handle_cleanup (RPMOSTreeOS *interface,
   if (transaction)
     goto out;
 
-  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (),
-                                      cancellable,
-                                      &ot_sysroot,
-                                      NULL,
+  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (), cancellable, &ot_sysroot, NULL,
                                       &local_error))
     goto out;
 
   osname = rpmostree_os_get_name (interface);
 
-  for (char **iter = (char**) args; iter && *iter; iter++)
+  for (char **iter = (char **)args; iter && *iter; iter++)
     {
       const char *v = *iter;
       if (strcmp (v, "base") == 0)
@@ -1428,19 +1277,14 @@ os_handle_cleanup (RPMOSTreeOS *interface,
         flags |= RPMOSTREE_TRANSACTION_CLEANUP_REPOMD;
       else
         {
-          g_set_error (&local_error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                       "Invalid cleanup type: %s", v);
+          g_set_error (&local_error, G_IO_ERROR, G_IO_ERROR_FAILED, "Invalid cleanup type: %s", v);
           goto out;
         }
     }
 
-
-  transaction = rpmostreed_transaction_new_cleanup (invocation,
-                                                    ot_sysroot,
-                                                    osname,
-                                                    static_cast<RpmOstreeTransactionCleanupFlags>(flags),
-                                                    cancellable,
-                                                    &local_error);
+  transaction = rpmostreed_transaction_new_cleanup (
+      invocation, ot_sysroot, osname, static_cast<RpmOstreeTransactionCleanupFlags> (flags),
+      cancellable, &local_error);
   if (transaction == NULL)
     goto out;
 
@@ -1461,22 +1305,20 @@ out:
 }
 
 static gboolean
-os_handle_get_cached_rebase_rpm_diff (RPMOSTreeOS *interface,
-                                      GDBusMethodInvocation *invocation,
-                                      const char *arg_refspec,
-                                      const char * const *arg_packages)
+os_handle_get_cached_rebase_rpm_diff (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
+                                      const char *arg_refspec, const char *const *arg_packages)
 {
   RpmostreedSysroot *global_sysroot;
-  g_autoptr(GCancellable) cancellable = NULL;
+  g_autoptr (GCancellable) cancellable = NULL;
   OstreeSysroot *ot_sysroot = NULL;
   OstreeRepo *ot_repo = NULL;
   const gchar *name;
   glnx_unref_object OstreeDeployment *base_deployment = NULL;
-  g_autoptr(RpmOstreeOrigin) origin = NULL;
+  g_autoptr (RpmOstreeOrigin) origin = NULL;
   g_autofree gchar *comp_ref = NULL;
   GError *local_error = NULL;
-  g_autoptr(GVariant) value = NULL;
-  g_autoptr(GVariant) details = NULL;
+  g_autoptr (GVariant) value = NULL;
+  g_autoptr (GVariant) details = NULL;
 
   /* TODO: Totally ignoring packages for now */
 
@@ -1489,8 +1331,8 @@ os_handle_get_cached_rebase_rpm_diff (RPMOSTreeOS *interface,
   base_deployment = ostree_sysroot_get_merge_deployment (ot_sysroot, name);
   if (base_deployment == NULL)
     {
-      local_error = g_error_new (G_IO_ERROR, G_IO_ERROR_FAILED,
-                                 "No deployments found for os %s", name);
+      local_error
+          = g_error_new (G_IO_ERROR, G_IO_ERROR_FAILED, "No deployments found for os %s", name);
       goto out;
     }
 
@@ -1498,21 +1340,16 @@ os_handle_get_cached_rebase_rpm_diff (RPMOSTreeOS *interface,
   if (!origin)
     goto out;
 
-  if (!rpmostreed_refspec_parse_partial (arg_refspec,
-                                         rpmostree_origin_get_refspec (origin),
-                                         &comp_ref,
-                                         &local_error))
+  if (!rpmostreed_refspec_parse_partial (arg_refspec, rpmostree_origin_get_refspec (origin),
+                                         &comp_ref, &local_error))
     goto out;
 
-  if (!rpm_ostree_db_diff_variant (ot_repo, ostree_deployment_get_csum (base_deployment),
-                                   comp_ref, FALSE, &value, cancellable, &local_error))
+  if (!rpm_ostree_db_diff_variant (ot_repo, ostree_deployment_get_csum (base_deployment), comp_ref,
+                                   FALSE, &value, cancellable, &local_error))
     goto out;
 
-  details = rpmostreed_commit_generate_cached_details_variant (base_deployment,
-                                                               ot_repo,
-                                                               comp_ref,
-                                                               NULL,
-                                                               &local_error);
+  details = rpmostreed_commit_generate_cached_details_variant (base_deployment, ot_repo, comp_ref,
+                                                               NULL, &local_error);
   if (!details)
     goto out;
 
@@ -1530,14 +1367,12 @@ out:
 }
 
 static gboolean
-os_handle_download_rebase_rpm_diff (RPMOSTreeOS *interface,
-                                    GDBusMethodInvocation *invocation,
-                                    const char *arg_refspec,
-                                    const char * const *arg_packages)
+os_handle_download_rebase_rpm_diff (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
+                                    const char *arg_refspec, const char *const *arg_packages)
 {
   /* TODO: Totally ignoring arg_packages for now */
   glnx_unref_object OstreeSysroot *ot_sysroot = NULL;
-  g_autoptr(GCancellable) cancellable = g_cancellable_new ();
+  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
   const char *osname;
   GError *local_error = NULL;
 
@@ -1549,22 +1384,15 @@ os_handle_download_rebase_rpm_diff (RPMOSTreeOS *interface,
   if (transaction)
     goto out;
 
-  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (),
-                                      cancellable,
-                                      &ot_sysroot,
-                                      NULL,
+  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (), cancellable, &ot_sysroot, NULL,
                                       &local_error))
     goto out;
 
   osname = rpmostree_os_get_name (interface);
 
-  transaction = rpmostreed_transaction_new_package_diff (invocation,
-                                                         ot_sysroot,
-                                                         osname,
-                                                         arg_refspec,
-                                                         NULL,  /* revision */
-                                                         cancellable,
-                                                         &local_error);
+  transaction = rpmostreed_transaction_new_package_diff (invocation, ot_sysroot, osname,
+                                                         arg_refspec, NULL, /* revision */
+                                                         cancellable, &local_error);
 
   if (transaction == NULL)
     goto out;
@@ -1587,15 +1415,12 @@ out:
 }
 
 static gboolean
-get_cached_deploy_rpm_diff (RPMOSTreeOS *interface,
-                            const char *arg_revision,
-                            GVariant **out_value,
-                            GVariant **out_details,
-                            GError    **error)
+get_cached_deploy_rpm_diff (RPMOSTreeOS *interface, const char *arg_revision, GVariant **out_value,
+                            GVariant **out_details, GError **error)
 {
-  g_autoptr(GCancellable) cancellable = NULL;
-  g_autoptr(GVariant) value = NULL;
-  g_autoptr(GVariant) details = NULL;
+  g_autoptr (GCancellable) cancellable = NULL;
+  g_autoptr (GVariant) value = NULL;
+  g_autoptr (GVariant) details = NULL;
 
   if (arg_revision == NULL)
     return glnx_throw (error, "Missing revision");
@@ -1604,49 +1429,44 @@ get_cached_deploy_rpm_diff (RPMOSTreeOS *interface,
   OstreeRepo *ot_repo = rpmostreed_sysroot_get_repo (rpmostreed_sysroot_get ());
 
   const char *osname = rpmostree_os_get_name (interface);
-  glnx_unref_object OstreeDeployment *base_deployment = ostree_sysroot_get_merge_deployment (ot_sysroot, osname);
+  glnx_unref_object OstreeDeployment *base_deployment
+      = ostree_sysroot_get_merge_deployment (ot_sysroot, osname);
   if (base_deployment == NULL)
     return glnx_throw (error, "No deployments found for OS '%s'", osname);
 
-  g_autoptr(RpmOstreeOrigin) origin = rpmostree_origin_parse_deployment (base_deployment, error);
+  g_autoptr (RpmOstreeOrigin) origin = rpmostree_origin_parse_deployment (base_deployment, error);
   if (origin == NULL)
     return glnx_prefix_error (error, "Parsing origin for deployment");
 
   const char *base_checksum = ostree_deployment_get_csum (base_deployment);
 
-  auto parsed_revision = CXX_TRY_VAL(parse_revision(arg_revision), error);
+  auto parsed_revision = CXX_TRY_VAL (parse_revision (arg_revision), error);
   g_autofree char *checksum = NULL;
   switch (parsed_revision.kind)
     {
-      case rpmostreecxx::ParsedRevisionKind::Checksum:
-        {
-          checksum = g_strdup (parsed_revision.value.c_str());
-        }
-        break;
-      case rpmostreecxx::ParsedRevisionKind::Version:
-        {
-          if (!rpmostreed_repo_lookup_cached_version (ot_repo,
-                                                      rpmostree_origin_get_refspec (origin),
-                                                      parsed_revision.value.c_str(),
-                                                      cancellable,
-                                                      &checksum,
-                                                      error))
-            return glnx_prefix_error (error, "Looking up cached version");
-        }
-        break;
-      default:
-        return glnx_throw (error, "Invalid revision kind");
+    case rpmostreecxx::ParsedRevisionKind::Checksum:
+      {
+        checksum = g_strdup (parsed_revision.value.c_str ());
+      }
+      break;
+    case rpmostreecxx::ParsedRevisionKind::Version:
+      {
+        if (!rpmostreed_repo_lookup_cached_version (ot_repo, rpmostree_origin_get_refspec (origin),
+                                                    parsed_revision.value.c_str (), cancellable,
+                                                    &checksum, error))
+          return glnx_prefix_error (error, "Looking up cached version");
+      }
+      break;
+    default:
+      return glnx_throw (error, "Invalid revision kind");
     }
 
-  if (!rpm_ostree_db_diff_variant (ot_repo, base_checksum, checksum, FALSE, &value,
-                                   cancellable, error))
+  if (!rpm_ostree_db_diff_variant (ot_repo, base_checksum, checksum, FALSE, &value, cancellable,
+                                   error))
     return glnx_prefix_error (error, "Assembling diff");
 
-  details = rpmostreed_commit_generate_cached_details_variant (base_deployment,
-                                                               ot_repo,
-                                                               rpmostree_origin_get_refspec (origin),
-                                                               checksum,
-                                                               error);
+  details = rpmostreed_commit_generate_cached_details_variant (
+      base_deployment, ot_repo, rpmostree_origin_get_refspec (origin), checksum, error);
   if (details == NULL)
     return glnx_prefix_error (error, "Generating cached details");
 
@@ -1656,41 +1476,36 @@ get_cached_deploy_rpm_diff (RPMOSTreeOS *interface,
 }
 
 static gboolean
-os_handle_get_cached_deploy_rpm_diff (RPMOSTreeOS *interface,
-                                      GDBusMethodInvocation *invocation,
-                                      const char *arg_revision,
-                                      const char * const *arg_packages)
+os_handle_get_cached_deploy_rpm_diff (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
+                                      const char *arg_revision, const char *const *arg_packages)
 {
   GError *local_error = NULL;
-  g_autoptr(GVariant) value = NULL;
-  g_autoptr(GVariant) details = NULL;
+  g_autoptr (GVariant) value = NULL;
+  g_autoptr (GVariant) details = NULL;
 
   /* XXX Ignoring arg_packages for now. */
-  gboolean is_ok = get_cached_deploy_rpm_diff (interface, arg_revision,
-                                               &value, &details, &local_error);
+  gboolean is_ok
+      = get_cached_deploy_rpm_diff (interface, arg_revision, &value, &details, &local_error);
   if (!is_ok)
     {
       g_assert (local_error != NULL);
       g_dbus_method_invocation_take_error (invocation, local_error);
-      return TRUE;  /* 🔚 Early return */
+      return TRUE; /* 🔚 Early return */
     }
 
   g_assert (value != NULL);
   g_assert (details != NULL);
-  g_dbus_method_invocation_return_value (invocation,
-                                         new_variant_diff_result (value, details));
+  g_dbus_method_invocation_return_value (invocation, new_variant_diff_result (value, details));
 
   return TRUE;
 }
 
 static gboolean
-os_handle_download_deploy_rpm_diff (RPMOSTreeOS *interface,
-                                    GDBusMethodInvocation *invocation,
-                                    const char *arg_revision,
-                                    const char * const *arg_packages)
+os_handle_download_deploy_rpm_diff (RPMOSTreeOS *interface, GDBusMethodInvocation *invocation,
+                                    const char *arg_revision, const char *const *arg_packages)
 {
   glnx_unref_object OstreeSysroot *ot_sysroot = NULL;
-  g_autoptr(GCancellable) cancellable = g_cancellable_new ();
+  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
   const char *osname;
   GError *local_error = NULL;
 
@@ -1704,22 +1519,15 @@ os_handle_download_deploy_rpm_diff (RPMOSTreeOS *interface,
   if (transaction)
     goto out;
 
-  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (),
-                                      cancellable,
-                                      &ot_sysroot,
-                                      NULL,
+  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (), cancellable, &ot_sysroot, NULL,
                                       &local_error))
     goto out;
 
   osname = rpmostree_os_get_name (interface);
 
-  transaction = rpmostreed_transaction_new_package_diff (invocation,
-                                                         ot_sysroot,
-                                                         osname,
-                                                         NULL, /* refspec */
-                                                         arg_revision,
-                                                         cancellable,
-                                                         &local_error);
+  transaction
+      = rpmostreed_transaction_new_package_diff (invocation, ot_sysroot, osname, NULL, /* refspec */
+                                                 arg_revision, cancellable, &local_error);
   if (transaction == NULL)
     goto out;
 
@@ -1742,11 +1550,9 @@ out:
 
 /* split out for easier handling of the NULL case */
 static gboolean
-refresh_cached_update_impl (RpmostreedOS *self,
-                            GVariant    **out_cached_update,
-                            GError      **error)
+refresh_cached_update_impl (RpmostreedOS *self, GVariant **out_cached_update, GError **error)
 {
-  g_autoptr(GVariant) cached_update = NULL;
+  g_autoptr (GVariant) cached_update = NULL;
 
   /* if we're not booted into our OS, don't look at cache; it's for another OS interface */
   const char *osname = rpmostree_os_get_name (RPMOSTREE_OS (self));
@@ -1756,9 +1562,8 @@ refresh_cached_update_impl (RpmostreedOS *self,
     return TRUE; /* Note early return */
 
   glnx_autofd int fd = -1;
-  g_autoptr(GError) local_error = NULL;
-  if (!glnx_openat_rdonly (AT_FDCWD, RPMOSTREE_AUTOUPDATES_CACHE_FILE, TRUE, &fd,
-                           &local_error))
+  g_autoptr (GError) local_error = NULL;
+  if (!glnx_openat_rdonly (AT_FDCWD, RPMOSTREE_AUTOUPDATES_CACHE_FILE, TRUE, &fd, &local_error))
     {
       if (!g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
         return g_propagate_error (error, util::move_nullify (local_error)), FALSE;
@@ -1774,17 +1579,17 @@ refresh_cached_update_impl (RpmostreedOS *self,
                                           RPMOSTREE_AUTOUPDATES_CACHE_FILE, error))
     return FALSE;
 
-  g_autoptr(GBytes) data = glnx_fd_readall_bytes (fd, NULL, error);
+  g_autoptr (GBytes) data = glnx_fd_readall_bytes (fd, NULL, error);
   if (!data)
     return FALSE;
 
-  cached_update =
-    g_variant_ref_sink (g_variant_new_from_bytes (G_VARIANT_TYPE_VARDICT, data, FALSE));
+  cached_update
+      = g_variant_ref_sink (g_variant_new_from_bytes (G_VARIANT_TYPE_VARDICT, data, FALSE));
 
   /* check if cache is still valid -- see rpmostreed_update_generate_variant() */
-  g_auto(GVariantDict) dict;
+  g_auto (GVariantDict) dict;
   g_variant_dict_init (&dict, cached_update);
-  auto state = static_cast<const char*>(vardict_lookup_ptr (&dict, "update-sha256", "&s"));
+  auto state = static_cast<const char *> (vardict_lookup_ptr (&dict, "update-sha256", "&s"));
   if (g_strcmp0 (state, ostree_deployment_get_csum (booted)) != 0)
     {
       sd_journal_print (LOG_INFO, "Deleting outdated cached update for OS '%s'", osname);
@@ -1800,7 +1605,7 @@ refresh_cached_update_impl (RpmostreedOS *self,
 static gboolean
 refresh_cached_update (RpmostreedOS *self, GError **error)
 {
-  g_autoptr(GVariant) cached_update = NULL;
+  g_autoptr (GVariant) cached_update = NULL;
   if (!refresh_cached_update_impl (self, &cached_update, error))
     return FALSE;
 
@@ -1819,29 +1624,29 @@ rpmostreed_os_load_internals (RpmostreedOS *self, GError **error)
   OstreeRepo *ot_repo = rpmostreed_sysroot_get_repo (rpmostreed_sysroot_get ());
 
   /* Booted */
-  g_autofree gchar* booted_id = NULL;
+  g_autofree gchar *booted_id = NULL;
   OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment (ot_sysroot);
-  g_autoptr(GVariant) booted_variant = NULL; /* Strong ref as we reuse it below */
+  g_autoptr (GVariant) booted_variant = NULL; /* Strong ref as we reuse it below */
   if (booted_deployment && g_strcmp0 (ostree_deployment_get_osname (booted_deployment), name) == 0)
     {
-      if (!rpmostreed_deployment_generate_variant (ot_sysroot, booted_deployment,
-                                                   booted_id, ot_repo, TRUE, &booted_variant, error))
+      if (!rpmostreed_deployment_generate_variant (ot_sysroot, booted_deployment, booted_id,
+                                                   ot_repo, TRUE, &booted_variant, error))
         return FALSE;
       g_variant_ref_sink (booted_variant);
-      auto bootedid_v = CXX_TRY_VAL(deployment_generate_id(*booted_deployment), error);
-      booted_id = g_strdup(bootedid_v.c_str());
+      auto bootedid_v = CXX_TRY_VAL (deployment_generate_id (*booted_deployment), error);
+      booted_id = g_strdup (bootedid_v.c_str ());
     }
   else
     booted_variant = g_variant_ref_sink (rpmostreed_deployment_generate_blank_variant ());
   rpmostree_os_set_booted_deployment (RPMOSTREE_OS (self), booted_variant);
 
   /* Default (pending or booted) and rollback */
-  g_autoptr(OstreeDeployment) rollback_deployment = NULL;
-  g_autoptr(OstreeDeployment) pending_deployment = NULL;
-  ostree_sysroot_query_deployments_for (ot_sysroot, name,
-                                        &pending_deployment, &rollback_deployment);
+  g_autoptr (OstreeDeployment) rollback_deployment = NULL;
+  g_autoptr (OstreeDeployment) pending_deployment = NULL;
+  ostree_sysroot_query_deployments_for (ot_sysroot, name, &pending_deployment,
+                                        &rollback_deployment);
 
-  g_autoptr(GVariant) default_variant = NULL;
+  g_autoptr (GVariant) default_variant = NULL;
   if (pending_deployment)
     {
       if (!rpmostreed_deployment_generate_variant (ot_sysroot, pending_deployment, booted_id,
@@ -1857,7 +1662,7 @@ rpmostreed_os_load_internals (RpmostreedOS *self, GError **error)
   if (rollback_deployment)
     {
       if (!rpmostreed_deployment_generate_variant (ot_sysroot, rollback_deployment, booted_id,
-                                                ot_repo, TRUE, &rollback_variant, error))
+                                                   ot_repo, TRUE, &rollback_variant, error))
         return FALSE;
     }
   else
@@ -1875,40 +1680,39 @@ rpmostreed_os_load_internals (RpmostreedOS *self, GError **error)
 static void
 rpmostreed_os_iface_init (RPMOSTreeOSIface *iface)
 {
-  iface->handle_automatic_update_trigger   = os_handle_automatic_update_trigger;
-  iface->handle_cleanup                    = os_handle_cleanup;
+  iface->handle_automatic_update_trigger = os_handle_automatic_update_trigger;
+  iface->handle_cleanup = os_handle_cleanup;
   iface->handle_get_deployment_boot_config = os_handle_get_deployment_boot_config;
-  iface->handle_kernel_args                = os_handle_kernel_args;
-  iface->handle_refresh_md                 = os_handle_refresh_md;
-  iface->handle_modify_yum_repo            = os_handle_modify_yum_repo;
-  iface->handle_rollback                   = os_handle_rollback;
-  iface->handle_initramfs_etc              = os_handle_initramfs_etc;
-  iface->handle_set_initramfs_state        = os_handle_set_initramfs_state;
-  iface->handle_update_deployment          = os_handle_update_deployment;
-  iface->handle_finalize_deployment        = os_handle_finalize_deployment;
+  iface->handle_kernel_args = os_handle_kernel_args;
+  iface->handle_refresh_md = os_handle_refresh_md;
+  iface->handle_modify_yum_repo = os_handle_modify_yum_repo;
+  iface->handle_rollback = os_handle_rollback;
+  iface->handle_initramfs_etc = os_handle_initramfs_etc;
+  iface->handle_set_initramfs_state = os_handle_set_initramfs_state;
+  iface->handle_update_deployment = os_handle_update_deployment;
+  iface->handle_finalize_deployment = os_handle_finalize_deployment;
   /* legacy cleanup API; superseded by Cleanup() */
-  iface->handle_clear_rollback_target      = os_handle_clear_rollback_target;
+  iface->handle_clear_rollback_target = os_handle_clear_rollback_target;
   /* legacy deployment change API; superseded by UpdateDeployment() */
-  iface->handle_upgrade                    = os_handle_upgrade;
-  iface->handle_rebase                     = os_handle_rebase;
-  iface->handle_deploy                     = os_handle_deploy;
-  iface->handle_pkg_change                 = os_handle_pkg_change;
+  iface->handle_upgrade = os_handle_upgrade;
+  iface->handle_rebase = os_handle_rebase;
+  iface->handle_deploy = os_handle_deploy;
+  iface->handle_pkg_change = os_handle_pkg_change;
   /* cache API; used by Cockpit at least */
-  iface->handle_get_deployments_rpm_diff   = os_handle_get_deployments_rpm_diff;
+  iface->handle_get_deployments_rpm_diff = os_handle_get_deployments_rpm_diff;
   iface->handle_get_cached_update_rpm_diff = os_handle_get_cached_update_rpm_diff;
   iface->handle_get_cached_rebase_rpm_diff = os_handle_get_cached_rebase_rpm_diff;
   iface->handle_get_cached_deploy_rpm_diff = os_handle_get_cached_deploy_rpm_diff;
-  iface->handle_download_update_rpm_diff   = os_handle_download_update_rpm_diff;
-  iface->handle_download_rebase_rpm_diff   = os_handle_download_rebase_rpm_diff;
-  iface->handle_download_deploy_rpm_diff   = os_handle_download_deploy_rpm_diff;
+  iface->handle_download_update_rpm_diff = os_handle_download_update_rpm_diff;
+  iface->handle_download_rebase_rpm_diff = os_handle_download_rebase_rpm_diff;
+  iface->handle_download_deploy_rpm_diff = os_handle_download_deploy_rpm_diff;
 }
 
-/* ---------------------------------------------------------------------------------------------------- */
+/* ----------------------------------------------------------------------------------------------------
+ */
 
 RPMOSTreeOS *
-rpmostreed_os_new (OstreeSysroot *sysroot,
-                   OstreeRepo *repo,
-                   const char *name)
+rpmostreed_os_new (OstreeSysroot *sysroot, OstreeRepo *repo, const char *name)
 {
   g_assert (OSTREE_IS_SYSROOT (sysroot));
   g_assert (name != NULL);
@@ -1918,7 +1722,8 @@ rpmostreed_os_new (OstreeSysroot *sysroot,
   auto obj = (RpmostreedOS *)g_object_new (RPMOSTREED_TYPE_OS, "name", name, NULL);
 
   /* FIXME - use GInitable */
-  { g_autoptr(GError) local_error = NULL;
+  {
+    g_autoptr (GError) local_error = NULL;
     if (!rpmostreed_os_load_internals (obj, &local_error))
       g_warning ("%s", local_error->message);
   }

--- a/src/daemon/rpmostreed-os.h
+++ b/src/daemon/rpmostreed-os.h
@@ -1,20 +1,20 @@
 /*
-* Copyright (C) 2015 Red Hat, Inc.
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program; if not, write to the Free Software
-* Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
-*/
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 #pragma once
 
@@ -22,15 +22,13 @@
 
 G_BEGIN_DECLS
 
-#define RPMOSTREED_TYPE_OS   (rpmostreed_os_get_type ())
-#define RPMOSTREED_OS(o)     (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_OS, RpmostreedOS))
-#define RPMOSTREED_IS_OS(o)  (G_TYPE_CHECK_INSTANCE_TYPE ((o), RPMOSTREED_TYPE_OS))
+#define RPMOSTREED_TYPE_OS (rpmostreed_os_get_type ())
+#define RPMOSTREED_OS(o) (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_OS, RpmostreedOS))
+#define RPMOSTREED_IS_OS(o) (G_TYPE_CHECK_INSTANCE_TYPE ((o), RPMOSTREED_TYPE_OS))
 
 typedef GVariant RpmOstreeUpdateDeploymentModifiers;
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeUpdateDeploymentModifiers, g_variant_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (RpmOstreeUpdateDeploymentModifiers, g_variant_unref)
 
-GType             rpmostreed_os_get_type           (void) G_GNUC_CONST;
-RPMOSTreeOS *     rpmostreed_os_new                (OstreeSysroot *sysroot,
-                                                    OstreeRepo *repo,
-                                                    const char *name);
+GType rpmostreed_os_get_type (void) G_GNUC_CONST;
+RPMOSTreeOS *rpmostreed_os_new (OstreeSysroot *sysroot, OstreeRepo *repo, const char *name);
 G_END_DECLS

--- a/src/daemon/rpmostreed-sysroot.h
+++ b/src/daemon/rpmostreed-sysroot.h
@@ -1,20 +1,20 @@
 /*
-* Copyright (C) 2015 Red Hat, Inc.
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program; if not, write to the Free Software
-* Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
-*/
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 #pragma once
 
@@ -24,50 +24,43 @@
 
 G_BEGIN_DECLS
 
-#define RPMOSTREED_TYPE_SYSROOT   (rpmostreed_sysroot_get_type ())
-#define RPMOSTREED_SYSROOT(o)     (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_SYSROOT, RpmostreedSysroot))
-#define RPMOSTREED_IS_SYSROOT(o)  (G_TYPE_CHECK_INSTANCE_TYPE ((o), RPMOSTREED_TYPE_SYSROOT))
+#define RPMOSTREED_TYPE_SYSROOT (rpmostreed_sysroot_get_type ())
+#define RPMOSTREED_SYSROOT(o)                                                                      \
+  (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_SYSROOT, RpmostreedSysroot))
+#define RPMOSTREED_IS_SYSROOT(o) (G_TYPE_CHECK_INSTANCE_TYPE ((o), RPMOSTREED_TYPE_SYSROOT))
 
 #define SYSROOT_DEFAULT_PATH "/"
 
-GType               rpmostreed_sysroot_get_type         (void) G_GNUC_CONST;
+GType rpmostreed_sysroot_get_type (void) G_GNUC_CONST;
 
-RpmostreedSysroot * rpmostreed_sysroot_get              (void);
+RpmostreedSysroot *rpmostreed_sysroot_get (void);
 
-gboolean            rpmostreed_sysroot_populate         (RpmostreedSysroot *self,
-                                                         GCancellable *cancellable,
-                                                         GError **error);
-gboolean            rpmostreed_sysroot_reload           (RpmostreedSysroot *self,
-                                                         GError **error);
+gboolean rpmostreed_sysroot_populate (RpmostreedSysroot *self, GCancellable *cancellable,
+                                      GError **error);
+gboolean rpmostreed_sysroot_reload (RpmostreedSysroot *self, GError **error);
 
-OstreeSysroot *     rpmostreed_sysroot_get_root         (RpmostreedSysroot *self);
-OstreeRepo *        rpmostreed_sysroot_get_repo         (RpmostreedSysroot *self);
-PolkitAuthority *   rpmostreed_sysroot_get_polkit_authority (RpmostreedSysroot *self);
-gboolean            rpmostreed_sysroot_is_on_session_bus    (RpmostreedSysroot *self);
+OstreeSysroot *rpmostreed_sysroot_get_root (RpmostreedSysroot *self);
+OstreeRepo *rpmostreed_sysroot_get_repo (RpmostreedSysroot *self);
+PolkitAuthority *rpmostreed_sysroot_get_polkit_authority (RpmostreedSysroot *self);
+gboolean rpmostreed_sysroot_is_on_session_bus (RpmostreedSysroot *self);
 
-gboolean            rpmostreed_sysroot_load_state       (RpmostreedSysroot *self,
-                                                         GCancellable *cancellable,
-                                                         OstreeSysroot **out_sysroot,
-                                                         OstreeRepo **out_repo,
-                                                         GError **error);
+gboolean rpmostreed_sysroot_load_state (RpmostreedSysroot *self, GCancellable *cancellable,
+                                        OstreeSysroot **out_sysroot, OstreeRepo **out_repo,
+                                        GError **error);
 
-gboolean            rpmostreed_sysroot_prep_for_txn (RpmostreedSysroot     *self,
-                                                     GDBusMethodInvocation *invocation,
-                                                     RpmostreedTransaction **out_compat_txn,
-                                                     GError               **error);
+gboolean rpmostreed_sysroot_prep_for_txn (RpmostreedSysroot *self,
+                                          GDBusMethodInvocation *invocation,
+                                          RpmostreedTransaction **out_compat_txn, GError **error);
 
-gboolean            rpmostreed_sysroot_has_txn (RpmostreedSysroot     *self);
+gboolean rpmostreed_sysroot_has_txn (RpmostreedSysroot *self);
 
-void                rpmostreed_sysroot_finish_txn (RpmostreedSysroot     *self,
-                                                   RpmostreedTransaction *txn);
+void rpmostreed_sysroot_finish_txn (RpmostreedSysroot *self, RpmostreedTransaction *txn);
 
-void                rpmostreed_sysroot_set_txn (RpmostreedSysroot     *self,
-                                                RpmostreedTransaction *txn);
+void rpmostreed_sysroot_set_txn (RpmostreedSysroot *self, RpmostreedTransaction *txn);
 
-void                rpmostreed_sysroot_set_txn_and_title (RpmostreedSysroot     *self,
-                                                          RpmostreedTransaction *txn,
-                                                          const char            *title);
+void rpmostreed_sysroot_set_txn_and_title (RpmostreedSysroot *self, RpmostreedTransaction *txn,
+                                           const char *title);
 
-void                rpmostreed_sysroot_emit_update      (RpmostreedSysroot *self);
+void rpmostreed_sysroot_emit_update (RpmostreedSysroot *self);
 
 G_END_DECLS

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -18,40 +18,30 @@
 
 #pragma once
 
-#include "rpmostreed-types.h"
 #include "rpmostreed-daemon.h"
 #include "rpmostreed-os.h"
+#include "rpmostreed-types.h"
 
 #include <gio/gunixfdlist.h>
 
 G_BEGIN_DECLS
 
-RpmostreedTransaction *
-                rpmostreed_transaction_new_package_diff    (GDBusMethodInvocation *invocation,
+RpmostreedTransaction *rpmostreed_transaction_new_package_diff (
+    GDBusMethodInvocation *invocation, OstreeSysroot *sysroot, const char *osname,
+    const char *refspec, const char *revision, GCancellable *cancellable, GError **error);
+
+RpmostreedTransaction *rpmostreed_transaction_new_rollback (GDBusMethodInvocation *invocation,
                                                             OstreeSysroot *sysroot,
-                                                            const char *osname,
-                                                            const char *refspec,
-                                                            const char *revision,
+                                                            const char *osname, gboolean reboot,
                                                             GCancellable *cancellable,
                                                             GError **error);
 
-RpmostreedTransaction *
-                rpmostreed_transaction_new_rollback        (GDBusMethodInvocation *invocation,
-                                                            OstreeSysroot *sysroot,
-                                                            const char *osname,
-                                                            gboolean reboot,
-                                                            GCancellable *cancellable,
-                                                            GError **error);
+RpmostreedTransaction *rpmostreed_transaction_new_clear_rollback (
+    GDBusMethodInvocation *invocation, OstreeSysroot *sysroot, const char *osname, gboolean reboot,
+    GCancellable *cancellable, GError **error);
 
-RpmostreedTransaction *
-                rpmostreed_transaction_new_clear_rollback  (GDBusMethodInvocation *invocation,
-                                                            OstreeSysroot *sysroot,
-                                                            const char *osname,
-                                                            gboolean reboot,
-                                                            GCancellable *cancellable,
-                                                            GError **error);
-
-typedef enum {
+typedef enum
+{
   RPMOSTREE_TRANSACTION_DEPLOY_FLAG_ALLOW_DOWNGRADE = (1 << 2),
   RPMOSTREE_TRANSACTION_DEPLOY_FLAG_NO_PULL_BASE = (1 << 4),
   RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DRY_RUN = (1 << 5),
@@ -59,49 +49,27 @@ typedef enum {
   RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_METADATA_ONLY = (1 << 9),
 } RpmOstreeTransactionDeployFlags;
 
-
 RpmostreedTransaction *
-rpmostreed_transaction_new_deploy (GDBusMethodInvocation *invocation,
-                                   OstreeSysroot *sysroot,
-                                   const char *osname,
-                                   RpmOstreeTransactionDeployFlags flags,
-                                   GVariant               *options,
-                                   RpmOstreeUpdateDeploymentModifiers *modifiers,
-                                   GUnixFDList            *fd_list,
-                                   GCancellable *cancellable,
-                                   GError **error);
+rpmostreed_transaction_new_deploy (GDBusMethodInvocation *invocation, OstreeSysroot *sysroot,
+                                   const char *osname, RpmOstreeTransactionDeployFlags flags,
+                                   GVariant *options, RpmOstreeUpdateDeploymentModifiers *modifiers,
+                                   GUnixFDList *fd_list, GCancellable *cancellable, GError **error);
 
-RpmostreedTransaction *
-rpmostreed_transaction_new_finalize_deployment (GDBusMethodInvocation *invocation,
-                                                OstreeSysroot         *sysroot,
-                                                const char            *osname,
-                                                GVariant              *options,
-                                                GCancellable          *cancellable,
-                                                GError               **error);
+RpmostreedTransaction *rpmostreed_transaction_new_finalize_deployment (
+    GDBusMethodInvocation *invocation, OstreeSysroot *sysroot, const char *osname,
+    GVariant *options, GCancellable *cancellable, GError **error);
 
-RpmostreedTransaction *
-rpmostreed_transaction_new_initramfs_etc (GDBusMethodInvocation *invocation,
-                                          OstreeSysroot         *sysroot,
-                                          const char            *osname,
-                                          char                 **track,
-                                          char                 **untrack,
-                                          gboolean               untrack_all,
-                                          gboolean               force_sync,
-                                          GVariant              *options,
-                                          GCancellable          *cancellable,
-                                          GError               **error);
+RpmostreedTransaction *rpmostreed_transaction_new_initramfs_etc (
+    GDBusMethodInvocation *invocation, OstreeSysroot *sysroot, const char *osname, char **track,
+    char **untrack, gboolean untrack_all, gboolean force_sync, GVariant *options,
+    GCancellable *cancellable, GError **error);
 
-RpmostreedTransaction *
-rpmostreed_transaction_new_initramfs_state       (GDBusMethodInvocation *invocation,
-                                                  OstreeSysroot         *sysroot,
-                                                  const char            *osname,
-                                                  gboolean               regenerate,
-                                                  char                 **args,
-                                                  GVariant              *options,
-                                                  GCancellable          *cancellable,
-                                                  GError               **error);
+RpmostreedTransaction *rpmostreed_transaction_new_initramfs_state (
+    GDBusMethodInvocation *invocation, OstreeSysroot *sysroot, const char *osname,
+    gboolean regenerate, char **args, GVariant *options, GCancellable *cancellable, GError **error);
 
-typedef enum {
+typedef enum
+{
   RPMOSTREE_TRANSACTION_CLEANUP_BASE = (1 << 0),
   RPMOSTREE_TRANSACTION_CLEANUP_PENDING_DEPLOY = (1 << 1),
   RPMOSTREE_TRANSACTION_CLEANUP_ROLLBACK_DEPLOY = (1 << 2),
@@ -109,60 +77,38 @@ typedef enum {
 } RpmOstreeTransactionCleanupFlags;
 
 RpmostreedTransaction *
-rpmostreed_transaction_new_cleanup       (GDBusMethodInvocation *invocation,
-                                          OstreeSysroot         *sysroot,
-                                          const char            *osname,
-                                          RpmOstreeTransactionCleanupFlags flags,
-                                          GCancellable          *cancellable,
-                                          GError               **error);
+rpmostreed_transaction_new_cleanup (GDBusMethodInvocation *invocation, OstreeSysroot *sysroot,
+                                    const char *osname, RpmOstreeTransactionCleanupFlags flags,
+                                    GCancellable *cancellable, GError **error);
 
-RpmostreedTransaction *
-rpmostreed_transaction_new_apply_live (GDBusMethodInvocation *invocation,
-                                       OstreeSysroot         *sysroot,
-                                       GVariant              *options,
-                                       GCancellable          *cancellable,
-                                       GError               **error);
-    
-typedef enum {
+RpmostreedTransaction *rpmostreed_transaction_new_apply_live (GDBusMethodInvocation *invocation,
+                                                              OstreeSysroot *sysroot,
+                                                              GVariant *options,
+                                                              GCancellable *cancellable,
+                                                              GError **error);
+
+typedef enum
+{
   RPMOSTREE_TRANSACTION_REFRESH_MD_FLAG_FORCE = (1 << 0),
 } RpmOstreeTransactionRefreshMdFlags;
 
 RpmostreedTransaction *
-rpmostreed_transaction_new_refresh_md (GDBusMethodInvocation *invocation,
-                                       OstreeSysroot         *sysroot,
-                                       RpmOstreeTransactionRefreshMdFlags flags,
-                                       const char            *osname,
-                                       GCancellable          *cancellable,
-                                       GError               **error);
+rpmostreed_transaction_new_refresh_md (GDBusMethodInvocation *invocation, OstreeSysroot *sysroot,
+                                       RpmOstreeTransactionRefreshMdFlags flags, const char *osname,
+                                       GCancellable *cancellable, GError **error);
 
-RpmostreedTransaction *
-rpmostreed_transaction_new_modify_yum_repo (GDBusMethodInvocation *invocation,
-                                            OstreeSysroot         *sysroot,
-                                            const char            *osname,
-                                            const char            *repo_id,
-                                            GVariant              *settings,
-                                            GCancellable          *cancellable,
-                                            GError               **error);
+RpmostreedTransaction *rpmostreed_transaction_new_modify_yum_repo (
+    GDBusMethodInvocation *invocation, OstreeSysroot *sysroot, const char *osname,
+    const char *repo_id, GVariant *settings, GCancellable *cancellable, GError **error);
 
-RpmostreedTransaction *
-rpmostreed_transaction_new_kernel_arg (GDBusMethodInvocation *invocation,
-                                       OstreeSysroot         *sysroot,
-                                       const char *           osname,
-                                       const char *           existing_kernel_args,
-                                       const char * const *kernel_args_added,
-                                       const char * const *kernel_args_replaced,
-                                       const char * const *kernel_args_deleted,
-                                       GVariant              *options,
-                                       GCancellable          *cancellable,
-                                       GError               **error);
+RpmostreedTransaction *rpmostreed_transaction_new_kernel_arg (
+    GDBusMethodInvocation *invocation, OstreeSysroot *sysroot, const char *osname,
+    const char *existing_kernel_args, const char *const *kernel_args_added,
+    const char *const *kernel_args_replaced, const char *const *kernel_args_deleted,
+    GVariant *options, GCancellable *cancellable, GError **error);
 
 G_END_DECLS
 
-gboolean
-get_driver_info (char   **name,
-                 char   **sd_unit,
-                 GError **error);
+gboolean get_driver_info (char **name, char **sd_unit, GError **error);
 
-gboolean
-get_driver_g_variant (GVariant **driver_info,
-                      GError   **error);
+gboolean get_driver_g_variant (GVariant **driver_info, GError **error);

--- a/src/daemon/rpmostreed-transaction.h
+++ b/src/daemon/rpmostreed-transaction.h
@@ -22,45 +22,46 @@
 
 G_BEGIN_DECLS
 
-#define RPMOSTREED_TYPE_TRANSACTION          (rpmostreed_transaction_get_type ())
-#define RPMOSTREED_TRANSACTION(o)            (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_TRANSACTION, RpmostreedTransaction))
-#define RPMOSTREED_TRANSACTION_CLASS(c)      (G_TYPE_CHECK_CLASS_CAST ((c), RPMOSTREED_TYPE_TRANSACTION, RpmostreedTransactionClass))
-#define RPMOSTREED_IS_TRANSACTION(o)         (G_TYPE_CHECK_INSTANCE_TYPE ((o), RPMOSTREED_TYPE_TRANSACTION))
-#define RPMOSTREED_TRANSACTION_GET_CLASS(o)  (G_TYPE_INSTANCE_GET_CLASS ((o), RPMOSTREED_TYPE_TRANSACTION, RpmostreedTransactionClass))
+#define RPMOSTREED_TYPE_TRANSACTION (rpmostreed_transaction_get_type ())
+#define RPMOSTREED_TRANSACTION(o)                                                                  \
+  (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_TRANSACTION, RpmostreedTransaction))
+#define RPMOSTREED_TRANSACTION_CLASS(c)                                                            \
+  (G_TYPE_CHECK_CLASS_CAST ((c), RPMOSTREED_TYPE_TRANSACTION, RpmostreedTransactionClass))
+#define RPMOSTREED_IS_TRANSACTION(o) (G_TYPE_CHECK_INSTANCE_TYPE ((o), RPMOSTREED_TYPE_TRANSACTION))
+#define RPMOSTREED_TRANSACTION_GET_CLASS(o)                                                        \
+  (G_TYPE_INSTANCE_GET_CLASS ((o), RPMOSTREED_TYPE_TRANSACTION, RpmostreedTransactionClass))
 
 typedef struct _RpmostreedTransactionClass RpmostreedTransactionClass;
 typedef struct _RpmostreedTransactionPrivate RpmostreedTransactionPrivate;
 
-struct _RpmostreedTransaction {
+struct _RpmostreedTransaction
+{
   RPMOSTreeTransactionSkeleton parent;
   RpmostreedTransactionPrivate *priv;
 };
 
-struct _RpmostreedTransactionClass {
+struct _RpmostreedTransactionClass
+{
   RPMOSTreeTransactionSkeletonClass parent_class;
 
-  gboolean      (*execute)                 (RpmostreedTransaction *transaction,
-                                            GCancellable *cancellable,
-                                            GError **error);
+  gboolean (*execute) (RpmostreedTransaction *transaction, GCancellable *cancellable,
+                       GError **error);
 };
 
-GType           rpmostreed_transaction_get_type            (void) G_GNUC_CONST;
-gboolean        rpmostreed_transaction_get_active          (RpmostreedTransaction *transaction);
-OstreeSysroot * rpmostreed_transaction_get_sysroot         (RpmostreedTransaction *transaction);
-const char *    rpmostreed_transaction_get_client          (RpmostreedTransaction *transaction);
-const char *    rpmostreed_transaction_get_agent_id        (RpmostreedTransaction *transaction);
-const char *    rpmostreed_transaction_get_sd_unit         (RpmostreedTransaction *transaction);
-GDBusMethodInvocation *
-                rpmostreed_transaction_get_invocation      (RpmostreedTransaction *transaction);
-const char *    rpmostreed_transaction_get_client_address  (RpmostreedTransaction *transaction);
-gboolean        rpmostreed_transaction_is_compatible       (RpmostreedTransaction *transaction,
-                                                            GDBusMethodInvocation *invocation);
-void            rpmostreed_transaction_connect_download_progress
-                                                           (RpmostreedTransaction *transaction,
-                                                            OstreeAsyncProgress *progress);
-void            rpmostreed_transaction_connect_signature_progress
-                                                           (RpmostreedTransaction *transaction,
-                                                            OstreeRepo *repo);
-void            rpmostreed_transaction_force_close         (RpmostreedTransaction *transaction);
+GType rpmostreed_transaction_get_type (void) G_GNUC_CONST;
+gboolean rpmostreed_transaction_get_active (RpmostreedTransaction *transaction);
+OstreeSysroot *rpmostreed_transaction_get_sysroot (RpmostreedTransaction *transaction);
+const char *rpmostreed_transaction_get_client (RpmostreedTransaction *transaction);
+const char *rpmostreed_transaction_get_agent_id (RpmostreedTransaction *transaction);
+const char *rpmostreed_transaction_get_sd_unit (RpmostreedTransaction *transaction);
+GDBusMethodInvocation *rpmostreed_transaction_get_invocation (RpmostreedTransaction *transaction);
+const char *rpmostreed_transaction_get_client_address (RpmostreedTransaction *transaction);
+gboolean rpmostreed_transaction_is_compatible (RpmostreedTransaction *transaction,
+                                               GDBusMethodInvocation *invocation);
+void rpmostreed_transaction_connect_download_progress (RpmostreedTransaction *transaction,
+                                                       OstreeAsyncProgress *progress);
+void rpmostreed_transaction_connect_signature_progress (RpmostreedTransaction *transaction,
+                                                        OstreeRepo *repo);
+void rpmostreed_transaction_force_close (RpmostreedTransaction *transaction);
 
 G_END_DECLS

--- a/src/daemon/rpmostreed-types.h
+++ b/src/daemon/rpmostreed-types.h
@@ -1,25 +1,25 @@
 /*
-* Copyright (C) 2015 Red Hat, Inc.
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program; if not, write to the Free Software
-* Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
-*/
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 #pragma once
 
-#include <glib-unix.h>
 #include <gio/gio.h>
+#include <glib-unix.h>
 
 #include "rpm-ostreed-generated.h"
 

--- a/src/daemon/rpmostreed-utils.cxx
+++ b/src/daemon/rpmostreed-utils.cxx
@@ -18,19 +18,18 @@
 
 #include "config.h"
 
-#include "rpmostree-util.h"
-#include "rpmostreed-utils.h"
-#include "rpmostreed-errors.h"
-#include "rpmostreed-daemon.h"
 #include "libglnx.h"
-#include <systemd/sd-journal.h>
+#include "rpmostree-util.h"
+#include "rpmostreed-daemon.h"
+#include "rpmostreed-errors.h"
+#include "rpmostreed-utils.h"
 #include <stdint.h>
+#include <systemd/sd-journal.h>
 
 #include <libglnx.h>
 
 static void
-append_to_object_path (GString *str,
-                       const gchar *s)
+append_to_object_path (GString *str, const gchar *s)
 {
   guint n;
 
@@ -74,9 +73,7 @@ append_to_object_path (GString *str,
  * Returns: An allocated string that must be freed with g_free ().
  */
 gchar *
-rpmostreed_generate_object_path (const gchar *base,
-                                 const gchar *part,
-                                 ...)
+rpmostreed_generate_object_path (const gchar *base, const gchar *part, ...)
 {
   gchar *result;
   va_list va;
@@ -89,9 +86,7 @@ rpmostreed_generate_object_path (const gchar *base,
 }
 
 gchar *
-rpmostreed_generate_object_path_from_va (const gchar *base,
-                                         const gchar *part,
-                                         va_list va)
+rpmostreed_generate_object_path_from_va (const gchar *base, const gchar *part, va_list va)
 {
   GString *path;
 
@@ -133,10 +128,8 @@ rpmostreed_generate_object_path_from_va (const gchar *base,
  * Returns: True on success.
  */
 gboolean
-rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
-                                  const gchar *base_refspec,
-                                  gchar **out_refspec,
-                                  GError **error)
+rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec, const gchar *base_refspec,
+                                  gchar **out_refspec, GError **error)
 {
   g_autofree gchar *ref = NULL;
   g_autofree gchar *remote = NULL;
@@ -145,7 +138,7 @@ rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
   /* Allow just switching remotes */
   if (g_str_has_suffix (new_provided_refspec, ":"))
     {
-      remote = g_strndup (new_provided_refspec, strlen(new_provided_refspec)-1);
+      remote = g_strndup (new_provided_refspec, strlen (new_provided_refspec) - 1);
     }
   /* Allow switching to a local branch */
   else if (g_str_has_prefix (new_provided_refspec, ":"))
@@ -155,12 +148,10 @@ rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
     }
   else
     {
-      g_autoptr(GError) parse_error = NULL;
-      if (!ostree_parse_refspec (new_provided_refspec, &remote,
-                                 &ref, &parse_error))
+      g_autoptr (GError) parse_error = NULL;
+      if (!ostree_parse_refspec (new_provided_refspec, &remote, &ref, &parse_error))
         {
-          g_set_error_literal (error, RPM_OSTREED_ERROR,
-                               RPM_OSTREED_ERROR_INVALID_REFSPEC,
+          g_set_error_literal (error, RPM_OSTREED_ERROR, RPM_OSTREED_ERROR_INVALID_REFSPEC,
                                parse_error->message);
           return FALSE;
         }
@@ -170,12 +161,10 @@ rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
   g_autofree gchar *origin_remote = NULL;
   if (base_refspec != NULL)
     {
-      g_autoptr(GError) parse_error = NULL;
-      if (!ostree_parse_refspec (base_refspec, &origin_remote,
-                                 &origin_ref, &parse_error))
+      g_autoptr (GError) parse_error = NULL;
+      if (!ostree_parse_refspec (base_refspec, &origin_remote, &origin_ref, &parse_error))
         {
-          g_set_error_literal (error, RPM_OSTREED_ERROR,
-                               RPM_OSTREED_ERROR_INVALID_REFSPEC,
+          g_set_error_literal (error, RPM_OSTREED_ERROR, RPM_OSTREED_ERROR_INVALID_REFSPEC,
                                parse_error->message);
           return FALSE;
         }
@@ -189,12 +178,10 @@ rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
         }
       else
         {
-          g_set_error (error, RPM_OSTREED_ERROR,
-                       RPM_OSTREED_ERROR_INVALID_REFSPEC,
-                      "Could not determine default ref to pull.");
+          g_set_error (error, RPM_OSTREED_ERROR, RPM_OSTREED_ERROR_INVALID_REFSPEC,
+                       "Could not determine default ref to pull.");
           return FALSE;
         }
-
     }
   else if (infer_remote && remote == NULL)
     {
@@ -205,9 +192,9 @@ rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
     }
 
   if (remote == NULL)
-      *out_refspec = util::move_nullify (ref);
+    *out_refspec = util::move_nullify (ref);
   else
-      *out_refspec = g_strconcat (remote, ":", ref, NULL);
+    *out_refspec = g_strconcat (remote, ":", ref, NULL);
 
   return TRUE;
 }
@@ -232,13 +219,10 @@ rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
  * Returns: %TRUE on success, %FALSE on failure
  */
 gboolean
-rpmostreed_repo_pull_ancestry (OstreeRepo               *repo,
-                               const char               *refspec,
-                               RpmostreedCommitVisitor   visitor,
-                               gpointer                  visitor_data,
-                               OstreeAsyncProgress      *progress,
-                               GCancellable             *cancellable,
-                               GError                  **error)
+rpmostreed_repo_pull_ancestry (OstreeRepo *repo, const char *refspec,
+                               RpmostreedCommitVisitor visitor, gpointer visitor_data,
+                               OstreeAsyncProgress *progress, GCancellable *cancellable,
+                               GError **error)
 {
   OstreeRepoPullFlags flags;
   GVariantDict options;
@@ -278,8 +262,7 @@ rpmostreed_repo_pull_ancestry (OstreeRepo               *repo,
       if (remote != NULL)
         {
           /* Floating reference, transferred to dictionary. */
-          refs_value =
-            g_variant_new_strv ((const char * const *) refs_array, -1);
+          refs_value = g_variant_new_strv ((const char *const *)refs_array, -1);
 
           g_variant_dict_init (&options, NULL);
           if (!first_pass)
@@ -287,9 +270,8 @@ rpmostreed_repo_pull_ancestry (OstreeRepo               *repo,
           g_variant_dict_insert (&options, "flags", "i", flags);
           g_variant_dict_insert_value (&options, "refs", refs_value);
 
-          if (!ostree_repo_pull_with_options (repo, remote,
-                                              g_variant_dict_end (&options),
-                                              progress, cancellable, error))
+          if (!ostree_repo_pull_with_options (repo, remote, g_variant_dict_end (&options), progress,
+                                              cancellable, error))
             goto out;
 
           if (progress)
@@ -307,11 +289,10 @@ rpmostreed_repo_pull_ancestry (OstreeRepo               *repo,
         {
           for (ii = 0; ii < (first_pass ? 1 : depth) && checksum != NULL; ii++)
             {
-              g_autoptr(GVariant) commit = NULL;
+              g_autoptr (GVariant) commit = NULL;
               gboolean stop = FALSE;
 
-              if (!ostree_repo_load_commit (repo, checksum, &commit,
-                                            NULL, error))
+              if (!ostree_repo_load_commit (repo, checksum, &commit, NULL, error))
                 goto out;
 
               if (!visitor (repo, checksum, commit, visitor_data, &stop, error))
@@ -342,21 +323,18 @@ out:
   return ret;
 }
 
-typedef struct {
+typedef struct
+{
   const char *version;
   char *checksum;
 } VersionVisitorClosure;
 
 static gboolean
-version_visitor (OstreeRepo  *repo,
-                 const char  *checksum,
-                 GVariant    *commit,
-                 gpointer     user_data,
-                 gboolean    *out_stop,
-                 GError     **error)
+version_visitor (OstreeRepo *repo, const char *checksum, GVariant *commit, gpointer user_data,
+                 gboolean *out_stop, GError **error)
 {
-  auto closure = static_cast<VersionVisitorClosure *>(user_data);
-  g_autoptr(GVariant) metadict = NULL;
+  auto closure = static_cast<VersionVisitorClosure *> (user_data);
+  g_autoptr (GVariant) metadict = NULL;
   const char *version = NULL;
 
   metadict = g_variant_get_child_value (commit, 0);
@@ -388,13 +366,9 @@ version_visitor (OstreeRepo  *repo,
  * Returns: %TRUE on success, %FALSE on failure
  */
 gboolean
-rpmostreed_repo_lookup_version (OstreeRepo           *repo,
-                                const char           *refspec,
-                                const char           *version,
-                                OstreeAsyncProgress  *progress,
-                                GCancellable         *cancellable,
-                                char                **out_checksum,
-                                GError              **error)
+rpmostreed_repo_lookup_version (OstreeRepo *repo, const char *refspec, const char *version,
+                                OstreeAsyncProgress *progress, GCancellable *cancellable,
+                                char **out_checksum, GError **error)
 {
   VersionVisitorClosure closure = { version, NULL };
 
@@ -402,16 +376,15 @@ rpmostreed_repo_lookup_version (OstreeRepo           *repo,
   g_assert (refspec != NULL);
   g_assert (version != NULL);
 
-  if (!rpmostreed_repo_pull_ancestry (repo, refspec,
-                                      version_visitor, &closure,
-                                      progress, cancellable, error))
+  if (!rpmostreed_repo_pull_ancestry (repo, refspec, version_visitor, &closure, progress,
+                                      cancellable, error))
     return FALSE;
 
   g_autofree char *checksum = util::move_nullify (closure.checksum);
   if (checksum == NULL)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
-                   "Version %s not found in %s", version, refspec);
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "Version %s not found in %s", version,
+                   refspec);
       return FALSE;
     }
 
@@ -420,20 +393,17 @@ rpmostreed_repo_lookup_version (OstreeRepo           *repo,
   return TRUE;
 }
 
-typedef struct {
+typedef struct
+{
   const char *wanted_checksum;
   gboolean found;
 } ChecksumVisitorClosure;
 
 static gboolean
-checksum_visitor (OstreeRepo  *repo,
-                  const char  *checksum,
-                  GVariant    *commit,
-                  gpointer     user_data,
-                  gboolean    *out_stop,
-                  GError     **error)
+checksum_visitor (OstreeRepo *repo, const char *checksum, GVariant *commit, gpointer user_data,
+                  gboolean *out_stop, GError **error)
 {
-  auto closure = static_cast<ChecksumVisitorClosure *>(user_data);
+  auto closure = static_cast<ChecksumVisitorClosure *> (user_data);
   *out_stop = closure->found = g_str_equal (checksum, closure->wanted_checksum);
   return TRUE;
 }
@@ -454,12 +424,9 @@ checksum_visitor (OstreeRepo  *repo,
  * Returns: %TRUE on success, %FALSE on failure
  */
 gboolean
-rpmostreed_repo_lookup_checksum (OstreeRepo           *repo,
-                                 const char           *refspec,
-                                 const char           *checksum,
-                                 OstreeAsyncProgress  *progress,
-                                 GCancellable         *cancellable,
-                                 GError              **error)
+rpmostreed_repo_lookup_checksum (OstreeRepo *repo, const char *refspec, const char *checksum,
+                                 OstreeAsyncProgress *progress, GCancellable *cancellable,
+                                 GError **error)
 {
   ChecksumVisitorClosure closure = { checksum, FALSE };
 
@@ -467,15 +434,14 @@ rpmostreed_repo_lookup_checksum (OstreeRepo           *repo,
   g_assert (refspec != NULL);
   g_assert (checksum != NULL);
 
-  if (!rpmostreed_repo_pull_ancestry (repo, refspec,
-                                      checksum_visitor, &closure,
-                                      progress, cancellable, error))
+  if (!rpmostreed_repo_pull_ancestry (repo, refspec, checksum_visitor, &closure, progress,
+                                      cancellable, error))
     return FALSE;
 
   if (!closure.found)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
-                   "Checksum %s not found in %s", checksum, refspec);
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "Checksum %s not found in %s", checksum,
+                   refspec);
       return FALSE;
     }
 
@@ -498,12 +464,9 @@ rpmostreed_repo_lookup_checksum (OstreeRepo           *repo,
  * Returns: %TRUE on success, %FALSE on failure
  */
 gboolean
-rpmostreed_repo_lookup_cached_version (OstreeRepo    *repo,
-                                       const char    *refspec,
-                                       const char    *version,
-                                       GCancellable  *cancellable,
-                                       char         **out_checksum,
-                                       GError       **error)
+rpmostreed_repo_lookup_cached_version (OstreeRepo *repo, const char *refspec, const char *version,
+                                       GCancellable *cancellable, char **out_checksum,
+                                       GError **error)
 {
   VersionVisitorClosure closure = { version, NULL };
   g_autofree char *checksum = NULL;
@@ -517,7 +480,7 @@ rpmostreed_repo_lookup_cached_version (OstreeRepo    *repo,
 
   while (checksum != NULL)
     {
-      g_autoptr(GVariant) commit = NULL;
+      g_autoptr (GVariant) commit = NULL;
       gboolean stop = FALSE;
 
       if (!ostree_repo_load_commit (repo, checksum, &commit, NULL, error))
@@ -546,29 +509,26 @@ rpmostreed_repo_lookup_cached_version (OstreeRepo    *repo,
  * Note: systemd 248 provides a `--check-inhibitors` option, but it also checks
  * for inhibitors in `delay` mode, which isn't what we want. */
 gboolean
-check_sd_inhibitor_locks (GCancellable    *cancellable,
-                          GError         **error)
+check_sd_inhibitor_locks (GCancellable *cancellable, GError **error)
 {
   GDBusConnection *connection = rpmostreed_daemon_connection ();
   // https://www.freedesktop.org/software/systemd/man/org.freedesktop.login1.html
-  g_autoptr(GVariant) inhibitors_array_tuple = 
-    g_dbus_connection_call_sync (connection, "org.freedesktop.login1", "/org/freedesktop/login1",
-                                 "org.freedesktop.login1.Manager", "ListInhibitors",
-                                 NULL, (const GVariantType*)"(a(ssssuu))",
-                                 G_DBUS_CALL_FLAGS_NONE, -1, cancellable, error);
+  g_autoptr (GVariant) inhibitors_array_tuple = g_dbus_connection_call_sync (
+      connection, "org.freedesktop.login1", "/org/freedesktop/login1",
+      "org.freedesktop.login1.Manager", "ListInhibitors", NULL, (const GVariantType *)"(a(ssssuu))",
+      G_DBUS_CALL_FLAGS_NONE, -1, cancellable, error);
   if (!inhibitors_array_tuple)
     return glnx_prefix_error (error, "Checking systemd inhibitor locks");
   else if (g_variant_n_children (inhibitors_array_tuple) < 1)
     return glnx_throw (error, "ListInhibitors returned empty tuple");
-  g_autoptr(GVariant) inhibitors_array =
-    g_variant_get_child_value (inhibitors_array_tuple, 0);
+  g_autoptr (GVariant) inhibitors_array = g_variant_get_child_value (inhibitors_array_tuple, 0);
 
   char *what = NULL;
   char *who = NULL;
   char *why = NULL;
   char *mode = NULL;
   int num_block_inhibitors = 0;
-  g_autoptr(GString) error_msg = g_string_new(NULL);
+  g_autoptr (GString) error_msg = g_string_new (NULL);
   GVariantIter viter;
   g_variant_iter_init (&viter, inhibitors_array);
   while (g_variant_iter_loop (&viter, "(ssssuu)", &what, &who, &why, &mode, NULL, NULL))
@@ -603,7 +563,7 @@ check_sd_inhibitor_locks (GCancellable    *cancellable,
 static void
 test_refspec_parse_partial (void)
 {
-  g_autoptr(GError) local_error = NULL;
+  g_autoptr (GError) local_error = NULL;
   GError **error = &local_error;
 
   g_autofree char *new_refspec = NULL;
@@ -614,7 +574,7 @@ test_refspec_parse_partial (void)
 }
 #endif
 
-void 
+void
 rpmostreed_utils_tests (void)
 {
 #ifdef BUILDOPT_BIN_UNIT_TESTS

--- a/src/daemon/rpmostreed-utils.h
+++ b/src/daemon/rpmostreed-utils.h
@@ -24,61 +24,39 @@
 
 G_BEGIN_DECLS
 
-gchar *    rpmostreed_generate_object_path (const gchar  *base,
-                                            const gchar  *part,
-                                            ...);
+gchar *rpmostreed_generate_object_path (const gchar *base, const gchar *part, ...);
 
-gchar *    rpmostreed_generate_object_path_from_va (const gchar *base,
-                                                    const gchar  *part,
-                                                    va_list va);
+gchar *rpmostreed_generate_object_path_from_va (const gchar *base, const gchar *part, va_list va);
 
-gboolean   rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
-                                             const gchar *base_refspec,
-                                             gchar **out_refspec,
-                                             GError **error);
+gboolean rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
+                                           const gchar *base_refspec, gchar **out_refspec,
+                                           GError **error);
 
 /* XXX These pull-ancestry and lookup-version functions should eventually
  *     be integrated into libostree, but it's still a bit premature to do
  *     so now.  Version integration in ostree needs more design work. */
 
-typedef gboolean (*RpmostreedCommitVisitor) (OstreeRepo  *repo,
-                                             const char  *checksum,
-                                             GVariant    *commit,
-                                             gpointer     user_data,
-                                             gboolean    *out_stop,
-                                             GError     **error);
+typedef gboolean (*RpmostreedCommitVisitor) (OstreeRepo *repo, const char *checksum,
+                                             GVariant *commit, gpointer user_data,
+                                             gboolean *out_stop, GError **error);
 
-gboolean   rpmostreed_repo_pull_ancestry (OstreeRepo               *repo,
-                                          const char               *refspec,
-                                          RpmostreedCommitVisitor   visitor,
-                                          gpointer                  visitor_data,
-                                          OstreeAsyncProgress      *progress,
-                                          GCancellable             *cancellable,
-                                          GError                  **error);
+gboolean rpmostreed_repo_pull_ancestry (OstreeRepo *repo, const char *refspec,
+                                        RpmostreedCommitVisitor visitor, gpointer visitor_data,
+                                        OstreeAsyncProgress *progress, GCancellable *cancellable,
+                                        GError **error);
 
-gboolean   rpmostreed_repo_lookup_version (OstreeRepo           *repo,
-                                           const char           *refspec,
-                                           const char           *version,
-                                           OstreeAsyncProgress  *progress,
-                                           GCancellable         *cancellable,
-                                           char                **out_checksum,
-                                           GError              **error);
+gboolean rpmostreed_repo_lookup_version (OstreeRepo *repo, const char *refspec, const char *version,
+                                         OstreeAsyncProgress *progress, GCancellable *cancellable,
+                                         char **out_checksum, GError **error);
 
-gboolean rpmostreed_repo_lookup_checksum (OstreeRepo           *repo,
-                                          const char           *refspec,
-                                          const char           *checksum,
-                                          OstreeAsyncProgress  *progress,
-                                          GCancellable         *cancellable,
-                                          GError              **error);
+gboolean rpmostreed_repo_lookup_checksum (OstreeRepo *repo, const char *refspec,
+                                          const char *checksum, OstreeAsyncProgress *progress,
+                                          GCancellable *cancellable, GError **error);
 
-gboolean   rpmostreed_repo_lookup_cached_version (OstreeRepo    *repo,
-                                                  const char    *refspec,
-                                                  const char    *version,
-                                                  GCancellable  *cancellable,
-                                                  char         **out_checksum,
-                                                  GError       **error);
+gboolean rpmostreed_repo_lookup_cached_version (OstreeRepo *repo, const char *refspec,
+                                                const char *version, GCancellable *cancellable,
+                                                char **out_checksum, GError **error);
 
-gboolean   check_sd_inhibitor_locks (GCancellable    *cancellable,
-                                     GError         **error);
+gboolean check_sd_inhibitor_locks (GCancellable *cancellable, GError **error);
 
 G_END_DECLS

--- a/src/lib/rpmostree-db.c
+++ b/src/lib/rpmostree-db.c
@@ -18,10 +18,10 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#include "config.h"
-#include "string.h"
 #include "rpmostree-db.h"
+#include "config.h"
 #include "rpmostree-package-priv.h"
+#include "string.h"
 
 /**
  * SECTION:librpmostree-dbquery
@@ -45,12 +45,10 @@
  * Returns: (transfer container) (element-type RpmOstreePackage): A query result, or %NULL on error
  */
 GPtrArray *
-rpm_ostree_db_query_all (OstreeRepo                *repo,
-                         const char                *ref,
-                         GCancellable              *cancellable,
-                         GError                   **error)
+rpm_ostree_db_query_all (OstreeRepo *repo, const char *ref, GCancellable *cancellable,
+                         GError **error)
 {
-  g_autoptr(GPtrArray) pkglist = NULL;
+  g_autoptr (GPtrArray) pkglist = NULL;
   if (!_rpm_ostree_package_list_for_commit (repo, ref, FALSE, &pkglist, cancellable, error))
     return NULL;
   return g_steal_pointer (&pkglist);
@@ -61,10 +59,14 @@ rpm_ostree_db_query_all (OstreeRepo                *repo,
  * @repo: An OSTree repository
  * @orig_ref: Original ref (branch or commit)
  * @new_ref: New ref (branch or commit)
- * @out_removed: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return location for removed packages
- * @out_added: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return location for added packages
- * @out_modified_old: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return location for modified old packages
- * @out_modified_new: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return location for modified new packages
+ * @out_removed: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return
+ * location for removed packages
+ * @out_added: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return
+ * location for added packages
+ * @out_modified_old: (out) (transfer container) (element-type RpmOstreePackage) (allow-none):
+ * Return location for modified old packages
+ * @out_modified_new: (out) (transfer container) (element-type RpmOstreePackage) (allow-none):
+ * Return location for modified new packages
  *
  * Compute the RPM package delta between two commits.
  *
@@ -78,26 +80,12 @@ rpm_ostree_db_query_all (OstreeRepo                *repo,
  *     be paired with the same arbitrary pkg coming from one of the N entries.
  */
 gboolean
-rpm_ostree_db_diff (OstreeRepo               *repo,
-                    const char               *orig_ref,
-                    const char               *new_ref,
-                    GPtrArray               **out_removed,
-                    GPtrArray               **out_added,
-                    GPtrArray               **out_modified_old,
-                    GPtrArray               **out_modified_new,
-                    GCancellable             *cancellable,
-                    GError                  **error)
+rpm_ostree_db_diff (OstreeRepo *repo, const char *orig_ref, const char *new_ref,
+                    GPtrArray **out_removed, GPtrArray **out_added, GPtrArray **out_modified_old,
+                    GPtrArray **out_modified_new, GCancellable *cancellable, GError **error)
 {
-  return rpm_ostree_db_diff_ext (repo,
-                                 orig_ref,
-                                 new_ref,
-                                 0,
-                                 out_removed,
-                                 out_added,
-                                 out_modified_old,
-                                 out_modified_new,
-                                 cancellable,
-                                 error);
+  return rpm_ostree_db_diff_ext (repo, orig_ref, new_ref, 0, out_removed, out_added,
+                                 out_modified_old, out_modified_new, cancellable, error);
 }
 
 /**
@@ -106,10 +94,14 @@ rpm_ostree_db_diff (OstreeRepo               *repo,
  * @orig_ref: Original ref (branch or commit)
  * @new_ref: New ref (branch or commit)
  * @flags: Flags controlling diff behaviour
- * @out_removed: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return location for removed packages
- * @out_added: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return location for added packages
- * @out_modified_old: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return location for modified old packages
- * @out_modified_new: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return location for modified new packages
+ * @out_removed: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return
+ * location for removed packages
+ * @out_added: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return
+ * location for added packages
+ * @out_modified_old: (out) (transfer container) (element-type RpmOstreePackage) (allow-none):
+ * Return location for modified old packages
+ * @out_modified_new: (out) (transfer container) (element-type RpmOstreePackage) (allow-none):
+ * Return location for modified new packages
  *
  * This function is identical to rpm_ostree_db_diff_ext(), but supports a @flags argument to
  * further control behaviour. At least one of the @out parameters must not be NULL.
@@ -117,31 +109,24 @@ rpm_ostree_db_diff (OstreeRepo               *repo,
  * Since: 2017.12
  */
 gboolean
-rpm_ostree_db_diff_ext (OstreeRepo               *repo,
-                        const char               *orig_ref,
-                        const char               *new_ref,
-                        RpmOstreeDbDiffExtFlags   flags,
-                        GPtrArray               **out_removed,
-                        GPtrArray               **out_added,
-                        GPtrArray               **out_modified_old,
-                        GPtrArray               **out_modified_new,
-                        GCancellable             *cancellable,
-                        GError                  **error)
+rpm_ostree_db_diff_ext (OstreeRepo *repo, const char *orig_ref, const char *new_ref,
+                        RpmOstreeDbDiffExtFlags flags, GPtrArray **out_removed,
+                        GPtrArray **out_added, GPtrArray **out_modified_old,
+                        GPtrArray **out_modified_new, GCancellable *cancellable, GError **error)
 {
-  g_return_val_if_fail (out_removed || out_added ||
-                        out_modified_old || out_modified_new, FALSE);
+  g_return_val_if_fail (out_removed || out_added || out_modified_old || out_modified_new, FALSE);
 
   const gboolean allow_noent = ((flags & RPM_OSTREE_DB_DIFF_EXT_ALLOW_NOENT) > 0);
 
-  g_autoptr(GPtrArray) orig_pkglist = NULL;
-  if (!_rpm_ostree_package_list_for_commit (repo, orig_ref, allow_noent, &orig_pkglist,
-                                            cancellable, error))
+  g_autoptr (GPtrArray) orig_pkglist = NULL;
+  if (!_rpm_ostree_package_list_for_commit (repo, orig_ref, allow_noent, &orig_pkglist, cancellable,
+                                            error))
     {
       g_prefix_error (error, "Failed to load package list: ");
       return FALSE;
     }
 
-  g_autoptr(GPtrArray) new_pkglist = NULL;
+  g_autoptr (GPtrArray) new_pkglist = NULL;
   if (orig_pkglist)
     {
       if (!_rpm_ostree_package_list_for_commit (repo, new_ref, allow_noent, &new_pkglist,

--- a/src/lib/rpmostree-db.h
+++ b/src/lib/rpmostree-db.h
@@ -25,20 +25,14 @@
 
 G_BEGIN_DECLS
 
-_RPMOSTREE_EXTERN GPtrArray *rpm_ostree_db_query_all (OstreeRepo               *repo,
-                                                      const char               *ref,
-                                                      GCancellable             *cancellable,
-                                                      GError                  **error);
+_RPMOSTREE_EXTERN GPtrArray *rpm_ostree_db_query_all (OstreeRepo *repo, const char *ref,
+                                                      GCancellable *cancellable, GError **error);
 
-_RPMOSTREE_EXTERN gboolean rpm_ostree_db_diff (OstreeRepo               *repo,
-                                               const char               *orig_ref,
-                                               const char               *new_ref,
-                                               GPtrArray               **out_removed,
-                                               GPtrArray               **out_added,
-                                               GPtrArray               **out_modified_old,
-                                               GPtrArray               **out_modified_new,
-                                               GCancellable             *cancellable,
-                                               GError                  **error);
+_RPMOSTREE_EXTERN gboolean rpm_ostree_db_diff (OstreeRepo *repo, const char *orig_ref,
+                                               const char *new_ref, GPtrArray **out_removed,
+                                               GPtrArray **out_added, GPtrArray **out_modified_old,
+                                               GPtrArray **out_modified_new,
+                                               GCancellable *cancellable, GError **error);
 
 /**
  * RpmOstreeDbDiffFlags:
@@ -48,19 +42,14 @@ _RPMOSTREE_EXTERN gboolean rpm_ostree_db_diff (OstreeRepo               *repo,
  *
  * Since: 2017.12
  */
-typedef enum {
-  RPM_OSTREE_DB_DIFF_EXT_NONE        = 0,
+typedef enum
+{
+  RPM_OSTREE_DB_DIFF_EXT_NONE = 0,
   RPM_OSTREE_DB_DIFF_EXT_ALLOW_NOENT = (1 << 0),
 } RpmOstreeDbDiffExtFlags;
 
-_RPMOSTREE_EXTERN gboolean rpm_ostree_db_diff_ext (OstreeRepo               *repo,
-                                                   const char               *orig_ref,
-                                                   const char               *new_ref,
-                                                   RpmOstreeDbDiffExtFlags   flags,
-                                                   GPtrArray               **out_removed,
-                                                   GPtrArray               **out_added,
-                                                   GPtrArray               **out_modified_old,
-                                                   GPtrArray               **out_modified_new,
-                                                   GCancellable             *cancellable,
-                                                   GError                  **error);
+_RPMOSTREE_EXTERN gboolean rpm_ostree_db_diff_ext (
+    OstreeRepo *repo, const char *orig_ref, const char *new_ref, RpmOstreeDbDiffExtFlags flags,
+    GPtrArray **out_removed, GPtrArray **out_added, GPtrArray **out_modified_old,
+    GPtrArray **out_modified_new, GCancellable *cancellable, GError **error);
 G_END_DECLS

--- a/src/lib/rpmostree-package-priv.h
+++ b/src/lib/rpmostree-package-priv.h
@@ -21,35 +21,22 @@
 
 #pragma once
 
-#include <ostree.h>
 #include "rpmostree-package.h"
+#include <ostree.h>
 
 G_BEGIN_DECLS
 
-RpmOstreePackage * _rpm_ostree_package_new_from_variant (GVariant *gv_nevra);
+RpmOstreePackage *_rpm_ostree_package_new_from_variant (GVariant *gv_nevra);
 
-gboolean
-_rpm_ostree_package_variant_list_for_commit (OstreeRepo   *repo,
-                                     const char   *rev,
-                                     gboolean      allow_noent,
-                                     GVariant    **out_pkglist,
-                                     GCancellable *cancellable,
-                                     GError      **error);
+gboolean _rpm_ostree_package_variant_list_for_commit (OstreeRepo *repo, const char *rev,
+                                                      gboolean allow_noent, GVariant **out_pkglist,
+                                                      GCancellable *cancellable, GError **error);
 
-gboolean
-_rpm_ostree_package_list_for_commit (OstreeRepo   *repo,
-                                     const char   *rev,
-                                     gboolean      allow_noent,
-                                     GPtrArray   **out_pkglist,
-                                     GCancellable *cancellable,
-                                     GError      **error);
-gboolean
-_rpm_ostree_diff_package_lists (GPtrArray  *a,
-                                GPtrArray  *b,
-                                GPtrArray **out_unique_a,
-                                GPtrArray **out_unique_b,
-                                GPtrArray **out_modified_a,
-                                GPtrArray **out_modified_b,
-                                GPtrArray **out_common);
+gboolean _rpm_ostree_package_list_for_commit (OstreeRepo *repo, const char *rev,
+                                              gboolean allow_noent, GPtrArray **out_pkglist,
+                                              GCancellable *cancellable, GError **error);
+gboolean _rpm_ostree_diff_package_lists (GPtrArray *a, GPtrArray *b, GPtrArray **out_unique_a,
+                                         GPtrArray **out_unique_b, GPtrArray **out_modified_a,
+                                         GPtrArray **out_modified_b, GPtrArray **out_common);
 
 G_END_DECLS

--- a/src/lib/rpmostree-package.h
+++ b/src/lib/rpmostree-package.h
@@ -27,9 +27,10 @@ G_BEGIN_DECLS
 
 typedef struct RpmOstreePackage RpmOstreePackage;
 
-#define RPM_OSTREE_TYPE_PACKAGE         (rpm_ostree_package_get_type ())
-#define RPM_OSTREE_PACKAGE(inst)        (G_TYPE_CHECK_INSTANCE_CAST ((inst), RPM_OSTREE_TYPE_PACKAGE, RpmOstreePackage))
-#define RPM_OSTREE_IS_PACKAGE(inst)     (G_TYPE_CHECK_INSTANCE_TYPE ((inst), RPM_OSTREE_TYPE_PACKAGE))
+#define RPM_OSTREE_TYPE_PACKAGE (rpm_ostree_package_get_type ())
+#define RPM_OSTREE_PACKAGE(inst)                                                                   \
+  (G_TYPE_CHECK_INSTANCE_CAST ((inst), RPM_OSTREE_TYPE_PACKAGE, RpmOstreePackage))
+#define RPM_OSTREE_IS_PACKAGE(inst) (G_TYPE_CHECK_INSTANCE_TYPE ((inst), RPM_OSTREE_TYPE_PACKAGE))
 
 _RPMOSTREE_EXTERN
 GType rpm_ostree_package_get_type (void);

--- a/src/lib/rpmostree-shlib-ipc-private.h
+++ b/src/lib/rpmostree-shlib-ipc-private.h
@@ -27,6 +27,7 @@ G_BEGIN_DECLS
 #define RPMOSTREE_SHLIB_IPC_FD 3
 #define RPMOSTREE_SHLIB_IPC_PKGLIST "a(sssss)"
 
-GVariant *_rpmostree_shlib_ipc_send (const char *variant_type, char **args, const char *wd, GError **error);
+GVariant *_rpmostree_shlib_ipc_send (const char *variant_type, char **args, const char *wd,
+                                     GError **error);
 
 G_END_DECLS

--- a/src/lib/rpmver-private.c
+++ b/src/lib/rpmver-private.c
@@ -9,18 +9,19 @@
 #include "config.h"
 #if !BUILDOPT_HAVE_RPMVER
 #include <glib.h>
-#define xmalloc(_size) g_malloc((_size))
-#define free(_mem) g_free((_mem))
+#define xmalloc(_size) g_malloc ((_size))
+#define free(_mem) g_free ((_mem))
 #include "rpmver-private.h"
 
 #include <rpm/rpmstring.h>
 #include <stdlib.h>
 
-struct rpmver_s {
-    const char *e;
-    const char *v;
-    const char *r;
-    char arena[];
+struct rpmver_s
+{
+  const char *e;
+  const char *v;
+  const char *r;
+  char arena[];
 };
 
 /**
@@ -30,194 +31,232 @@ struct rpmver_s {
  * @retval *vp                pointer to version
  * @retval *rp                pointer to release
  */
-static
-void parseEVR(char * evr,
-                const char ** ep,
-                const char ** vp,
-                const char ** rp)
+static void
+parseEVR (char *evr, const char **ep, const char **vp, const char **rp)
 {
-    const char *epoch;
-    const char *version;                /* assume only version is present */
-    const char *release;
-    char *s, *se;
+  const char *epoch;
+  const char *version; /* assume only version is present */
+  const char *release;
+  char *s, *se;
 
-    s = evr;
-    while (*s && risdigit(*s)) s++;        /* s points to epoch terminator */
-    se = strrchr(s, '-');                /* se points to version terminator */
+  s = evr;
+  while (*s && risdigit (*s))
+    s++;                 /* s points to epoch terminator */
+  se = strrchr (s, '-'); /* se points to version terminator */
 
-    if (*s == ':') {
-        epoch = evr;
-        *s++ = '\0';
-        version = s;
-        if (*epoch == '\0') epoch = "0";
-    } else {
-        epoch = NULL;        /* XXX disable epoch compare if missing */
-        version = evr;
+  if (*s == ':')
+    {
+      epoch = evr;
+      *s++ = '\0';
+      version = s;
+      if (*epoch == '\0')
+        epoch = "0";
     }
-    if (se) {
-        *se++ = '\0';
-        release = se;
-    } else {
-        release = NULL;
+  else
+    {
+      epoch = NULL; /* XXX disable epoch compare if missing */
+      version = evr;
+    }
+  if (se)
+    {
+      *se++ = '\0';
+      release = se;
+    }
+  else
+    {
+      release = NULL;
     }
 
-    if (ep) *ep = epoch;
-    if (vp) *vp = version;
-    if (rp) *rp = release;
+  if (ep)
+    *ep = epoch;
+  if (vp)
+    *vp = version;
+  if (rp)
+    *rp = release;
 }
 
-int rpmverOverlap(rpmver v1, rpmsenseFlags f1, rpmver v2, rpmsenseFlags f2)
+int
+rpmverOverlap (rpmver v1, rpmsenseFlags f1, rpmver v2, rpmsenseFlags f2)
 {
-    int sense = 0;
-    int result = 0;
+  int sense = 0;
+  int result = 0;
 
-    /* Compare {A,B} [epoch:]version[-release] */
-    if (v1->e && *v1->e && v2->e && *v2->e)
-        sense = rpmvercmp(v1->e, v2->e);
-    else if (v1->e && *v1->e && atol(v1->e) > 0) {
-        sense = 1;
-    } else if (v2->e && *v2->e && atol(v2->e) > 0)
-        sense = -1;
+  /* Compare {A,B} [epoch:]version[-release] */
+  if (v1->e && *v1->e && v2->e && *v2->e)
+    sense = rpmvercmp (v1->e, v2->e);
+  else if (v1->e && *v1->e && atol (v1->e) > 0)
+    {
+      sense = 1;
+    }
+  else if (v2->e && *v2->e && atol (v2->e) > 0)
+    sense = -1;
 
-    if (sense == 0) {
-        sense = rpmvercmp(v1->v, v2->v);
-        if (sense == 0) {
-            if (v1->r && *v1->r && v2->r && *v2->r) {
-                sense = rpmvercmp(v1->r, v2->r);
-            } else {
-                /* always matches if the side with no release has SENSE_EQUAL */
-                if ((v1->r && *v1->r && (f2 & RPMSENSE_EQUAL)) ||
-                    (v2->r && *v2->r && (f1 & RPMSENSE_EQUAL))) {
-                    result = 1;
-                    goto exit;
+  if (sense == 0)
+    {
+      sense = rpmvercmp (v1->v, v2->v);
+      if (sense == 0)
+        {
+          if (v1->r && *v1->r && v2->r && *v2->r)
+            {
+              sense = rpmvercmp (v1->r, v2->r);
+            }
+          else
+            {
+              /* always matches if the side with no release has SENSE_EQUAL */
+              if ((v1->r && *v1->r && (f2 & RPMSENSE_EQUAL))
+                  || (v2->r && *v2->r && (f1 & RPMSENSE_EQUAL)))
+                {
+                  result = 1;
+                  goto exit;
                 }
             }
         }
     }
 
-    /* Detect overlap of {A,B} range. */
-    if (sense < 0 && ((f1 & RPMSENSE_GREATER) || (f2 & RPMSENSE_LESS))) {
-        result = 1;
-    } else if (sense > 0 && ((f1 & RPMSENSE_LESS) || (f2 & RPMSENSE_GREATER))) {
-        result = 1;
-    } else if (sense == 0 &&
-        (((f1 & RPMSENSE_EQUAL) && (f2 & RPMSENSE_EQUAL)) ||
-         ((f1 & RPMSENSE_LESS) && (f2 & RPMSENSE_LESS)) ||
-         ((f1 & RPMSENSE_GREATER) && (f2 & RPMSENSE_GREATER)))) {
-        result = 1;
+  /* Detect overlap of {A,B} range. */
+  if (sense < 0 && ((f1 & RPMSENSE_GREATER) || (f2 & RPMSENSE_LESS)))
+    {
+      result = 1;
+    }
+  else if (sense > 0 && ((f1 & RPMSENSE_LESS) || (f2 & RPMSENSE_GREATER)))
+    {
+      result = 1;
+    }
+  else if (sense == 0
+           && (((f1 & RPMSENSE_EQUAL) && (f2 & RPMSENSE_EQUAL))
+               || ((f1 & RPMSENSE_LESS) && (f2 & RPMSENSE_LESS))
+               || ((f1 & RPMSENSE_GREATER) && (f2 & RPMSENSE_GREATER))))
+    {
+      result = 1;
     }
 
 exit:
-    return result;
+  return result;
 }
 
-static int compare_values(const char *str1, const char *str2)
+static int
+compare_values (const char *str1, const char *str2)
 {
-    if (!str1 && !str2)
-        return 0;
-    else if (str1 && !str2)
-        return 1;
-    else if (!str1 && str2)
-        return -1;
-    return rpmvercmp(str1, str2);
+  if (!str1 && !str2)
+    return 0;
+  else if (str1 && !str2)
+    return 1;
+  else if (!str1 && str2)
+    return -1;
+  return rpmvercmp (str1, str2);
 }
 
-int rpmverCmp(rpmver v1, rpmver v2)
+int
+rpmverCmp (rpmver v1, rpmver v2)
 {
-    const char *e1 = (v1->e != NULL) ? v1->e : "0";
-    const char *e2 = (v2->e != NULL) ? v2->e : "0";
+  const char *e1 = (v1->e != NULL) ? v1->e : "0";
+  const char *e2 = (v2->e != NULL) ? v2->e : "0";
 
-    int rc = compare_values(e1, e2);
-    if (!rc) {
-        rc = compare_values(v1->v, v2->v);
-        if (!rc)
-            rc = compare_values(v1->r, v2->r);
+  int rc = compare_values (e1, e2);
+  if (!rc)
+    {
+      rc = compare_values (v1->v, v2->v);
+      if (!rc)
+        rc = compare_values (v1->r, v2->r);
     }
-    return rc;
+  return rc;
 }
 
-uint32_t rpmverEVal(rpmver rv)
+uint32_t
+rpmverEVal (rpmver rv)
 {
-    return (rv != NULL && rv->e != NULL) ? atol(rv->e) : 0;
+  return (rv != NULL && rv->e != NULL) ? atol (rv->e) : 0;
 }
 
-const char *rpmverE(rpmver rv)
+const char *
+rpmverE (rpmver rv)
 {
-    return (rv != NULL) ? rv->e : NULL;
+  return (rv != NULL) ? rv->e : NULL;
 }
 
-const char *rpmverV(rpmver rv)
+const char *
+rpmverV (rpmver rv)
 {
-    return (rv != NULL) ? rv->v : NULL;
+  return (rv != NULL) ? rv->v : NULL;
 }
 
-const char *rpmverR(rpmver rv)
+const char *
+rpmverR (rpmver rv)
 {
-    return (rv != NULL) ? rv->r : NULL;
+  return (rv != NULL) ? rv->r : NULL;
 }
 
-char *rpmverEVR(rpmver rv)
+char *
+rpmverEVR (rpmver rv)
 {
-    char *EVR = NULL;
-    if (rv) {
-        rstrscat(&EVR, rv->e ? rv-> e : "", rv->e ? ":" : "",
-                       rv->v,
-                       rv->r ? "-" : "", rv->r ? rv->r : "", NULL);
+  char *EVR = NULL;
+  if (rv)
+    {
+      rstrscat (&EVR, rv->e ? rv->e : "", rv->e ? ":" : "", rv->v, rv->r ? "-" : "",
+                rv->r ? rv->r : "", NULL);
     }
-    return EVR;
+  return EVR;
 }
 
-rpmver rpmverParse(const char *evr)
+rpmver
+rpmverParse (const char *evr)
 {
-    rpmver rv = NULL;
-    if (evr && *evr) {
-        size_t evrlen = strlen(evr) + 1;
-        rv = xmalloc(sizeof(*rv) + evrlen);
-        memcpy(rv->arena, evr, evrlen);
-        parseEVR(rv->arena, &rv->e, &rv->v, &rv->r);
+  rpmver rv = NULL;
+  if (evr && *evr)
+    {
+      size_t evrlen = strlen (evr) + 1;
+      rv = xmalloc (sizeof (*rv) + evrlen);
+      memcpy (rv->arena, evr, evrlen);
+      parseEVR (rv->arena, &rv->e, &rv->v, &rv->r);
     }
-    return rv;
+  return rv;
 }
 
-rpmver rpmverNew(const char *e, const char *v, const char *r)
+rpmver
+rpmverNew (const char *e, const char *v, const char *r)
 {
-    rpmver rv = NULL;
+  rpmver rv = NULL;
 
-    if (v && *v) {
-        size_t nb = strlen(v) + 1;
-        nb += (e != NULL) ? strlen(e) + 1 : 0;
-        nb += (r != NULL) ? strlen(r) + 1 : 0;
-        rv = xmalloc(sizeof(*rv) + nb);
+  if (v && *v)
+    {
+      size_t nb = strlen (v) + 1;
+      nb += (e != NULL) ? strlen (e) + 1 : 0;
+      nb += (r != NULL) ? strlen (r) + 1 : 0;
+      rv = xmalloc (sizeof (*rv) + nb);
 
-        rv->e = NULL;
-        rv->v = NULL;
-        rv->r = NULL;
+      rv->e = NULL;
+      rv->v = NULL;
+      rv->r = NULL;
 
-        char *p = rv->arena;
-        if (e) {
-            rv->e = p;
-            p = stpcpy(p, e);
-            p++;
+      char *p = rv->arena;
+      if (e)
+        {
+          rv->e = p;
+          p = stpcpy (p, e);
+          p++;
         }
 
-        rv->v = p;
-        p = stpcpy(p, v);
-        p++;
+      rv->v = p;
+      p = stpcpy (p, v);
+      p++;
 
-        if (r) {
-            rv->r = p;
-            p = stpcpy(p, r);
-            p++;
+      if (r)
+        {
+          rv->r = p;
+          p = stpcpy (p, r);
+          p++;
         }
     }
-    return rv;
+  return rv;
 }
 
-rpmver rpmverFree(rpmver rv)
+rpmver
+rpmverFree (rpmver rv)
 {
-    if (rv) {
-        free(rv);
+  if (rv)
+    {
+      free (rv);
     }
-    return NULL;
+  return NULL;
 }
 #endif

--- a/src/lib/rpmver-private.h
+++ b/src/lib/rpmver-private.h
@@ -5,101 +5,102 @@
 #ifndef _RPMVER_H
 #define _RPMVER_H
 
+#include <rpm/rpmds.h> /* sense flags */
 #include <rpm/rpmtypes.h>
-#include <rpm/rpmds.h>                /* sense flags */
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 // NOTE(lucab): Backported from <rpm/rpmtypes.h>.
 #ifndef rpmver
-typedef struct rpmver_s * rpmver;
+  typedef struct rpmver_s *rpmver;
 #endif
 
-/** \ingroup rpmver
- * Segmented string compare for version or release strings.
- *
- * @param a                1st string
- * @param b                2nd string
- * @return                +1 if a is "newer", 0 if equal, -1 if b is "newer"
- */
-int rpmvercmp(const char * a, const char * b);
+  /** \ingroup rpmver
+   * Segmented string compare for version or release strings.
+   *
+   * @param a                1st string
+   * @param b                2nd string
+   * @return                +1 if a is "newer", 0 if equal, -1 if b is "newer"
+   */
+  int rpmvercmp (const char *a, const char *b);
 
-/** \ingroup rpmver
- * Parse rpm version handle from evr string
- *
- * @param evr                [epoch:]version[-release] string
- * @return                rpm version, NULL on invalid evr
- */
-rpmver rpmverParse(const char *evr);
+  /** \ingroup rpmver
+   * Parse rpm version handle from evr string
+   *
+   * @param evr                [epoch:]version[-release] string
+   * @return                rpm version, NULL on invalid evr
+   */
+  rpmver rpmverParse (const char *evr);
 
-/** \ingroup rpmver
- * Create new rpm version handle from e, v, r components
- *
- * @param e                epoch (or NULL)
- * @param v                version
- * @param r                release (or NULL)
- * @return                rpm version, NULL on invalid
- */
-rpmver rpmverNew(const char *e, const char *v, const char *r);
+  /** \ingroup rpmver
+   * Create new rpm version handle from e, v, r components
+   *
+   * @param e                epoch (or NULL)
+   * @param v                version
+   * @param r                release (or NULL)
+   * @return                rpm version, NULL on invalid
+   */
+  rpmver rpmverNew (const char *e, const char *v, const char *r);
 
-/** \ingroup rpmver
- * Free rpm version handle
- *
- * @param rv                rpm version handle
- * @return                NULL always
- */
-rpmver rpmverFree(rpmver rv);
+  /** \ingroup rpmver
+   * Free rpm version handle
+   *
+   * @param rv                rpm version handle
+   * @return                NULL always
+   */
+  rpmver rpmverFree (rpmver rv);
 
-/** \ingroup rpmver
- * @param rv                rpm version handle
- * @return                numerical value of epoch
- */
-uint32_t rpmverEVal(rpmver rv);
+  /** \ingroup rpmver
+   * @param rv                rpm version handle
+   * @return                numerical value of epoch
+   */
+  uint32_t rpmverEVal (rpmver rv);
 
-/** \ingroup rpmver
- * @param rv                rpm version handle
- * @return                epoch portion
- */
-const char *rpmverE(rpmver rv);
+  /** \ingroup rpmver
+   * @param rv                rpm version handle
+   * @return                epoch portion
+   */
+  const char *rpmverE (rpmver rv);
 
-/** \ingroup rpmver
- * @param rv                rpm version handle
- * @return                version portion
- */
-const char *rpmverV(rpmver rv);
+  /** \ingroup rpmver
+   * @param rv                rpm version handle
+   * @return                version portion
+   */
+  const char *rpmverV (rpmver rv);
 
-/** \ingroup rpmver
- * @param rv                rpm version handle
- * @return                release portion
- */
-const char *rpmverR(rpmver rv);
+  /** \ingroup rpmver
+   * @param rv                rpm version handle
+   * @return                release portion
+   */
+  const char *rpmverR (rpmver rv);
 
-/** \ingroup rpmver
- * @param rv                rpm version handle
- * @return                formatted [E:]V[-R] string (malloced)
- */
-char *rpmverEVR(rpmver rv);
+  /** \ingroup rpmver
+   * @param rv                rpm version handle
+   * @return                formatted [E:]V[-R] string (malloced)
+   */
+  char *rpmverEVR (rpmver rv);
 
-/** \ingroup rpmver
- * Compare two rpm version handles
- *
- * @param v1                1st version handle
- * @param v2                2nd version handle
- * @return                0 if equal, -1 if v1 smaller, 1 if greater, than v2
- */
-int rpmverCmp(rpmver v1, rpmver v2);
+  /** \ingroup rpmver
+   * Compare two rpm version handles
+   *
+   * @param v1                1st version handle
+   * @param v2                2nd version handle
+   * @return                0 if equal, -1 if v1 smaller, 1 if greater, than v2
+   */
+  int rpmverCmp (rpmver v1, rpmver v2);
 
-/** \ingroup rpmver
- * Determine whether two versioned ranges overlap.
- * @param v1                1st version
- * @param f1                1st sense flags
- * @param v2                2nd version
- * @param f2                2nd sense flags
- * @return                1 if ranges overlap, 0 otherwise
- */
-int rpmverOverlap(rpmver v1, rpmsenseFlags f1, rpmver v2, rpmsenseFlags f2);
+  /** \ingroup rpmver
+   * Determine whether two versioned ranges overlap.
+   * @param v1                1st version
+   * @param f1                1st sense flags
+   * @param v2                2nd version
+   * @param f2                2nd sense flags
+   * @return                1 if ranges overlap, 0 otherwise
+   */
+  int rpmverOverlap (rpmver v1, rpmsenseFlags f1, rpmver v2, rpmsenseFlags f2);
 
 #ifdef __cplusplus
 }

--- a/src/libpriv/libdnf/dnf-version.h
+++ b/src/libpriv/libdnf/dnf-version.h
@@ -4,4 +4,3 @@
 // like LIBDNF_MAJOR_VERSION, if anything depends on them it will
 // fail at build time.
 #pragma once
-

--- a/src/libpriv/libsd-locale-util.c
+++ b/src/libpriv/libsd-locale-util.c
@@ -34,31 +34,27 @@
 
 #include "libsd-locale-util.h"
 
-const char *libsd_special_glyph(SpecialGlyph code) {
-        static const char* const draw_table_ascii[_SPECIAL_GLYPH_MAX] = {
-                [TREE_VERTICAL]      = "| ",
-                [TREE_BRANCH]        = "|-",
-                [TREE_RIGHT]         = "`-",
-                [TREE_SPACE]         = "  ",
-                [TRIANGULAR_BULLET]  = ">",
-                [BLACK_CIRCLE]       = "*",
-                [ARROW]              = "->",
-                [MDASH]              = "-",
-        };
-        static const char* const draw_table_utf8[_SPECIAL_GLYPH_MAX] = {
-                [TREE_VERTICAL]      = "\342\224\202 ",            /* │  */
-                [TREE_BRANCH]        = "\342\224\234\342\224\200", /* ├─ */
-                [TREE_RIGHT]         = "\342\224\224\342\224\200", /* └─ */
-                [TREE_SPACE]         = "  ",                       /*    */
-                [TRIANGULAR_BULLET]  = "\342\200\243",             /* ‣ */
-                [BLACK_CIRCLE]       = "\342\227\217",             /* ● */
-                [ARROW]              = "\342\206\222",             /* → */
-                [MDASH]              = "\342\200\223",             /* – */
-        };
+const char *
+libsd_special_glyph (SpecialGlyph code)
+{
+  static const char *const draw_table_ascii[_SPECIAL_GLYPH_MAX] = {
+    [TREE_VERTICAL] = "| ",    [TREE_BRANCH] = "|-", [TREE_RIGHT] = "`-", [TREE_SPACE] = "  ",
+    [TRIANGULAR_BULLET] = ">", [BLACK_CIRCLE] = "*", [ARROW] = "->",      [MDASH] = "-",
+  };
+  static const char *const draw_table_utf8[_SPECIAL_GLYPH_MAX] = {
+    [TREE_VERTICAL] = "\342\224\202 ",          /* │  */
+    [TREE_BRANCH] = "\342\224\234\342\224\200", /* ├─ */
+    [TREE_RIGHT] = "\342\224\224\342\224\200",  /* └─ */
+    [TREE_SPACE] = "  ",                        /*    */
+    [TRIANGULAR_BULLET] = "\342\200\243",       /* ‣ */
+    [BLACK_CIRCLE] = "\342\227\217",            /* ● */
+    [ARROW] = "\342\206\222",                   /* → */
+    [MDASH] = "\342\200\223",                   /* – */
+  };
 
-        gboolean locale_is_utf8 = g_get_charset (NULL);
+  gboolean locale_is_utf8 = g_get_charset (NULL);
 
-        if (locale_is_utf8)
-          return draw_table_utf8[code];
-        return draw_table_ascii[code];
+  if (locale_is_utf8)
+    return draw_table_utf8[code];
+  return draw_table_ascii[code];
 }

--- a/src/libpriv/libsd-locale-util.h
+++ b/src/libpriv/libsd-locale-util.h
@@ -23,18 +23,19 @@
 
 G_BEGIN_DECLS
 
-typedef enum {
-        TREE_VERTICAL,
-        TREE_BRANCH,
-        TREE_RIGHT,
-        TREE_SPACE,
-        TRIANGULAR_BULLET,
-        BLACK_CIRCLE,
-        ARROW,
-        MDASH,
-        _SPECIAL_GLYPH_MAX
+typedef enum
+{
+  TREE_VERTICAL,
+  TREE_BRANCH,
+  TREE_RIGHT,
+  TREE_SPACE,
+  TRIANGULAR_BULLET,
+  BLACK_CIRCLE,
+  ARROW,
+  MDASH,
+  _SPECIAL_GLYPH_MAX
 } SpecialGlyph;
 
-const char *libsd_special_glyph(SpecialGlyph code) __attribute__ ((const));
+const char *libsd_special_glyph (SpecialGlyph code) __attribute__ ((const));
 
 G_END_DECLS

--- a/src/libpriv/libsd-time-util.c
+++ b/src/libpriv/libsd-time-util.c
@@ -23,125 +23,121 @@
 
 #include "libsd-time-util.h"
 
-static clockid_t map_clock_id(clockid_t c) {
+static clockid_t
+map_clock_id (clockid_t c)
+{
 
-        /* Some more exotic archs (s390, ppc, …) lack the "ALARM" flavour of the clocks. Thus, clock_gettime() will
-         * fail for them. Since they are essentially the same as their non-ALARM pendants (their only difference is
-         * when timers are set on them), let's just map them accordingly. This way, we can get the correct time even on
-         * those archs. */
+  /* Some more exotic archs (s390, ppc, …) lack the "ALARM" flavour of the clocks. Thus,
+   * clock_gettime() will fail for them. Since they are essentially the same as their non-ALARM
+   * pendants (their only difference is when timers are set on them), let's just map them
+   * accordingly. This way, we can get the correct time even on those archs. */
 
-        switch (c) {
+  switch (c)
+    {
 
-        case CLOCK_BOOTTIME_ALARM:
-                return CLOCK_BOOTTIME;
+    case CLOCK_BOOTTIME_ALARM:
+      return CLOCK_BOOTTIME;
 
-        case CLOCK_REALTIME_ALARM:
-                return CLOCK_REALTIME;
+    case CLOCK_REALTIME_ALARM:
+      return CLOCK_REALTIME;
 
-        default:
-                return c;
-        }
+    default:
+      return c;
+    }
 }
 
-static usec_t timespec_load(const struct timespec *ts) {
-        g_assert(ts);
+static usec_t
+timespec_load (const struct timespec *ts)
+{
+  g_assert (ts);
 
-        if (ts->tv_sec < 0 || ts->tv_nsec < 0)
-                return USEC_INFINITY;
+  if (ts->tv_sec < 0 || ts->tv_nsec < 0)
+    return USEC_INFINITY;
 
-        if ((usec_t) ts->tv_sec > (UINT64_MAX - (ts->tv_nsec / NSEC_PER_USEC)) / USEC_PER_SEC)
-                return USEC_INFINITY;
+  if ((usec_t)ts->tv_sec > (UINT64_MAX - (ts->tv_nsec / NSEC_PER_USEC)) / USEC_PER_SEC)
+    return USEC_INFINITY;
 
-        return
-                (usec_t) ts->tv_sec * USEC_PER_SEC +
-                (usec_t) ts->tv_nsec / NSEC_PER_USEC;
+  return (usec_t)ts->tv_sec * USEC_PER_SEC + (usec_t)ts->tv_nsec / NSEC_PER_USEC;
 }
 
-static usec_t now(clockid_t clock_id) {
-        struct timespec ts;
+static usec_t
+now (clockid_t clock_id)
+{
+  struct timespec ts;
 
-        g_assert_cmpint (clock_gettime(map_clock_id(clock_id), &ts), ==, 0);
+  g_assert_cmpint (clock_gettime (map_clock_id (clock_id), &ts), ==, 0);
 
-        return timespec_load(&ts);
+  return timespec_load (&ts);
 }
 
-char *libsd_format_timestamp_relative(char *buf, size_t l, usec_t t) {
-        const char *s;
-        usec_t n, d;
+char *
+libsd_format_timestamp_relative (char *buf, size_t l, usec_t t)
+{
+  const char *s;
+  usec_t n, d;
 
-        if (t <= 0 || t == USEC_INFINITY)
-                return NULL;
+  if (t <= 0 || t == USEC_INFINITY)
+    return NULL;
 
-        n = now(CLOCK_REALTIME);
-        if (n > t) {
-                d = n - t;
-                s = "ago";
-        } else {
-                d = t - n;
-                s = "left";
-        }
+  n = now (CLOCK_REALTIME);
+  if (n > t)
+    {
+      d = n - t;
+      s = "ago";
+    }
+  else
+    {
+      d = t - n;
+      s = "left";
+    }
 
-        if (d >= USEC_PER_YEAR) {
-                usec_t years = d / USEC_PER_YEAR;
-                usec_t months = (d % USEC_PER_YEAR) / USEC_PER_MONTH;
+  if (d >= USEC_PER_YEAR)
+    {
+      usec_t years = d / USEC_PER_YEAR;
+      usec_t months = (d % USEC_PER_YEAR) / USEC_PER_MONTH;
 
-                (void) snprintf(buf, l, USEC_FMT " %s " USEC_FMT " %s %s",
-                                years,
-                                years == 1 ? "year" : "years",
-                                months,
-                                months == 1 ? "month" : "months",
-                                s);
-        } else if (d >= USEC_PER_MONTH) {
-                usec_t months = d / USEC_PER_MONTH;
-                usec_t days = (d % USEC_PER_MONTH) / USEC_PER_DAY;
+      (void)snprintf (buf, l, USEC_FMT " %s " USEC_FMT " %s %s", years,
+                      years == 1 ? "year" : "years", months, months == 1 ? "month" : "months", s);
+    }
+  else if (d >= USEC_PER_MONTH)
+    {
+      usec_t months = d / USEC_PER_MONTH;
+      usec_t days = (d % USEC_PER_MONTH) / USEC_PER_DAY;
 
-                (void) snprintf(buf, l, USEC_FMT " %s " USEC_FMT " %s %s",
-                                months,
-                                months == 1 ? "month" : "months",
-                                days,
-                                days == 1 ? "day" : "days",
-                                s);
-        } else if (d >= USEC_PER_WEEK) {
-                usec_t weeks = d / USEC_PER_WEEK;
-                usec_t days = (d % USEC_PER_WEEK) / USEC_PER_DAY;
+      (void)snprintf (buf, l, USEC_FMT " %s " USEC_FMT " %s %s", months,
+                      months == 1 ? "month" : "months", days, days == 1 ? "day" : "days", s);
+    }
+  else if (d >= USEC_PER_WEEK)
+    {
+      usec_t weeks = d / USEC_PER_WEEK;
+      usec_t days = (d % USEC_PER_WEEK) / USEC_PER_DAY;
 
-                (void) snprintf(buf, l, USEC_FMT " %s " USEC_FMT " %s %s",
-                                weeks,
-                                weeks == 1 ? "week" : "weeks",
-                                days,
-                                days == 1 ? "day" : "days",
-                                s);
-        } else if (d >= 2*USEC_PER_DAY)
-                (void) snprintf(buf, l, USEC_FMT " days %s", d / USEC_PER_DAY, s);
-        else if (d >= 25*USEC_PER_HOUR)
-                (void) snprintf(buf, l, "1 day " USEC_FMT "h %s",
-                                (d - USEC_PER_DAY) / USEC_PER_HOUR, s);
-        else if (d >= 6*USEC_PER_HOUR)
-                (void) snprintf(buf, l, USEC_FMT "h %s",
-                                d / USEC_PER_HOUR, s);
-        else if (d >= USEC_PER_HOUR)
-                (void) snprintf(buf, l, USEC_FMT "h " USEC_FMT "min %s",
-                                d / USEC_PER_HOUR,
-                                (d % USEC_PER_HOUR) / USEC_PER_MINUTE, s);
-        else if (d >= 5*USEC_PER_MINUTE)
-                (void) snprintf(buf, l, USEC_FMT "min %s",
-                                d / USEC_PER_MINUTE, s);
-        else if (d >= USEC_PER_MINUTE)
-                (void) snprintf(buf, l, USEC_FMT "min " USEC_FMT "s %s",
-                                d / USEC_PER_MINUTE,
-                                (d % USEC_PER_MINUTE) / USEC_PER_SEC, s);
-        else if (d >= USEC_PER_SEC)
-                (void) snprintf(buf, l, USEC_FMT "s %s",
-                                d / USEC_PER_SEC, s);
-        else if (d >= USEC_PER_MSEC)
-                (void) snprintf(buf, l, USEC_FMT "ms %s",
-                                d / USEC_PER_MSEC, s);
-        else if (d > 0)
-                (void) snprintf(buf, l, USEC_FMT"us %s",
-                                d, s);
-        else
-                (void) snprintf(buf, l, "now");
+      (void)snprintf (buf, l, USEC_FMT " %s " USEC_FMT " %s %s", weeks,
+                      weeks == 1 ? "week" : "weeks", days, days == 1 ? "day" : "days", s);
+    }
+  else if (d >= 2 * USEC_PER_DAY)
+    (void)snprintf (buf, l, USEC_FMT " days %s", d / USEC_PER_DAY, s);
+  else if (d >= 25 * USEC_PER_HOUR)
+    (void)snprintf (buf, l, "1 day " USEC_FMT "h %s", (d - USEC_PER_DAY) / USEC_PER_HOUR, s);
+  else if (d >= 6 * USEC_PER_HOUR)
+    (void)snprintf (buf, l, USEC_FMT "h %s", d / USEC_PER_HOUR, s);
+  else if (d >= USEC_PER_HOUR)
+    (void)snprintf (buf, l, USEC_FMT "h " USEC_FMT "min %s", d / USEC_PER_HOUR,
+                    (d % USEC_PER_HOUR) / USEC_PER_MINUTE, s);
+  else if (d >= 5 * USEC_PER_MINUTE)
+    (void)snprintf (buf, l, USEC_FMT "min %s", d / USEC_PER_MINUTE, s);
+  else if (d >= USEC_PER_MINUTE)
+    (void)snprintf (buf, l, USEC_FMT "min " USEC_FMT "s %s", d / USEC_PER_MINUTE,
+                    (d % USEC_PER_MINUTE) / USEC_PER_SEC, s);
+  else if (d >= USEC_PER_SEC)
+    (void)snprintf (buf, l, USEC_FMT "s %s", d / USEC_PER_SEC, s);
+  else if (d >= USEC_PER_MSEC)
+    (void)snprintf (buf, l, USEC_FMT "ms %s", d / USEC_PER_MSEC, s);
+  else if (d > 0)
+    (void)snprintf (buf, l, USEC_FMT "us %s", d, s);
+  else
+    (void)snprintf (buf, l, "now");
 
-        buf[l-1] = 0;
-        return buf;
+  buf[l - 1] = 0;
+  return buf;
 }

--- a/src/libpriv/libsd-time-util.h
+++ b/src/libpriv/libsd-time-util.h
@@ -37,36 +37,36 @@ typedef uint64_t nsec_t;
 #define NSEC_FMT "%" PRI_NSEC
 #define USEC_FMT "%" PRI_USEC
 
-#define USEC_INFINITY ((usec_t) UINT64_MAX)
-#define NSEC_INFINITY ((nsec_t) UINT64_MAX)
+#define USEC_INFINITY ((usec_t)UINT64_MAX)
+#define NSEC_INFINITY ((nsec_t)UINT64_MAX)
 
-#define MSEC_PER_SEC  1000ULL
-#define USEC_PER_SEC  ((usec_t) 1000000ULL)
-#define USEC_PER_MSEC ((usec_t) 1000ULL)
-#define NSEC_PER_SEC  ((nsec_t) 1000000000ULL)
-#define NSEC_PER_MSEC ((nsec_t) 1000000ULL)
-#define NSEC_PER_USEC ((nsec_t) 1000ULL)
+#define MSEC_PER_SEC 1000ULL
+#define USEC_PER_SEC ((usec_t)1000000ULL)
+#define USEC_PER_MSEC ((usec_t)1000ULL)
+#define NSEC_PER_SEC ((nsec_t)1000000000ULL)
+#define NSEC_PER_MSEC ((nsec_t)1000000ULL)
+#define NSEC_PER_USEC ((nsec_t)1000ULL)
 
-#define USEC_PER_MINUTE ((usec_t) (60ULL*USEC_PER_SEC))
-#define NSEC_PER_MINUTE ((nsec_t) (60ULL*NSEC_PER_SEC))
-#define USEC_PER_HOUR ((usec_t) (60ULL*USEC_PER_MINUTE))
-#define NSEC_PER_HOUR ((nsec_t) (60ULL*NSEC_PER_MINUTE))
-#define USEC_PER_DAY ((usec_t) (24ULL*USEC_PER_HOUR))
-#define NSEC_PER_DAY ((nsec_t) (24ULL*NSEC_PER_HOUR))
-#define USEC_PER_WEEK ((usec_t) (7ULL*USEC_PER_DAY))
-#define NSEC_PER_WEEK ((nsec_t) (7ULL*NSEC_PER_DAY))
-#define USEC_PER_MONTH ((usec_t) (2629800ULL*USEC_PER_SEC))
-#define NSEC_PER_MONTH ((nsec_t) (2629800ULL*NSEC_PER_SEC))
-#define USEC_PER_YEAR ((usec_t) (31557600ULL*USEC_PER_SEC))
-#define NSEC_PER_YEAR ((nsec_t) (31557600ULL*NSEC_PER_SEC))
+#define USEC_PER_MINUTE ((usec_t)(60ULL * USEC_PER_SEC))
+#define NSEC_PER_MINUTE ((nsec_t)(60ULL * NSEC_PER_SEC))
+#define USEC_PER_HOUR ((usec_t)(60ULL * USEC_PER_MINUTE))
+#define NSEC_PER_HOUR ((nsec_t)(60ULL * NSEC_PER_MINUTE))
+#define USEC_PER_DAY ((usec_t)(24ULL * USEC_PER_HOUR))
+#define NSEC_PER_DAY ((nsec_t)(24ULL * NSEC_PER_HOUR))
+#define USEC_PER_WEEK ((usec_t)(7ULL * USEC_PER_DAY))
+#define NSEC_PER_WEEK ((nsec_t)(7ULL * NSEC_PER_DAY))
+#define USEC_PER_MONTH ((usec_t)(2629800ULL * USEC_PER_SEC))
+#define NSEC_PER_MONTH ((nsec_t)(2629800ULL * NSEC_PER_SEC))
+#define USEC_PER_YEAR ((usec_t)(31557600ULL * USEC_PER_SEC))
+#define NSEC_PER_YEAR ((nsec_t)(31557600ULL * NSEC_PER_SEC))
 
-/* We assume a maximum timezone length of 6. TZNAME_MAX is not defined on Linux, but glibc internally initializes this
- * to 6. Let's rely on that. */
-#define FORMAT_TIMESTAMP_MAX (3U+1U+10U+1U+8U+1U+6U+1U+6U+1U)
+/* We assume a maximum timezone length of 6. TZNAME_MAX is not defined on Linux, but glibc
+ * internally initializes this to 6. Let's rely on that. */
+#define FORMAT_TIMESTAMP_MAX (3U + 1U + 10U + 1U + 8U + 1U + 6U + 1U + 6U + 1U)
 #define FORMAT_TIMESTAMP_WIDTH 28U /* when outputting, assume this width */
 #define FORMAT_TIMESTAMP_RELATIVE_MAX 256U
 #define FORMAT_TIMESPAN_MAX 64U
 
-char *libsd_format_timestamp_relative(char *buf, size_t l, usec_t t);
+char *libsd_format_timestamp_relative (char *buf, size_t l, usec_t t);
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-container.cxx
+++ b/src/libpriv/rpmostree-container.cxx
@@ -24,6 +24,7 @@
 #include <glib-unix.h>
 
 #include "rpmostree-core.h"
+
 #include "rpmostree-container.h"
 
 #include <libglnx.h>

--- a/src/libpriv/rpmostree-container.cxx
+++ b/src/libpriv/rpmostree-container.cxx
@@ -20,8 +20,8 @@
 
 #include "config.h"
 
-#include <string.h>
 #include <glib-unix.h>
+#include <string.h>
 
 #include "rpmostree-core.h"
 
@@ -30,11 +30,10 @@
 #include <libglnx.h>
 
 gboolean
-rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile,
-                             GCancellable           *cancellable,
-                             GError                **error)
+rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile, GCancellable *cancellable,
+                             GError **error)
 {
-  g_autoptr(RpmOstreeContext) ctx = rpmostree_context_new_container ();
+  g_autoptr (RpmOstreeContext) ctx = rpmostree_context_new_container ();
   rpmostree_context_set_treefile (ctx, treefile);
 
   if (!rpmostree_context_setup (ctx, "/", "/", cancellable, error))
@@ -57,13 +56,11 @@ rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile,
 }
 
 gboolean
-rpmostree_container_install_packages (char **packages,
-                                      GCancellable  *cancellable,
-                                      GError       **error)
+rpmostree_container_install_packages (char **packages, GCancellable *cancellable, GError **error)
 {
   rust::Vec<rust::String> pkgs;
   for (char **it = packages; it && *it; it++)
-    pkgs.push_back(std::string(*it));
-  auto treefile = CXX_TRY_VAL(treefile_new_from_fields(pkgs), error);
+    pkgs.push_back (std::string (*it));
+  auto treefile = CXX_TRY_VAL (treefile_new_from_fields (pkgs), error);
   return rpmostree_container_rebuild (*treefile, cancellable, error);
 }

--- a/src/libpriv/rpmostree-container.h
+++ b/src/libpriv/rpmostree-container.h
@@ -22,14 +22,10 @@
 
 G_BEGIN_DECLS
 
-gboolean
-rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile,
-                             GCancellable           *cancellable,
-                             GError                **error);
+gboolean rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile, GCancellable *cancellable,
+                                      GError **error);
 
-gboolean
-rpmostree_container_install_packages (char **packages,
-                                      GCancellable  *cancellable,
-                                      GError       **error);
+gboolean rpmostree_container_install_packages (char **packages, GCancellable *cancellable,
+                                               GError **error);
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -24,19 +24,20 @@
 
 #include "libglnx.h"
 #include "rpmostree-core.h"
-#include "rpmostree-output.h"
 #include "rpmostree-cxxrs.h"
+#include "rpmostree-output.h"
 
 G_BEGIN_DECLS
 
-struct _RpmOstreeContext {
+struct _RpmOstreeContext
+{
   GObject parent;
 
   /* Whether we were created with new_system() or new_container() */
   gboolean is_system;
   /* Whether we were created with new_container() */
   gboolean is_container;
-  std::optional<rust::Box<rpmostreecxx::Treefile>> treefile_owned;
+  std::optional<rust::Box<rpmostreecxx::Treefile> > treefile_owned;
   rpmostreecxx::Treefile *treefile_rs; /* For composes for now */
   gboolean empty;
   gboolean disable_selinux;
@@ -72,7 +73,7 @@ struct _RpmOstreeContext {
 
   GHashTable *fileoverride_pkgs; /* set of nevras */
 
-  std::optional<rust::Box<rpmostreecxx::LockfileConfig>> lockfile;
+  std::optional<rust::Box<rpmostreecxx::LockfileConfig> > lockfile;
   gboolean lockfile_strict;
 
   GLnxTmpDir tmpdir;

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -22,15 +22,15 @@
 
 #include <gio/gio.h>
 #include <libdnf/libdnf.h>
-#include <ostree.h>
 #include <memory>
+#include <ostree.h>
 
-#include "rpmostree-cxxrs.h"
 #include "libglnx.h"
-
+#include "rpmostree-cxxrs.h"
 
 // C++ APIs
-std::unique_ptr<rust::Vec<rpmostreecxx::StringMapping>> rpmostree_dnfcontext_get_varsubsts (DnfContext *context);
+std::unique_ptr<rust::Vec<rpmostreecxx::StringMapping> >
+rpmostree_dnfcontext_get_varsubsts (DnfContext *context);
 
 // Begin C APIs
 G_BEGIN_DECLS
@@ -56,7 +56,8 @@ G_BEGIN_DECLS
 #define RPMOSTREE_TYPE_CONTEXT (rpmostree_context_get_type ())
 G_DECLARE_FINAL_TYPE (RpmOstreeContext, rpmostree_context, RPMOSTREE, CONTEXT, GObject)
 
-typedef enum {
+typedef enum
+{
   RPMOSTREE_REFSPEC_TYPE_OSTREE,
   RPMOSTREE_REFSPEC_TYPE_CHECKSUM,
   RPMOSTREE_REFSPEC_TYPE_CONTAINER,
@@ -66,155 +67,122 @@ typedef enum {
 #define RPMOSTREE_REFSPEC_OSTREE_BASE_ORIGIN_KEY "baserefspec"
 #define RPMOSTREE_REFSPEC_CONTAINER_ORIGIN_KEY "container-image-reference"
 
-gboolean rpmostree_refspec_classify (const char *refspec,
-                                     RpmOstreeRefspecType *out_type,
-                                     GError     **error);
+gboolean rpmostree_refspec_classify (const char *refspec, RpmOstreeRefspecType *out_type,
+                                     GError **error);
 
-namespace rpmostreecxx {
-void core_libdnf_process_global_init();
+namespace rpmostreecxx
+{
+void core_libdnf_process_global_init ();
 }
 
-RpmOstreeContext *rpmostree_context_new_base (OstreeRepo   *repo);
+RpmOstreeContext *rpmostree_context_new_base (OstreeRepo *repo);
 
-RpmOstreeContext *rpmostree_context_new_client (OstreeRepo   *repo);
+RpmOstreeContext *rpmostree_context_new_client (OstreeRepo *repo);
 
-RpmOstreeContext * rpmostree_context_new_container ();
+RpmOstreeContext *rpmostree_context_new_container ();
 
-RpmOstreeContext *rpmostree_context_new_compose (int basedir_dfd,
-                                                 OstreeRepo  *repo,
+RpmOstreeContext *rpmostree_context_new_compose (int basedir_dfd, OstreeRepo *repo,
                                                  rpmostreecxx::Treefile &treefile_rs);
 
-void rpmostree_context_set_cache_root (RpmOstreeContext *self,
-                                       int               userroot_dfd);
+void rpmostree_context_set_cache_root (RpmOstreeContext *self, int userroot_dfd);
 
-void rpmostree_context_set_pkgcache_only (RpmOstreeContext *self,
-                                          gboolean          pkgcache_only);
+void rpmostree_context_set_pkgcache_only (RpmOstreeContext *self, gboolean pkgcache_only);
 
-typedef enum {
-      RPMOSTREE_CONTEXT_DNF_CACHE_FOREVER,
-      RPMOSTREE_CONTEXT_DNF_CACHE_DEFAULT,
-      RPMOSTREE_CONTEXT_DNF_CACHE_NEVER,
+typedef enum
+{
+  RPMOSTREE_CONTEXT_DNF_CACHE_FOREVER,
+  RPMOSTREE_CONTEXT_DNF_CACHE_DEFAULT,
+  RPMOSTREE_CONTEXT_DNF_CACHE_NEVER,
 } RpmOstreeContextDnfCachePolicy;
 
 void rpmostree_context_set_dnf_caching (RpmOstreeContext *self,
                                         RpmOstreeContextDnfCachePolicy policy);
 
-DnfContext * rpmostree_context_get_dnf (RpmOstreeContext *self);
+DnfContext *rpmostree_context_get_dnf (RpmOstreeContext *self);
 
-GVariant *rpmostree_context_get_rpmmd_repo_commit_metadata (RpmOstreeContext  *self);
+GVariant *rpmostree_context_get_rpmmd_repo_commit_metadata (RpmOstreeContext *self);
 
 void rpmostree_context_set_treefile (RpmOstreeContext *self, rpmostreecxx::Treefile &treefile);
 
-gboolean rpmostree_context_setup (RpmOstreeContext     *self,
-                                  const char    *install_root,
-                                  const char    *source_root,
-                                  GCancellable  *cancellable,
-                                  GError       **error);
+gboolean rpmostree_context_setup (RpmOstreeContext *self, const char *install_root,
+                                  const char *source_root, GCancellable *cancellable,
+                                  GError **error);
 
-void
-rpmostree_context_configure_from_deployment (RpmOstreeContext *self,
-                                             OstreeSysroot    *sysroot,
-                                             OstreeDeployment *cfg_deployment);
+void rpmostree_context_configure_from_deployment (RpmOstreeContext *self, OstreeSysroot *sysroot,
+                                                  OstreeDeployment *cfg_deployment);
 
 void rpmostree_context_set_is_empty (RpmOstreeContext *self);
 void rpmostree_context_disable_selinux (RpmOstreeContext *self);
 const char *rpmostree_context_get_ref (RpmOstreeContext *self);
 
-void rpmostree_context_set_repos (RpmOstreeContext *self,
-                                  OstreeRepo       *base_repo,
-                                  OstreeRepo       *pkgcache_repo);
+void rpmostree_context_set_repos (RpmOstreeContext *self, OstreeRepo *base_repo,
+                                  OstreeRepo *pkgcache_repo);
 void rpmostree_context_set_devino_cache (RpmOstreeContext *self,
                                          OstreeRepoDevInoCache *devino_cache);
 void rpmostree_context_disable_rofiles (RpmOstreeContext *self);
-void rpmostree_context_set_sepolicy (RpmOstreeContext *self,
-                                     OstreeSePolicy   *sepolicy);
+void rpmostree_context_set_sepolicy (RpmOstreeContext *self, OstreeSePolicy *sepolicy);
 
-gboolean rpmostree_dnf_add_checksum_goal (GChecksum  *checksum,
-                                          HyGoal      goal,
-                                          OstreeRepo *pkgcache_repo,
-                                          GError    **error);
+gboolean rpmostree_dnf_add_checksum_goal (GChecksum *checksum, HyGoal goal,
+                                          OstreeRepo *pkgcache_repo, GError **error);
 
-gboolean rpmostree_context_get_state_sha512 (RpmOstreeContext *self,
-                                             char            **out_checksum,
-                                             GError          **error);
+gboolean rpmostree_context_get_state_sha512 (RpmOstreeContext *self, char **out_checksum,
+                                             GError **error);
 
-gboolean
-rpmostree_pkgcache_find_pkg_header (OstreeRepo    *pkgcache,
-                                    const char    *nevra,
-                                    const char    *expected_sha256,
-                                    GVariant     **out_header,
-                                    GCancellable  *cancellable,
-                                    GError       **error);
+gboolean rpmostree_pkgcache_find_pkg_header (OstreeRepo *pkgcache, const char *nevra,
+                                             const char *expected_sha256, GVariant **out_header,
+                                             GCancellable *cancellable, GError **error);
 
-gboolean rpmostree_context_download_metadata (RpmOstreeContext  *context,
+gboolean rpmostree_context_download_metadata (RpmOstreeContext *context,
                                               DnfContextSetupSackFlags flags,
-                                              GCancellable      *cancellable,
-                                              GError           **error);
+                                              GCancellable *cancellable, GError **error);
 
 /* This API allocates an install context, use with one of the later ones */
-gboolean rpmostree_context_prepare (RpmOstreeContext     *self,
-                                    GCancellable   *cancellable,
-                                    GError        **error);
+gboolean rpmostree_context_prepare (RpmOstreeContext *self, GCancellable *cancellable,
+                                    GError **error);
 
 GPtrArray *rpmostree_context_get_packages (RpmOstreeContext *self);
 
 GPtrArray *rpmostree_context_get_packages_to_import (RpmOstreeContext *self);
 
-gboolean
-rpmostree_context_set_lockfile (RpmOstreeContext *self,
-                                char            **lockfiles,
-                                gboolean          strict,
-                                GError          **error);
+gboolean rpmostree_context_set_lockfile (RpmOstreeContext *self, char **lockfiles, gboolean strict,
+                                         GError **error);
 
-gboolean rpmostree_download_packages (GPtrArray      *packages,
-                                      GCancellable   *cancellable,
-                                      GError        **error);
+gboolean rpmostree_download_packages (GPtrArray *packages, GCancellable *cancellable,
+                                      GError **error);
 
-gboolean rpmostree_context_download (RpmOstreeContext *self,
-                                     GCancellable     *cancellable,
-                                     GError           **error);
+gboolean rpmostree_context_download (RpmOstreeContext *self, GCancellable *cancellable,
+                                     GError **error);
 
-void rpmostree_set_repos_on_packages (DnfContext *dnfctx,
-                                      GPtrArray  *packages);
+void rpmostree_set_repos_on_packages (DnfContext *dnfctx, GPtrArray *packages);
 
-gboolean
-rpmostree_context_consume_package (RpmOstreeContext  *self,
-                                   DnfPackage        *package,
-                                   int               *out_fd,
-                                   GError           **error);
+gboolean rpmostree_context_consume_package (RpmOstreeContext *self, DnfPackage *package,
+                                            int *out_fd, GError **error);
 
-gboolean rpmostree_context_import (RpmOstreeContext *self,
-                                   GCancellable     *cancellable,
-                                   GError          **error);
+gboolean rpmostree_context_import (RpmOstreeContext *self, GCancellable *cancellable,
+                                   GError **error);
 
-gboolean rpmostree_context_force_relabel (RpmOstreeContext *self,
-                                          GCancellable     *cancellable,
-                                          GError          **error);
+gboolean rpmostree_context_force_relabel (RpmOstreeContext *self, GCancellable *cancellable,
+                                          GError **error);
 
-typedef enum {
+typedef enum
+{
   RPMOSTREE_ASSEMBLE_TYPE_SERVER_BASE,
   RPMOSTREE_ASSEMBLE_TYPE_CLIENT_LAYERING
 } RpmOstreeAssembleType;
 
-void rpmostree_context_set_tmprootfs_dfd (RpmOstreeContext *self,
-                                          int               dfd);
-int rpmostree_context_get_tmprootfs_dfd  (RpmOstreeContext *self);
+void rpmostree_context_set_tmprootfs_dfd (RpmOstreeContext *self, int dfd);
+int rpmostree_context_get_tmprootfs_dfd (RpmOstreeContext *self);
 
 gboolean rpmostree_context_get_kernel_changed (RpmOstreeContext *self);
 
 /* NB: tmprootfs_dfd is allowed to have pre-existing data */
 /* devino_cache can be NULL if no previous cache established */
-gboolean rpmostree_context_assemble (RpmOstreeContext      *self,
-                                     GCancellable          *cancellable,
-                                     GError               **error);
-gboolean rpmostree_context_assemble_end (RpmOstreeContext      *self,
-                                         GCancellable          *cancellable,
-                                         GError               **error);
-gboolean rpmostree_context_commit (RpmOstreeContext      *self,
-                                   const char            *parent,
-                                   RpmOstreeAssembleType  assemble_type,
-                                   char                 **out_commit,
-                                   GCancellable          *cancellable,
-                                   GError               **error);
+gboolean rpmostree_context_assemble (RpmOstreeContext *self, GCancellable *cancellable,
+                                     GError **error);
+gboolean rpmostree_context_assemble_end (RpmOstreeContext *self, GCancellable *cancellable,
+                                         GError **error);
+gboolean rpmostree_context_commit (RpmOstreeContext *self, const char *parent,
+                                   RpmOstreeAssembleType assemble_type, char **out_commit,
+                                   GCancellable *cancellable, GError **error);
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-cxxrs-prelude.h
+++ b/src/libpriv/rpmostree-cxxrs-prelude.h
@@ -22,25 +22,27 @@
 
 #include <ostree.h>
 
-namespace rpmostreecxx {
-    // Currently cxx-rs requires that external bindings are in the same namespace as
-    // its own bindings, so we maintain typedefs.  Update cxxrsutil.rs first.
-    typedef ::OstreeDeployment OstreeDeployment;
-    typedef ::OstreeRepo OstreeRepo;
-    typedef ::OstreeRepoTransactionStats OstreeRepoTransactionStats;
-    typedef ::OstreeSysroot OstreeSysroot;
-    typedef ::GObject GObject;
-    typedef ::GCancellable GCancellable;
-    typedef ::GDBusConnection GDBusConnection;
-    typedef ::GFileInfo GFileInfo;
-    typedef ::GVariant GVariant;
-    typedef ::GVariantDict GVariantDict;
-    typedef ::GKeyFile GKeyFile;
+namespace rpmostreecxx
+{
+// Currently cxx-rs requires that external bindings are in the same namespace as
+// its own bindings, so we maintain typedefs.  Update cxxrsutil.rs first.
+typedef ::OstreeDeployment OstreeDeployment;
+typedef ::OstreeRepo OstreeRepo;
+typedef ::OstreeRepoTransactionStats OstreeRepoTransactionStats;
+typedef ::OstreeSysroot OstreeSysroot;
+typedef ::GObject GObject;
+typedef ::GCancellable GCancellable;
+typedef ::GDBusConnection GDBusConnection;
+typedef ::GFileInfo GFileInfo;
+typedef ::GVariant GVariant;
+typedef ::GVariantDict GVariantDict;
+typedef ::GKeyFile GKeyFile;
 }
 
 // XXX: really should just include! libdnf.hxx in the bridge
 #include <libdnf/libdnf.h>
-namespace dnfcxx {
-  typedef ::DnfPackage DnfPackage;
-  typedef ::DnfRepo DnfRepo;
+namespace dnfcxx
+{
+typedef ::DnfPackage DnfPackage;
+typedef ::DnfRepo DnfRepo;
 }

--- a/src/libpriv/rpmostree-cxxrsutil.hpp
+++ b/src/libpriv/rpmostree-cxxrsutil.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
  * by the Free Software Foundation; either version 2 of the licence or (at
@@ -17,37 +17,39 @@
 
 #pragma once
 
-#include <string>
 #include <exception>
-#include <sstream>
 #include <gio/gio.h>
+#include <sstream>
+#include <string>
 
 #include "rust/cxx.h"
 
 // Helpers corresponding to cxxrsutil.rs
-namespace rpmostreecxx {
+namespace rpmostreecxx
+{
 
 // Wrapper for an array of GObjects.  This is a hack until
 // cxx-rs gains support for either std::vector<> or Vec<T>
 // with nontrivial types.
-class CxxGObjectArray final {
+class CxxGObjectArray final
+{
 public:
-    CxxGObjectArray(GPtrArray *arr_p) : arr(arr_p) {
-        g_ptr_array_ref(arr);
-    };
-    ~CxxGObjectArray() {
-        g_ptr_array_unref(arr);
-    }
+  CxxGObjectArray (GPtrArray *arr_p) : arr (arr_p) { g_ptr_array_ref (arr); };
+  ~CxxGObjectArray () { g_ptr_array_unref (arr); }
 
-    unsigned int length() {
-        return (unsigned int)arr->len;
-    }
+  unsigned int
+  length ()
+  {
+    return (unsigned int)arr->len;
+  }
 
-    ::GObject& get(unsigned int i) {
-        g_assert_cmpuint(i, <, arr->len);
-        return *(::GObject*)arr->pdata[i];
-    }
-    GPtrArray* arr;
+  ::GObject &
+  get (unsigned int i)
+  {
+    g_assert_cmpuint (i, <, arr->len);
+    return *(::GObject *)arr->pdata[i];
+  }
+  GPtrArray *arr;
 };
 
 } // namespace

--- a/src/libpriv/rpmostree-diff.cxx
+++ b/src/libpriv/rpmostree-diff.cxx
@@ -17,51 +17,55 @@
 
 #include <memory>
 
-#include "rpmostree-diff.hpp"
 #include "rpmostree-db.h"
+#include "rpmostree-diff.hpp"
 #include "rpmostree-util.h"
 
 // Only used by Rust side.
-namespace rpmostreecxx {
+namespace rpmostreecxx
+{
 
-RPMDiff::RPMDiff(GPtrArray *removed, GPtrArray *added, GPtrArray *modified_old, GPtrArray *modified_new) {
-  removed_ = g_ptr_array_ref(removed);
-  added_ = g_ptr_array_ref(added);
-  modified_old_ = g_ptr_array_ref(modified_old);
-  modified_new_ = g_ptr_array_ref(modified_new);
+RPMDiff::RPMDiff (GPtrArray *removed, GPtrArray *added, GPtrArray *modified_old,
+                  GPtrArray *modified_new)
+{
+  removed_ = g_ptr_array_ref (removed);
+  added_ = g_ptr_array_ref (added);
+  modified_old_ = g_ptr_array_ref (modified_old);
+  modified_new_ = g_ptr_array_ref (modified_new);
 }
 
-RPMDiff::~RPMDiff() {
-  g_ptr_array_unref(removed_);
-  g_ptr_array_unref(added_);
-  g_ptr_array_unref(modified_old_);
-  g_ptr_array_unref(modified_new_);
+RPMDiff::~RPMDiff ()
+{
+  g_ptr_array_unref (removed_);
+  g_ptr_array_unref (added_);
+  g_ptr_array_unref (modified_old_);
+  g_ptr_array_unref (modified_new_);
 }
 
 std::unique_ptr<RPMDiff>
-rpmdb_diff(OstreeRepo &repo, const std::string &from, const std::string &to, bool allow_noent) {
-  g_autoptr(GPtrArray) removed = NULL;
-  g_autoptr(GPtrArray) added = NULL;
-  g_autoptr(GPtrArray) modified_old = NULL;
-  g_autoptr(GPtrArray) modified_new = NULL;
-  g_autoptr(GError) local_error = NULL;
+rpmdb_diff (OstreeRepo &repo, const std::string &from, const std::string &to, bool allow_noent)
+{
+  g_autoptr (GPtrArray) removed = NULL;
+  g_autoptr (GPtrArray) added = NULL;
+  g_autoptr (GPtrArray) modified_old = NULL;
+  g_autoptr (GPtrArray) modified_new = NULL;
+  g_autoptr (GError) local_error = NULL;
 
   int flags = 0;
   if (allow_noent)
     flags |= RPM_OSTREE_DB_DIFF_EXT_ALLOW_NOENT;
 
-  if (!rpm_ostree_db_diff_ext(&repo, from.c_str(), to.c_str(), (RpmOstreeDbDiffExtFlags)flags,
-                              &removed, &added, &modified_old, &modified_new,
-                              NULL, &local_error))
-    util::throw_gerror(local_error);
-  return std::make_unique<RPMDiff>(removed, added, modified_old, modified_new);
+  if (!rpm_ostree_db_diff_ext (&repo, from.c_str (), to.c_str (), (RpmOstreeDbDiffExtFlags)flags,
+                               &removed, &added, &modified_old, &modified_new, NULL, &local_error))
+    util::throw_gerror (local_error);
+  return std::make_unique<RPMDiff> (removed, added, modified_old, modified_new);
 }
 
 void
-RPMDiff::print() const
+RPMDiff::print () const
 {
-  rpmostree_diff_print_formatted (RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, NULL, 0,
-                                  removed_, added_, modified_old_, modified_new_);
+  rpmostree_diff_print_formatted (RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, NULL, 0, removed_,
+                                  added_, modified_old_, modified_new_);
 }
 
 } /* namespace */

--- a/src/libpriv/rpmostree-diff.hpp
+++ b/src/libpriv/rpmostree-diff.hpp
@@ -17,44 +17,50 @@
 
 #pragma once
 
-#include <string>
 #include <exception>
-#include <sstream>
 #include <memory>
+#include <sstream>
+#include <string>
 
 #include <ostree.h>
 
 #include "rust/cxx.h"
 
-namespace rpmostreecxx {
+namespace rpmostreecxx
+{
 
-class RPMDiff final {
+class RPMDiff final
+{
 public:
-    int n_removed() const {
-        return removed_->len;
-    }
-    int n_added() const {
-        return added_->len;
-    }
-    int n_modified() const {
-        return modified_old_->len + modified_new_->len;
-    }
-    ~RPMDiff();
-    RPMDiff(GPtrArray *removed, GPtrArray *added, GPtrArray *modified_old, GPtrArray *modified_new);
+  int
+  n_removed () const
+  {
+    return removed_->len;
+  }
+  int
+  n_added () const
+  {
+    return added_->len;
+  }
+  int
+  n_modified () const
+  {
+    return modified_old_->len + modified_new_->len;
+  }
+  ~RPMDiff ();
+  RPMDiff (GPtrArray *removed, GPtrArray *added, GPtrArray *modified_old, GPtrArray *modified_new);
 
-    // TODO(cgwalters) enhance this with options
-    void print() const;
+  // TODO(cgwalters) enhance this with options
+  void print () const;
 
 private:
-    GPtrArray *removed_;
-    GPtrArray *added_;
-    GPtrArray *modified_old_;
-    GPtrArray *modified_new_;
+  GPtrArray *removed_;
+  GPtrArray *added_;
+  GPtrArray *modified_old_;
+  GPtrArray *modified_new_;
 };
 
-std::unique_ptr<RPMDiff> rpmdb_diff(OstreeRepo &repo,
-                                    const std::string &src,
-                                    const std::string &dest,
-                                    bool allow_noent);
+std::unique_ptr<RPMDiff> rpmdb_diff (OstreeRepo &repo, const std::string &src,
+                                     const std::string &dest, bool allow_noent);
 
 } /* namespace */

--- a/src/libpriv/rpmostree-editor.cxx
+++ b/src/libpriv/rpmostree-editor.cxx
@@ -24,8 +24,8 @@
 #include "libglnx.h"
 #include "rpmostree-editor.h"
 #include "rpmostree-util.h"
-#include <sys/wait.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #ifndef DEFAULT_EDITOR
 #define DEFAULT_EDITOR "vi"
@@ -55,14 +55,11 @@ get_editor (void)
 }
 
 char *
-ot_editor_prompt (OstreeRepo *repo,
-                  const char *input,
-                  GCancellable *cancellable,
-                  GError **error)
+ot_editor_prompt (OstreeRepo *repo, const char *input, GCancellable *cancellable, GError **error)
 {
   glnx_unref_object GSubprocess *proc = NULL;
-  g_autoptr(GFile) file = NULL;
-  g_autoptr(GFileIOStream) io = NULL;
+  g_autoptr (GFile) file = NULL;
+  g_autoptr (GFileIOStream) io = NULL;
   GOutputStream *output;
   const char *editor;
   char *ret = NULL;
@@ -81,8 +78,8 @@ ot_editor_prompt (OstreeRepo *repo,
     goto out;
 
   output = g_io_stream_get_output_stream (G_IO_STREAM (io));
-  if (!g_output_stream_write_all (output, input, strlen (input), NULL, cancellable, error) ||
-      !g_io_stream_close (G_IO_STREAM (io), cancellable, error))
+  if (!g_output_stream_write_all (output, input, strlen (input), NULL, cancellable, error)
+      || !g_io_stream_close (G_IO_STREAM (io), cancellable, error))
     goto out;
 
   {
@@ -90,8 +87,7 @@ ot_editor_prompt (OstreeRepo *repo,
     args = g_strconcat (editor, " ", quoted_file, NULL);
   }
 
-  proc = g_subprocess_new (G_SUBPROCESS_FLAGS_STDIN_INHERIT, error, 
-                           "/bin/sh", "-c", args, NULL);
+  proc = g_subprocess_new (G_SUBPROCESS_FLAGS_STDIN_INHERIT, error, "/bin/sh", "-c", args, NULL);
 
   if (!g_subprocess_wait_check (proc, cancellable, error))
     {
@@ -99,11 +95,11 @@ ot_editor_prompt (OstreeRepo *repo,
       goto out;
     }
 
-  ret = glnx_file_get_contents_utf8_at (AT_FDCWD, gs_file_get_path_cached (file), NULL,
-                                        cancellable, error);
+  ret = glnx_file_get_contents_utf8_at (AT_FDCWD, gs_file_get_path_cached (file), NULL, cancellable,
+                                        error);
 
 out:
   if (file)
-    (void )g_file_delete (file, NULL, NULL);
+    (void)g_file_delete (file, NULL, NULL);
   return ret;
 }

--- a/src/libpriv/rpmostree-editor.h
+++ b/src/libpriv/rpmostree-editor.h
@@ -27,7 +27,7 @@
 
 G_BEGIN_DECLS
 
-char *  ot_editor_prompt    (OstreeRepo *repo, const char *input,
-                             GCancellable *cancellable, GError **error);
+char *ot_editor_prompt (OstreeRepo *repo, const char *input, GCancellable *cancellable,
+                        GError **error);
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-importer.h
+++ b/src/libpriv/rpmostree-importer.h
@@ -23,16 +23,17 @@
 #include <ostree.h>
 
 #include "libglnx.h"
-#include <rpm/rpmlib.h>
 #include <libdnf/libdnf.h>
+#include <rpm/rpmlib.h>
 
 G_BEGIN_DECLS
 
 typedef struct RpmOstreeImporter RpmOstreeImporter;
 
-#define RPMOSTREE_TYPE_IMPORTER         (rpmostree_importer_get_type ())
-#define RPMOSTREE_IMPORTER(inst)        (G_TYPE_CHECK_INSTANCE_CAST ((inst), RPMOSTREE_TYPE_IMPORTER, RpmOstreeImporter))
-#define RPMOSTREE_IS_IMPORTER(inst)     (G_TYPE_CHECK_INSTANCE_TYPE ((inst), RPMOSTREE_TYPE_IMPORTER))
+#define RPMOSTREE_TYPE_IMPORTER (rpmostree_importer_get_type ())
+#define RPMOSTREE_IMPORTER(inst)                                                                   \
+  (G_TYPE_CHECK_INSTANCE_CAST ((inst), RPMOSTREE_TYPE_IMPORTER, RpmOstreeImporter))
+#define RPMOSTREE_IS_IMPORTER(inst) (G_TYPE_CHECK_INSTANCE_TYPE ((inst), RPMOSTREE_TYPE_IMPORTER))
 
 GType rpmostree_importer_get_type (void);
 
@@ -40,55 +41,38 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (RpmOstreeImporter, g_object_unref)
 
 /**
  * RpmOstreeImporterFlags:
- * @RPMOSTREE_IMPORTER_FLAGS_SKIP_EXTRANEOUS: Skip files/directories outside of supported ostree-compliant paths rather than erroring out
+ * @RPMOSTREE_IMPORTER_FLAGS_SKIP_EXTRANEOUS: Skip files/directories outside of supported
+ * ostree-compliant paths rather than erroring out
  * @RPMOSTREE_IMPORTER_FLAGS_NODOCS: Skip documentation files
  * @RPMOSTREE_IMPORTER_FLAGS_RO_EXECUTABLES: Make executable files readonly
  */
-typedef enum {
-  RPMOSTREE_IMPORTER_FLAGS_SKIP_EXTRANEOUS =  (1 << 0),
-  RPMOSTREE_IMPORTER_FLAGS_NODOCS =  (1 << 1),
-  RPMOSTREE_IMPORTER_FLAGS_RO_EXECUTABLES =  (1 << 2),
+typedef enum
+{
+  RPMOSTREE_IMPORTER_FLAGS_SKIP_EXTRANEOUS = (1 << 0),
+  RPMOSTREE_IMPORTER_FLAGS_NODOCS = (1 << 1),
+  RPMOSTREE_IMPORTER_FLAGS_RO_EXECUTABLES = (1 << 2),
 } RpmOstreeImporterFlags;
 
-RpmOstreeImporter*
-rpmostree_importer_new_take_fd (int                     *fd,
-                                OstreeRepo              *repo,
-                                DnfPackage              *pkg,
-                                RpmOstreeImporterFlags   flags,
-                                OstreeSePolicy          *sepolicy,
-                                GError                 **error);
+RpmOstreeImporter *rpmostree_importer_new_take_fd (int *fd, OstreeRepo *repo, DnfPackage *pkg,
+                                                   RpmOstreeImporterFlags flags,
+                                                   OstreeSePolicy *sepolicy, GError **error);
 
-gboolean
-rpmostree_importer_read_metainfo (int fd,
-                                  Header *out_header,
-                                  gsize *out_cpio_offset,
-                                  rpmfi *out_fi,
-                                  GError **error);
+gboolean rpmostree_importer_read_metainfo (int fd, Header *out_header, gsize *out_cpio_offset,
+                                           rpmfi *out_fi, GError **error);
 
-const char*
-rpmostree_importer_get_ostree_branch (RpmOstreeImporter *unpacker);
+const char *rpmostree_importer_get_ostree_branch (RpmOstreeImporter *unpacker);
 
-gboolean
-rpmostree_importer_run (RpmOstreeImporter *unpacker,
-                        char             **out_commit,
-                        GCancellable      *cancellable,
-                        GError           **error);
+gboolean rpmostree_importer_run (RpmOstreeImporter *unpacker, char **out_commit,
+                                 GCancellable *cancellable, GError **error);
 
-void
-rpmostree_importer_run_async (RpmOstreeImporter  *unpacker,
-                              GCancellable       *cancellable,
-                              GAsyncReadyCallback callback,
-                              gpointer            user_data);
+void rpmostree_importer_run_async (RpmOstreeImporter *unpacker, GCancellable *cancellable,
+                                   GAsyncReadyCallback callback, gpointer user_data);
 
-char *
-rpmostree_importer_run_async_finish (RpmOstreeImporter  *self,
-                                     GAsyncResult       *res,
-                                     GError            **error);
+char *rpmostree_importer_run_async_finish (RpmOstreeImporter *self, GAsyncResult *res,
+                                           GError **error);
 
-char *
-rpmostree_importer_get_nevra (RpmOstreeImporter *self);
+char *rpmostree_importer_get_nevra (RpmOstreeImporter *self);
 
-const char *
-rpmostree_importer_get_header_sha256 (RpmOstreeImporter *self);
+const char *rpmostree_importer_get_header_sha256 (RpmOstreeImporter *self);
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-json-parsing.cxx
+++ b/src/libpriv/rpmostree-json-parsing.cxx
@@ -20,17 +20,15 @@
 
 #include "config.h"
 
-#include "rpmostree-json-parsing.h"
 #include "libglnx.h"
+#include "rpmostree-json-parsing.h"
 
-#include <string.h>
 #include <glib-unix.h>
+#include <string.h>
 
 gboolean
-_rpmostree_jsonutil_object_get_optional_string_member (JsonObject     *object,
-                                                       const char     *member_name,
-                                                       const char    **out_value,
-                                                       GError        **error)
+_rpmostree_jsonutil_object_get_optional_string_member (JsonObject *object, const char *member_name,
+                                                       const char **out_value, GError **error)
 {
   *out_value = NULL;
 
@@ -49,23 +47,20 @@ _rpmostree_jsonutil_object_get_optional_string_member (JsonObject     *object,
 }
 
 const char *
-_rpmostree_jsonutil_object_require_string_member (JsonObject     *object,
-                                                  const char     *member_name,
-                                                  GError        **error)
+_rpmostree_jsonutil_object_require_string_member (JsonObject *object, const char *member_name,
+                                                  GError **error)
 {
   const char *ret;
   if (!_rpmostree_jsonutil_object_get_optional_string_member (object, member_name, &ret, error))
     return NULL;
   if (!ret)
-    return (char*)glnx_null_throw (error, "Member '%s' not found", member_name);
+    return (char *)glnx_null_throw (error, "Member '%s' not found", member_name);
   return ret;
 }
 
 gboolean
-_rpmostree_jsonutil_object_get_optional_boolean_member (JsonObject     *object,
-                                                       const char     *member_name,
-                                                       gboolean       *out_value,
-                                                       GError        **error)
+_rpmostree_jsonutil_object_get_optional_boolean_member (JsonObject *object, const char *member_name,
+                                                        gboolean *out_value, GError **error)
 {
   if (!object)
     return TRUE;
@@ -82,12 +77,10 @@ _rpmostree_jsonutil_object_get_optional_boolean_member (JsonObject     *object,
 }
 
 const char *
-_rpmostree_jsonutil_array_require_string_element (JsonArray      *array,
-                                                  guint           i,
-                                                  GError        **error)
+_rpmostree_jsonutil_array_require_string_element (JsonArray *array, guint i, GError **error)
 {
   const char *ret = json_array_get_string_element (array, i);
   if (!ret)
-    return (char*)glnx_null_throw (error, "Element at index %u is not a string", i);
+    return (char *)glnx_null_throw (error, "Element at index %u is not a string", i);
   return ret;
 }

--- a/src/libpriv/rpmostree-json-parsing.h
+++ b/src/libpriv/rpmostree-json-parsing.h
@@ -25,25 +25,20 @@
 
 G_BEGIN_DECLS
 
-gboolean
-_rpmostree_jsonutil_object_get_optional_string_member (JsonObject     *object,
-                                                       const char     *member_name,
-                                                       const char    **out_value,
-                                                       GError        **error);
+gboolean _rpmostree_jsonutil_object_get_optional_string_member (JsonObject *object,
+                                                                const char *member_name,
+                                                                const char **out_value,
+                                                                GError **error);
 
-const char *
-_rpmostree_jsonutil_object_require_string_member (JsonObject     *object,
-                                                  const char     *member_name,
-                                                  GError        **error);
+const char *_rpmostree_jsonutil_object_require_string_member (JsonObject *object,
+                                                              const char *member_name,
+                                                              GError **error);
 
-gboolean
-_rpmostree_jsonutil_object_get_optional_boolean_member (JsonObject     *object,
-                                                       const char     *member_name,
-                                                       gboolean       *out_value,
-                                                       GError        **error);
+gboolean _rpmostree_jsonutil_object_get_optional_boolean_member (JsonObject *object,
+                                                                 const char *member_name,
+                                                                 gboolean *out_value,
+                                                                 GError **error);
 
-const char *
-_rpmostree_jsonutil_array_require_string_element (JsonArray      *array,
-                                                  guint           i,
-                                                  GError        **error);
+const char *_rpmostree_jsonutil_array_require_string_element (JsonArray *array, guint i,
+                                                              GError **error);
 G_END_DECLS

--- a/src/libpriv/rpmostree-kernel.cxx
+++ b/src/libpriv/rpmostree-kernel.cxx
@@ -22,21 +22,21 @@
 
 #include "string.h"
 
-#include <ostree.h>
-#include <errno.h>
-#include <stdio.h>
-#include <utime.h>
 #include <err.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <libglnx.h>
-#include <stdlib.h>
+#include <errno.h>
 #include <gio/gunixinputstream.h>
 #include <gio/gunixoutputstream.h>
+#include <libglnx.h>
+#include <ostree.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <utime.h>
 
 #include "rpmostree-core.h"
-#include "rpmostree-kernel.h"
 #include "rpmostree-cxxrs.h"
+#include "rpmostree-kernel.h"
 #include "rpmostree-util.h"
 
 static const char usrlib_ostreeboot[] = "usr/lib/ostree-boot";
@@ -46,17 +46,16 @@ static const char usrlib_ostreeboot[] = "usr/lib/ostree-boot";
  * to support grabbing wherever the Fedora kernel RPM dropped files as well.
  */
 static gboolean
-find_kernel_and_initramfs_in_bootdir (int          rootfs_dfd,
-                                      const char  *bootdir,
-                                      char       **out_kernel,
-                                      char       **out_initramfs,
-                                      GCancellable *cancellable,
-                                      GError     **error)
+find_kernel_and_initramfs_in_bootdir (int rootfs_dfd, const char *bootdir, char **out_kernel,
+                                      char **out_initramfs, GCancellable *cancellable,
+                                      GError **error)
 {
-  g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
+  g_auto (GLnxDirFdIterator) dfd_iter = {
+    0,
+  };
   glnx_autofd int dfd = -1;
-  g_autofree char* ret_kernel = NULL;
-  g_autofree char* ret_initramfs = NULL;
+  g_autofree char *ret_kernel = NULL;
+  g_autofree char *ret_initramfs = NULL;
 
   *out_kernel = *out_initramfs = NULL;
 
@@ -111,14 +110,13 @@ find_kernel_and_initramfs_in_bootdir (int          rootfs_dfd,
  * return an error.
  */
 static gboolean
-find_ensure_one_subdirectory (int            rootfs_dfd,
-                              const char    *subpath,
-                              char         **out_subdir,
-                              GCancellable  *cancellable,
-                              GError       **error)
+find_ensure_one_subdirectory (int rootfs_dfd, const char *subpath, char **out_subdir,
+                              GCancellable *cancellable, GError **error)
 {
   g_autofree char *ret_subdir = NULL;
-  g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
+  g_auto (GLnxDirFdIterator) dfd_iter = {
+    0,
+  };
 
   if (!glnx_dirfd_iterator_init_at (rootfs_dfd, subpath, TRUE, &dfd_iter, error))
     return FALSE;
@@ -138,7 +136,8 @@ find_ensure_one_subdirectory (int            rootfs_dfd,
       if (ret_subdir)
         {
           g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                       "Multiple subdirectories found in: %s: %s %s", subpath, glnx_basename (ret_subdir), dent->d_name);
+                       "Multiple subdirectories found in: %s: %s %s", subpath,
+                       glnx_basename (ret_subdir), dent->d_name);
           return FALSE;
         }
       ret_subdir = g_strconcat (subpath, "/", dent->d_name, NULL);
@@ -149,15 +148,11 @@ find_ensure_one_subdirectory (int            rootfs_dfd,
 }
 
 static gboolean
-kernel_remove_in (int rootfs_dfd,
-                  const char *bootdir,
-                  GCancellable *cancellable,
-                  GError **error)
+kernel_remove_in (int rootfs_dfd, const char *bootdir, GCancellable *cancellable, GError **error)
 {
-  g_autofree char* kernel_path = NULL;
-  g_autofree char* initramfs_path = NULL;
-  if (!find_kernel_and_initramfs_in_bootdir (rootfs_dfd, bootdir,
-                                             &kernel_path, &initramfs_path,
+  g_autofree char *kernel_path = NULL;
+  g_autofree char *initramfs_path = NULL;
+  if (!find_kernel_and_initramfs_in_bootdir (rootfs_dfd, bootdir, &kernel_path, &initramfs_path,
                                              cancellable, error))
     return FALSE;
 
@@ -173,7 +168,6 @@ kernel_remove_in (int rootfs_dfd,
     }
 
   return TRUE;
-
 }
 
 /* Given a root filesystem, delete all kernel/initramfs data from it.
@@ -182,13 +176,11 @@ kernel_remove_in (int rootfs_dfd,
  * Used by `rpm-ostree override replace ./kernel-42.x86_64.rpm`.
  */
 gboolean
-rpmostree_kernel_remove (int rootfs_dfd,
-                         GCancellable *cancellable,
-                         GError **error)
+rpmostree_kernel_remove (int rootfs_dfd, GCancellable *cancellable, GError **error)
 {
-  g_autofree char* modversion_dir = NULL;
-  if (!find_ensure_one_subdirectory (rootfs_dfd, "usr/lib/modules",
-                                     &modversion_dir, cancellable, error))
+  g_autofree char *modversion_dir = NULL;
+  if (!find_ensure_one_subdirectory (rootfs_dfd, "usr/lib/modules", &modversion_dir, cancellable,
+                                     error))
     return FALSE;
   if (modversion_dir)
     {
@@ -205,9 +197,11 @@ rpmostree_kernel_remove (int rootfs_dfd,
        * See also `/usr/lib/kernel/install.d/50-depmod.install`
        * which is run by `kernel-install remove` from RPM `%postun`.
        */
-      const char *depmod_files[] = {"modules.alias", "modules.alias.bin", "modules.builtin.alias.bin", "modules.builtin.bin",
-                                    "modules.dep", "modules.dep.bin", "modules.devname",
-                                    "modules.softdep", "modules.symbols", "modules.symbols.bin" };
+      const char *depmod_files[]
+          = { "modules.alias",       "modules.alias.bin", "modules.builtin.alias.bin",
+              "modules.builtin.bin", "modules.dep",       "modules.dep.bin",
+              "modules.devname",     "modules.softdep",   "modules.symbols",
+              "modules.symbols.bin" };
       for (guint i = 0; i < G_N_ELEMENTS (depmod_files); i++)
         {
           const char *name = depmod_files[i];
@@ -233,27 +227,24 @@ rpmostree_kernel_remove (int rootfs_dfd,
  *  - initramfs_path: Relative (to rootfs) path to initramfs (may be NULL if no initramfs)
  */
 GVariant *
-rpmostree_find_kernel (int rootfs_dfd,
-                       GCancellable *cancellable,
-                       GError **error)
+rpmostree_find_kernel (int rootfs_dfd, GCancellable *cancellable, GError **error)
 {
   /* Fetch the kver from /usr/lib/modules */
-  g_autofree char* modversion_dir = NULL;
-  if (!find_ensure_one_subdirectory (rootfs_dfd, "usr/lib/modules",
-                                     &modversion_dir, cancellable, error))
+  g_autofree char *modversion_dir = NULL;
+  if (!find_ensure_one_subdirectory (rootfs_dfd, "usr/lib/modules", &modversion_dir, cancellable,
+                                     error))
     return NULL;
 
   if (!modversion_dir)
-    return (GVariant*)glnx_null_throw (error, "/usr/lib/modules is empty");
+    return (GVariant *)glnx_null_throw (error, "/usr/lib/modules is empty");
 
   const char *kver = glnx_basename (modversion_dir);
 
   /* First, look for the kernel in the canonical ostree directory */
-  g_autofree char* kernel_path = NULL;
-  g_autofree char* initramfs_path = NULL;
+  g_autofree char *kernel_path = NULL;
+  g_autofree char *initramfs_path = NULL;
   g_autofree char *bootdir = g_strdup (usrlib_ostreeboot);
-  if (!find_kernel_and_initramfs_in_bootdir (rootfs_dfd, bootdir,
-                                             &kernel_path, &initramfs_path,
+  if (!find_kernel_and_initramfs_in_bootdir (rootfs_dfd, bootdir, &kernel_path, &initramfs_path,
                                              cancellable, error))
     return NULL;
 
@@ -263,8 +254,7 @@ rpmostree_find_kernel (int rootfs_dfd,
       g_free (bootdir);
       bootdir = g_strdup ("boot");
 
-      if (!find_kernel_and_initramfs_in_bootdir (rootfs_dfd, bootdir,
-                                                 &kernel_path, &initramfs_path,
+      if (!find_kernel_and_initramfs_in_bootdir (rootfs_dfd, bootdir, &kernel_path, &initramfs_path,
                                                  cancellable, error))
         return NULL;
     }
@@ -274,15 +264,16 @@ rpmostree_find_kernel (int rootfs_dfd,
     {
       g_free (bootdir);
       bootdir = util::move_nullify (modversion_dir);
-      if (!find_kernel_and_initramfs_in_bootdir (rootfs_dfd, bootdir,
-                                                 &kernel_path, &initramfs_path,
+      if (!find_kernel_and_initramfs_in_bootdir (rootfs_dfd, bootdir, &kernel_path, &initramfs_path,
                                                  cancellable, error))
         return NULL;
     }
 
   if (kernel_path == NULL)
-    return (GVariant*)glnx_null_throw (error, "Unable to find kernel (vmlinuz) in /boot "
-                                              "or /usr/lib/modules (bootdir=%s)", bootdir);
+    return (GVariant *)glnx_null_throw (error,
+                                        "Unable to find kernel (vmlinuz) in /boot "
+                                        "or /usr/lib/modules (bootdir=%s)",
+                                        bootdir);
 
   return g_variant_ref_sink (g_variant_new ("(sssms)", kver, bootdir, kernel_path, initramfs_path));
 }
@@ -294,21 +285,15 @@ rpmostree_find_kernel (int rootfs_dfd,
  * if it isn't being used.
  */
 static gboolean
-copy_kernel_into (int rootfs_dfd,
-                  const char *kver,
-                  const char *boot_checksum_str,
-                  const char *kernel_modules_path,
-                  const char *initramfs_modules_path,
-                  gboolean only_if_found,
-                  const char *bootdir,
-                  GCancellable *cancellable,
+copy_kernel_into (int rootfs_dfd, const char *kver, const char *boot_checksum_str,
+                  const char *kernel_modules_path, const char *initramfs_modules_path,
+                  gboolean only_if_found, const char *bootdir, GCancellable *cancellable,
                   GError **error)
 {
   g_autofree char *legacy_kernel_path = NULL;
-  g_autofree char* legacy_initramfs_path = NULL;
-  if (!find_kernel_and_initramfs_in_bootdir (rootfs_dfd, bootdir,
-                                             &legacy_kernel_path, &legacy_initramfs_path,
-                                             cancellable, error))
+  g_autofree char *legacy_initramfs_path = NULL;
+  if (!find_kernel_and_initramfs_in_bootdir (rootfs_dfd, bootdir, &legacy_kernel_path,
+                                             &legacy_initramfs_path, cancellable, error))
     return FALSE;
 
   /* No kernel found? Skip to the next if we're in "auto"
@@ -335,7 +320,8 @@ copy_kernel_into (int rootfs_dfd,
         return FALSE;
       g_free (legacy_initramfs_path);
     }
-  legacy_initramfs_path = g_strconcat (bootdir, "/", "initramfs-", kver, ".img-", boot_checksum_str, NULL);
+  legacy_initramfs_path
+      = g_strconcat (bootdir, "/", "initramfs-", kver, ".img-", boot_checksum_str, NULL);
   if (linkat (rootfs_dfd, initramfs_modules_path, rootfs_dfd, legacy_initramfs_path, 0) < 0)
     return glnx_throw_errno_prefix (error, "linkat(%s)", legacy_initramfs_path);
 
@@ -347,13 +333,9 @@ copy_kernel_into (int rootfs_dfd,
  * /boot paths where we need to pre-compute their checksum.
  */
 gboolean
-rpmostree_finalize_kernel (int rootfs_dfd,
-                           const char *bootdir,
-                           const char *kver,
-                           const char *kernel_path,
-                           GLnxTmpfile *initramfs_tmpf,
-                           RpmOstreeFinalizeKernelDestination dest,
-                           GCancellable *cancellable,
+rpmostree_finalize_kernel (int rootfs_dfd, const char *bootdir, const char *kver,
+                           const char *kernel_path, GLnxTmpfile *initramfs_tmpf,
+                           RpmOstreeFinalizeKernelDestination dest, GCancellable *cancellable,
                            GError **error)
 {
   const char slash_bootdir[] = "boot";
@@ -363,20 +345,20 @@ rpmostree_finalize_kernel (int rootfs_dfd,
    * checksum"). We checksum the initramfs from the tmpfile fd (via mmap()) to
    * avoid writing it to disk in another temporary location.
    */
-  g_autoptr(GChecksum) boot_checksum = g_checksum_new (G_CHECKSUM_SHA256);
+  g_autoptr (GChecksum) boot_checksum = g_checksum_new (G_CHECKSUM_SHA256);
   if (!_rpmostree_util_update_checksum_from_file (boot_checksum, rootfs_dfd, kernel_path,
                                                   cancellable, error))
     return FALSE;
 
-  g_autofree char *initramfs_modules_path =
-    g_build_filename (modules_bootdir, "initramfs.img", NULL);
+  g_autofree char *initramfs_modules_path
+      = g_build_filename (modules_bootdir, "initramfs.img", NULL);
 
   if (initramfs_tmpf && initramfs_tmpf->initialized)
     {
-      g_autoptr(GMappedFile) mfile = g_mapped_file_new_from_fd (initramfs_tmpf->fd, FALSE, error);
+      g_autoptr (GMappedFile) mfile = g_mapped_file_new_from_fd (initramfs_tmpf->fd, FALSE, error);
       if (!mfile)
         return glnx_prefix_error (error, "mmap(initramfs)");
-      g_checksum_update (boot_checksum, (guint8*)g_mapped_file_get_contents (mfile),
+      g_checksum_update (boot_checksum, (guint8 *)g_mapped_file_get_contents (mfile),
                          g_mapped_file_get_length (mfile));
 
       /* Replace the initramfs */
@@ -385,17 +367,15 @@ rpmostree_finalize_kernel (int rootfs_dfd,
           if (errno != ENOENT)
             return glnx_throw_errno_prefix (error, "unlinkat(%s)", initramfs_modules_path);
         }
-      if (!glnx_link_tmpfile_at (initramfs_tmpf, GLNX_LINK_TMPFILE_NOREPLACE,
-                                 rootfs_dfd, initramfs_modules_path,
-                                 error))
+      if (!glnx_link_tmpfile_at (initramfs_tmpf, GLNX_LINK_TMPFILE_NOREPLACE, rootfs_dfd,
+                                 initramfs_modules_path, error))
         return glnx_prefix_error (error, "Linking initramfs");
     }
   else
     {
       /* we're not replacing the initramfs; use built-in one */
       if (!_rpmostree_util_update_checksum_from_file (boot_checksum, rootfs_dfd,
-                                                      initramfs_modules_path, cancellable,
-                                                      error))
+                                                      initramfs_modules_path, cancellable, error))
         return FALSE;
     }
 
@@ -431,16 +411,15 @@ rpmostree_finalize_kernel (int rootfs_dfd,
     return FALSE;
   if (errno == 0)
     {
-      g_autofree char *contents = glnx_file_get_contents_utf8_at (rootfs_dfd, hmac_path,
-                                                                  NULL, cancellable, error);
+      g_autofree char *contents
+          = glnx_file_get_contents_utf8_at (rootfs_dfd, hmac_path, NULL, cancellable, error);
       if (contents == NULL)
         return FALSE;
 
       /* rather than trying to parse and understand the *sum format, just hackily replace */
       g_autofree char *old_path = g_strconcat ("  /boot/vmlinuz-", kver, NULL);
       g_autofree char *new_path = g_strconcat ("  vmlinuz-", kver, NULL);
-      g_autofree char *new_contents =
-        rpmostree_str_replace (contents, old_path, new_path, error);
+      g_autofree char *new_contents = rpmostree_str_replace (contents, old_path, new_path, error);
       if (!new_contents)
         return FALSE;
 
@@ -449,9 +428,9 @@ rpmostree_finalize_kernel (int rootfs_dfd,
       if (strchr (new_contents, '/') != 0)
         return glnx_throw (error, "Unexpected / in .vmlinuz.hmac: %s", new_contents);
 
-      if (!glnx_file_replace_contents_at (rootfs_dfd, hmac_path,
-                                          (guint8*)new_contents, -1, static_cast<GLnxFileReplaceFlags>(0),
-                                          cancellable, error))
+      if (!glnx_file_replace_contents_at (rootfs_dfd, hmac_path, (guint8 *)new_contents, -1,
+                                          static_cast<GLnxFileReplaceFlags> (0), cancellable,
+                                          error))
         return FALSE;
     }
 
@@ -459,69 +438,64 @@ rpmostree_finalize_kernel (int rootfs_dfd,
   const gboolean only_if_found = (dest == RPMOSTREE_FINALIZE_KERNEL_AUTO);
   if (only_if_found || dest >= RPMOSTREE_FINALIZE_KERNEL_USRLIB_OSTREEBOOT)
     {
-      if (!copy_kernel_into (rootfs_dfd, kver, boot_checksum_str,
-                             kernel_modules_path, initramfs_modules_path,
-                             only_if_found, usrlib_ostreeboot,
-                             cancellable, error))
+      if (!copy_kernel_into (rootfs_dfd, kver, boot_checksum_str, kernel_modules_path,
+                             initramfs_modules_path, only_if_found, usrlib_ostreeboot, cancellable,
+                             error))
         return FALSE;
     }
   if (only_if_found || dest >= RPMOSTREE_FINALIZE_KERNEL_SLASH_BOOT)
     {
-      if (!copy_kernel_into (rootfs_dfd, kver, boot_checksum_str,
-                             kernel_modules_path, initramfs_modules_path,
-                             only_if_found, slash_bootdir,
-                             cancellable, error))
+      if (!copy_kernel_into (rootfs_dfd, kver, boot_checksum_str, kernel_modules_path,
+                             initramfs_modules_path, only_if_found, slash_bootdir, cancellable,
+                             error))
         return FALSE;
     }
   return TRUE;
 }
 
-struct Unlinker {
+struct Unlinker
+{
   int rootfs_dfd;
   const char *path;
 
-  ~Unlinker() {
-    (void) unlinkat (rootfs_dfd, path, 0);
-  }
+  ~Unlinker () { (void)unlinkat (rootfs_dfd, path, 0); }
 };
 
 gboolean
-rpmostree_run_dracut (int     rootfs_dfd,
-                      const char *const* argv,
-                      const char *kver,
-                      const char *rebuild_from_initramfs,
-                      gboolean     use_root_etc,
-                      GLnxTmpDir  *dracut_host_tmpdir,
-                      GLnxTmpfile *out_initramfs_tmpf,
-                      GCancellable  *cancellable,
-                      GError **error)
+rpmostree_run_dracut (int rootfs_dfd, const char *const *argv, const char *kver,
+                      const char *rebuild_from_initramfs, gboolean use_root_etc,
+                      GLnxTmpDir *dracut_host_tmpdir, GLnxTmpfile *out_initramfs_tmpf,
+                      GCancellable *cancellable, GError **error)
 {
-  auto destdir = rpmostreecxx::cliwrap_destdir();
+  auto destdir = rpmostreecxx::cliwrap_destdir ();
   /* Shell wrapper around dracut to write to the O_TMPFILE fd;
    * at some point in the future we should add --fd X instead of -f
    * to dracut.
    */
   static const char rpmostree_dracut_wrapper_path[] = "usr/bin/rpmostree-dracut-wrapper";
   /* This also hardcodes a few arguments */
-  g_autofree char * rpmostree_dracut_wrapper =
-    g_strdup_printf (
-    "#!/usr/bin/bash\n"
-    "set -euo pipefail\n"
-    "export PATH=%s:${PATH}\n"
-    "extra_argv=; if (dracut --help; true) | grep -q -e --reproducible; then extra_argv=\"--reproducible --gzip\"; fi\n"
-    "mkdir -p /tmp/dracut && dracut $extra_argv -v --add ostree --tmpdir=/tmp/dracut -f /tmp/initramfs.img \"$@\"\n"
-    "cat /tmp/initramfs.img >/proc/self/fd/3\n",
-    destdir.c_str());
-  g_autoptr(GPtrArray) rebuild_argv = NULL;
-  g_auto(GLnxTmpfile) tmpf = { 0, };
+  g_autofree char *rpmostree_dracut_wrapper
+      = g_strdup_printf ("#!/usr/bin/bash\n"
+                         "set -euo pipefail\n"
+                         "export PATH=%s:${PATH}\n"
+                         "extra_argv=; if (dracut --help; true) | grep -q -e --reproducible; then "
+                         "extra_argv=\"--reproducible --gzip\"; fi\n"
+                         "mkdir -p /tmp/dracut && dracut $extra_argv -v --add ostree "
+                         "--tmpdir=/tmp/dracut -f /tmp/initramfs.img \"$@\"\n"
+                         "cat /tmp/initramfs.img >/proc/self/fd/3\n",
+                         destdir.c_str ());
+  g_autoptr (GPtrArray) rebuild_argv = NULL;
+  g_auto (GLnxTmpfile) tmpf = {
+    0,
+  };
 
   /* We need to have /etc/passwd since dracut doesn't have altfiles
    * today.  Though maybe in the future we should add it, but
    * in the end we want to use systemd-sysusers of course.
    **/
-  auto etc_guard = CXX_TRY_VAL(prepare_tempetc_guard (rootfs_dfd), error);
+  auto etc_guard = CXX_TRY_VAL (prepare_tempetc_guard (rootfs_dfd), error);
 
-  gboolean have_passwd = CXX_TRY_VAL(prepare_rpm_layering (rootfs_dfd, ""), error);
+  gboolean have_passwd = CXX_TRY_VAL (prepare_rpm_layering (rootfs_dfd, ""), error);
 
   /* Note rebuild_from_initramfs now is only used as a fallback in the client-side regen
    * path when we can't fetch the canonical initramfs args to use. */
@@ -529,69 +503,64 @@ rpmostree_run_dracut (int     rootfs_dfd,
   if (rebuild_from_initramfs)
     {
       rebuild_argv = g_ptr_array_new ();
-      g_ptr_array_add (rebuild_argv, (char*)"--rebuild");
-      g_ptr_array_add (rebuild_argv, (char*)rebuild_from_initramfs);
+      g_ptr_array_add (rebuild_argv, (char *)"--rebuild");
+      g_ptr_array_add (rebuild_argv, (char *)rebuild_from_initramfs);
 
       /* In this case, any args specified in argv are *additional*
        * to the rebuild from the base.
        */
-      for (char **iter = (char**)argv; iter && *iter; iter++)
+      for (char **iter = (char **)argv; iter && *iter; iter++)
         g_ptr_array_add (rebuild_argv, *iter);
       g_ptr_array_add (rebuild_argv, NULL);
-      argv = (const char *const*)rebuild_argv->pdata;
+      argv = (const char *const *)rebuild_argv->pdata;
     }
 
   /* First tempfile is just our shell script */
-  if (!glnx_open_tmpfile_linkable_at (rootfs_dfd, "usr/bin",
-                                      O_RDWR | O_CLOEXEC,
-                                      &tmpf, error))
+  if (!glnx_open_tmpfile_linkable_at (rootfs_dfd, "usr/bin", O_RDWR | O_CLOEXEC, &tmpf, error))
     return FALSE;
   if (glnx_loop_write (tmpf.fd, rpmostree_dracut_wrapper, strlen (rpmostree_dracut_wrapper)) < 0
       || fchmod (tmpf.fd, 0755) < 0)
     return glnx_throw_errno_prefix (error, "writing");
 
-  if (!glnx_link_tmpfile_at (&tmpf, GLNX_LINK_TMPFILE_NOREPLACE,
-                             rootfs_dfd, rpmostree_dracut_wrapper_path,
-                             error))
+  if (!glnx_link_tmpfile_at (&tmpf, GLNX_LINK_TMPFILE_NOREPLACE, rootfs_dfd,
+                             rpmostree_dracut_wrapper_path, error))
     return FALSE;
   /* Close the fd now, otherwise an exec will fail */
   glnx_tmpfile_clear (&tmpf);
 
-  auto unlinker = Unlinker{ .rootfs_dfd=rootfs_dfd, .path=rpmostree_dracut_wrapper_path };
+  auto unlinker = Unlinker{ .rootfs_dfd = rootfs_dfd, .path = rpmostree_dracut_wrapper_path };
 
   /* Second tempfile is the initramfs contents.  Note we generate the tmpfile
    * in . since in the current rpm-ostree design the temporary rootfs may not have tmp/
    * as a real mountpoint.
    */
-  if (!glnx_open_tmpfile_linkable_at (rootfs_dfd, ".",
-                                      O_RDWR | O_CLOEXEC,
-                                      &tmpf, error))
+  if (!glnx_open_tmpfile_linkable_at (rootfs_dfd, ".", O_RDWR | O_CLOEXEC, &tmpf, error))
     return FALSE;
 
-  auto bwrap = CXX_TRY_VAL(bubblewrap_new(rootfs_dfd), error);
+  auto bwrap = CXX_TRY_VAL (bubblewrap_new (rootfs_dfd), error);
   if (use_root_etc)
     {
-      bwrap->bind_read("/etc", "/etc");
-      bwrap->bind_read("usr", "/usr");
+      bwrap->bind_read ("/etc", "/etc");
+      bwrap->bind_read ("usr", "/usr");
     }
   else
     {
-      bwrap->bind_read("usr/etc", "/etc");
-      bwrap->bind_read("usr", "/usr");
+      bwrap->bind_read ("usr/etc", "/etc");
+      bwrap->bind_read ("usr", "/usr");
     }
 
   if (dracut_host_tmpdir)
-    bwrap->bind_readwrite(dracut_host_tmpdir->path, "/tmp/dracut");
+    bwrap->bind_readwrite (dracut_host_tmpdir->path, "/tmp/dracut");
 
   /* Set up argv and run */
-  bwrap->append_child_arg((const char*)glnx_basename (rpmostree_dracut_wrapper_path));
-  for (char **iter = (char**)argv; iter && *iter; iter++)
-    bwrap->append_child_arg(*iter);
+  bwrap->append_child_arg ((const char *)glnx_basename (rpmostree_dracut_wrapper_path));
+  for (char **iter = (char **)argv; iter && *iter; iter++)
+    bwrap->append_child_arg (*iter);
 
   if (kver)
     {
-      bwrap->append_child_arg("--kver");
-      bwrap->append_child_arg(kver);
+      bwrap->append_child_arg ("--kver");
+      bwrap->append_child_arg (kver);
     }
 
   // Pass the tempfile to the child as fd 3
@@ -600,7 +569,7 @@ rpmostree_run_dracut (int     rootfs_dfd,
     return glnx_throw_errno_prefix (error, "fnctl");
   bwrap->take_fd (glnx_steal_fd (&tmpf_child), 3);
 
-  bwrap->run(*cancellable);
+  bwrap->run (*cancellable);
 
   /* For FIPS mode we need /dev/urandom pre-created because the FIPS
    * standards authors require that randomness is tested in a
@@ -613,17 +582,18 @@ rpmostree_run_dracut (int     rootfs_dfd,
   auto random_cpio_data = rpmostreecxx::get_dracut_random_cpio ();
   if (lseek (tmpf.fd, 0, SEEK_END) < 0)
     return glnx_throw_errno_prefix (error, "lseek");
-  if (glnx_loop_write (tmpf.fd, random_cpio_data.data(), random_cpio_data.length()) < 0)
+  if (glnx_loop_write (tmpf.fd, random_cpio_data.data (), random_cpio_data.length ()) < 0)
     return glnx_throw_errno_prefix (error, "write");
 
   if (rebuild_from_initramfs)
-    (void) unlinkat (rootfs_dfd, rebuild_from_initramfs, 0);
+    (void)unlinkat (rootfs_dfd, rebuild_from_initramfs, 0);
 
   if (have_passwd)
-    CXX_TRY(complete_rpm_layering (rootfs_dfd), error);
+    CXX_TRY (complete_rpm_layering (rootfs_dfd), error);
 
-  etc_guard->undo();
+  etc_guard->undo ();
 
-  *out_initramfs_tmpf = tmpf; tmpf.initialized = FALSE; /* Transfer */
+  *out_initramfs_tmpf = tmpf;
+  tmpf.initialized = FALSE; /* Transfer */
   return TRUE;
 }

--- a/src/libpriv/rpmostree-kernel.h
+++ b/src/libpriv/rpmostree-kernel.h
@@ -24,42 +24,26 @@
 
 G_BEGIN_DECLS
 
-typedef enum {
+typedef enum
+{
   RPMOSTREE_FINALIZE_KERNEL_AUTO,
   RPMOSTREE_FINALIZE_KERNEL_USRLIB_MODULES,
   RPMOSTREE_FINALIZE_KERNEL_USRLIB_OSTREEBOOT,
   RPMOSTREE_FINALIZE_KERNEL_SLASH_BOOT,
 } RpmOstreeFinalizeKernelDestination;
 
-GVariant *
-rpmostree_find_kernel (int rootfs_dfd,
-                       GCancellable *cancellable,
-                       GError **error);
+GVariant *rpmostree_find_kernel (int rootfs_dfd, GCancellable *cancellable, GError **error);
 
-gboolean
-rpmostree_kernel_remove (int rootfs_dfd,
-                         GCancellable *cancellable,
-                         GError **error);
+gboolean rpmostree_kernel_remove (int rootfs_dfd, GCancellable *cancellable, GError **error);
 
-gboolean
-rpmostree_finalize_kernel (int rootfs_dfd,
-                           const char *bootdir,
-                           const char *kver,
-                           const char *kernel_path,
-                           GLnxTmpfile *initramfs_tmpf,
-                           RpmOstreeFinalizeKernelDestination dest,
-                           GCancellable *cancellable,
-                           GError **error);
+gboolean rpmostree_finalize_kernel (int rootfs_dfd, const char *bootdir, const char *kver,
+                                    const char *kernel_path, GLnxTmpfile *initramfs_tmpf,
+                                    RpmOstreeFinalizeKernelDestination dest,
+                                    GCancellable *cancellable, GError **error);
 
-gboolean
-rpmostree_run_dracut (int     rootfs_dfd,
-                      const char *const* argv,
-                      const char *kver,
-                      const char *rebuild_from_initramfs,
-                      gboolean     use_root_etc,
-                      GLnxTmpDir  *dracut_host_tmpdir,
-                      GLnxTmpfile *out_initramfs_tmpf,
-                      GCancellable  *cancellable,
-                      GError **error);
+gboolean rpmostree_run_dracut (int rootfs_dfd, const char *const *argv, const char *kver,
+                               const char *rebuild_from_initramfs, gboolean use_root_etc,
+                               GLnxTmpDir *dracut_host_tmpdir, GLnxTmpfile *out_initramfs_tmpf,
+                               GCancellable *cancellable, GError **error);
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-libarchive-input-stream.cxx
+++ b/src/libpriv/rpmostree-libarchive-input-stream.cxx
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2011 Colin Walters <walters@verbum.org>
  *
  * This library is free software; you can redistribute it and/or
@@ -19,38 +19,35 @@
 
 #include "config.h"
 
-
+#include "rpmostree-libarchive-input-stream.h"
 #include <archive.h>
 #include <gio/gio.h>
-#include "rpmostree-libarchive-input-stream.h"
 
-enum {
+enum
+{
   PROP_0,
   PROP_ARCHIVE
 };
 
-G_DEFINE_TYPE (RpmOstreeLibarchiveInputStream, _rpm_ostree_libarchive_input_stream, G_TYPE_INPUT_STREAM)
+G_DEFINE_TYPE (RpmOstreeLibarchiveInputStream, _rpm_ostree_libarchive_input_stream,
+               G_TYPE_INPUT_STREAM)
 
-struct _RpmOstreeLibarchiveInputStreamPrivate {
+struct _RpmOstreeLibarchiveInputStreamPrivate
+{
   struct archive *archive;
 };
 
-static void     rpm_ostree_libarchive_input_stream_set_property (GObject              *object,
-                                                                 guint                 prop_id,
-                                                                 const GValue         *value,
-                                                                 GParamSpec           *pspec);
-static void     rpm_ostree_libarchive_input_stream_get_property (GObject              *object,
-                                                                 guint                 prop_id,
-                                                                 GValue               *value,
-                                                                 GParamSpec           *pspec);
-static gssize   rpm_ostree_libarchive_input_stream_read         (GInputStream         *stream,
-                                                                 void                 *buffer,
-                                                                 gsize                 count,
-                                                                 GCancellable         *cancellable,
-                                                                 GError              **error);
-static gboolean rpm_ostree_libarchive_input_stream_close        (GInputStream         *stream,
-                                                                 GCancellable         *cancellable,
-                                                                 GError              **error);
+static void rpm_ostree_libarchive_input_stream_set_property (GObject *object, guint prop_id,
+                                                             const GValue *value,
+                                                             GParamSpec *pspec);
+static void rpm_ostree_libarchive_input_stream_get_property (GObject *object, guint prop_id,
+                                                             GValue *value, GParamSpec *pspec);
+static gssize rpm_ostree_libarchive_input_stream_read (GInputStream *stream, void *buffer,
+                                                       gsize count, GCancellable *cancellable,
+                                                       GError **error);
+static gboolean rpm_ostree_libarchive_input_stream_close (GInputStream *stream,
+                                                          GCancellable *cancellable,
+                                                          GError **error);
 
 static void
 rpm_ostree_libarchive_input_stream_finalize (GObject *object)
@@ -78,27 +75,22 @@ _rpm_ostree_libarchive_input_stream_class_init (RpmOstreeLibarchiveInputStreamCl
    *
    * The archive that the stream reads from.
    */
-  g_object_class_install_property (gobject_class,
-                                   PROP_ARCHIVE,
-                                   g_param_spec_pointer ("archive",
-                                                         "", "",
-                                                         (GParamFlags)(G_PARAM_READWRITE |
-                                                         G_PARAM_CONSTRUCT_ONLY |
-                                                         G_PARAM_STATIC_STRINGS)));
-
+  g_object_class_install_property (
+      gobject_class, PROP_ARCHIVE,
+      g_param_spec_pointer (
+          "archive", "", "",
+          (GParamFlags)(G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS)));
 }
 
 static void
-rpm_ostree_libarchive_input_stream_set_property (GObject         *object,
-               guint            prop_id,
-               const GValue    *value,
-               GParamSpec      *pspec)
+rpm_ostree_libarchive_input_stream_set_property (GObject *object, guint prop_id,
+                                                 const GValue *value, GParamSpec *pspec)
 {
   RpmOstreeLibarchiveInputStream *self = RPM_OSTREE_LIBARCHIVE_INPUT_STREAM (object);
   switch (prop_id)
     {
     case PROP_ARCHIVE:
-      self->priv->archive = static_cast<archive*>(g_value_get_pointer (value));
+      self->priv->archive = static_cast<archive *> (g_value_get_pointer (value));
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -107,10 +99,8 @@ rpm_ostree_libarchive_input_stream_set_property (GObject         *object,
 }
 
 static void
-rpm_ostree_libarchive_input_stream_get_property (GObject    *object,
-               guint       prop_id,
-               GValue     *value,
-               GParamSpec *pspec)
+rpm_ostree_libarchive_input_stream_get_property (GObject *object, guint prop_id, GValue *value,
+                                                 GParamSpec *pspec)
 {
   RpmOstreeLibarchiveInputStream *self = RPM_OSTREE_LIBARCHIVE_INPUT_STREAM (object);
 
@@ -127,25 +117,20 @@ rpm_ostree_libarchive_input_stream_get_property (GObject    *object,
 static void
 _rpm_ostree_libarchive_input_stream_init (RpmOstreeLibarchiveInputStream *self)
 {
-  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self,
-                                            RPM_OSTREE_TYPE_LIBARCHIVE_INPUT_STREAM,
+  self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, RPM_OSTREE_TYPE_LIBARCHIVE_INPUT_STREAM,
                                             RpmOstreeLibarchiveInputStreamPrivate);
-
 }
 
 GInputStream *
 _rpm_ostree_libarchive_input_stream_new (struct archive *a)
 {
-  return G_INPUT_STREAM (g_object_new (RPM_OSTREE_TYPE_LIBARCHIVE_INPUT_STREAM,
-                                       "archive", a, NULL));
+  return G_INPUT_STREAM (
+      g_object_new (RPM_OSTREE_TYPE_LIBARCHIVE_INPUT_STREAM, "archive", a, NULL));
 }
 
 static gssize
-rpm_ostree_libarchive_input_stream_read (GInputStream  *stream,
-             void          *buffer,
-             gsize          count,
-             GCancellable  *cancellable,
-             GError       **error)
+rpm_ostree_libarchive_input_stream_read (GInputStream *stream, void *buffer, gsize count,
+                                         GCancellable *cancellable, GError **error)
 {
   RpmOstreeLibarchiveInputStream *self = RPM_OSTREE_LIBARCHIVE_INPUT_STREAM (stream);
 
@@ -155,17 +140,16 @@ rpm_ostree_libarchive_input_stream_read (GInputStream  *stream,
   gssize res = archive_read_data (self->priv->archive, buffer, count);
   if (res < 0)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "%s", archive_error_string (self->priv->archive));
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "%s",
+                   archive_error_string (self->priv->archive));
     }
 
   return res;
 }
 
 static gboolean
-rpm_ostree_libarchive_input_stream_close (GInputStream  *stream,
-                                          GCancellable  *cancellable,
-                                          GError       **error)
+rpm_ostree_libarchive_input_stream_close (GInputStream *stream, GCancellable *cancellable,
+                                          GError **error)
 {
   return TRUE;
 }

--- a/src/libpriv/rpmostree-libarchive-input-stream.h
+++ b/src/libpriv/rpmostree-libarchive-input-stream.h
@@ -21,22 +21,30 @@
 
 #pragma once
 
-#include <gio/gio.h>
 #include <archive.h>
 #include <archive_entry.h>
+#include <gio/gio.h>
 
 G_BEGIN_DECLS
 
-#define RPM_OSTREE_TYPE_LIBARCHIVE_INPUT_STREAM         (_rpm_ostree_libarchive_input_stream_get_type ())
-#define RPM_OSTREE_LIBARCHIVE_INPUT_STREAM(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), RPM_OSTREE_TYPE_LIBARCHIVE_INPUT_STREAM, RpmOstreeLibarchiveInputStream))
-#define RPM_OSTREE_LIBARCHIVE_INPUT_STREAM_CLASS(k)     (G_TYPE_CHECK_CLASS_CAST((k), RPM_OSTREE_TYPE_LIBARCHIVE_INPUT_STREAM, RpmOstreeLibarchiveInputStreamClass))
-#define RPM_OSTREE_IS_LIBARCHIVE_INPUT_STREAM(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), RPM_OSTREE_TYPE_LIBARCHIVE_INPUT_STREAM))
-#define RPM_OSTREE_IS_LIBARCHIVE_INPUT_STREAM_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), RPM_OSTREE_TYPE_LIBARCHIVE_INPUT_STREAM))
-#define RPM_OSTREE_LIBARCHIVE_INPUT_STREAM_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), RPM_OSTREE_TYPE_LIBARCHIVE_INPUT_STREAM, RpmOstreeLibarchiveInputStreamClass))
+#define RPM_OSTREE_TYPE_LIBARCHIVE_INPUT_STREAM (_rpm_ostree_libarchive_input_stream_get_type ())
+#define RPM_OSTREE_LIBARCHIVE_INPUT_STREAM(o)                                                      \
+  (G_TYPE_CHECK_INSTANCE_CAST ((o), RPM_OSTREE_TYPE_LIBARCHIVE_INPUT_STREAM,                       \
+                               RpmOstreeLibarchiveInputStream))
+#define RPM_OSTREE_LIBARCHIVE_INPUT_STREAM_CLASS(k)                                                \
+  (G_TYPE_CHECK_CLASS_CAST ((k), RPM_OSTREE_TYPE_LIBARCHIVE_INPUT_STREAM,                          \
+                            RpmOstreeLibarchiveInputStreamClass))
+#define RPM_OSTREE_IS_LIBARCHIVE_INPUT_STREAM(o)                                                   \
+  (G_TYPE_CHECK_INSTANCE_TYPE ((o), RPM_OSTREE_TYPE_LIBARCHIVE_INPUT_STREAM))
+#define RPM_OSTREE_IS_LIBARCHIVE_INPUT_STREAM_CLASS(k)                                             \
+  (G_TYPE_CHECK_CLASS_TYPE ((k), RPM_OSTREE_TYPE_LIBARCHIVE_INPUT_STREAM))
+#define RPM_OSTREE_LIBARCHIVE_INPUT_STREAM_GET_CLASS(o)                                            \
+  (G_TYPE_INSTANCE_GET_CLASS ((o), RPM_OSTREE_TYPE_LIBARCHIVE_INPUT_STREAM,                        \
+                              RpmOstreeLibarchiveInputStreamClass))
 
-typedef struct _RpmOstreeLibarchiveInputStream         RpmOstreeLibarchiveInputStream;
-typedef struct _RpmOstreeLibarchiveInputStreamClass    RpmOstreeLibarchiveInputStreamClass;
-typedef struct _RpmOstreeLibarchiveInputStreamPrivate  RpmOstreeLibarchiveInputStreamPrivate;
+typedef struct _RpmOstreeLibarchiveInputStream RpmOstreeLibarchiveInputStream;
+typedef struct _RpmOstreeLibarchiveInputStreamClass RpmOstreeLibarchiveInputStreamClass;
+typedef struct _RpmOstreeLibarchiveInputStreamPrivate RpmOstreeLibarchiveInputStreamPrivate;
 
 struct _RpmOstreeLibarchiveInputStream
 {
@@ -59,8 +67,8 @@ struct _RpmOstreeLibarchiveInputStreamClass
   void (*_g_reserved5) (void);
 };
 
-GType          _rpm_ostree_libarchive_input_stream_get_type     (void) G_GNUC_CONST;
+GType _rpm_ostree_libarchive_input_stream_get_type (void) G_GNUC_CONST;
 
-GInputStream * _rpm_ostree_libarchive_input_stream_new          (struct archive  *a);
+GInputStream *_rpm_ostree_libarchive_input_stream_new (struct archive *a);
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -20,30 +20,25 @@
 
 #pragma once
 
-#include <ostree.h>
 #include "rpmostree-core.h"
+#include <ostree.h>
 
 G_BEGIN_DECLS
 
 typedef struct RpmOstreeOrigin RpmOstreeOrigin;
 RpmOstreeOrigin *rpmostree_origin_ref (RpmOstreeOrigin *origin);
 void rpmostree_origin_unref (RpmOstreeOrigin *origin);
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeOrigin, rpmostree_origin_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (RpmOstreeOrigin, rpmostree_origin_unref)
 
-RpmOstreeOrigin *
-rpmostree_origin_parse_keyfile (GKeyFile *keyfile,
-                                GError **error);
+RpmOstreeOrigin *rpmostree_origin_parse_keyfile (GKeyFile *keyfile, GError **error);
 
-static inline
-RpmOstreeOrigin *
-rpmostree_origin_parse_deployment (OstreeDeployment *deployment,
-                                   GError **error)
+static inline RpmOstreeOrigin *
+rpmostree_origin_parse_deployment (OstreeDeployment *deployment, GError **error)
 {
   GKeyFile *origin = ostree_deployment_get_origin (deployment);
   if (!origin)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "No origin known for deployment %s.%d",
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "No origin known for deployment %s.%d",
                    ostree_deployment_get_csum (deployment),
                    ostree_deployment_get_deployserial (deployment));
       return NULL;
@@ -51,173 +46,108 @@ rpmostree_origin_parse_deployment (OstreeDeployment *deployment,
   return rpmostree_origin_parse_keyfile (origin, error);
 }
 
-RpmOstreeOrigin *
-rpmostree_origin_dup (RpmOstreeOrigin *origin);
+RpmOstreeOrigin *rpmostree_origin_dup (RpmOstreeOrigin *origin);
 
-void
-rpmostree_origin_remove_transient_state (RpmOstreeOrigin *origin);
+void rpmostree_origin_remove_transient_state (RpmOstreeOrigin *origin);
 
-const char *
-rpmostree_origin_get_refspec (RpmOstreeOrigin *origin);
+const char *rpmostree_origin_get_refspec (RpmOstreeOrigin *origin);
 
-void
-rpmostree_origin_classify_refspec (RpmOstreeOrigin      *origin,
-                                   RpmOstreeRefspecType *out_type,
-                                   const char          **out_refspecdata);
+void rpmostree_origin_classify_refspec (RpmOstreeOrigin *origin, RpmOstreeRefspecType *out_type,
+                                        const char **out_refspecdata);
 
-char *
-rpmostree_origin_get_full_refspec (RpmOstreeOrigin *origin,
-                                   RpmOstreeRefspecType *out_refspectype);
+char *rpmostree_origin_get_full_refspec (RpmOstreeOrigin *origin,
+                                         RpmOstreeRefspecType *out_refspectype);
 
-void
-rpmostree_origin_get_custom_description (RpmOstreeOrigin *origin,
-                                         char           **custom_type,
-                                         char           **custom_description);
+void rpmostree_origin_get_custom_description (RpmOstreeOrigin *origin, char **custom_type,
+                                              char **custom_description);
 
-GHashTable *
-rpmostree_origin_get_packages (RpmOstreeOrigin *origin);
+GHashTable *rpmostree_origin_get_packages (RpmOstreeOrigin *origin);
 
-GHashTable *
-rpmostree_origin_get_modules_enable (RpmOstreeOrigin *origin);
+GHashTable *rpmostree_origin_get_modules_enable (RpmOstreeOrigin *origin);
 
-GHashTable *
-rpmostree_origin_get_modules_install (RpmOstreeOrigin *origin);
+GHashTable *rpmostree_origin_get_modules_install (RpmOstreeOrigin *origin);
 
-GHashTable *
-rpmostree_origin_get_local_packages (RpmOstreeOrigin *origin);
+GHashTable *rpmostree_origin_get_local_packages (RpmOstreeOrigin *origin);
 
-GHashTable *
-rpmostree_origin_get_local_fileoverride_packages (RpmOstreeOrigin *origin);
+GHashTable *rpmostree_origin_get_local_fileoverride_packages (RpmOstreeOrigin *origin);
 
-GHashTable *
-rpmostree_origin_get_overrides_remove (RpmOstreeOrigin *origin);
+GHashTable *rpmostree_origin_get_overrides_remove (RpmOstreeOrigin *origin);
 
-GHashTable *
-rpmostree_origin_get_overrides_local_replace (RpmOstreeOrigin *origin);
+GHashTable *rpmostree_origin_get_overrides_local_replace (RpmOstreeOrigin *origin);
 
-const char *
-rpmostree_origin_get_override_commit (RpmOstreeOrigin *origin);
+const char *rpmostree_origin_get_override_commit (RpmOstreeOrigin *origin);
 
-GHashTable *
-rpmostree_origin_get_initramfs_etc_files (RpmOstreeOrigin *origin);
+GHashTable *rpmostree_origin_get_initramfs_etc_files (RpmOstreeOrigin *origin);
 
-gboolean
-rpmostree_origin_get_regenerate_initramfs (RpmOstreeOrigin *origin);
+gboolean rpmostree_origin_get_regenerate_initramfs (RpmOstreeOrigin *origin);
 
-const char *const*
-rpmostree_origin_get_initramfs_args (RpmOstreeOrigin *origin);
+const char *const *rpmostree_origin_get_initramfs_args (RpmOstreeOrigin *origin);
 
-const char *
-rpmostree_origin_get_unconfigured_state (RpmOstreeOrigin *origin);
+const char *rpmostree_origin_get_unconfigured_state (RpmOstreeOrigin *origin);
 
-gboolean
-rpmostree_origin_may_require_local_assembly (RpmOstreeOrigin *origin);
+gboolean rpmostree_origin_may_require_local_assembly (RpmOstreeOrigin *origin);
 
-gboolean
-rpmostree_origin_has_packages (RpmOstreeOrigin *origin);
+gboolean rpmostree_origin_has_packages (RpmOstreeOrigin *origin);
 
-char *
-rpmostree_origin_get_string (RpmOstreeOrigin *origin,
-                             const char *section,
-                             const char *value);
+char *rpmostree_origin_get_string (RpmOstreeOrigin *origin, const char *section, const char *value);
 
-GKeyFile *
-rpmostree_origin_dup_keyfile (RpmOstreeOrigin *origin);
+GKeyFile *rpmostree_origin_dup_keyfile (RpmOstreeOrigin *origin);
 
-void
-rpmostree_origin_initramfs_etc_files_track (RpmOstreeOrigin *origin,
-                                            char **paths,
-                                            gboolean *out_changed);
+void rpmostree_origin_initramfs_etc_files_track (RpmOstreeOrigin *origin, char **paths,
+                                                 gboolean *out_changed);
 
-void
-rpmostree_origin_initramfs_etc_files_untrack (RpmOstreeOrigin *origin,
-                                              char **paths,
-                                              gboolean *out_changed);
+void rpmostree_origin_initramfs_etc_files_untrack (RpmOstreeOrigin *origin, char **paths,
+                                                   gboolean *out_changed);
 
-void
-rpmostree_origin_initramfs_etc_files_untrack_all (RpmOstreeOrigin *origin,
-                                                  gboolean *out_changed);
+void rpmostree_origin_initramfs_etc_files_untrack_all (RpmOstreeOrigin *origin,
+                                                       gboolean *out_changed);
 
-void
-rpmostree_origin_set_regenerate_initramfs (RpmOstreeOrigin *origin,
-                                           gboolean regenerate,
-                                           char **args);
+void rpmostree_origin_set_regenerate_initramfs (RpmOstreeOrigin *origin, gboolean regenerate,
+                                                char **args);
 
-void
-rpmostree_origin_set_override_commit (RpmOstreeOrigin *origin,
-                                      const char      *checksum,
-                                      const char      *version);
+void rpmostree_origin_set_override_commit (RpmOstreeOrigin *origin, const char *checksum,
+                                           const char *version);
 
-gboolean
-rpmostree_origin_get_cliwrap (RpmOstreeOrigin *origin);
-void
-rpmostree_origin_set_cliwrap (RpmOstreeOrigin *origin, gboolean cliwrap);
+gboolean rpmostree_origin_get_cliwrap (RpmOstreeOrigin *origin);
+void rpmostree_origin_set_cliwrap (RpmOstreeOrigin *origin, gboolean cliwrap);
 
-gboolean
-rpmostree_origin_set_rebase (RpmOstreeOrigin *origin,
-                             const char      *new_refspec,
-                             GError         **error);
-gboolean
-rpmostree_origin_set_rebase_custom (RpmOstreeOrigin *origin,
-                                    const char      *new_refspec,
-                                    const char      *custom_origin_url,
-                                    const char      *custom_origin_description,
-                                    GError         **error);
+gboolean rpmostree_origin_set_rebase (RpmOstreeOrigin *origin, const char *new_refspec,
+                                      GError **error);
+gboolean rpmostree_origin_set_rebase_custom (RpmOstreeOrigin *origin, const char *new_refspec,
+                                             const char *custom_origin_url,
+                                             const char *custom_origin_description, GError **error);
 
-gboolean
-rpmostree_origin_add_packages (RpmOstreeOrigin   *origin,
-                               char             **packages,
-                               gboolean           local,
-                               gboolean           fileoverride,
-                               gboolean           allow_existing,
-                               gboolean          *out_changed,
-                               GError           **error);
+gboolean rpmostree_origin_add_packages (RpmOstreeOrigin *origin, char **packages, gboolean local,
+                                        gboolean fileoverride, gboolean allow_existing,
+                                        gboolean *out_changed, GError **error);
 
-gboolean
-rpmostree_origin_remove_packages (RpmOstreeOrigin  *origin,
-                                  char            **packages,
-                                  gboolean          allow_noent,
-                                  gboolean         *out_changed,
-                                  GError          **error);
-gboolean
-rpmostree_origin_remove_all_packages (RpmOstreeOrigin  *origin,
-                                      gboolean         *out_changed,
-                                      GError          **error);
+gboolean rpmostree_origin_remove_packages (RpmOstreeOrigin *origin, char **packages,
+                                           gboolean allow_noent, gboolean *out_changed,
+                                           GError **error);
+gboolean rpmostree_origin_remove_all_packages (RpmOstreeOrigin *origin, gboolean *out_changed,
+                                               GError **error);
 
-gboolean
-rpmostree_origin_add_modules (RpmOstreeOrigin  *origin,
-                              char           **modules,
-                              gboolean         enable_only,
-                              gboolean        *out_changed,
-                              GError         **error);
+gboolean rpmostree_origin_add_modules (RpmOstreeOrigin *origin, char **modules,
+                                       gboolean enable_only, gboolean *out_changed, GError **error);
 
-gboolean
-rpmostree_origin_remove_modules (RpmOstreeOrigin  *origin,
-                                 char           **modules,
-                                 gboolean         enable_only,
-                                 gboolean        *out_changed,
-                                 GError         **error);
+gboolean rpmostree_origin_remove_modules (RpmOstreeOrigin *origin, char **modules,
+                                          gboolean enable_only, gboolean *out_changed,
+                                          GError **error);
 
-typedef enum {
+typedef enum
+{
   /* RPMOSTREE_ORIGIN_OVERRIDE_REPLACE, */
   RPMOSTREE_ORIGIN_OVERRIDE_REPLACE_LOCAL,
   RPMOSTREE_ORIGIN_OVERRIDE_REMOVE
 } RpmOstreeOriginOverrideType;
 
-gboolean
-rpmostree_origin_add_overrides (RpmOstreeOrigin  *origin,
-                                char            **packages,
-                                RpmOstreeOriginOverrideType type,
-                                GError          **error);
+gboolean rpmostree_origin_add_overrides (RpmOstreeOrigin *origin, char **packages,
+                                         RpmOstreeOriginOverrideType type, GError **error);
 
-gboolean
-rpmostree_origin_remove_override (RpmOstreeOrigin  *origin,
-                                  const char       *package,
-                                  RpmOstreeOriginOverrideType type);
+gboolean rpmostree_origin_remove_override (RpmOstreeOrigin *origin, const char *package,
+                                           RpmOstreeOriginOverrideType type);
 
-gboolean
-rpmostree_origin_remove_all_overrides (RpmOstreeOrigin  *origin,
-                                       gboolean         *out_changed,
-                                       GError          **error);
+gboolean rpmostree_origin_remove_all_overrides (RpmOstreeOrigin *origin, gboolean *out_changed,
+                                                GError **error);
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-output.cxx
+++ b/src/libpriv/rpmostree-output.cxx
@@ -1,30 +1,30 @@
 /*
-* Copyright (C) 2016 Red Hat, Inc.
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program; if not, write to the Free Software
-* Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
-*/
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 #include "config.h"
 
-#include <ostree.h>
 #include <libglnx.h>
 #include <memory>
+#include <ostree.h>
 
+#include "rpmostree-cxxrs.h"
 #include "rpmostree-output.h"
 #include "rpmostree-util.h"
-#include "rpmostree-cxxrs.h"
 
 /* These are helper functions that automatically determine whether data should
  * be sent through an appropriate D-Bus signal or sent directly to the local
@@ -32,64 +32,64 @@
  * from the daemon and daemon-less. */
 
 void
-rpmostree_output_default_handler (RpmOstreeOutputType type,
-                                  void *data,
-                                  void *opaque)
+rpmostree_output_default_handler (RpmOstreeOutputType type, void *data, void *opaque)
 {
   switch (type)
-  {
-  case RPMOSTREE_OUTPUT_MESSAGE:
-    g_print ("%s\n", ((RpmOstreeOutputMessage*)data)->text);
-    break;
-  case RPMOSTREE_OUTPUT_PROGRESS_BEGIN:
     {
-      auto begin = static_cast<RpmOstreeOutputProgressBegin *>(data);
-      if (begin->percent)
-        rpmostreecxx::console_progress_begin_percent (begin->prefix);
-      else if (begin->n > 0)
-        rpmostreecxx::console_progress_begin_n_items (begin->prefix, begin->n);
-      else
-        rpmostreecxx::console_progress_begin_task (begin->prefix);
-    }
-    break;
-  case RPMOSTREE_OUTPUT_PROGRESS_UPDATE:
-    {
-      auto upd = static_cast<RpmOstreeOutputProgressUpdate *>(data);
-      rpmostreecxx::console_progress_update (upd->c);
-    }
-    break;
-  case RPMOSTREE_OUTPUT_PROGRESS_SUB_MESSAGE:
-    {
-      auto msg = static_cast<const char *>(data);
-      rpmostreecxx::console_progress_set_sub_message (util::ruststr_or_empty(msg));
-    }
-    break;
-  case RPMOSTREE_OUTPUT_PROGRESS_END:
-    {
-      auto end = static_cast<RpmOstreeOutputProgressEnd *>(data);
-      rpmostreecxx::console_progress_end (util::ruststr_or_empty(end->msg));
+    case RPMOSTREE_OUTPUT_MESSAGE:
+      g_print ("%s\n", ((RpmOstreeOutputMessage *)data)->text);
       break;
+    case RPMOSTREE_OUTPUT_PROGRESS_BEGIN:
+      {
+        auto begin = static_cast<RpmOstreeOutputProgressBegin *> (data);
+        if (begin->percent)
+          rpmostreecxx::console_progress_begin_percent (begin->prefix);
+        else if (begin->n > 0)
+          rpmostreecxx::console_progress_begin_n_items (begin->prefix, begin->n);
+        else
+          rpmostreecxx::console_progress_begin_task (begin->prefix);
+      }
+      break;
+    case RPMOSTREE_OUTPUT_PROGRESS_UPDATE:
+      {
+        auto upd = static_cast<RpmOstreeOutputProgressUpdate *> (data);
+        rpmostreecxx::console_progress_update (upd->c);
+      }
+      break;
+    case RPMOSTREE_OUTPUT_PROGRESS_SUB_MESSAGE:
+      {
+        auto msg = static_cast<const char *> (data);
+        rpmostreecxx::console_progress_set_sub_message (util::ruststr_or_empty (msg));
+      }
+      break;
+    case RPMOSTREE_OUTPUT_PROGRESS_END:
+      {
+        auto end = static_cast<RpmOstreeOutputProgressEnd *> (data);
+        rpmostreecxx::console_progress_end (util::ruststr_or_empty (end->msg));
+        break;
+      }
     }
-  }
 }
 
-static void (*active_cb)(RpmOstreeOutputType, void*, void*) =
-  rpmostree_output_default_handler;
+static void (*active_cb) (RpmOstreeOutputType, void *, void *) = rpmostree_output_default_handler;
 
 static void *active_cb_opaque;
 
 void
-rpmostree_output_set_callback (void (*cb)(RpmOstreeOutputType, void*, void*),
-                               void* opaque)
+rpmostree_output_set_callback (void (*cb) (RpmOstreeOutputType, void *, void *), void *opaque)
 {
   active_cb = cb ?: rpmostree_output_default_handler;
   active_cb_opaque = opaque;
 }
 
-#define strdup_vprintf(format)                  \
-  ({ va_list args; va_start (args, format);     \
-     char *s = g_strdup_vprintf (format, args); \
-     va_end (args); s; })
+#define strdup_vprintf(format)                                                                     \
+  ({                                                                                               \
+    va_list args;                                                                                  \
+    va_start (args, format);                                                                       \
+    char *s = g_strdup_vprintf (format, args);                                                     \
+    va_end (args);                                                                                 \
+    s;                                                                                             \
+  })
 
 // For a lot of originally-C code it's just convenient to
 // use this global C-style format API and not have to deal
@@ -102,49 +102,50 @@ rpmostree_output_message (const char *format, ...)
   active_cb (RPMOSTREE_OUTPUT_MESSAGE, &task, active_cb_opaque);
 }
 
-namespace rpmostreecxx {
+namespace rpmostreecxx
+{
 
 void
 output_message (const rust::Str msg)
 {
-  auto msg_c = std::string(msg);
-  RpmOstreeOutputMessage task = { msg_c.c_str() };
+  auto msg_c = std::string (msg);
+  RpmOstreeOutputMessage task = { msg_c.c_str () };
   active_cb (RPMOSTREE_OUTPUT_MESSAGE, &task, active_cb_opaque);
 }
 
 // Begin a task (that can't easily be "nitems" or percentage).
 // This will render as a spinner.
-std::unique_ptr<Progress> 
-progress_begin_task(const rust::Str msg) noexcept
+std::unique_ptr<Progress>
+progress_begin_task (const rust::Str msg) noexcept
 {
-  auto msg_c = std::string(msg);
-  RpmOstreeOutputProgressBegin begin = { msg_c.c_str(), false, 0 };
+  auto msg_c = std::string (msg);
+  RpmOstreeOutputProgressBegin begin = { msg_c.c_str (), false, 0 };
   active_cb (RPMOSTREE_OUTPUT_PROGRESS_BEGIN, &begin, active_cb_opaque);
-  return std::make_unique<Progress>(ProgressType::TASK);
+  return std::make_unique<Progress> (ProgressType::TASK);
 }
 
 // When working on a task/percent/nitems, often we want to display a particular
 // item (such as a package).
-void 
-Progress::set_sub_message(const rust::Str msg)
+void
+Progress::set_sub_message (const rust::Str msg)
 {
-  g_autofree char *msg_c = util::ruststr_dup_c_optempty(msg);
-  active_cb (RPMOSTREE_OUTPUT_PROGRESS_SUB_MESSAGE, (void*)msg_c, active_cb_opaque);
+  g_autofree char *msg_c = util::ruststr_dup_c_optempty (msg);
+  active_cb (RPMOSTREE_OUTPUT_PROGRESS_SUB_MESSAGE, (void *)msg_c, active_cb_opaque);
 }
 
 // Start working on a 0-n task.
-std::unique_ptr<Progress> 
-progress_nitems_begin(guint n, const rust::Str msg) noexcept
+std::unique_ptr<Progress>
+progress_nitems_begin (guint n, const rust::Str msg) noexcept
 {
-  auto msg_c = std::string(msg);
-  RpmOstreeOutputProgressBegin begin = { msg_c.c_str(), false, n };
+  auto msg_c = std::string (msg);
+  RpmOstreeOutputProgressBegin begin = { msg_c.c_str (), false, n };
   active_cb (RPMOSTREE_OUTPUT_PROGRESS_BEGIN, &begin, active_cb_opaque);
-  return std::make_unique<Progress>(ProgressType::N_ITEMS);
+  return std::make_unique<Progress> (ProgressType::N_ITEMS);
 }
 
 // Update the nitems counter.
-void 
-Progress::nitems_update(guint n)
+void
+Progress::nitems_update (guint n)
 {
   RpmOstreeOutputProgressUpdate progress = { n };
   active_cb (RPMOSTREE_OUTPUT_PROGRESS_UPDATE, &progress, active_cb_opaque);
@@ -152,17 +153,17 @@ Progress::nitems_update(guint n)
 
 // Start a percentage task.
 std::unique_ptr<Progress>
-progress_percent_begin(const rust::Str msg) noexcept
+progress_percent_begin (const rust::Str msg) noexcept
 {
-  auto msg_c = std::string(msg);
-  RpmOstreeOutputProgressBegin begin = { msg_c.c_str(), true, 0 };
+  auto msg_c = std::string (msg);
+  RpmOstreeOutputProgressBegin begin = { msg_c.c_str (), true, 0 };
   active_cb (RPMOSTREE_OUTPUT_PROGRESS_BEGIN, &begin, active_cb_opaque);
-  return std::make_unique<Progress>(ProgressType::PERCENT);
+  return std::make_unique<Progress> (ProgressType::PERCENT);
 }
 
 // Update the percentage.
 void
-Progress::percent_update(guint n)
+Progress::percent_update (guint n)
 {
   RpmOstreeOutputProgressUpdate progress = { (guint)n };
   active_cb (RPMOSTREE_OUTPUT_PROGRESS_UPDATE, &progress, active_cb_opaque);
@@ -170,10 +171,10 @@ Progress::percent_update(guint n)
 
 // End the current task.
 void
-Progress::end(const rust::Str msg)
+Progress::end (const rust::Str msg)
 {
   g_assert (!this->ended);
-  g_autofree char *final_msg = util::ruststr_dup_c_optempty(msg);
+  g_autofree char *final_msg = util::ruststr_dup_c_optempty (msg);
   RpmOstreeOutputProgressEnd done = { final_msg };
   active_cb (RPMOSTREE_OUTPUT_PROGRESS_END, &done, active_cb_opaque);
   this->ended = true;

--- a/src/libpriv/rpmostree-output.h
+++ b/src/libpriv/rpmostree-output.h
@@ -1,50 +1,55 @@
 /*
-* Copyright (C) 2016 Red Hat, Inc.
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program; if not, write to the Free Software
-* Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
-*/
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 #pragma once
 
-#include <stdbool.h>
-#include <memory>
 #include "rust/cxx.h"
+#include <memory>
+#include <stdbool.h>
 
 // C++ APIs here
-namespace rpmostreecxx {
+namespace rpmostreecxx
+{
 
-enum class ProgressType {
-   TASK,
-   N_ITEMS,
-   PERCENT,
+enum class ProgressType
+{
+  TASK,
+  N_ITEMS,
+  PERCENT,
 };
 
 void output_message (rust::Str msg);
 
-struct Progress {
+struct Progress
+{
 public:
-  void set_sub_message(rust::Str msg);
-  void nitems_update(guint n);
-  void percent_update(guint n);
+  void set_sub_message (rust::Str msg);
+  void nitems_update (guint n);
+  void percent_update (guint n);
 
-  void end(rust::Str msg);
-  ~Progress() {
+  void end (rust::Str msg);
+  ~Progress ()
+  {
     if (!this->ended)
-      this->end("");
+      this->end ("");
   }
-  Progress(ProgressType t) {
+  Progress (ProgressType t)
+  {
     ptype = t;
     ended = false;
   }
@@ -52,15 +57,16 @@ public:
   bool ended;
 };
 
-std::unique_ptr<Progress> progress_begin_task(rust::Str msg) noexcept;
-std::unique_ptr<Progress> progress_nitems_begin(guint n, rust::Str msg) noexcept;
-std::unique_ptr<Progress> progress_percent_begin(rust::Str msg) noexcept;
+std::unique_ptr<Progress> progress_begin_task (rust::Str msg) noexcept;
+std::unique_ptr<Progress> progress_nitems_begin (guint n, rust::Str msg) noexcept;
+std::unique_ptr<Progress> progress_percent_begin (rust::Str msg) noexcept;
 }
 
 // C APIs
 G_BEGIN_DECLS
 
-typedef enum {
+typedef enum
+{
   RPMOSTREE_OUTPUT_MESSAGE,
   RPMOSTREE_OUTPUT_PROGRESS_BEGIN,
   RPMOSTREE_OUTPUT_PROGRESS_UPDATE,
@@ -68,31 +74,31 @@ typedef enum {
   RPMOSTREE_OUTPUT_PROGRESS_END,
 } RpmOstreeOutputType;
 
-void
-rpmostree_output_default_handler (RpmOstreeOutputType type, void *data, void *opaque);
+void rpmostree_output_default_handler (RpmOstreeOutputType type, void *data, void *opaque);
 
-void
-rpmostree_output_set_callback (void (*cb)(RpmOstreeOutputType, void*, void*), void*);
+void rpmostree_output_set_callback (void (*cb) (RpmOstreeOutputType, void *, void *), void *);
 
-typedef struct {
+typedef struct
+{
   const char *text;
 } RpmOstreeOutputMessage;
 
-void
-rpmostree_output_message (const char *format, ...) G_GNUC_PRINTF (1,2);
+void rpmostree_output_message (const char *format, ...) G_GNUC_PRINTF (1, 2);
 
 /* For implementers of the output backend. If percent is TRUE, then n is
  * ignored. If n is zero, then it is taken to be an indefinite task.  Otherwise,
  * n is used for n_items.
  */
-typedef struct {
+typedef struct
+{
   const char *prefix;
   bool percent;
   guint n;
 } RpmOstreeOutputProgressBegin;
 
 /* Update progress */
-typedef struct {
+typedef struct
+{
   /* If we're in percent mode, this should be between 0 and 100,
    * otherwise less than the total.
    */
@@ -100,7 +106,8 @@ typedef struct {
 } RpmOstreeOutputProgressUpdate;
 
 /* End progress */
-typedef struct {
+typedef struct
+{
   const char *msg;
 } RpmOstreeOutputProgressEnd;
 

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -20,51 +20,32 @@
 
 #pragma once
 
-#include <ostree.h>
-#include "rpmostree-json-parsing.h"
 #include "rpmostree-cxxrs.h"
+#include "rpmostree-json-parsing.h"
+#include <ostree.h>
 
 G_BEGIN_DECLS
 
-gboolean
-rpmostree_cleanup_leftover_rpmdb_files (int            rootfs_fd,
-                                        GCancellable  *cancellable,
-                                        GError       **error);
+gboolean rpmostree_cleanup_leftover_rpmdb_files (int rootfs_fd, GCancellable *cancellable,
+                                                 GError **error);
 
-gboolean
-rpmostree_rootfs_postprocess_common (int           rootfs_fd,
-                                     GCancellable *cancellable,
-                                     GError       **error);
+gboolean rpmostree_rootfs_postprocess_common (int rootfs_fd, GCancellable *cancellable,
+                                              GError **error);
 
-gboolean
-rpmostree_prepare_rootfs_get_sepolicy (int            dfd,
-                                       OstreeSePolicy **out_sepolicy,
-                                       GCancellable  *cancellable,
-                                       GError       **error);
+gboolean rpmostree_prepare_rootfs_get_sepolicy (int dfd, OstreeSePolicy **out_sepolicy,
+                                                GCancellable *cancellable, GError **error);
 
-gboolean
-rpmostree_rootfs_fixup_selinux_store_root (int rootfs_dfd,
-                                           GCancellable *cancellable,
-                                           GError       **error);
+gboolean rpmostree_rootfs_fixup_selinux_store_root (int rootfs_dfd, GCancellable *cancellable,
+                                                    GError **error);
 
-gboolean
-rpmostree_postprocess_final (int            rootfs_dfd,
-                             JsonObject    *treefile,
-                             gboolean       unified_core_mode,
-                             GCancellable  *cancellable,
-                             GError       **error);
+gboolean rpmostree_postprocess_final (int rootfs_dfd, JsonObject *treefile,
+                                      gboolean unified_core_mode, GCancellable *cancellable,
+                                      GError **error);
 
-gboolean
-rpmostree_compose_commit (int            rootfs_dfd,
-                          OstreeRepo    *repo,
-                          const char    *parent,
-                          GVariant      *metadata,
-                          GVariant      *detached_metadata,
-                          const char    *gpg_keyid,
-                          gboolean       enable_selinux,
-                          OstreeRepoDevInoCache *devino_cache,
-                          char         **out_new_revision,
-                          GCancellable  *cancellable,
-                          GError       **error);
+gboolean rpmostree_compose_commit (int rootfs_dfd, OstreeRepo *repo, const char *parent,
+                                   GVariant *metadata, GVariant *detached_metadata,
+                                   const char *gpg_keyid, gboolean enable_selinux,
+                                   OstreeRepoDevInoCache *devino_cache, char **out_new_revision,
+                                   GCancellable *cancellable, GError **error);
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-refsack.cxx
+++ b/src/libpriv/rpmostree-refsack.cxx
@@ -20,15 +20,15 @@
 
 #include "config.h"
 
-#include <string.h>
 #include "rpmostree-refsack.h"
 #include "rpmostree-rpm-util.h"
+#include <string.h>
 
 RpmOstreeRefSack *
 rpmostree_refsack_new (DnfSack *sack, GLnxTmpDir *tmpdir)
 {
   RpmOstreeRefSack *rsack = g_new0 (RpmOstreeRefSack, 1);
-  rsack->sack = (DnfSack*)g_object_ref (sack);
+  rsack->sack = (DnfSack *)g_object_ref (sack);
   rsack->refcount = 1;
   if (tmpdir)
     {

--- a/src/libpriv/rpmostree-refsack.h
+++ b/src/libpriv/rpmostree-refsack.h
@@ -21,27 +21,25 @@
 
 #pragma once
 
+#include "libglnx.h"
 #include <gio/gio.h>
 #include <libdnf/libdnf.h>
-#include "libglnx.h"
 
 G_BEGIN_DECLS
 
-typedef struct {
-  gint refcount;  /* atomic */
+typedef struct
+{
+  gint refcount; /* atomic */
   DnfSack *sack;
   GLnxTmpDir tmpdir;
 } RpmOstreeRefSack;
 
-RpmOstreeRefSack *
-rpmostree_refsack_new (DnfSack *sack, GLnxTmpDir *tmpdir);
+RpmOstreeRefSack *rpmostree_refsack_new (DnfSack *sack, GLnxTmpDir *tmpdir);
 
-RpmOstreeRefSack *
-rpmostree_refsack_ref (RpmOstreeRefSack *rsack);
+RpmOstreeRefSack *rpmostree_refsack_ref (RpmOstreeRefSack *rsack);
 
-void
-rpmostree_refsack_unref (RpmOstreeRefSack *rsack);
+void rpmostree_refsack_unref (RpmOstreeRefSack *rsack);
 
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeRefSack, rpmostree_refsack_unref);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (RpmOstreeRefSack, rpmostree_refsack_unref);
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-refts.cxx
+++ b/src/libpriv/rpmostree-refts.cxx
@@ -20,9 +20,9 @@
 
 #include "config.h"
 
-#include <string.h>
 #include "rpmostree-refts.h"
 #include "rpmostree-rpm-util.h"
+#include <string.h>
 
 /*
  * A wrapper for an `rpmts` that supports:

--- a/src/libpriv/rpmostree-refts.h
+++ b/src/libpriv/rpmostree-refts.h
@@ -21,27 +21,25 @@
 
 #pragma once
 
+#include "libglnx.h"
 #include <gio/gio.h>
 #include <libdnf/libdnf.h>
-#include "libglnx.h"
 
 G_BEGIN_DECLS
 
-typedef struct {
-  gint refcount;  /* atomic */
+typedef struct
+{
+  gint refcount; /* atomic */
   rpmts ts;
   GLnxTmpDir tmpdir;
 } RpmOstreeRefTs;
 
-RpmOstreeRefTs *
-rpmostree_refts_new (rpmts ts, GLnxTmpDir *tmpdir);
+RpmOstreeRefTs *rpmostree_refts_new (rpmts ts, GLnxTmpDir *tmpdir);
 
-RpmOstreeRefTs *
-rpmostree_refts_ref (RpmOstreeRefTs *rts);
+RpmOstreeRefTs *rpmostree_refts_ref (RpmOstreeRefTs *rts);
 
-void
-rpmostree_refts_unref (RpmOstreeRefTs *rts);
+void rpmostree_refts_unref (RpmOstreeRefTs *rts);
 
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeRefTs, rpmostree_refts_unref);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (RpmOstreeRefTs, rpmostree_refts_unref);
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -23,20 +23,21 @@
 #include <memory>
 #include <ostree.h>
 
-#include <rpm/rpmlib.h>
-#include <rpm/rpmlog.h>
-#include <rpm/rpmdb.h>
 #include "libglnx.h"
-#include "rpmostree-util.h"
 #include "rpmostree-refsack.h"
 #include "rpmostree-refts.h"
+#include "rpmostree-util.h"
+#include <rpm/rpmdb.h>
+#include <rpm/rpmlib.h>
+#include <rpm/rpmlog.h>
 
 #include "libglnx.h"
 
 // C++ code
-namespace rpmostreecxx {
-  rust::String nevra_to_cache_branch(const std::string &nevra);
-  rust::String get_repodata_chksum_repr(DnfPackage &pkg);
+namespace rpmostreecxx
+{
+rust::String nevra_to_cache_branch (const std::string &nevra);
+rust::String get_repodata_chksum_repr (DnfPackage &pkg);
 }
 
 // C code follows
@@ -45,198 +46,138 @@ G_BEGIN_DECLS
 struct RpmHeaders
 {
   RpmOstreeRefTs *refts; /* rpm transaction set the headers belong to */
-  GPtrArray *hs; /* list of rpm header objects from <rpm.h> = Header */
+  GPtrArray *hs;         /* list of rpm header objects from <rpm.h> = Header */
 };
 
 typedef struct RpmHeaders RpmHeaders;
 
 struct RpmHeadersDiff
 {
-  GPtrArray *hs_add; /* list of rpm header objects from <rpm.h> = Header */
-  GPtrArray *hs_del; /* list of rpm header objects from <rpm.h> = Header */
+  GPtrArray *hs_add;     /* list of rpm header objects from <rpm.h> = Header */
+  GPtrArray *hs_del;     /* list of rpm header objects from <rpm.h> = Header */
   GPtrArray *hs_mod_old; /* list of rpm header objects from <rpm.h> = Header */
   GPtrArray *hs_mod_new; /* list of rpm header objects from <rpm.h> = Header */
 };
 
 typedef struct RpmRevisionData RpmRevisionData;
 
-struct RpmHeadersDiff *
-rpmhdrs_diff (struct RpmHeaders *l1,
-              struct RpmHeaders *l2);
+struct RpmHeadersDiff *rpmhdrs_diff (struct RpmHeaders *l1, struct RpmHeaders *l2);
 
-void
-rpmhdrs_list (struct RpmHeaders *l1);
+void rpmhdrs_list (struct RpmHeaders *l1);
 
-char *
-rpmhdrs_rpmdbv (struct RpmHeaders *l1,
-                GCancellable *cancellable,
-                GError **error);
+char *rpmhdrs_rpmdbv (struct RpmHeaders *l1, GCancellable *cancellable, GError **error);
 
-void
-rpmhdrs_diff_prnt_block (gboolean changelogs, struct RpmHeadersDiff *diff);
+void rpmhdrs_diff_prnt_block (gboolean changelogs, struct RpmHeadersDiff *diff);
 
 /* Define cleanup functions for librpm here. Note that this
  * will break if one day librpm ever decides to define these
  * itself. TODO: Move them to libdnf */
-G_DEFINE_AUTO_CLEANUP_FREE_FUNC(Header, headerFree, NULL)
-G_DEFINE_AUTO_CLEANUP_FREE_FUNC(rpmfi, rpmfiFree, NULL)
-G_DEFINE_AUTO_CLEANUP_FREE_FUNC(rpmts, rpmtsFree, NULL)
-G_DEFINE_AUTO_CLEANUP_FREE_FUNC(rpmdbMatchIterator, rpmdbFreeIterator, NULL)
-G_DEFINE_AUTO_CLEANUP_FREE_FUNC(rpmfiles, rpmfilesFree, NULL)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC (Header, headerFree, NULL)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC (rpmfi, rpmfiFree, NULL)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC (rpmts, rpmtsFree, NULL)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC (rpmdbMatchIterator, rpmdbFreeIterator, NULL)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC (rpmfiles, rpmfilesFree, NULL)
 
-void
-rpmhdrs_diff_prnt_diff (struct RpmHeadersDiff *diff);
+void rpmhdrs_diff_prnt_diff (struct RpmHeadersDiff *diff);
 
-struct RpmRevisionData *
-rpmrev_new (OstreeRepo *repo,
-            const char *rev,
-            const GPtrArray *patterns,
-            GCancellable *cancellable,
-            GError **error);
+struct RpmRevisionData *rpmrev_new (OstreeRepo *repo, const char *rev, const GPtrArray *patterns,
+                                    GCancellable *cancellable, GError **error);
 
 struct RpmHeaders *rpmrev_get_headers (struct RpmRevisionData *self);
 
 const char *rpmrev_get_commit (struct RpmRevisionData *self);
 
 void rpmrev_free (struct RpmRevisionData *ptr);
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmRevisionData, rpmrev_free);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (RpmRevisionData, rpmrev_free);
 
 void rpmhdrs_free (RpmHeaders *hdrs);
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmHeaders, rpmhdrs_free);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (RpmHeaders, rpmhdrs_free);
 
-RpmOstreeRefSack *
-rpmostree_get_refsack_for_commit (OstreeRepo                *repo,
-                                  const char                *ref,
-                                  GCancellable              *cancellable,
-                                  GError                   **error);
+RpmOstreeRefSack *rpmostree_get_refsack_for_commit (OstreeRepo *repo, const char *ref,
+                                                    GCancellable *cancellable, GError **error);
 
-RpmOstreeRefSack *
-rpmostree_get_refsack_for_root (int              dfd,
-                                const char      *path,
-                                GError         **error);
+RpmOstreeRefSack *rpmostree_get_refsack_for_root (int dfd, const char *path, GError **error);
 
-gboolean
-rpmostree_get_base_refsack_for_root (int                dfd,
-                                     const char        *path,
-                                     RpmOstreeRefSack **out_sack,
-                                     GCancellable      *cancellable,
-                                     GError           **error);
+gboolean rpmostree_get_base_refsack_for_root (int dfd, const char *path,
+                                              RpmOstreeRefSack **out_sack,
+                                              GCancellable *cancellable, GError **error);
 
-RpmOstreeRefSack *
-rpmostree_get_base_refsack_for_commit (OstreeRepo                *repo,
-                                       const char                *ref,
-                                       GCancellable              *cancellable,
-                                       GError                   **error);
+RpmOstreeRefSack *rpmostree_get_base_refsack_for_commit (OstreeRepo *repo, const char *ref,
+                                                         GCancellable *cancellable, GError **error);
 
-gboolean
-rpmostree_get_refts_for_commit (OstreeRepo                *repo,
-                                const char                *ref,
-                                RpmOstreeRefTs           **out_ts,
-                                GCancellable              *cancellable,
-                                GError                   **error);
+gboolean rpmostree_get_refts_for_commit (OstreeRepo *repo, const char *ref, RpmOstreeRefTs **out_ts,
+                                         GCancellable *cancellable, GError **error);
 
 GVariant *rpmostree_variant_pkgs_from_sack (RpmOstreeRefSack *sack);
 
-gint
-rpmostree_pkg_array_compare (DnfPackage **p_pkg1,
-                             DnfPackage **p_pkg2);
+gint rpmostree_pkg_array_compare (DnfPackage **p_pkg1, DnfPackage **p_pkg2);
 
-void
-rpmostree_print_transaction (DnfContext   *context);
-
+void rpmostree_print_transaction (DnfContext *context);
 
 /* This cleanup struct wraps _rpmostree_reset_rpm_sighandlers(). We have a dummy
  * variable to pacify clang's unused variable detection.
  */
-typedef struct {
+typedef struct
+{
   gboolean v;
 } RpmSighandlerResetCleanup;
 void rpmostree_sighandler_reset_cleanup (RpmSighandlerResetCleanup *cleanup);
-G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(RpmSighandlerResetCleanup, rpmostree_sighandler_reset_cleanup);
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC (RpmSighandlerResetCleanup, rpmostree_sighandler_reset_cleanup);
 
-#define DECLARE_RPMSIGHANDLER_RESET __attribute__((unused)) g_auto(RpmSighandlerResetCleanup) sigcleanup = { 0, };
+#define DECLARE_RPMSIGHANDLER_RESET                                                                \
+  __attribute__ ((unused)) g_auto (RpmSighandlerResetCleanup) sigcleanup = {                       \
+    0,                                                                                             \
+  };
 
-GVariant *
-rpmostree_fcap_to_xattr_variant (const char *fcap);
+GVariant *rpmostree_fcap_to_xattr_variant (const char *fcap);
 
-typedef enum {
+typedef enum
+{
   PKG_NEVRA_FLAGS_NAME = (1 << 0),
   PKG_NEVRA_FLAGS_EPOCH_VERSION_RELEASE = (1 << 1),
   PKG_NEVRA_FLAGS_EVR = PKG_NEVRA_FLAGS_EPOCH_VERSION_RELEASE,
   PKG_NEVRA_FLAGS_VERSION_RELEASE = (1 << 2),
   PKG_NEVRA_FLAGS_ARCH = (1 << 3),
-  PKG_NEVRA_FLAGS_NEVRA = (PKG_NEVRA_FLAGS_NAME |
-                           PKG_NEVRA_FLAGS_EVR  |
-                           PKG_NEVRA_FLAGS_ARCH),
+  PKG_NEVRA_FLAGS_NEVRA = (PKG_NEVRA_FLAGS_NAME | PKG_NEVRA_FLAGS_EVR | PKG_NEVRA_FLAGS_ARCH),
 } RpmOstreePkgNevraFlags;
 
-void
-rpmostree_custom_nevra (GString    *buffer,
-                        const char *name,
-                        uint64_t    epoch,
-                        const char *version,
-                        const char *release,
-                        const char *arch,
-                        RpmOstreePkgNevraFlags flags);
+void rpmostree_custom_nevra (GString *buffer, const char *name, uint64_t epoch, const char *version,
+                             const char *release, const char *arch, RpmOstreePkgNevraFlags flags);
 
-char *
-rpmostree_custom_nevra_strdup (const char *name,
-                               uint64_t    epoch,
-                               const char *version,
-                               const char *release,
-                               const char *arch,
-                               RpmOstreePkgNevraFlags flags);
+char *rpmostree_custom_nevra_strdup (const char *name, uint64_t epoch, const char *version,
+                                     const char *release, const char *arch,
+                                     RpmOstreePkgNevraFlags flags);
 
-char *
-rpmostree_header_custom_nevra_strdup (Header h, RpmOstreePkgNevraFlags flags);
+char *rpmostree_header_custom_nevra_strdup (Header h, RpmOstreePkgNevraFlags flags);
 
-GPtrArray*
-rpmostree_get_matching_packages (DnfSack *sack,
-                                 const char *pattern);
+GPtrArray *rpmostree_get_matching_packages (DnfSack *sack, const char *pattern);
 
-gboolean
-rpmostree_sack_has_subject (DnfSack *sack,
-                            const char *pattern);
+gboolean rpmostree_sack_has_subject (DnfSack *sack, const char *pattern);
 
-gboolean
-rpmostree_sack_get_by_pkgname (DnfSack     *sack,
-                               const char  *pkgname,
-                               DnfPackage **out_pkg,
-                               GError     **error);
+gboolean rpmostree_sack_get_by_pkgname (DnfSack *sack, const char *pkgname, DnfPackage **out_pkg,
+                                        GError **error);
 
-GPtrArray*
-rpmostree_sack_get_packages (DnfSack *sack);
+GPtrArray *rpmostree_sack_get_packages (DnfSack *sack);
 
-GPtrArray*
-rpmostree_sack_get_sorted_packages (DnfSack *sack);
+GPtrArray *rpmostree_sack_get_sorted_packages (DnfSack *sack);
 
-gboolean
-rpmostree_create_rpmdb_pkglist_variant (int              dfd,
-                                        const char      *path,
-                                        GVariant       **out_variant,
-                                        GCancellable    *cancellable,
-                                        GError         **error);
+gboolean rpmostree_create_rpmdb_pkglist_variant (int dfd, const char *path, GVariant **out_variant,
+                                                 GCancellable *cancellable, GError **error);
 
-char * rpmostree_get_cache_branch_for_n_evr_a (const char *name, const char *evr, const char *arch);
+char *rpmostree_get_cache_branch_for_n_evr_a (const char *name, const char *evr, const char *arch);
 char *rpmostree_get_cache_branch_header (Header hdr);
 char *rpmostree_get_cache_branch_pkg (DnfPackage *pkg);
 
-gboolean
-rpmostree_decompose_nevra (const char  *nevra,
-                           char       **out_name,    /* allow-none */
-                           guint64     *out_epoch,   /* allow-none */
-                           char       **out_version, /* allow-none */
-                           char       **out_release, /* allow-none */
-                           char       **out_arch,    /* allow-none */
-                           GError     **error);
+gboolean rpmostree_decompose_nevra (const char *nevra, char **out_name, /* allow-none */
+                                    guint64 *out_epoch,                 /* allow-none */
+                                    char **out_version,                 /* allow-none */
+                                    char **out_release,                 /* allow-none */
+                                    char **out_arch,                    /* allow-none */
+                                    GError **error);
 
-gboolean
-rpmostree_nevra_to_cache_branch (const char *nevra,
-                                 char      **cache_branch,
-                                 GError    **error);
+gboolean rpmostree_nevra_to_cache_branch (const char *nevra, char **cache_branch, GError **error);
 
-GPtrArray *
-rpmostree_get_enabled_rpmmd_repos (DnfContext *dnfctx, DnfRepoEnabled enablement);
+GPtrArray *rpmostree_get_enabled_rpmmd_repos (DnfContext *dnfctx, DnfRepoEnabled enablement);
 
 /*  s     advisory id (e.g. FEDORA-2018-a1b2c3d4e5f6)
     u     advisory kind (enum DnfAdvisoryKind)
@@ -250,8 +191,9 @@ rpmostree_get_enabled_rpmmd_repos (DnfContext *dnfctx, DnfRepoEnabled enablement
     This is also defined in utils.rs.
 */
 #define RPMOSTREE_UPDATE_ADVISORY_GVARIANT_STRING "a(suuasa{sv})"
-#define RPMOSTREE_UPDATE_ADVISORY_GVARIANT_FORMAT G_VARIANT_TYPE (RPMOSTREE_UPDATE_ADVISORY_GVARIANT_STRING)
+#define RPMOSTREE_UPDATE_ADVISORY_GVARIANT_FORMAT                                                  \
+  G_VARIANT_TYPE (RPMOSTREE_UPDATE_ADVISORY_GVARIANT_STRING)
 
-GVariant*       rpmostree_advisories_variant (DnfSack    *sack, GPtrArray  *pkgs);
+GVariant *rpmostree_advisories_variant (DnfSack *sack, GPtrArray *pkgs);
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-scripts.h
+++ b/src/libpriv/rpmostree-scripts.h
@@ -21,73 +21,50 @@
 #pragma once
 
 #include <gio/gio.h>
+#include <libdnf/libdnf.h>
 #include <ostree.h>
-#include <rpm/rpmsq.h>
+#include <rpm/rpmfi.h>
 #include <rpm/rpmlib.h>
 #include <rpm/rpmlog.h>
-#include <rpm/rpmfi.h>
 #include <rpm/rpmmacro.h>
+#include <rpm/rpmsq.h>
 #include <rpm/rpmts.h>
-#include <libdnf/libdnf.h>
 
 #include "libglnx.h"
 
 G_BEGIN_DECLS
 
-typedef enum {
+typedef enum
+{
   RPMOSTREE_SCRIPT_PREIN,
   RPMOSTREE_SCRIPT_POSTIN,
   RPMOSTREE_SCRIPT_POSTTRANS,
 } RpmOstreeScriptKind;
 
-gboolean
-rpmostree_script_txn_validate (DnfPackage    *package,
-                               Header         hdr,
-                               GCancellable  *cancellable,
-                               GError       **error);
+gboolean rpmostree_script_txn_validate (DnfPackage *package, Header hdr, GCancellable *cancellable,
+                                        GError **error);
 
-gboolean
-rpmostree_script_run_sync (DnfPackage    *pkg,
-                           Header         hdr,
-                           RpmOstreeScriptKind kind,
-                           int            rootfs_fd,
-                           GLnxTmpDir    *var_lib_rpm_statedir,
-                           gboolean       enable_rofiles,
-                           guint         *out_n_run,
-                           GCancellable  *cancellable,
-                           GError       **error);
+gboolean rpmostree_script_run_sync (DnfPackage *pkg, Header hdr, RpmOstreeScriptKind kind,
+                                    int rootfs_fd, GLnxTmpDir *var_lib_rpm_statedir,
+                                    gboolean enable_rofiles, guint *out_n_run,
+                                    GCancellable *cancellable, GError **error);
 
-gboolean
-rpmostree_transfiletriggers_run_sync (Header         hdr,
-                                      int            rootfs_fd,
-                                      gboolean       enable_rofiles,
-                                      guint         *out_n_run,
-                                      GCancellable  *cancellable,
-                                      GError       **error);
+gboolean rpmostree_transfiletriggers_run_sync (Header hdr, int rootfs_fd, gboolean enable_rofiles,
+                                               guint *out_n_run, GCancellable *cancellable,
+                                               GError **error);
 
-gboolean
-rpmostree_deployment_sanitycheck_true (int           rootfs_fd,
-                                       GCancellable *cancellable,
-                                       GError      **error);
+gboolean rpmostree_deployment_sanitycheck_true (int rootfs_fd, GCancellable *cancellable,
+                                                GError **error);
 
-gboolean
-rpmostree_deployment_sanitycheck_rpmdb (int           rootfs_fd,
-                                        GPtrArray     *overlays,
-                                        GPtrArray     *overrides,
-                                        GCancellable *cancellable,
-                                        GError      **error);
+gboolean rpmostree_deployment_sanitycheck_rpmdb (int rootfs_fd, GPtrArray *overlays,
+                                                 GPtrArray *overrides, GCancellable *cancellable,
+                                                 GError **error);
 
-gboolean
-rpmostree_run_script_in_bwrap_container (int rootfs_fd,
-                               GLnxTmpDir *var_lib_rpm_statedir,
-                               gboolean    enable_fuse,
-                               const char *name,
-                               const char *scriptdesc,
-                               const char *interp,
-                               const char *script,
-                               const char *script_arg,
-                               int         stdin_fd,
-                               GCancellable  *cancellable,
-                               GError       **error);
+gboolean rpmostree_run_script_in_bwrap_container (int rootfs_fd, GLnxTmpDir *var_lib_rpm_statedir,
+                                                  gboolean enable_fuse, const char *name,
+                                                  const char *scriptdesc, const char *interp,
+                                                  const char *script, const char *script_arg,
+                                                  int stdin_fd, GCancellable *cancellable,
+                                                  GError **error);
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-types.h
+++ b/src/libpriv/rpmostree-types.h
@@ -23,18 +23,21 @@ G_BEGIN_DECLS
 /* These types are used by both the daemon and the client. Some of them should probably be
  * added to the public API eventually. */
 
-typedef enum {
+typedef enum
+{
   RPM_OSTREE_PKG_TYPE_BASE,
   RPM_OSTREE_PKG_TYPE_LAYER,
 } RpmOstreePkgTypes;
 
-typedef enum {
+typedef enum
+{
   RPMOSTREED_AUTOMATIC_UPDATE_POLICY_NONE,
   RPMOSTREED_AUTOMATIC_UPDATE_POLICY_CHECK,
   RPMOSTREED_AUTOMATIC_UPDATE_POLICY_STAGE,
 } RpmostreedAutomaticUpdatePolicy;
 
-typedef enum {
+typedef enum
+{
   RPM_OSTREE_ADVISORY_SEVERITY_NONE,
   RPM_OSTREE_ADVISORY_SEVERITY_LOW,
   RPM_OSTREE_ADVISORY_SEVERITY_MODERATE,
@@ -63,6 +66,7 @@ typedef enum {
  * - (ss) - evr & arch of new package
  */
 #define RPMOSTREE_DIFF_MODIFIED_GVARIANT_STRING "a(us(ss)(ss))"
-#define RPMOSTREE_DIFF_MODIFIED_GVARIANT_FORMAT G_VARIANT_TYPE (RPMOSTREE_DIFF_MODIFIED_GVARIANT_STRING)
+#define RPMOSTREE_DIFF_MODIFIED_GVARIANT_FORMAT                                                    \
+  G_VARIANT_TYPE (RPMOSTREE_DIFF_MODIFIED_GVARIANT_STRING)
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-unpacker-core.cxx
+++ b/src/libpriv/rpmostree-unpacker-core.cxx
@@ -25,28 +25,26 @@
 
 #include "config.h"
 
-#include <pwd.h>
-#include <grp.h>
-#include <gio/gunixinputstream.h>
-#include "rpmostree-unpacker-core.h"
 #include "rpmostree-core.h"
 #include "rpmostree-rpm-util.h"
+#include "rpmostree-unpacker-core.h"
+#include <gio/gunixinputstream.h>
+#include <grp.h>
+#include <pwd.h>
+#include <rpm/rpmfi.h>
 #include <rpm/rpmlib.h>
 #include <rpm/rpmlog.h>
-#include <rpm/rpmfi.h>
 #include <rpm/rpmts.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
 static void
-propagate_libarchive_error (GError      **error,
-                            struct archive *a)
+propagate_libarchive_error (GError **error, struct archive *a)
 {
-  g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                       archive_error_string (a));
+  g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED, archive_error_string (a));
 }
 
-typedef int(*archive_setup_func)(struct archive *);
+typedef int (*archive_setup_func) (struct archive *);
 
 /**
  * rpmostree_unpack_rpm2cpio:
@@ -68,16 +66,15 @@ rpmostree_unpack_rpm2cpio (int fd, GError **error)
   g_assert (ret);
 
   /* We only do the subset necessary for RPM */
-  { archive_setup_func archive_setup_funcs[] =
-      { archive_read_support_filter_rpm,
-        archive_read_support_filter_lzma,
-        archive_read_support_filter_gzip,
-        archive_read_support_filter_xz,
-        archive_read_support_filter_bzip2,
+  {
+    archive_setup_func archive_setup_funcs[]
+        = { archive_read_support_filter_rpm,   archive_read_support_filter_lzma,
+            archive_read_support_filter_gzip,  archive_read_support_filter_xz,
+            archive_read_support_filter_bzip2,
 #ifdef HAVE_LIBARCHIVE_ZSTD
-        archive_read_support_filter_zstd,
+            archive_read_support_filter_zstd,
 #endif
-        archive_read_support_format_cpio };
+            archive_read_support_format_cpio };
 
     for (i = 0; i < G_N_ELEMENTS (archive_setup_funcs); i++)
       {
@@ -97,13 +94,13 @@ rpmostree_unpack_rpm2cpio (int fd, GError **error)
     }
 
   success = TRUE;
- out:
+out:
   if (success)
     return util::move_nullify (ret);
   else
     {
       if (ret)
-        (void) archive_read_free (ret);
+        (void)archive_read_free (ret);
       return NULL;
     }
 }

--- a/src/libpriv/rpmostree-unpacker-core.h
+++ b/src/libpriv/rpmostree-unpacker-core.h
@@ -23,13 +23,13 @@
 #include <ostree.h>
 
 #include "libglnx.h"
-#include <rpm/rpmlib.h>
-#include <libdnf/libdnf.h>
 #include <archive.h>
 #include <archive_entry.h>
+#include <libdnf/libdnf.h>
+#include <rpm/rpmlib.h>
 
 G_BEGIN_DECLS
 
-struct archive * rpmostree_unpack_rpm2cpio (int fd, GError **error);
+struct archive *rpmostree_unpack_rpm2cpio (int fd, GError **error);
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -21,49 +21,52 @@
 #pragma once
 
 // C++ includes
-#include <string>
 #include <exception>
 #include <sstream>
+#include <string>
 // C includes
 #include <gio/gio.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <ostree.h>
 #include <libdnf/libdnf.h>
 #include <optional>
+#include <ostree.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 
 #include "libglnx.h"
-#include "rpmostree.h"
 #include "rpmostree-types.h"
+#include "rpmostree.h"
 #include "rust/cxx.h"
 
 // C++ code here
-namespace util {
+namespace util
+{
 // Sadly std::move() doesn't do anything for raw pointer types by default.
 // This is our C++ equivalent of g_steal_pointer().
-template<typename T>
-  T move_nullify(T& v) noexcept
-  {
-    auto p = v;
-    v = nullptr;
-    return p;
-  }
+template <typename T>
+T
+move_nullify (T &v) noexcept
+{
+  auto p = v;
+  v = nullptr;
+  return p;
+}
 
 // In rpm-ostree we always use C++ exceptions as a "fatal error, unwind the stack"
 // tool.  We don't try to catch specific exception types, they just carry
 // a string that will be displayed to a human.  This helper encapsulates a common
 // pattern of adding a "prefix" to the string.  When used multiple times it's
 // a bit like a human-friendly stack trace subset.
-template<typename T>
-  [[ noreturn ]] inline void rethrow_prefixed (std::exception& e, T prefix)
-  {
-    std::ostringstream msg;
-    msg << prefix << ": " << e.what();
-    throw std::runtime_error(msg.str());
-  }
+template <typename T>
+[[noreturn]] inline void
+rethrow_prefixed (std::exception &e, T prefix)
+{
+  std::ostringstream msg;
+  msg << prefix << ": " << e.what ();
+  throw std::runtime_error (msg.str ());
+}
 
 // Convert a GError into a C++ exception.  Takes ownership of the error.
-[[ noreturn ]] static inline void
+[[noreturn]] static inline void
 throw_gerror (GError *&error)
 {
   auto s = std::string (error->message);
@@ -74,12 +77,16 @@ throw_gerror (GError *&error)
 
 // Calls a rpmostreecxx function, returning any error immediately.
 // Similar to Rust's ?  operator.
-#define CXX_TRY(cxxfn, err)                    \
-  ({ try {                                     \
-       rpmostreecxx::cxxfn;                    \
-     } catch (std::exception &e) {             \
-       return glnx_throw(err, "%s", e.what()); \
-     }                                         \
+#define CXX_TRY(cxxfn, err)                                                                        \
+  ({                                                                                               \
+    try                                                                                            \
+      {                                                                                            \
+        rpmostreecxx::cxxfn;                                                                       \
+      }                                                                                            \
+    catch (std::exception & e)                                                                     \
+      {                                                                                            \
+        return glnx_throw (err, "%s", e.what ());                                                  \
+      }                                                                                            \
   })
 
 // Have to use the optional<> dance here so that we don't implicitly call a constructor
@@ -87,14 +94,18 @@ throw_gerror (GError *&error)
 // Also the constructor might be explicitly deleted (e.g. rust::Box). The C++ compiler
 // doesn't understand that the final value will always be initialized since we return in the
 // catch block.
-#define CXX_TRY_VAL(cxxfn, err)                      \
-  ({ std::optional<decltype(rpmostreecxx::cxxfn)> v; \
-     try {                                           \
-       v.emplace(rpmostreecxx::cxxfn);               \
-     } catch (std::exception &e) {                   \
-       return glnx_throw(err, "%s", e.what());       \
-     }                                               \
-     std::move(v.value());                           \
+#define CXX_TRY_VAL(cxxfn, err)                                                                    \
+  ({                                                                                               \
+    std::optional<decltype (rpmostreecxx::cxxfn)> v;                                               \
+    try                                                                                            \
+      {                                                                                            \
+        v.emplace (rpmostreecxx::cxxfn);                                                           \
+      }                                                                                            \
+    catch (std::exception & e)                                                                     \
+      {                                                                                            \
+        return glnx_throw (err, "%s", e.what ());                                                  \
+      }                                                                                            \
+    std::move (v.value ());                                                                        \
   })
 
 // Duplicate a non-empty Rust Str to a NUL-terminated C string.
@@ -102,9 +113,10 @@ throw_gerror (GError *&error)
 // This method should be viewed as a workaround for the lack
 // of Option<> binding in cxx-rs.
 static inline char *
-ruststr_dup_c_optempty(const rust::Str s) {
-  if (s.length() > 0)
-    return g_strndup(s.data(), s.length());
+ruststr_dup_c_optempty (const rust::Str s)
+{
+  if (s.length () > 0)
+    return g_strndup (s.data (), s.length ());
   return NULL;
 }
 
@@ -113,109 +125,83 @@ ruststr_dup_c_optempty(const rust::Str s) {
 // This method should be viewed as a workaround for the lack
 // of Option<> binding in cxx-rs.
 static inline rust::Str
-ruststr_or_empty (const char *c_str) {
-  return rust::Str(c_str ?: "");
+ruststr_or_empty (const char *c_str)
+{
+  return rust::Str (c_str ?: "");
 }
 
 // Copy convert a NULL-terminated C string array to a Rust vector of owned strings.
 static inline rust::Vec<rust::String>
-rust_stringvec_from_strv(const char *const*strv) {
+rust_stringvec_from_strv (const char *const *strv)
+{
   rust::Vec<rust::String> ret;
-  for (const char *const*it = strv; it && *it; it++)
-    ret.push_back(*it);
+  for (const char *const *it = strv; it && *it; it++)
+    ret.push_back (*it);
   return ret;
 }
 
 }
 
-namespace rpmostreecxx {
-rust::String
-util_next_version (rust::Str auto_version_prefix,
-                   rust::Str version_suffix,
-                   rust::Str last_version);
+namespace rpmostreecxx
+{
+rust::String util_next_version (rust::Str auto_version_prefix, rust::Str version_suffix,
+                                rust::Str last_version);
 
-int
-testutil_validate_cxxrs_passthrough(OstreeRepo &repo) noexcept;
+int testutil_validate_cxxrs_passthrough (OstreeRepo &repo) noexcept;
 
 }
 
 // Below here is C code
 G_BEGIN_DECLS
 
-#define _N(single, plural, n) ( (n) == 1 ? (single) : (plural) )
-#define _NS(n) _N("", "s", n)
+#define _N(single, plural, n) ((n) == 1 ? (single) : (plural))
+#define _NS(n) _N ("", "s", n)
 
 #define VAR_SELINUX_TARGETED_PATH "var/lib/selinux/targeted/"
 
-int
-rpmostree_ptrarray_sort_compare_strings (gconstpointer ap,
-                                         gconstpointer bp);
+int rpmostree_ptrarray_sort_compare_strings (gconstpointer ap, gconstpointer bp);
 
-GVariant *_rpmostree_vardict_lookup_value_required (GVariantDict *dict,
-                                                    const char *key,
-                                                    const GVariantType *fmt,
-                                                    GError     **error);
+GVariant *_rpmostree_vardict_lookup_value_required (GVariantDict *dict, const char *key,
+                                                    const GVariantType *fmt, GError **error);
 
-gboolean
-_rpmostree_util_update_checksum_from_file (GChecksum    *checksum,
-                                           int           rootfs_dfd,
-                                           const char   *path,
-                                           GCancellable *cancellable,
-                                           GError      **error);
+gboolean _rpmostree_util_update_checksum_from_file (GChecksum *checksum, int rootfs_dfd,
+                                                    const char *path, GCancellable *cancellable,
+                                                    GError **error);
 
-gboolean
-rpmostree_pkg_is_local (DnfPackage *pkg);
+gboolean rpmostree_pkg_is_local (DnfPackage *pkg);
 
-char *
-rpmostree_pkg_get_local_path (DnfPackage *pkg);
+char *rpmostree_pkg_get_local_path (DnfPackage *pkg);
 
-gboolean
-rpmostree_check_size_within_limit (guint64     actual,
-                                   guint64     limit,
-                                   const char *subject,
-                                   GError    **error);
+gboolean rpmostree_check_size_within_limit (guint64 actual, guint64 limit, const char *subject,
+                                            GError **error);
 
-char*
-rpmostree_translate_path_for_ostree (const char *path);
+char *rpmostree_translate_path_for_ostree (const char *path);
 
-char *
-rpmostree_str_replace (const char  *buf,
-                       const char  *old,
-                       const char  *newval,
-                       GError     **error);
+char *rpmostree_str_replace (const char *buf, const char *old, const char *newval, GError **error);
 
-char *
-rpmostree_checksum_version (GVariant *checksum);
+char *rpmostree_checksum_version (GVariant *checksum);
 
-gboolean
-rpmostree_pull_content_only (OstreeRepo  *dest,
-                             OstreeRepo  *src,
-                             const char  *src_commit,
-                             GCancellable *cancellable,
-                             GError      **error);
-const char *
-rpmostree_file_get_path_cached (GFile *file);
+gboolean rpmostree_pull_content_only (OstreeRepo *dest, OstreeRepo *src, const char *src_commit,
+                                      GCancellable *cancellable, GError **error);
+const char *rpmostree_file_get_path_cached (GFile *file);
 
-static inline
-const char *
+static inline const char *
 gs_file_get_path_cached (GFile *file)
 {
   return rpmostree_file_get_path_cached (file);
 }
 
-char*
-rpmostree_generate_diff_summary (guint upgraded,
-                                 guint downgraded,
-                                 guint removed,
-                                 guint added);
+char *rpmostree_generate_diff_summary (guint upgraded, guint downgraded, guint removed,
+                                       guint added);
 
 // note this enum is shared with Rust via the cxxbridge
-typedef enum : std::uint8_t {
-  RPMOSTREE_DIFF_PRINT_FORMAT_SUMMARY,       /* Diff: 1 upgraded, 2 downgraded, 3 removed, 4 added */
-  RPMOSTREE_DIFF_PRINT_FORMAT_FULL_ALIGNED,  /* Upgraded: ...
-                                                          ...
-                                                   Added: ...
-                                                          ...  */
+typedef enum : std::uint8_t
+{
+  RPMOSTREE_DIFF_PRINT_FORMAT_SUMMARY,      /* Diff: 1 upgraded, 2 downgraded, 3 removed, 4 added */
+  RPMOSTREE_DIFF_PRINT_FORMAT_FULL_ALIGNED, /* Upgraded: ...
+                                                         ...
+                                                  Added: ...
+                                                         ...  */
   RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE /* Upgraded:
                                                    ...
                                                    ...
@@ -224,84 +210,52 @@ typedef enum : std::uint8_t {
                                                    ...  */
 } RpmOstreeDiffPrintFormat;
 
-namespace rpmostreecxx {
-  using RpmOstreeDiffPrintFormat = ::RpmOstreeDiffPrintFormat;
+namespace rpmostreecxx
+{
+using RpmOstreeDiffPrintFormat = ::RpmOstreeDiffPrintFormat;
 }
 
-void
-rpmostree_diff_print_formatted (RpmOstreeDiffPrintFormat format,
-                                const char *prefix,
-                                guint      max_key_len,
-                                GPtrArray *removed,
-                                GPtrArray *added,
-                                GPtrArray *modified_old,
-                                GPtrArray *modified_new);
+void rpmostree_diff_print_formatted (RpmOstreeDiffPrintFormat format, const char *prefix,
+                                     guint max_key_len, GPtrArray *removed, GPtrArray *added,
+                                     GPtrArray *modified_old, GPtrArray *modified_new);
 
-void
-rpmostree_variant_diff_print_formatted (guint     max_key_len,
-                                        GVariant *upgraded,
-                                        GVariant *downgraded,
-                                        GVariant *removed,
-                                        GVariant *added);
+void rpmostree_variant_diff_print_formatted (guint max_key_len, GVariant *upgraded,
+                                             GVariant *downgraded, GVariant *removed,
+                                             GVariant *added);
 
-void
-rpmostree_diff_print (GPtrArray *removed,
-                      GPtrArray *added,
-                      GPtrArray *modified_old,
-                      GPtrArray *modified_new);
+void rpmostree_diff_print (GPtrArray *removed, GPtrArray *added, GPtrArray *modified_old,
+                           GPtrArray *modified_new);
 
-gboolean
-rpmostree_str_has_prefix_in_strv (const char *str,
-                                  char      **strv,
-                                  int         n);
+gboolean rpmostree_str_has_prefix_in_strv (const char *str, char **strv, int n);
 
-gboolean
-rpmostree_str_has_prefix_in_ptrarray (const char *str,
-                                      GPtrArray  *prefixes);
+gboolean rpmostree_str_has_prefix_in_ptrarray (const char *str, GPtrArray *prefixes);
 
-gboolean
-rpmostree_str_ptrarray_contains (GPtrArray  *strs,
-                                 const char *str);
+gboolean rpmostree_str_ptrarray_contains (GPtrArray *strs, const char *str);
 
 /* XXX: just return a struct out of these */
-gboolean
-rpmostree_deployment_get_layered_info (OstreeRepo        *repo,
-                                       OstreeDeployment  *deployment,
-                                       gboolean          *out_is_layered,
-                                       guint             *out_layer_version,
-                                       char             **out_base_layer,
-                                       char            ***out_layered_pkgs,
-                                       char            ***out_layered_modules,
-                                       GVariant         **out_removed_base_pkgs,
-                                       GVariant         **out_replaced_base_pkgs,
-                                       GError           **error);
+gboolean rpmostree_deployment_get_layered_info (OstreeRepo *repo, OstreeDeployment *deployment,
+                                                gboolean *out_is_layered, guint *out_layer_version,
+                                                char **out_base_layer, char ***out_layered_pkgs,
+                                                char ***out_layered_modules,
+                                                GVariant **out_removed_base_pkgs,
+                                                GVariant **out_replaced_base_pkgs, GError **error);
 
 /* simpler version of the above */
-gboolean
-rpmostree_deployment_get_base_layer (OstreeRepo        *repo,
-                                     OstreeDeployment  *deployment,
-                                     char             **out_base_layer,
-                                     GError           **error);
+gboolean rpmostree_deployment_get_base_layer (OstreeRepo *repo, OstreeDeployment *deployment,
+                                              char **out_base_layer, GError **error);
 
-gboolean
-rpmostree_migrate_pkgcache_repo (OstreeRepo   *repo,
-                                 GCancellable *cancellable,
-                                 GError      **error);
+gboolean rpmostree_migrate_pkgcache_repo (OstreeRepo *repo, GCancellable *cancellable,
+                                          GError **error);
 
-gboolean
-rpmostree_decompose_sha256_nevra (const char **nevra,
-                                  char       **sha256,
-                                  GError     **error);
+gboolean rpmostree_decompose_sha256_nevra (const char **nevra, char **sha256, GError **error);
 
-char*
-rpmostree_get_deployment_root (OstreeSysroot     *sysroot,
-                               OstreeDeployment *deployment);
+char *rpmostree_get_deployment_root (OstreeSysroot *sysroot, OstreeDeployment *deployment);
 
-char *
-rpmostree_commit_content_checksum (GVariant *commit);
+char *rpmostree_commit_content_checksum (GVariant *commit);
 
 /* https://github.com/ostreedev/ostree/pull/1132 */
-typedef struct {
+typedef struct
+{
   gboolean initialized;
   gboolean commit_on_failure;
   OstreeRepo *repo;
@@ -318,17 +272,15 @@ rpmostree_repo_auto_transaction_cleanup (void *p)
    * to avoid redownloading.
    */
   if (autotxn->commit_on_failure)
-    (void) ostree_repo_commit_transaction (autotxn->repo, NULL, NULL, NULL);
+    (void)ostree_repo_commit_transaction (autotxn->repo, NULL, NULL, NULL);
   else
-    (void) ostree_repo_abort_transaction (autotxn->repo, NULL, NULL);
+    (void)ostree_repo_abort_transaction (autotxn->repo, NULL, NULL);
 }
 
 static inline gboolean
-rpmostree_repo_auto_transaction_start (RpmOstreeRepoAutoTransaction     *autotxn,
-                                       OstreeRepo                       *repo,
-                                       gboolean                          commit_on_failure,
-                                       GCancellable                     *cancellable,
-                                       GError                          **error)
+rpmostree_repo_auto_transaction_start (RpmOstreeRepoAutoTransaction *autotxn, OstreeRepo *repo,
+                                       gboolean commit_on_failure, GCancellable *cancellable,
+                                       GError **error)
 {
   if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
     return FALSE;
@@ -337,38 +289,28 @@ rpmostree_repo_auto_transaction_start (RpmOstreeRepoAutoTransaction     *autotxn
   autotxn->initialized = TRUE;
   return TRUE;
 }
-G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC (RpmOstreeRepoAutoTransaction, rpmostree_repo_auto_transaction_cleanup)
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC (RpmOstreeRepoAutoTransaction,
+                                  rpmostree_repo_auto_transaction_cleanup)
 
-gboolean
-rpmostree_variant_bsearch_str (GVariant   *array,
-                               const char *str,
-                               int        *out_pos);
+gboolean rpmostree_variant_bsearch_str (GVariant *array, const char *str, int *out_pos);
 
-const char*
-rpmostree_auto_update_policy_to_str (RpmostreedAutomaticUpdatePolicy policy,
-                                     GError **error);
+const char *rpmostree_auto_update_policy_to_str (RpmostreedAutomaticUpdatePolicy policy,
+                                                 GError **error);
 
-gboolean
-rpmostree_str_to_auto_update_policy (const char *str,
-                                     RpmostreedAutomaticUpdatePolicy *out_policy,
-                                     GError **error);
+gboolean rpmostree_str_to_auto_update_policy (const char *str,
+                                              RpmostreedAutomaticUpdatePolicy *out_policy,
+                                              GError **error);
 
-char*
-rpmostree_timestamp_str_from_unix_utc (guint64 t);
+char *rpmostree_timestamp_str_from_unix_utc (guint64 t);
 
-void
-rpmostree_journal_error (GError *error);
+void rpmostree_journal_error (GError *error);
 
-void
-rpmostree_variant_be_to_native (GVariant **v);
+void rpmostree_variant_be_to_native (GVariant **v);
 
-void
-rpmostree_variant_native_to_be (GVariant **v);
+void rpmostree_variant_native_to_be (GVariant **v);
 
-char**
-rpmostree_cxx_string_vec_to_strv (rust::Vec<rust::String> &v);
+char **rpmostree_cxx_string_vec_to_strv (rust::Vec<rust::String> &v);
 
-void 
-rpmostreed_utils_tests (void);
+void rpmostreed_utils_tests (void);
 
 G_END_DECLS


### PR DESCRIPTION
This could be considered a very mild troll of @cgwalters.

This change would allow anyone using an editor like Visual Studio Code (or many others) to enable formatting on save using clang-format's definition of GNU style.

I'm more than happy to tweak the style configuration if needed/desired.