### PR TITLE
packaging: Canonicalize tarballs to uid/gid 0

### DIFF
--- a/packaging/make-git-snapshot.sh
+++ b/packaging/make-git-snapshot.sh
@@ -57,7 +57,7 @@ j = json.load(open(checksum_file))
 j["files"] = {f:c for f, c in j["files"].items() if not f.startswith(subdir)}
 open(checksum_file, "w").write(json.dumps(j))' $crate_subdir
  done
- tar --transform="s,^,${PKG_VER}/," -rf ${TARFILE_TMP} * .cargo/
+ tar --owner=0 --group=0 --transform="s,^,${PKG_VER}/," -rf ${TARFILE_TMP} * .cargo/
  )
 
 # And finally, vendor generated code.  See installdeps.sh
@@ -66,6 +66,6 @@ open(checksum_file, "w").write(json.dumps(j))' $crate_subdir
  cp rpmostree-cxxrs{,-prebuilt}.h
  cp rpmostree-cxxrs{,-prebuilt}.cxx
  cp rust/cxx.h rust/cxx-prebuilt.h
- tar --transform "s,^,${PKG_VER}/," -rf ${TARFILE_TMP} rpmostree-cxxrs-prebuilt.h rpmostree-cxxrs-prebuilt.cxx rust/cxx-prebuilt.h)
+ tar --owner=0 --group=0 --transform "s,^,${PKG_VER}/," -rf ${TARFILE_TMP} rpmostree-cxxrs-prebuilt.h rpmostree-cxxrs-prebuilt.cxx rust/cxx-prebuilt.h)
 
 mv ${TARFILE_TMP} ${TARFILE}

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -208,7 +208,7 @@ $PYTHON autofiles.py > files \
   '%{_prefix}/lib/systemd/system/*' \
   '%{_libexecdir}/rpm-ostree*' \
   '%{_datadir}/polkit-1/actions/*.policy' \
-  '%{_datadir}/dbus-1/system-services' \
+  '%{_datadir}/dbus-1/system-services/*' \
   '%{_datadir}/bash-completion/completions/*'
 
 $PYTHON autofiles.py > files.lib \


### PR DESCRIPTION
Otherwise when building unprivileged in OpenShift as a large uid, we can
get errors like:

```
tar: value 1000710000 out of uid_t range 0..2097151
```

It's good hygiene anyway.