### PR TITLE
Update to ostree-ext 0.7, add new `container-encapsulate`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "containers-image-proxy"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6139635005aca6a2f7ef7f623bfc7f2f447e78174321088f7b4ef81c2e188e"
+checksum = "1181da40ec6d2001179ba396b3860f14a95229731e80f45c459975fd1fe7ffb2"
 dependencies = [
  "anyhow",
  "capctl",
@@ -337,6 +337,7 @@ dependencies = [
  "futures-util",
  "libc",
  "nix",
+ "oci-spec",
  "once_cell",
  "semver",
  "serde",
@@ -1500,9 +1501,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "oci-spec"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b409d52fff741f330914aa6b8ab73e9113607bb13fbc09f95cdb04d16c8dd5d"
+checksum = "71a85b9f9654fe5c3eab8907369250c05aeda9d807b76bd06c740601f881dc02"
 dependencies = [
  "derive_builder",
  "getset",
@@ -1611,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "ostree-ext"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6d186573b7713d0794d2aa34c32ea5fa45a4f7fe77127c89815029ccc0bf3d"
+checksum = "0feb85eda4aa146654a73bad0d2a31282a8e83ca85ffa2ae1a52e696e8df0664"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1638,11 +1639,13 @@ dependencies = [
  "openssl",
  "ostree",
  "pin-project",
+ "regex",
  "serde",
  "serde_json",
  "structopt",
  "tar",
  "tempfile",
+ "term_size",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2396,6 +2399,16 @@ dependencies = [
  "libc",
  "redox_syscall",
  "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ openat-ext = "^0.2.3"
 openssl = "0.10.38"
 once_cell = "1.10.0"
 os-release = "0.1.0"
-ostree-ext = "0.6.5"
+ostree-ext = "0.7.0"
 paste = "1.0"
 phf = { version = "0.10", features = ["macros"] }
 rand = "0.8.5"

--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -2,7 +2,28 @@
 
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::convert::TryInto;
+use std::num::NonZeroU32;
+use std::rc::Rc;
+
 use anyhow::Result;
+use camino::{Utf8Path, Utf8PathBuf};
+use cap_std::fs::Dir;
+use cap_std_ext::cap_std;
+use cap_std_ext::prelude::*;
+use chrono::prelude::*;
+use ostree::glib;
+use ostree_ext::chunking::ObjectMetaSized;
+use ostree_ext::container::{Config, ExportOpts, ImageReference};
+use ostree_ext::objectsource::{
+    ContentID, ObjectMeta, ObjectMetaMap, ObjectMetaSet, ObjectSourceMeta,
+};
+use ostree_ext::prelude::*;
+use ostree_ext::{gio, ostree};
+use structopt::StructOpt;
+
+use crate::cxxrsutil::FFIGObjectReWrap;
 
 /// Main entrypoint for container
 pub async fn entrypoint(args: &[&str]) -> Result<i32> {
@@ -13,4 +34,360 @@ pub async fn entrypoint(args: &[&str]) -> Result<i32> {
         .chain(args.iter().skip(2));
     ostree_ext::cli::run_from_iter(args).await?;
     Ok(0)
+}
+
+#[derive(Debug, StructOpt)]
+struct ContainerEncapsulateOpts {
+    #[structopt(long)]
+    #[structopt(parse(try_from_str = ostree_ext::cli::parse_repo))]
+    repo: ostree::Repo,
+
+    /// OSTree branch name or checksum
+    ostree_ref: String,
+
+    /// Image reference, e.g. registry:quay.io/exampleos/exampleos:latest
+    #[structopt(parse(try_from_str = ostree_ext::cli::parse_base_imgref))]
+    imgref: ImageReference,
+
+    /// Additional labels for the container
+    #[structopt(name = "label", long, short)]
+    labels: Vec<String>,
+
+    /// Propagate an OSTree commit metadata key to container label
+    #[structopt(name = "copymeta", long)]
+    copy_meta_keys: Vec<String>,
+
+    /// Corresponds to the Dockerfile `CMD` instruction.
+    #[structopt(long)]
+    cmd: Option<Vec<String>>,
+
+    /// Maximum number of container image layers
+    #[structopt(long)]
+    max_layers: Option<NonZeroU32>,
+
+    #[structopt(long)]
+    /// Output content metadata as JSON
+    write_contentmeta_json: Option<Utf8PathBuf>,
+}
+
+#[derive(Debug)]
+struct MappingBuilder {
+    /// Maps from package ID to metadata
+    packagemeta: ObjectMetaSet,
+    /// Mapping from content object sha256 to package numeric ID
+    content: ObjectMetaMap,
+    /// Mapping from content object sha256 to package numeric ID
+    duplicates: BTreeMap<String, Vec<ContentID>>,
+    multi_provider: Vec<Utf8PathBuf>,
+
+    unpackaged_id: Rc<str>,
+
+    /// Files that were processed before the global tree walk
+    skip: HashSet<Utf8PathBuf>,
+
+    /// Size according to RPM database
+    rpmsize: u64,
+}
+
+impl MappingBuilder {
+    /// For now, we stick everything that isn't a package inside a single "unpackaged" state.
+    /// In the future though if we support e.g. containers in /usr/share/containers or the
+    /// like, this will need to change.
+    const UNPACKAGED_ID: &'static str = "rpmostree-unpackaged-content";
+}
+
+impl From<MappingBuilder> for ObjectMeta {
+    fn from(b: MappingBuilder) -> ObjectMeta {
+        ObjectMeta {
+            map: b.content,
+            set: b.packagemeta,
+        }
+    }
+}
+
+/// Walk over the whole filesystem, and generate mappings from content object checksums
+/// to the package that owns them.  
+///
+/// In the future, we could compute this much more efficiently by walking that
+/// instead.  But this design is currently oriented towards accepting a single ostree
+/// commit as input.
+fn build_mapping_recurse(
+    path: &mut Utf8PathBuf,
+    dir: &gio::File,
+    ts: &crate::ffi::RpmTs,
+    state: &mut MappingBuilder,
+) -> Result<()> {
+    use std::collections::btree_map::Entry;
+    let cancellable = gio::NONE_CANCELLABLE;
+    let e = dir.enumerate_children(
+        "standard::name,standard::type",
+        gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
+        cancellable,
+    )?;
+    for child in e {
+        let childi = child?;
+        let name: Utf8PathBuf = childi.name().try_into()?;
+        let child = dir.child(&name);
+        path.push(&name);
+        match childi.file_type() {
+            gio::FileType::Regular | gio::FileType::SymbolicLink => {
+                let child = child.downcast::<ostree::RepoFile>().unwrap();
+
+                // Remove the skipped path, since we can't hit it again.
+                if state.skip.remove(Utf8Path::new(path)) {
+                    path.pop();
+                    continue;
+                }
+
+                let mut pkgs = ts.packages_providing_file(path.as_str())?;
+                // Let's be deterministic (but _unstable because we don't care about behavior of equal strings)
+                pkgs.sort_unstable();
+                // For now, we pick the alphabetically first package providing a file
+                let mut pkgs = pkgs.into_iter();
+                let pkgid = pkgs
+                    .next()
+                    .map(|v| -> Result<_> {
+                        // Safety: we should have the package in metadata
+                        let meta = state.packagemeta.get(v.as_str()).ok_or_else(|| {
+                            anyhow::anyhow!("Internal error: missing pkgmeta for {}", &v)
+                        })?;
+                        Ok(Rc::clone(&meta.identifier))
+                    })
+                    .transpose()?
+                    .unwrap_or_else(|| Rc::clone(&state.unpackaged_id));
+                // Track cases of duplicate owners
+                match pkgs.len() {
+                    0 => {}
+                    _ => {
+                        state.multi_provider.push(path.clone());
+                    }
+                }
+
+                let checksum = child.checksum().unwrap().to_string();
+                match state.content.entry(checksum) {
+                    Entry::Vacant(v) => {
+                        v.insert(pkgid);
+                    }
+                    Entry::Occupied(_) => {
+                        let checksum = child.checksum().unwrap().to_string();
+                        let v = state.duplicates.entry(checksum).or_default();
+                        v.push(pkgid);
+                    }
+                }
+            }
+            gio::FileType::Directory => {
+                build_mapping_recurse(path, &child, ts, state)?;
+            }
+            o => anyhow::bail!("Unhandled file type: {}", o),
+        }
+        path.pop();
+    }
+    Ok(())
+}
+
+fn gv_nevra_to_string(pkg: &glib::Variant) -> String {
+    let name = pkg.child_value(0);
+    let name = name.str().unwrap();
+    let epoch = pkg.child_value(1);
+    let epoch = epoch.str().unwrap();
+    let version = pkg.child_value(2);
+    let version = version.str().unwrap();
+    let release = pkg.child_value(3);
+    let release = release.str().unwrap();
+    let arch = pkg.child_value(4);
+    let arch = arch.str().unwrap();
+    if epoch == "0" {
+        format!("{}-{}-{}.{}", name, version, release, arch)
+    } else {
+        format!("{}-{}:{}-{}.{}", name, epoch, version, release, arch)
+    }
+}
+
+/// Like `ostree container encapsulate`, but uses chunks derived from package data.
+/// Note this isn't *really* asynchronous in many parts.
+pub async fn container_encapsulate(args: &[&str]) -> Result<()> {
+    let args = args.iter().skip(1);
+    let opt = ContainerEncapsulateOpts::from_iter(args);
+    let repo = &opt.repo;
+    let (root, rev) = repo.read_commit(opt.ostree_ref.as_str(), gio::NONE_CANCELLABLE)?;
+    let pkglist = {
+        let repo = repo.gobj_rewrap();
+        let cancellable = gio::Cancellable::new();
+        unsafe {
+            let r = crate::ffi::package_variant_list_for_commit(
+                repo,
+                rev.as_str(),
+                cancellable.gobj_rewrap(),
+            )?;
+            let r: glib::Variant = glib::translate::from_glib_full(r as *mut _);
+            r
+        }
+    };
+
+    // Open the RPM database for this commit.
+    let q = crate::ffi::rpmts_for_commit(repo.gobj_rewrap(), rev.as_str())?;
+
+    let mut state = MappingBuilder {
+        unpackaged_id: Rc::from(MappingBuilder::UNPACKAGED_ID),
+        packagemeta: Default::default(),
+        content: Default::default(),
+        duplicates: Default::default(),
+        multi_provider: Default::default(),
+        skip: Default::default(),
+        rpmsize: Default::default(),
+    };
+    // Insert metadata for unpakaged content.
+    state.packagemeta.insert(ObjectSourceMeta {
+        identifier: Rc::clone(&state.unpackaged_id),
+        name: Rc::clone(&state.unpackaged_id),
+        srcid: Rc::clone(&state.unpackaged_id),
+        // Assume that content in here changes frequently.
+        change_time_offset: u32::MAX,
+    });
+
+    let mut lowest_change_time = None;
+    let mut package_meta = HashMap::new();
+    for pkg in pkglist.iter() {
+        let name = pkg.child_value(0);
+        let name = name.str().unwrap();
+        let nevra = Rc::from(gv_nevra_to_string(&pkg).into_boxed_str());
+        let pkgmeta = q.package_meta(name)?;
+        let buildtime = pkgmeta.buildtime();
+        if let Some((lowid, lowtime)) = lowest_change_time.as_mut() {
+            if *lowtime > buildtime {
+                *lowid = Rc::clone(&nevra);
+                *lowtime = buildtime;
+            }
+        } else {
+            lowest_change_time = Some((Rc::clone(&nevra), pkgmeta.buildtime()))
+        }
+        state.rpmsize += pkgmeta.size();
+        package_meta.insert(nevra, pkgmeta);
+    }
+
+    // SAFETY: There must be at least one package.
+    let (lowest_change_name, lowest_change_time) =
+        lowest_change_time.expect("Failed to find any packages");
+    // Walk over the packages, and generate the `packagemeta` mapping, which is basically a subset of
+    // package metadata abstracted for ostree.  Note that right now, the package metadata includes
+    // both a "unique identifer" and a "human readable name", but for rpm-ostree we're just making
+    // those the same thing.
+    for (nevra, pkgmeta) in package_meta.iter() {
+        let buildtime = pkgmeta.buildtime();
+        let change_time_offset_secs: u32 = buildtime
+            .checked_sub(lowest_change_time)
+            .unwrap()
+            .try_into()
+            .unwrap();
+        // Convert to hours, because there's no strong use for caring about the relative difference of builds in terms
+        // of minutes or seconds.
+        let change_time_offset = change_time_offset_secs / (60 * 60);
+        state.packagemeta.insert(ObjectSourceMeta {
+            identifier: Rc::clone(&nevra),
+            name: Rc::clone(&nevra),
+            srcid: Rc::from(pkgmeta.src_pkg().to_str().unwrap()),
+            change_time_offset,
+        });
+    }
+
+    let kernel_dir = ostree_ext::bootabletree::find_kernel_dir(&root, gio::NONE_CANCELLABLE)?;
+    if let Some(kernel_dir) = kernel_dir {
+        let kernel_ver: Utf8PathBuf = kernel_dir.basename().unwrap().try_into()?;
+        let initramfs = kernel_dir.child("initramfs.img");
+        if initramfs.query_exists(gio::NONE_CANCELLABLE) {
+            let path: Utf8PathBuf = initramfs.path().unwrap().try_into()?;
+            let initramfs = initramfs.downcast_ref::<ostree::RepoFile>().unwrap();
+            let checksum = initramfs.checksum().unwrap();
+            let name = format!("initramfs (kernel {})", kernel_ver).into_boxed_str();
+            let name = Rc::from(name);
+            state.content.insert(checksum.to_string(), Rc::clone(&name));
+            state.packagemeta.insert(ObjectSourceMeta {
+                identifier: Rc::clone(&name),
+                name: Rc::clone(&name),
+                srcid: Rc::clone(&name),
+                change_time_offset: u32::MAX,
+            });
+            state.skip.insert(path);
+        }
+    }
+
+    let rpmdb = root.resolve_relative_path(crate::composepost::RPMOSTREE_RPMDB_LOCATION);
+    if rpmdb.query_exists(gio::NONE_CANCELLABLE) {
+        // TODO add mapping for rpmdb
+    }
+
+    // Walk the filesystem
+    build_mapping_recurse(&mut Utf8PathBuf::from("/"), &root, &q, &mut state)?;
+    let src_pkgs: HashSet<_> = state.packagemeta.iter().map(|p| &p.srcid).collect();
+
+    // Print out information about what we found
+    println!(
+        "{} objects in {} packages ({} source)",
+        state.content.len(),
+        state.packagemeta.len(),
+        src_pkgs.len(),
+    );
+    println!("rpm size: {}", state.rpmsize);
+    println!(
+        "Earliest changed package: {} at {}",
+        lowest_change_name,
+        Utc.timestamp_opt(lowest_change_time.try_into().unwrap(), 0)
+            .unwrap()
+    );
+    println!("{} duplicates", state.duplicates.len());
+    if !state.multi_provider.is_empty() {
+        println!("Multiple owners:");
+        for v in state.multi_provider.iter() {
+            println!("  {}", v);
+        }
+    }
+
+    // Convert our build state into the state that ostree consumes, discarding
+    // transient data such as the cases of files owned by multiple packages.
+    let meta: ObjectMeta = state.into();
+    // Now generate the sized version
+    let meta = ObjectMetaSized::compute_sizes(repo, meta)?;
+    if let Some(v) = opt.write_contentmeta_json {
+        let v = v.strip_prefix("/").unwrap_or(&v);
+        let root = Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
+        root.replace_file_with(v, |w| {
+            serde_json::to_writer(w, &meta.sizes).map_err(anyhow::Error::msg)
+        })?;
+    }
+    // TODO: Put this in a public API in ostree-rs-ext?
+    let labels = opt
+        .labels
+        .into_iter()
+        .map(|l| {
+            let (k, v) = l
+                .split_once('=')
+                .ok_or_else(|| anyhow::anyhow!("Missing '=' in label {}", l))?;
+            Ok((k.to_string(), v.to_string()))
+        })
+        .collect::<Result<_>>()?;
+
+    let mut copy_meta_keys = opt.copy_meta_keys;
+    // Default to copying the input hash to support cheap change detection
+    copy_meta_keys.push("rpmostree.inputhash".to_string());
+
+    let config = Config {
+        labels: Some(labels),
+        cmd: opt.cmd,
+    };
+    let opts = ExportOpts {
+        copy_meta_keys: copy_meta_keys,
+        max_layers: opt.max_layers,
+        ..Default::default()
+    };
+    let digest = ostree_ext::container::encapsulate(
+        repo,
+        rev.as_str(),
+        &config,
+        Some(opts),
+        Some(meta),
+        &opt.imgref,
+    )
+    .await?;
+    println!("Pushed digest: {}", digest);
+    Ok(())
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -726,14 +726,28 @@ pub mod ffi {
 
         fn output_message(msg: &str);
     }
-
     // rpmostree-rpm-util.h
     unsafe extern "C++" {
         include!("rpmostree-rpm-util.h");
+        #[allow(missing_debug_implementations)]
+        type RpmTs;
+        #[allow(missing_debug_implementations)]
+        type PackageMeta;
+
         // Currently only used in unit tests
         #[allow(dead_code)]
         fn nevra_to_cache_branch(nevra: &CxxString) -> Result<String>;
         fn get_repodata_chksum_repr(pkg: &mut DnfPackage) -> Result<String>;
+        fn rpmts_for_commit(repo: Pin<&mut OstreeRepo>, rev: &str) -> Result<UniquePtr<RpmTs>>;
+
+        // Methods on RpmTs
+        fn packages_providing_file(self: &RpmTs, path: &str) -> Result<Vec<String>>;
+        fn package_meta(self: &RpmTs, name: &str) -> Result<UniquePtr<PackageMeta>>;
+
+        // Methods on PackageMeta
+        fn size(self: &PackageMeta) -> u64;
+        fn buildtime(self: &PackageMeta) -> u64;
+        fn src_pkg(self: &PackageMeta) -> &CxxString;
     }
 
     // rpmostree-package-variants.h

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -44,6 +44,11 @@ async fn inner_async_main(args: Vec<String>) -> Result<i32> {
         "ex-container" => {
             return rpmostree_rust::container::entrypoint(&args_borrowed).await;
         }
+        // This is a custom wrapper for
+        "container-encapsulate" => {
+            rpmostree_rust::container::container_encapsulate(&args_borrowed).await?;
+            return Ok(0);
+        }
         _ => {}
     }
     // Everything below here is a blocking API, and run on a worker thread so

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -6,17 +6,18 @@ use crate::cxxrsutil::*;
 use crate::ffi::{output_message, ContainerImageState};
 use anyhow::Result;
 use ostree::glib;
-use ostree_container::store::LayeredImageImporter;
+use ostree_container::store::ImageImporter;
 use ostree_container::store::PrepareResult;
 use ostree_container::OstreeImageReference;
 use ostree_ext::container as ostree_container;
+use ostree_ext::container::store::ManifestLayerState;
 use ostree_ext::ostree;
 use std::convert::TryFrom;
 use std::pin::Pin;
 use tokio::runtime::Handle;
 
-impl From<ostree_container::store::LayeredImageState> for crate::ffi::ContainerImageState {
-    fn from(s: ostree_container::store::LayeredImageState) -> crate::ffi::ContainerImageState {
+impl From<Box<ostree_container::store::LayeredImageState>> for crate::ffi::ContainerImageState {
+    fn from(s: Box<ostree_container::store::LayeredImageState>) -> crate::ffi::ContainerImageState {
         crate::ffi::ContainerImageState {
             base_commit: s.base_commit,
             merge_commit: s.merge_commit,
@@ -26,36 +27,50 @@ impl From<ostree_container::store::LayeredImageState> for crate::ffi::ContainerI
     }
 }
 
+/// Return a two-tuple where the second element is a two-tuple too:
+/// (number of layers already stored, (number of layers to fetch, size of layers to fetch))
+fn layer_counts<'a>(layers: impl Iterator<Item = &'a ManifestLayerState>) -> (u32, (u32, u64)) {
+    layers.fold(
+        (0u32, (0u32, 0u64)),
+        |(stored, (n_to_fetch, size_to_fetch)), v| {
+            if v.commit.is_some() {
+                (stored + 1, (n_to_fetch, size_to_fetch))
+            } else {
+                (stored, (n_to_fetch + 1, size_to_fetch + v.size()))
+            }
+        },
+    )
+}
+
 async fn pull_container_async(
     repo: &ostree::Repo,
     imgref: &OstreeImageReference,
 ) -> Result<ContainerImageState> {
     output_message(&format!("Pulling manifest: {}", &imgref));
-    let mut imp = LayeredImageImporter::new(repo, imgref, Default::default()).await?;
+    let mut imp = ImageImporter::new(repo, imgref, Default::default()).await?;
     let prep = match imp.prepare().await? {
         PrepareResult::AlreadyPresent(r) => return Ok(r.into()),
         PrepareResult::Ready(r) => r,
     };
     let digest = prep.manifest_digest.clone();
     output_message(&format!("Importing: {} (digest: {})", &imgref, &digest));
-    if prep.base_layer.commit.is_none() {
-        let size = glib::format_size(prep.base_layer.size());
+    let ostree_layers = prep
+        .ostree_layers
+        .iter()
+        .chain(std::iter::once(&prep.ostree_commit_layer));
+    let (stored, (n_to_fetch, size_to_fetch)) = layer_counts(ostree_layers);
+    if stored > 0 || n_to_fetch > 0 {
+        let size = glib::format_size(size_to_fetch);
         output_message(&format!(
-            "Downloading base layer: {} ({})",
-            prep.base_layer.digest(),
-            size
+            "ostree chunk layers stored: {stored} needed: {n_to_fetch} ({size})"
         ));
-    } else {
-        output_message(&format!("Using base: {}", prep.base_layer.digest()));
     }
-    // TODO add nice download progress
-    for layer in prep.layers.iter() {
-        if layer.commit.is_some() {
-            output_message(&format!("Using layer: {}", layer.digest()));
-        } else {
-            let size = glib::format_size(layer.size());
-            output_message(&format!("Downloading layer: {} ({})", layer.digest(), size));
-        }
+    let (stored, (n_to_fetch, size_to_fetch)) = layer_counts(prep.layers.iter());
+    if stored > 0 || n_to_fetch > 0 {
+        let size = glib::format_size(size_to_fetch);
+        output_message(&format!(
+            "custom layers stored: {stored} needed: {n_to_fetch} ({size})"
+        ));
     }
     let import = imp.import(prep).await?;
     // TODO log the discarded bits from import

--- a/src/lib/rpmostree-package-priv.h
+++ b/src/lib/rpmostree-package-priv.h
@@ -23,6 +23,9 @@
 
 #include "rpmostree-package.h"
 #include <ostree.h>
+#ifdef __cplusplus
+#include "rust/cxx.h"
+#endif
 
 G_BEGIN_DECLS
 

--- a/src/libpriv/rpmostree-refts.h
+++ b/src/libpriv/rpmostree-refts.h
@@ -22,8 +22,11 @@
 #pragma once
 
 #include "libglnx.h"
+#include "rpmostree-util.h"
+#include "rust/cxx.h"
 #include <gio/gio.h>
 #include <libdnf/libdnf.h>
+#include <memory>
 
 G_BEGIN_DECLS
 
@@ -41,5 +44,47 @@ RpmOstreeRefTs *rpmostree_refts_ref (RpmOstreeRefTs *rts);
 void rpmostree_refts_unref (RpmOstreeRefTs *rts);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (RpmOstreeRefTs, rpmostree_refts_unref);
+
+namespace rpmostreecxx
+{
+
+struct PackageMeta
+{
+  uint64_t _size;
+  uint64_t _buildtime;
+  std::string _src_pkg;
+
+  uint64_t
+  size () const
+  {
+    return _size;
+  };
+  uint64_t
+  buildtime () const
+  {
+    return _buildtime;
+  };
+  const std::string &
+  src_pkg () const
+  {
+    return _src_pkg;
+  };
+};
+
+// A simple C++ wrapper for a librpm C type, so we can expose it to Rust via cxx.rs.
+class RpmTs
+{
+public:
+  RpmTs (::RpmOstreeRefTs *ts);
+  ~RpmTs ();
+  rpmts get_ts () const;
+  rust::Vec<rust::String> packages_providing_file (const rust::Str path) const;
+  std::unique_ptr<PackageMeta> package_meta (const rust::Str package) const;
+
+private:
+  ::RpmOstreeRefTs *_ts;
+};
+
+}
 
 G_END_DECLS

--- a/src/libpriv/rpmostree-rpm-util.cxx
+++ b/src/libpriv/rpmostree-rpm-util.cxx
@@ -954,6 +954,7 @@ get_refts_for_rootfs (const char *rootfs, GLnxTmpDir *tmpdir)
 gboolean
 rpmostree_get_refts_for_commit (OstreeRepo *repo, const char *ref, RpmOstreeRefTs **out_ts,
                                 GCancellable *cancellable, GError **error)
+
 {
   ROSCXX_TRY (core_libdnf_process_global_init (), error);
   g_auto (GLnxTmpDir) tmpdir = {
@@ -1597,4 +1598,21 @@ rpmostree_advisories_variant (DnfSack *sack, GPtrArray *pkgs)
   GLNX_HASH_TABLE_FOREACH_KV (advisories, DnfAdvisory *, advisory, GPtrArray *, pkgs)
   g_variant_builder_add_value (&builder, advisory_variant_new (advisory, pkgs));
   return g_variant_ref_sink (g_variant_builder_end (&builder));
+}
+
+namespace rpmostreecxx
+{
+
+std::unique_ptr<RpmTs>
+rpmts_for_commit (OstreeRepo &repo, rust::Str rev)
+{
+  g_autoptr (GError) local_error = NULL;
+  RpmOstreeRefTs *refts = NULL;
+  auto rev_c = std::string (rev);
+  if (!rpmostree_get_refts_for_commit (&repo, rev_c.c_str (), &refts, NULL, &local_error))
+    util::throw_gerror (local_error);
+
+  return std::make_unique<RpmTs> (refts);
+}
+
 }

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -38,6 +38,7 @@ namespace rpmostreecxx
 {
 rust::String nevra_to_cache_branch (const std::string &nevra);
 rust::String get_repodata_chksum_repr (DnfPackage &pkg);
+std::unique_ptr<RpmTs> rpmts_for_commit (OstreeRepo &repo, rust::Str rev);
 }
 
 // C code follows


### PR DESCRIPTION


The headlining feature here is https://github.com/ostreedev/ostree-rs-ext/pull/123
which adds support for "chunked ostree".

We gain a new `rpm-ostree container-encapsulate` option which
is like `ostree container encapsulate`, but generates chunked
images using the RPM database.

And on the client side, we now know how to handle incremental
updates - chunks that haven't changed won't be redownloaded.

---

