### PR TITLE
Revert "compose: move and symlink content under /var/lib"

### DIFF
--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -374,9 +374,8 @@ impl Bubblewrap {
     /// Set /var to be read-only, but with a transient writable /var/tmp
     /// and compat symlinks for scripts.
     pub(crate) fn setup_compat_var(&mut self) -> CxxResult<()> {
-        use crate::composepost::COMPAT_VARLIB_SYMLINKS;
-
-        for entry in COMPAT_VARLIB_SYMLINKS {
+        let content_dirs = &["alternatives", "vagrant"];
+        for entry in content_dirs {
             let varlib_path = format!("var/lib/{}", &entry);
             if !self.rootfs_fd.exists(&varlib_path)? {
                 let target = format!("../../usr/lib/{}", &entry);

--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -372,25 +372,9 @@ impl Bubblewrap {
     }
 
     /// Set /var to be read-only, but with a transient writable /var/tmp
-    /// and compat symlinks for scripts.
-    pub(crate) fn setup_compat_var(&mut self) -> CxxResult<()> {
-        let content_dirs = &["alternatives", "vagrant"];
-        for entry in content_dirs {
-            let varlib_path = format!("var/lib/{}", &entry);
-            if !self.rootfs_fd.exists(&varlib_path)? {
-                let target = format!("../../usr/lib/{}", &entry);
-                self.rootfs_fd
-                    .symlink(&varlib_path, &target)
-                    .with_context(|| {
-                        format!("Creating compatibility symlink at /var/lib/{}", &entry)
-                    })?;
-            };
-        }
-
+    pub(crate) fn var_tmp_tmpfs(&mut self) {
         self.bind_read("./var", "/var");
         self.append_bwrap_argv(&["--tmpfs", "/var/tmp"]);
-
-        Ok(())
     }
 
     /// Launch the process, returning a handle as well as a description for argv0

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -37,10 +37,6 @@ use std::path::Path;
 use std::pin::Pin;
 use std::process::Stdio;
 
-/// Directories that are moved out and symlinked from their `/var/lib/<entry>`
-/// location to `/usr/lib/<entry>`.
-pub(crate) static COMPAT_VARLIB_SYMLINKS: &[&str] = &["alternatives", "vagrant"];
-
 /* See rpmostree-core.h */
 const RPMOSTREE_BASE_RPMDB: &str = "usr/lib/sysimage/rpm-ostree-base-db";
 const RPMOSTREE_RPMDB_LOCATION: &str = "usr/share/rpm";
@@ -810,7 +806,8 @@ pub fn rootfs_prepare_links(rootfs_dfd: i32) -> CxxResult<()> {
     rootfs
         .ensure_dir_all("usr/lib", 0o0755)
         .context("Creating /usr/lib")?;
-    for entry in COMPAT_VARLIB_SYMLINKS {
+    let content_dirs = &["alternatives", "vagrant"];
+    for entry in content_dirs {
         let varlib_path = format!("var/lib/{}", entry);
         let is_var_dir = rootfs
             .metadata_optional(&varlib_path)?

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -127,7 +127,7 @@ pub mod ffi {
 
         fn bind_read(&mut self, src: &str, dest: &str);
         fn bind_readwrite(&mut self, src: &str, dest: &str);
-        fn setup_compat_var(&mut self) -> Result<()>;
+        fn var_tmp_tmpfs(&mut self);
 
         fn run(&mut self, cancellable: Pin<&mut GCancellable>) -> Result<()>;
     }

--- a/src/libpriv/rpmostree-importer.cxx
+++ b/src/libpriv/rpmostree-importer.cxx
@@ -70,9 +70,6 @@ struct RpmOstreeImporter
   // Hashset of filepath entries which are direct children of /opt;
   // each key is a plain path fragment, e.g. 'foo' for '/opt/foo/bar'.
   GHashTable *opt_direntries;
-  // Hashset of directories which got moved from '/var/lib' to '/usr/lib';
-  // each key is a plain directory name, e.g. 'foo' for '/var/lib/foo/'.
-  GHashTable *varlib_direntries;
   GString *tmpfiles_d;
   RpmOstreeImporterFlags flags;
   DnfPackage *pkg;
@@ -102,7 +99,6 @@ rpmostree_importer_finalize (GObject *object)
   g_clear_pointer (&self->rpmfi_overrides, (GDestroyNotify)g_hash_table_unref);
   g_clear_pointer (&self->doc_files, (GDestroyNotify)g_hash_table_unref);
   g_clear_pointer (&self->opt_direntries, (GDestroyNotify)g_hash_table_unref);
-  g_clear_pointer (&self->varlib_direntries, (GDestroyNotify)g_hash_table_unref);
 
   g_free (self->hdr_sha256);
 
@@ -275,7 +271,6 @@ rpmostree_importer_new_take_fd (int                     *fd,
   ret->cpio_offset = cpio_offset;
   ret->pkg = (DnfPackage*)(pkg ? g_object_ref (pkg) : NULL);
   ret->opt_direntries = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
-  ret->varlib_direntries = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 
   if (flags & RPMOSTREE_IMPORTER_FLAGS_NODOCS)
     ret->doc_files = g_hash_table_new_full (g_str_hash, g_str_equal,
@@ -613,10 +608,6 @@ handle_translate_pathname (OstreeRepo   *repo,
   if (g_str_has_prefix (path, "opt/"))
     g_hash_table_add (self->opt_direntries,
                       get_first_path_element (path + strlen("opt/")));
-  else if ((strcmp (path, "var/lib/alternatives") == 0) ||
-           (strcmp (path, "var/lib/vagrant") == 0))
-    g_hash_table_add (self->varlib_direntries,
-                      g_strdup (path + strlen("var/lib/")));
 
   return rpmostree_translate_path_for_ostree (path);
 }
@@ -661,22 +652,13 @@ import_rpm_to_repo (RpmOstreeImporter *self,
   GLNX_HASH_TABLE_FOREACH (self->opt_direntries, const char*, filename)
     {
       g_autofree char *opt = g_strconcat ("/opt/", filename, NULL);
-      auto quoted = rpmostreecxx::maybe_shell_quote (opt);
+      auto opt_quoted = rpmostreecxx::maybe_shell_quote (opt);
       /* Note that the destination can't be quoted as systemd just
        * parses the remainder of the line, and doesn't expand quotes.
        **/
       g_string_append_printf (self->tmpfiles_d,
                               "L %s - - - - /usr/lib/opt/%s\n",
-                              quoted.c_str(), filename);
-    }
-
-  GLNX_HASH_TABLE_FOREACH (self->varlib_direntries, const char*, dirname)
-    {
-      g_autofree char *linkpath = g_strconcat ("/var/lib/", dirname, NULL);
-      auto quoted = rpmostreecxx::maybe_shell_quote (linkpath);
-      g_string_append_printf (self->tmpfiles_d,
-                              "L %s - - - - ../../usr/lib/%s\n",
-                              quoted.c_str(), dirname);
+                              opt_quoted.c_str(), filename);
     }
 
   /* Handle any data we've accumulated to write to tmpfiles.d.

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -467,9 +467,9 @@ rpmostree_postprocess_final (int            rootfs_dfd,
         return glnx_prefix_error (error, "SELinux postprocess");
     }
 
-  CXX_TRY(rootfs_prepare_links(rootfs_dfd), error);
-
   CXX_TRY(convert_var_to_tmpfiles_d (rootfs_dfd, *cancellable), error);
+
+  CXX_TRY(rootfs_prepare_links(rootfs_dfd), error);
 
   if (!rpmostree_rootfs_postprocess_common (rootfs_dfd, cancellable, error))
     return FALSE;

--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -368,11 +368,7 @@ rpmostree_run_script_in_bwrap_container (int rootfs_fd,
     (is_glibc_locales || !enable_fuse) ? rpmostreecxx::BubblewrapMutability::MutateFreely : rpmostreecxx::BubblewrapMutability::RoFiles;
   auto bwrap = CXX_TRY_VAL(bubblewrap_new_with_mutability (rootfs_fd, mutability), error);
   /* Scripts can see a /var with compat links like alternatives */
-  try {
-    bwrap->setup_compat_var();
-  } catch (std::exception&e) {
-    return glnx_throw (error, "%s", e.what());
-  }
+  bwrap->var_tmp_tmpfs();
 
   struct stat stbuf;
   if (glnx_fstatat (rootfs_fd, "usr/lib/opt", &stbuf, AT_SYMLINK_NOFOLLOW, NULL) && S_ISDIR(stbuf.st_mode))

--- a/src/libpriv/rpmostree-util.cxx
+++ b/src/libpriv/rpmostree-util.cxx
@@ -141,11 +141,6 @@ rpmostree_translate_path_for_ostree (const char *path)
     return g_strconcat ("usr/etc/selinux/targeted/", path + strlen (VAR_SELINUX_TARGETED_PATH), NULL);
   else if (g_str_has_prefix (path, "opt/"))
     return g_strconcat ("usr/lib/", path, NULL);
-  else if ((strcmp (path, "var/lib/alternatives/") == 0) ||
-           g_str_has_prefix (path, "var/lib/alternatives") ||
-           (strcmp (path, "var/lib/vagrant/") == 0) ||
-           g_str_has_prefix (path, "var/lib/vagrant"))
-    return g_strconcat ("usr/", path + strlen ("var/"), NULL);
 
   return NULL;
 }

--- a/tests/compose/libbasic-test.sh
+++ b/tests/compose/libbasic-test.sh
@@ -124,10 +124,13 @@ assert_file_has_content parent.txt 01ba4719c80b6fe911b091a7c05124b64eeece964e09c
 echo "ok --parent"
 
 # Check symlinks injected into the rootfs.
-ostree --repo="${repo}" ls "${treeref}" /usr/lib/alternatives | grep '^d00755'> dirs.txt
-assert_file_has_content_literal dirs.txt '/usr/lib/alternatives'
-ostree --repo="${repo}" ls "${treeref}" /usr/local | grep '^l00777' > symlinks.txt
+ostree --repo="${repo}" ls "${treeref}" /usr/lib/alternatives /usr/lib/vagrant | grep '^d00755'> symlinks.txt
+assert_file_has_content_literal symlinks.txt '/usr/lib/alternatives'
+assert_file_has_content_literal symlinks.txt '/usr/lib/vagrant'
+ostree --repo="${repo}" ls "${treeref}" /var/lib/alternatives /var/lib/vagrant /usr/local | grep '^l00777' > symlinks.txt
 assert_file_has_content_literal symlinks.txt '/usr/local -> ../var/usrlocal'
+assert_file_has_content_literal symlinks.txt '/var/lib/alternatives -> ../../usr/lib/alternatives'
+assert_file_has_content_literal symlinks.txt '/var/lib/vagrant -> ../../usr/lib/vagrant'
 echo "ok symlinks"
 }
 

--- a/tests/compose/libbasic-test.sh
+++ b/tests/compose/libbasic-test.sh
@@ -129,13 +129,5 @@ assert_file_has_content_literal dirs.txt '/usr/lib/alternatives'
 ostree --repo="${repo}" ls "${treeref}" /usr/local | grep '^l00777' > symlinks.txt
 assert_file_has_content_literal symlinks.txt '/usr/local -> ../var/usrlocal'
 echo "ok symlinks"
-
-# Check iptables setup through alternatives.
-ostree --repo="${repo}" ls "${treeref}" '/usr/lib/alternatives/iptables' | grep '^-' > alternatives.txt
-assert_file_has_content_literal alternatives.txt '/usr/lib/alternatives/iptables'
-ostree --repo="${repo}" ls "${treeref}" '/usr/etc/alternatives/iptables' | grep '^l00777' > symlinks.txt
-# NOTE: this does not check the whole symlink target, but only a reasonably-stable leading portion of it.
-assert_file_has_content_literal symlinks.txt '/usr/etc/alternatives/iptables -> /usr/sbin/ip'
-echo "ok alternatives"
 }
 


### PR DESCRIPTION
This is a revert of https://github.com/coreos/rpm-ostree/pull/3387 and https://github.com/coreos/rpm-ostree/pull/3441, which get postponed to a later point after a lossless pkgcache gets implemented.

See https://github.com/coreos/rpm-ostree/issues/3473#issuecomment-1054425238 for details.