### PR TITLE
packaging: Remove unneeded Windows binaries from vendor snapshot

### DIFF
--- a/packaging/make-git-snapshot.sh
+++ b/packaging/make-git-snapshot.sh
@@ -57,6 +57,8 @@ j = json.load(open(checksum_file))
 j["files"] = {f:c for f, c in j["files"].items() if not f.startswith(subdir)}
 open(checksum_file, "w").write(json.dumps(j))' $crate_subdir
  done
+ # Remove unneeded Windows binaries
+ rm -rf vendor/winapi*gnu*/lib/*.a
  tar --owner=0 --group=0 --transform="s,^,${PKG_VER}/," -rf ${TARFILE_TMP} * .cargo/
  )
 


### PR DESCRIPTION
Workaround to remove Windows specific binaries that we don't need from the vendored sources.

See: [rust-lang/cargo#7058](https://github.com/rust-lang/cargo/issues/7058)