### PR TITLE
treefile: Add from_fields() constructor, use for `install` in container

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -397,6 +397,7 @@ pub mod ffi {
         fn treefile_new(filename: &str, basearch: &str, workdir: i32) -> Result<Box<Treefile>>;
         fn treefile_new_empty() -> Result<Box<Treefile>>;
         fn treefile_new_from_string(buf: &str, client: bool) -> Result<Box<Treefile>>;
+        fn treefile_new_from_fields(packages: &Vec<String>) -> Result<Box<Treefile>>;
         fn treefile_new_compose(
             filename: &str,
             basearch: &str,

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -2884,6 +2884,13 @@ pub(crate) fn treefile_new_from_string(buf: &str, client: bool) -> CxxResult<Box
     Ok(r)
 }
 
+/// Create a new treefile from fields.
+pub(crate) fn treefile_new_from_fields(packages: &Vec<String>) -> CxxResult<Box<Treefile>> {
+    let mut cfg = TreeComposeConfig::default();
+    cfg.packages = Some(packages.clone());
+    Ok(Box::new(Treefile::new_from_config(cfg, None)?))
+}
+
 /// Create a new empty treefile.
 pub(crate) fn treefile_new_empty() -> CxxResult<Box<Treefile>> {
     Ok(Treefile::new_from_string("{}")?)

--- a/src/app/rpmostree-builtin-rebuild.cxx
+++ b/src/app/rpmostree-builtin-rebuild.cxx
@@ -75,7 +75,7 @@ rpmostree_ex_builtin_rebuild (int             argc,
       if (n == 0)
         {
           g_print ("No changes to apply.\n");
-        } 
+        }
     }
   else
     {

--- a/src/libpriv/rpmostree-container.cxx
+++ b/src/libpriv/rpmostree-container.cxx
@@ -60,10 +60,9 @@ rpmostree_container_install_packages (char **packages,
                                       GCancellable  *cancellable,
                                       GError       **error)
 {
-  // XXX: awkward: add a e.g. `treefile_new_client_from_fields()`
-  g_autofree char *joined = g_strjoinv ("\",\"", packages);
-  g_autofree char *treefile_s = g_strdup_printf ("{\"packages\": [\"%s\"]}", joined);
-  auto treefile = CXX_TRY_VAL(treefile_new_from_string (treefile_s, true), error);
-
+  rust::Vec<rust::String> pkgs;
+  for (char **it = packages; it && *it; it++)
+    pkgs.push_back(std::string(*it));
+  auto treefile = CXX_TRY_VAL(treefile_new_from_fields(pkgs), error);
   return rpmostree_container_rebuild (*treefile, cancellable, error);
 }


### PR DESCRIPTION
This cleans up the hack of creating a treefile from a generated string
just so we can install packages in the container path.

Prep for having more CLI commands work too, like `override remove`.