### PR TITLE
deploy: Warn about reliability of `--preview`

### DIFF
--- a/src/app/rpmostree-builtin-deploy.cxx
+++ b/src/app/rpmostree-builtin-deploy.cxx
@@ -124,6 +124,8 @@ rpmostree_builtin_deploy (int argc, char **argv, RpmOstreeCommandInvocation *inv
       if (!rpmostree_os_call_download_deploy_rpm_diff_sync (
               os_proxy, revision, packages, &transaction_address, cancellable, error))
         return FALSE;
+      g_print ("Note: The information output from --preview may be unreliable.  See "
+               "https://github.com/coreos/rpm-ostree/issues/1579\n");
     }
   else
     {

--- a/src/app/rpmostree-builtin-upgrade.cxx
+++ b/src/app/rpmostree-builtin-upgrade.cxx
@@ -200,6 +200,8 @@ rpmostree_builtin_upgrade (int argc, char **argv, RpmOstreeCommandInvocation *in
 
   if (check_or_preview)
     {
+      g_print ("Note: --check and --preview may be unreliable.  See "
+               "https://github.com/coreos/rpm-ostree/issues/1579\n");
       g_autoptr (GVariant) cached_update = NULL;
       if (rpmostree_os_get_has_cached_update_rpm_diff (os_proxy))
         cached_update = rpmostree_os_dup_cached_update (os_proxy);

--- a/tests/vmcheck/test-autoupdate-check.sh
+++ b/tests/vmcheck/test-autoupdate-check.sh
@@ -78,7 +78,9 @@ assert_check_preview_rc() {
   local rc=0
   vm_rpmostree upgrade --check > out.txt || rc=$?
   assert_streq $rc $expected_rc
+  assert_file_has_content out.txt "Note:.*may be unreliable"
   vm_rpmostree upgrade --preview > out-verbose.txt || rc=$?
+  assert_file_has_content out-verbose.txt "Note:.*may be unreliable"
   assert_streq $rc $expected_rc
 }
 


### PR DESCRIPTION
We're unlikely to fix this soon (and IMO what we really want is automatic
updates on by default everywhere, not to polish `--preview`), but for
now let's try to stem the tide of duplicates.
