### PR TITLE
rpmutil: Ensure libdnf is initialized when loading rpmdb

### DIFF
--- a/src/libpriv/rpmostree-rpm-util.cxx
+++ b/src/libpriv/rpmostree-rpm-util.cxx
@@ -955,6 +955,7 @@ gboolean
 rpmostree_get_refts_for_commit (OstreeRepo *repo, const char *ref, RpmOstreeRefTs **out_ts,
                                 GCancellable *cancellable, GError **error)
 {
+  ROSCXX_TRY (core_libdnf_process_global_init (), error);
   g_auto (GLnxTmpDir) tmpdir = {
     0,
   };


### PR DESCRIPTION
I hit this when doing some bits in the compose path that
query the rpmdb.
