### PR TITLE
scripts: Also ignore `kernel-debug-core.posttrans`

### DIFF
--- a/rust/src/scripts.rs
+++ b/rust/src/scripts.rs
@@ -20,6 +20,7 @@ static IGNORED_PKG_SCRIPTS: phf::Set<&'static str> = phf_set! {
     // We take over depmod/dracut etc.  It's `kernel` in C7 and kernel-core in F25+
     "kernel.posttrans",
     "kernel-core.posttrans",
+    "kernel-debug-core.posttrans",
     // Additionally ignore posttrans scripts for the Oracle Linux `kernel-uek` package
     "kernel-uek.posttrans",
     // Legacy workaround


### PR DESCRIPTION
For the same reasons as `kernel.posttrans` mentioned in the comment
block above.