### PR TITLE
rust/origin: support converting treefile to origin

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -606,6 +606,7 @@ pub mod ffi {
     // origin.rs
     extern "Rust" {
         fn origin_to_treefile(kf: Pin<&mut GKeyFile>) -> Result<Box<Treefile>>;
+        fn treefile_to_origin(tf: &Treefile) -> Result<*mut GKeyFile>;
         fn origin_validate_roundtrip(mut kf: Pin<&mut GKeyFile>);
     }
 

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -10,6 +10,7 @@ use crate::cxxrsutil::*;
 use crate::treefile::Treefile;
 use anyhow::Result;
 use fn_error_context::context;
+use glib::translate::ToGlibPtr;
 use glib::KeyFile;
 use ostree_ext::glib;
 use std::collections::BTreeMap;
@@ -99,6 +100,12 @@ pub(crate) fn origin_to_treefile(
 ) -> CxxResult<Box<Treefile>> {
     let kf = kf.gobj_wrap();
     Ok(origin_to_treefile_inner(&kf)?)
+}
+
+/// Convert a treefile config to an origin keyfile.
+pub(crate) fn treefile_to_origin(tf: &Treefile) -> Result<*mut crate::FFIGKeyFile> {
+    let kf = treefile_to_origin_inner(tf)?;
+    Ok(kf.to_glib_full() as *mut _)
 }
 
 /// Set a keyfile value to a string list.


### PR DESCRIPTION
I'd like to implement https://github.com/coreos/rpm-ostree/issues/1265
for both the client-side and the container flow. But to do that, I'd
rather not have to wire it through all the layers that need to know
about it.

In a move towards https://github.com/coreos/rpm-ostree/issues/2326, I'd
like to try to have everything in the `DeployTransaction` ->
`RpmOstreeSysrootUpgrader` -> `RpmOstreeContext` flow only deal in
treefiles. But to not change the format on disk just yet, we still need
to deserialize from and serialize back into a `GKeyFile` at the I/O
boundaries (really, libostree API boundaries).

We have a function for the former, but not the latter. This patch adds
one.
