### PR TITLE
Makefile: add `make clang-format` to format tree

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -97,6 +97,10 @@ clean-local-cargo:
 	cargo clean
 CLEAN_LOCAL_HOOKS += clean-local-cargo
 
+.PHONY: clang-format
+clang-format:
+	git ls-files '**.c' '**.cxx' '**.h' '**.hpp' | xargs clang-format -i
+
 use-git-not-dist-hook:
 	@echo
 	@echo 'ERROR: rpm-ostree does not use/support "make dist"; see packaging/Makefile.dist-packaging' 1>&2


### PR DESCRIPTION
Follow-up to https://github.com/coreos/rpm-ostree/pull/3475 and https://github.com/coreos/rpm-ostree/pull/3498.