### PR TITLE
scripts: Support transfiletriggerin lua replacements

### DIFF
--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -849,6 +849,7 @@ rpmostree_transfiletriggers_run_sync (Header        hdr,
       rpmFlags flags = 0;
       if (rpmtdSetIndex (&tscriptflags, i) >= 0)
         flags = rpmtdGetNumber (&tscriptflags);
+      gboolean expand = (flags & RPMSCRIPT_FLAG_EXPAND) > 0;
 
       g_assert_cmpint (rpmtdSetIndex (&tscripts, i), ==, i);
       const char *script = rpmtdGetString (&tscripts);
@@ -863,7 +864,7 @@ rpmostree_transfiletriggers_run_sync (Header        hdr,
         return FALSE;
 
       g_autofree char *script_owned = NULL;
-      if (flags & RPMSCRIPT_FLAG_EXPAND)
+      if (expand)
         script = script_owned = rpmExpand (script, NULL);
       (void)script_owned; /* Pacify static analysis */
 

--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -850,6 +850,11 @@ rpmostree_transfiletriggers_run_sync (Header        hdr,
       if (rpmtdSetIndex (&tscriptflags, i) >= 0)
         flags = rpmtdGetNumber (&tscriptflags);
 
+      g_assert_cmpint (rpmtdSetIndex (&tscripts, i), ==, i);
+      const char *script = rpmtdGetString (&tscripts);
+      if (!script)
+        continue;
+
       g_assert_cmpint (rpmtdSetIndex (&tprogs, i), ==, i);
       const char *interp = rpmtdGetString (&tprogs);
       if (!interp)
@@ -858,10 +863,6 @@ rpmostree_transfiletriggers_run_sync (Header        hdr,
         return FALSE;
 
       g_autofree char *script_owned = NULL;
-      g_assert_cmpint (rpmtdSetIndex (&tscripts, i), ==, i);
-      const char *script = rpmtdGetString (&tscripts);
-      if (!script)
-        continue;
       if (flags & RPMSCRIPT_FLAG_EXPAND)
         script = script_owned = rpmExpand (script, NULL);
       (void)script_owned; /* Pacify static analysis */


### PR DESCRIPTION
Ideally we should probably rework this function instead to dedupe a bit
with `rpmostree_script_run_sync`. But specifically for lua, hopefully we
can eventually clean things up somehow as discussed in
https://github.com/coreos/fedora-coreos-tracker/issues/1080.

Fixes: https://github.com/coreos/rpm-ostree/issues/3487