### PR TITLE
Require clang-format on all C/C++ files

### DIFF
--- a/ci/codestyle.sh
+++ b/ci/codestyle.sh
@@ -15,7 +15,7 @@ echo "ok"
 
 echo -n "checking clang-format... "
 rm -f clang-unformatted.txt
-git ls-files 'src/**.c' 'src/**.cxx' 'src/**.h' 'src/**.hpp' | while read f; do
+git ls-files '**.c' '**.cxx' '**.h' '**.hpp' | while read f; do
     if ! clang-format --Werror --ferror-limit=1 --dry-run "$f" > /dev/null 2>&1; then
         echo "$f" >> clang-unformatted.txt
     fi

--- a/ci/codestyle.sh
+++ b/ci/codestyle.sh
@@ -14,18 +14,7 @@ rm tabdamage.txt
 echo "ok"
 
 echo -n "checking clang-format... "
-rm -f clang-unformatted.txt
-git ls-files '**.c' '**.cxx' '**.h' '**.hpp' | while read f; do
-    if ! clang-format --Werror --ferror-limit=1 --dry-run "$f" > /dev/null 2>&1; then
-        echo "$f" >> clang-unformatted.txt
-    fi
-done
-if test -s clang-unformatted.txt; then
-    echo "Error: clang-format needed on these files:" 1>&2
-    cat clang-unformatted.txt 1>&2
-    exit 1
-fi
-rm -f clang-unformatted.txt
+git ls-files '**.c' '**.cxx' '**.h' '**.hpp' | xargs clang-format --Werror --dry-run
 echo "ok"
 
 echo -n "checking rustfmt... "

--- a/rust/libdnf-sys/cxx/libdnf.cxx
+++ b/rust/libdnf-sys/cxx/libdnf.cxx
@@ -20,25 +20,38 @@
 
 #include "libdnf.hxx"
 
-namespace dnfcxx {
-  // XXX: use macro to dedupe
-  rust::String dnf_package_get_nevra(DnfPackage &pkg) {
-    return rust::String(::dnf_package_get_nevra(&pkg));
-  }
-  rust::String dnf_package_get_name(DnfPackage &pkg) {
-    return rust::String(::dnf_package_get_name(&pkg));
-  }
-  rust::String dnf_package_get_evr(DnfPackage &pkg) {
-    return rust::String(::dnf_package_get_evr(&pkg));
-  }
-  rust::String dnf_package_get_arch(DnfPackage &pkg) {
-    return rust::String(::dnf_package_get_arch(&pkg));
-  }
+namespace dnfcxx
+{
+// XXX: use macro to dedupe
+rust::String
+dnf_package_get_nevra (DnfPackage &pkg)
+{
+  return rust::String (::dnf_package_get_nevra (&pkg));
+}
+rust::String
+dnf_package_get_name (DnfPackage &pkg)
+{
+  return rust::String (::dnf_package_get_name (&pkg));
+}
+rust::String
+dnf_package_get_evr (DnfPackage &pkg)
+{
+  return rust::String (::dnf_package_get_evr (&pkg));
+}
+rust::String
+dnf_package_get_arch (DnfPackage &pkg)
+{
+  return rust::String (::dnf_package_get_arch (&pkg));
+}
 
-  rust::String dnf_repo_get_id(DnfRepo &repo) {
-    return rust::String(::dnf_repo_get_id(&repo));
-  }
-  guint64 dnf_repo_get_timestamp_generated(DnfRepo &repo) {
-    return ::dnf_repo_get_timestamp_generated(&repo);
-  }
+rust::String
+dnf_repo_get_id (DnfRepo &repo)
+{
+  return rust::String (::dnf_repo_get_id (&repo));
+}
+guint64
+dnf_repo_get_timestamp_generated (DnfRepo &repo)
+{
+  return ::dnf_repo_get_timestamp_generated (&repo);
+}
 }

--- a/tests/common/libtest.cxx
+++ b/tests/common/libtest.cxx
@@ -33,22 +33,22 @@ rot_test_run_libtest (const char *cmd, GError **error)
 {
   const char *srcdir = g_getenv ("topsrcdir");
   int estatus;
-  g_autoptr(GPtrArray) argv = g_ptr_array_new ();
-  g_autoptr(GString) cmdstr = g_string_new ("");
+  g_autoptr (GPtrArray) argv = g_ptr_array_new ();
+  g_autoptr (GString) cmdstr = g_string_new ("");
 
-  g_ptr_array_add (argv, (char*)"bash");
-  g_ptr_array_add (argv, (char*)"-c");
+  g_ptr_array_add (argv, (char *)"bash");
+  g_ptr_array_add (argv, (char *)"-c");
 
   g_string_append (cmdstr, "set -xeuo pipefail; . ");
   g_string_append (cmdstr, srcdir);
   g_string_append (cmdstr, "/tests/common/libtest.sh; ");
   g_string_append (cmdstr, cmd);
 
-  g_ptr_array_add (argv, (char*)cmdstr->str);
+  g_ptr_array_add (argv, (char *)cmdstr->str);
   g_ptr_array_add (argv, NULL);
 
-  if (!g_spawn_sync (NULL, (char**)argv->pdata, NULL, G_SPAWN_SEARCH_PATH,
-                     NULL, NULL, NULL, NULL, &estatus, error))
+  if (!g_spawn_sync (NULL, (char **)argv->pdata, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL,
+                     &estatus, error))
     return FALSE;
 
   if (!g_spawn_check_exit_status (estatus, error))
@@ -56,4 +56,3 @@ rot_test_run_libtest (const char *cmd, GError **error)
 
   return TRUE;
 }
-


### PR DESCRIPTION
Followup to the previous patch.  When I was testing the original
PR I ran `clang-format` on everything (i.e. not just stuff in `src`)
and was confused why these files differed from the original PR.

I see no reason to limit to files in `src`, even though there's only
two C++ files outside of there today.

CC @jeamland 
