### PR TITLE
Fix handling of lockfile parent directory

### DIFF
--- a/rust/src/capstdext.rs
+++ b/rust/src/capstdext.rs
@@ -5,10 +5,33 @@
 
 use cap_std::fs::DirBuilder;
 use cap_std_ext::cap_std;
+use cap_std_ext::cap_std::fs::Dir;
+use std::ffi::OsStr;
+use std::io::Result;
 use std::os::unix::fs::DirBuilderExt;
+use std::path::Path;
 
 pub(crate) fn dirbuilder_from_mode(m: u32) -> DirBuilder {
     let mut r = DirBuilder::new();
     r.mode(m);
     r
+}
+
+/// Given a (possibly absolute) filename, return its parent directory and filename.
+pub(crate) fn open_dir_of(
+    path: &Path,
+    ambient_authority: cap_std::AmbientAuthority,
+) -> Result<(Dir, &OsStr)> {
+    let parent = path
+        .parent()
+        .filter(|v| !v.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let parent = Dir::open_ambient_dir(parent, ambient_authority)?;
+    let filename = path.file_name().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "the source path does not name a file",
+        )
+    })?;
+    Ok((parent, filename))
 }

--- a/rust/src/lockfile.rs
+++ b/rust/src/lockfile.rs
@@ -37,7 +37,7 @@ fn lockfile_parse<P: AsRef<Path>>(filename: P) -> Result<LockfileConfig> {
     let lf = utils::parse_stream(&fmt, &mut f).map_err(|e| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("Parsing {}: {}", filename.to_string_lossy(), e.to_string()),
+            format!("Parsing {}: {}", filename.to_string_lossy(), e),
         )
     })?;
     Ok(lf)


### PR DESCRIPTION
openat::Dir::open will fail when asked to open an empty path
(e.g. the result of Path::new("")) which can happen when a compose
command is given a filename with no preceeding path components.

For example, `--ex-write-lockfile-to=./lockfile.json` would
succeed while `--ex-write-lockfile-to=lockfile.json` would fail.

This change special cases the handling of an empty path by
replacing it with `Path::new(".")`.