### PR TITLE
libpriv/import: implement autocleanup for rpmfd

### DIFF
--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -72,6 +72,7 @@ void rpmhdrs_diff_prnt_block (gboolean changelogs, struct RpmHeadersDiff *diff);
 /* Define cleanup functions for librpm here. Note that this
  * will break if one day librpm ever decides to define these
  * itself. TODO: Move them to libdnf */
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC (FD_t, Fclose, NULL)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC (Header, headerFree, NULL)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC (rpmfi, rpmfiFree, NULL)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC (rpmts, rpmtsFree, NULL)


### PR DESCRIPTION
This adds the autocleanup definition for librpm `FD_t`. It allows
simplifying a bunch of error handlers and dropping some `goto`
statements.
