### PR TITLE
app/override: Support `override remove` and `override replace` in container flow

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -452,6 +452,7 @@ pub mod ffi {
         fn print_deprecation_warnings(&self);
         fn print_experimental_notices(&self);
         fn sanitycheck_externals(&self) -> Result<()>;
+        fn validate_for_container(&self) -> Result<()>;
     }
 
     // treefile.rs (split out from above to make &self nice to use)

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -425,6 +425,7 @@ pub mod ffi {
         fn get_packages_local_fileoverride(&self) -> Vec<String>;
         fn get_packages_override_replace_local(&self) -> Vec<String>;
         fn get_packages_override_remove(&self) -> Vec<String>;
+        fn set_packages_override_remove(&mut self, packages: &Vec<String>);
         fn get_modules_enable(&self) -> Vec<String>;
         fn get_modules_install(&self) -> Vec<String>;
         fn get_exclude_packages(&self) -> Vec<String>;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -424,6 +424,8 @@ pub mod ffi {
         fn get_packages_local(&self) -> Vec<String>;
         fn get_packages_local_fileoverride(&self) -> Vec<String>;
         fn get_packages_override_replace_local(&self) -> Vec<String>;
+        fn get_packages_override_replace_local_rpms(&self) -> Vec<String>;
+        fn set_packages_override_replace_local_rpms(&mut self, packages: &Vec<String>);
         fn get_packages_override_remove(&self) -> Vec<String>;
         fn set_packages_override_remove(&mut self, packages: &Vec<String>);
         fn get_modules_enable(&self) -> Vec<String>;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -767,6 +767,21 @@ impl Treefile {
             .collect()
     }
 
+    pub(crate) fn get_packages_override_replace_local_rpms(&self) -> Vec<String> {
+        self.parsed
+            .derive
+            .override_replace_local_rpms
+            .clone()
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn set_packages_override_replace_local_rpms(&mut self, packages: &Vec<String>) {
+        let _ = self.parsed.derive.override_replace_local_rpms.take();
+        if !packages.is_empty() {
+            self.parsed.derive.override_replace_local_rpms = Some(packages.clone());
+        }
+    }
+
     pub(crate) fn get_exclude_packages(&self) -> Vec<String> {
         self.parsed
             .base
@@ -1045,6 +1060,7 @@ impl Treefile {
         let mut clone = self.parsed.derive.clone();
         // neuter everything we *do* support
         clone.override_remove.take();
+        clone.override_replace_local_rpms.take();
         if clone != Default::default() {
             let j = serde_json::to_string_pretty(&clone)?;
             bail!(
@@ -1751,6 +1767,8 @@ pub(crate) struct DeriveConfigFields {
     pub(crate) override_remove: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) override_replace_local: Option<BTreeMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) override_replace_local_rpms: Option<Vec<String>>,
 
     // Initramfs
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -750,6 +750,13 @@ impl Treefile {
             .unwrap_or_default()
     }
 
+    pub(crate) fn set_packages_override_remove(&mut self, packages: &Vec<String>) {
+        let _ = self.parsed.derive.override_remove.take();
+        if !packages.is_empty() {
+            self.parsed.derive.override_remove = Some(packages.clone());
+        }
+    }
+
     pub(crate) fn get_packages_override_replace_local(&self) -> Vec<String> {
         self.parsed
             .derive
@@ -1036,7 +1043,8 @@ impl Treefile {
         // this is pretty wasteful but it allows us to make this an opt-in, instead of an opt-out
         // and avoid regressing if we add more fields in the future
         let mut clone = self.parsed.derive.clone();
-        // here in the future, we'll neuter everything we *do* support
+        // neuter everything we *do* support
+        clone.override_remove.take();
         if clone != Default::default() {
             let j = serde_json::to_string_pretty(&clone)?;
             bail!(

--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -20,6 +20,7 @@
 
 #include "config.h"
 
+#include "rpmostree-container.h"
 #include "rpmostree-libbuiltin.h"
 #include "rpmostree-override-builtins.h"
 
@@ -251,6 +252,14 @@ rpmostree_override_builtin_remove (int argc, char **argv, RpmOstreeCommandInvoca
   argv++;
   argc--;
   argv[argc] = NULL;
+
+  auto is_ostree_container = ROSCXX_TRY_VAL (is_ostree_container (), error);
+  if (is_ostree_container)
+    {
+      auto treefile = ROSCXX_TRY_VAL (treefile_new_empty (), error);
+      treefile->set_packages_override_remove (util::rust_stringvec_from_strv (argv));
+      return rpmostree_container_rebuild (*treefile, cancellable, error);
+    }
 
   return handle_override (sysroot_proxy, invocation, (const char *const *)argv, opt_replace_pkgs,
                           NULL, cancellable, error);

--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -221,6 +221,15 @@ rpmostree_override_builtin_replace (int argc, char **argv, RpmOstreeCommandInvoc
   argc--;
   argv[argc] = NULL;
 
+  auto is_ostree_container = ROSCXX_TRY_VAL (is_ostree_container (), error);
+  if (is_ostree_container)
+    {
+      auto treefile = ROSCXX_TRY_VAL (treefile_new_empty (), error);
+      treefile->set_packages_override_remove (util::rust_stringvec_from_strv (opt_remove_pkgs));
+      treefile->set_packages_override_replace_local_rpms (util::rust_stringvec_from_strv (argv));
+      return rpmostree_container_rebuild (*treefile, cancellable, error);
+    }
+
   return handle_override (sysroot_proxy, invocation, opt_remove_pkgs, (const char *const *)argv,
                           NULL, cancellable, error);
 }
@@ -257,6 +266,8 @@ rpmostree_override_builtin_remove (int argc, char **argv, RpmOstreeCommandInvoca
   if (is_ostree_container)
     {
       auto treefile = ROSCXX_TRY_VAL (treefile_new_empty (), error);
+      treefile->set_packages_override_replace_local_rpms (
+          util::rust_stringvec_from_strv (opt_replace_pkgs));
       treefile->set_packages_override_remove (util::rust_stringvec_from_strv (argv));
       return rpmostree_container_rebuild (*treefile, cancellable, error);
     }

--- a/src/libpriv/rpmostree-container.cxx
+++ b/src/libpriv/rpmostree-container.cxx
@@ -33,6 +33,8 @@ gboolean
 rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile, GCancellable *cancellable,
                              GError **error)
 {
+  CXX_TRY (treefile.validate_for_container (), error);
+
   g_autoptr (RpmOstreeContext) ctx = rpmostree_context_new_container ();
   rpmostree_context_set_treefile (ctx, treefile);
 

--- a/src/libpriv/rpmostree-container.cxx
+++ b/src/libpriv/rpmostree-container.cxx
@@ -21,6 +21,7 @@
 #include "config.h"
 
 #include <glib-unix.h>
+#include <libdnf/libdnf.h>
 #include <string.h>
 
 #include "rpmostree-core.h"
@@ -48,6 +49,9 @@ rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile, GCancellable *can
     return FALSE;
 
   DnfContext *dnfctx = rpmostree_context_get_dnf (ctx);
+  DnfTransaction *t = dnf_context_get_transaction (dnfctx);
+  guint64 flags = dnf_transaction_get_flags (t);
+  dnf_transaction_set_flags (t, flags | DNF_TRANSACTION_FLAG_ALLOW_DOWNGRADE);
 
   /* can't use cancellable here because it wants to re-set it on the state,
    * which will trigger an assertion; XXX: tweak libdnf */

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -1737,6 +1737,17 @@ rpmostree_context_prepare (RpmOstreeContext *self, GCancellable *cancellable, GE
       g_assert_cmpint (packages_override_remove.size (), ==, 0);
     }
 
+  if (self->is_container)
+    {
+      /* There are things we don't support in the container flow. */
+      g_assert_cmpint (packages_local.size (), ==, 0);
+      g_assert_cmpint (packages_local_fileoverride.size (), ==, 0);
+      g_assert_cmpint (packages_override_replace_local.size (), ==, 0);
+      g_assert_cmpint (exclude_packages.size (), ==, 0);
+      g_assert_cmpint (modules_enable.size (), ==, 0);
+      g_assert_cmpint (modules_install.size (), ==, 0);
+    }
+
   /* setup sack if not yet set up */
   if (dnf_context_get_sack (dnfctx) == NULL)
     {

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -114,7 +114,7 @@ baseurl=http://127.0.0.1
 EOF
     cat >baz.yaml << 'EOF'
 packages:
-  - baz
+  - baz-1.0
 EOF
     cat >testdaemon-query.yaml << 'EOF'
 repo-packages:
@@ -127,6 +127,11 @@ override-remove:
   - nano
   - nano-default-editor
 EOF
+    cp ${KOLA_EXT_DATA}/rpm-repos/0/packages/x86_64/baz-2.0-1.x86_64.rpm .
+    cat >replace-baz.yaml <<EOF
+override-replace-local-rpms:
+  - /var/tmp/baz-2.0-1.x86_64.rpm
+EOF
 cat > Dockerfile << 'EOF'
 FROM localhost/fcos
 RUN rm -rf /etc/yum.repos.d/*  # Ensure we work offline
@@ -134,6 +139,9 @@ ADD local.repo /etc/yum.repos.d/
 RUN rpm-ostree install bar
 RUN mkdir -p /etc/rpm-ostree/origin.d
 ADD baz.yaml testdaemon-query.yaml nonano.yaml /etc/rpm-ostree/origin.d/
+RUN rpm-ostree ex rebuild
+ADD replace-baz.yaml /etc/rpm-ostree/origin.d/
+ADD baz-2.0-1.x86_64.rpm /var/tmp/
 RUN rpm-ostree ex rebuild
 RUN echo some config file > /etc/someconfig.conf
 RUN echo somedata > /usr/share/somenewdata
@@ -160,10 +168,12 @@ EOF
   3) 
     grep -qF 'some config file' /etc/someconfig.conf || (echo missing someconfig.conf; exit 1)
     grep -qF somedata /usr/share/somenewdata || (echo missing somenewdata; exit 1)
-    for p in bar baz testdaemon; do
+    for p in bar testdaemon; do
       assert_streq $(rpm -q $p) $p-1.0-1.${arch}
       test -f /usr/bin/$p
     done
+    assert_streq $(rpm -q baz) baz-2.0-1.${arch}
+    test -f /usr/bin/baz
     ! rpm -q nano
     rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"ostree-unverified-image:oci:$image_dir:derived\""
     ;;

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -122,13 +122,18 @@ repo-packages:
     packages:
       - testdaemon
 EOF
+    cat >nonano.yaml << 'EOF'
+override-remove:
+  - nano
+  - nano-default-editor
+EOF
 cat > Dockerfile << 'EOF'
 FROM localhost/fcos
 RUN rm -rf /etc/yum.repos.d/*  # Ensure we work offline
 ADD local.repo /etc/yum.repos.d/
 RUN rpm-ostree install bar
 RUN mkdir -p /etc/rpm-ostree/origin.d
-ADD baz.yaml testdaemon-query.yaml /etc/rpm-ostree/origin.d/
+ADD baz.yaml testdaemon-query.yaml nonano.yaml /etc/rpm-ostree/origin.d/
 RUN rpm-ostree ex rebuild
 RUN echo some config file > /etc/someconfig.conf
 RUN echo somedata > /usr/share/somenewdata
@@ -159,6 +164,7 @@ EOF
       assert_streq $(rpm -q $p) $p-1.0-1.${arch}
       test -f /usr/bin/$p
     done
+    ! rpm -q nano
     rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"ostree-unverified-image:oci:$image_dir:derived\""
     ;;
   *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;

--- a/tests/kolainst/kolainst-build.sh
+++ b/tests/kolainst/kolainst-build.sh
@@ -21,6 +21,7 @@ mkdir ${test_tmpdir}/rpm-repos/${repover}
 build_rpm foo version 1.2 release 3
 build_rpm bar
 build_rpm baz
+build_rpm baz version 2.0
 # And from here we lose our creativity and name things starting
 # with `testpkg` and grow more content.
 # This one has various files in /etc


### PR DESCRIPTION
```
commit 98bd1cff568206545167c6c82c9274c63e60ee58
Date:   Tue Mar 22 16:53:44 2022 -0400

    app/override: Support override remove in container flow

    This one doesn't really require any work. The core already does the
    right thing for the generated treefile with the `override-remove` knob
    set. So it's just a matter of wiring it through.
```
---
```
commit a55205829f43a188e37a166869ac04a4c08e74b2
Date:   Tue Mar 22 16:54:23 2022 -0400

    app/override: Support override replace in container flow

    This one requires a bit more work. The main issue is that replacement
    overrides usually heavily leverage the package cache repo. But here we
    don't have that.

    I think it's simpler to keep them separate instead of trying to make the
    same key work in both modes. So we add a new
    `override-replace-local-rpms` which takes paths to local RPMs.

    Then in the core, it's a matter of adding the packages to the sack and
    the goal just like we do for cached packages.

    Note this only works for trivial packages for now. E.g. replacing the
    kernel with this does not work yet. We also need support for fetching
    overrides from repos.
```
