### PR TITLE
composepost: Also remove stamp file created by recent RPM `%posttrans`

### DIFF
--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -1014,7 +1014,11 @@ fn hardlink_rpmdb_base_location(
 
     // And write a symlink from the proposed standard /usr/lib/sysimage/rpm
     // to our /usr/share/rpm - eventually we will invert this.
+
     // Temporarily remove the directory if it exists until then.
+    // Also, delete a stamp file created by https://src.fedoraproject.org/rpms/rpm/c/391c3aeb66e8c2a0ac684580ac82c41d7da2128b?branch=rawhide
+    let stampfile = &Path::new(RPMOSTREE_SYSIMAGE_RPMDB).join(".rpmdbdirsymlink_created");
+    rootfs.remove_file_optional(stampfile)?;
     rootfs.remove_dir_optional(RPMOSTREE_SYSIMAGE_RPMDB)?;
     rootfs.symlink(RPMOSTREE_SYSIMAGE_RPMDB, "../../share/rpm")?;
 


### PR DESCRIPTION
See https://src.fedoraproject.org/rpms/rpm/c/391c3aeb66e8c2a0ac684580ac82c41d7da2128b?branch=rawhide

We don't need this and it breaks our current flow.
