### PR TITLE
Bump to cap-std 0.24.2, use `try_exists()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cbe56c8ed4cdf8360deb80dcced538968d3bac45e71befee65e95a0e262caf2"
+checksum = "3430d1b5ba78fa381eb227525578d2b85d77b42ff49be85d1e72a94f305e603c"
 dependencies = [
  "cap-primitives",
  "io-extras",

--- a/rust/src/cliwrap.rs
+++ b/rust/src/cliwrap.rs
@@ -70,7 +70,7 @@ pub fn entrypoint(args: &[&str]) -> Result<()> {
 
 #[context("Writing wrapper for {:?}", binpath)]
 fn write_one_wrapper(rootfs_dfd: &Dir, binpath: &Path, allow_noent: bool) -> Result<()> {
-    let exists = rootfs_dfd.exists(binpath);
+    let exists = rootfs_dfd.try_exists(binpath)?;
     if !exists && allow_noent {
         return Ok(());
     }
@@ -163,7 +163,7 @@ mod tests {
             "usr/bin/rpm",
             "binary is now located at: usr/libexec/rpm-ostree/wrapped/rpm"
         )?);
-        assert!(!td.exists("usr/sbin/grubby"));
+        assert!(!td.try_exists("usr/sbin/grubby")?);
         assert!(file_contains(
             td,
             "usr/bin/yum",

--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -64,7 +64,7 @@ pub(crate) fn get_live_state(
     deploy: &ostree::Deployment,
 ) -> Result<Option<LiveApplyState>> {
     let run = Dir::open_ambient_dir("/run", cap_std::ambient_authority())?;
-    if !run.exists(&get_runstate_dir(deploy).join(LIVE_STATE_NAME)) {
+    if !run.try_exists(&get_runstate_dir(deploy).join(LIVE_STATE_NAME))? {
         return Ok(None);
     }
     let live_commit = repo.resolve_rev(LIVE_REF, true)?;


### PR DESCRIPTION
I really don't like the "error swallowing" behavior of `.exists()`,
so let's use this.
