### PR TITLE
Minor prep patches for treefile and container work

### DIFF
--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1729,6 +1729,7 @@ pub(crate) struct DeriveConfigFields {
     pub(crate) custom: Option<DeriveCustom>,
 
     // Misc
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) override_commit: Option<String>,
 }
 

--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -181,7 +181,11 @@ rpmostree_builtin_install (int argc, char **argv, RpmOstreeCommandInvocation *in
 
   auto is_ostree_container = CXX_TRY_VAL (is_ostree_container (), error);
   if (is_ostree_container)
-    return rpmostree_container_install_packages (argv, cancellable, error);
+    {
+      auto pkgs = util::rust_stringvec_from_strv (argv);
+      auto treefile = CXX_TRY_VAL (treefile_new_from_fields (pkgs), error);
+      return rpmostree_container_rebuild (*treefile, cancellable, error);
+    }
 
   return pkg_change (invocation, sysroot_proxy, (const char *const *)argv,
                      (const char *const *)opt_uninstall, cancellable, error);

--- a/src/libpriv/rpmostree-container.cxx
+++ b/src/libpriv/rpmostree-container.cxx
@@ -54,13 +54,3 @@ rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile, GCancellable *can
 
   return TRUE;
 }
-
-gboolean
-rpmostree_container_install_packages (char **packages, GCancellable *cancellable, GError **error)
-{
-  rust::Vec<rust::String> pkgs;
-  for (char **it = packages; it && *it; it++)
-    pkgs.push_back (std::string (*it));
-  auto treefile = CXX_TRY_VAL (treefile_new_from_fields (pkgs), error);
-  return rpmostree_container_rebuild (*treefile, cancellable, error);
-}

--- a/src/libpriv/rpmostree-container.h
+++ b/src/libpriv/rpmostree-container.h
@@ -25,7 +25,4 @@ G_BEGIN_DECLS
 gboolean rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile, GCancellable *cancellable,
                                       GError **error);
 
-gboolean rpmostree_container_install_packages (char **packages, GCancellable *cancellable,
-                                               GError **error);
-
 G_END_DECLS

--- a/src/libpriv/rpmostree-container.h
+++ b/src/libpriv/rpmostree-container.h
@@ -18,6 +18,10 @@
  * Boston, MA 02111-1307, USA.
  */
 
+#include <glib.h>
+
+#include "rpmostree-cxxrs.h"
+
 #pragma once
 
 G_BEGIN_DECLS


### PR DESCRIPTION
Split out of https://github.com/coreos/rpm-ostree/pull/3501.