### PR TITLE
compose extensions: Support `--rootfs`

### DIFF
--- a/src/libpriv/rpmostree-rpm-util.cxx
+++ b/src/libpriv/rpmostree-rpm-util.cxx
@@ -1379,6 +1379,7 @@ rpmostree_get_enabled_rpmmd_repos (DnfContext *dnfctx, DnfRepoEnabled enablement
   g_autoptr (GPtrArray) ret = g_ptr_array_new ();
   GPtrArray *repos = dnf_context_get_repos (dnfctx);
 
+  g_assert (repos);
   for (guint i = 0; i < repos->len; i++)
     {
       auto repo = static_cast<DnfRepo *> (repos->pdata[i]);


### PR DESCRIPTION
As we're working on "container native" (rpm)-ostree, it feels
natural to have the extensions build happen as part of e.g. a
`Dockerfile` build that simply pulls in the base image.

And to do that, we don't need any of this "offline" stuff that
the compose extensions path is using.  Here we're running
rpm-ostree inside a container, and conceptually we mostly just
need the libdnf side.
