### PR TITLE
Update to cap-std-ext 0.23.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std-ext"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fce4ce38b8f2b25c5f60ea3542adfb0f536e6539d1d79e2ce47b13421b8cdef"
+checksum = "35542c3139ae910606e9de752706b6ebd676ae31f35c963d6e64dd07f8f18c7c"
 dependencies = [
  "cap-std",
  "rustix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = "1.0.55"
 binread = "2.2.0"
 c_utf8 = "0.1.0"
 camino = "1.0.7"
-cap-std-ext = "0.24.0"
+cap-std-ext = "0.24.3"
 cap-tempfile = "0.24.1"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = "2.34.0"


### PR DESCRIPTION
We want the new `symlink_metadata_optional` flag to aid cap-std porting,
xref https://github.com/coreos/rpm-ostree/pull/3468
