### PR TITLE
Ignore .vscode and libgnlx-config.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .deps
 .dirstamp
 .libs
+.vscode
 /*.bak
 /*.gcda
 /*.gcno
@@ -53,6 +54,7 @@
 /gtk-doc.make
 /insttree/
 /libglnx.la
+/libglnx-config.h
 /librpmostree-1.la
 /librpmostreecxxrs.la
 /librpmostreeinternals.la


### PR DESCRIPTION
Not sure whether the latter is a new arrival or not but it's showing up in my list. The former is due to my use of Visual Studio Code.