### PR TITLE
 cli: Opt-in some CLI verbs to working inside ostree containers

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -38,6 +38,6 @@ jobs:
         with:
           name: install.tar
       - name: Install
-        run: tar -C / -xf install.tar
+        run: tar -C / -xzvf install.tar
       - name: Integration tests
         run: ./ci/test-container.sh

--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -6,6 +6,15 @@ fatal() {
     exit 1
 }
 
+# Verify container flow
+if rpm-ostree status 2>err.txt; then
+    fatal "status in container"
+fi
+if ! grep -qe "error.*This system was not booted via libostree" err.txt; then
+    cat err.txt
+    fatal "did not find expected error"
+fi
+
 origindir=/etc/rpm-ostree/origin.d
 mkdir -p "${origindir}"
 cat > "${origindir}/clienterror.yaml" << 'EOF'

--- a/src/app/rpmostree-builtin-cleanup.cxx
+++ b/src/app/rpmostree-builtin-cleanup.cxx
@@ -82,10 +82,14 @@ rpmostree_builtin_cleanup (int argc, char **argv, RpmOstreeCommandInvocation *in
     }
 
   auto is_ostree_container = ROSCXX_TRY_VAL (is_ostree_container (), error);
-  if (is_ostree_container && cleanup_types->len == 1 && opt_repomd)
+  if (is_ostree_container)
     {
-      /* just directly nuke the cachedir */
-      return glnx_shutil_rm_rf_at (AT_FDCWD, RPMOSTREE_CORE_CACHEDIR, cancellable, error);
+      if (cleanup_types->len == 1 && opt_repomd)
+        {
+          /* just directly nuke the cachedir */
+          return glnx_shutil_rm_rf_at (AT_FDCWD, RPMOSTREE_CORE_CACHEDIR, cancellable, error);
+        }
+      return rpmostreecxx::client_throw_non_ostree_host_error (error);
     }
 
   g_ptr_array_add (cleanup_types, NULL);

--- a/src/app/rpmostree-builtin-ex.cxx
+++ b/src/app/rpmostree-builtin-ex.cxx
@@ -33,7 +33,9 @@ static RpmOstreeCommand ex_subcommands[] = {
     rpmostree_ex_builtin_initramfs_etc },
   /* This is currently only for CoreOS layering; so hide it to not confuse
    * users. */
-  { "rebuild", (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_HIDDEN),
+  { "rebuild",
+    (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_HIDDEN
+                            | RPM_OSTREE_BUILTIN_FLAG_CONTAINER_CAPABLE),
     "Rebuild system based on configuration", rpmostree_ex_builtin_rebuild },
   /* To graduate out of experimental, simply revert:
    * https://github.com/coreos/rpm-ostree/pull/3078 */

--- a/src/app/rpmostree-builtin-types.h
+++ b/src/app/rpmostree-builtin-types.h
@@ -38,6 +38,7 @@ typedef enum
   RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT = 1 << 1,
   RPM_OSTREE_BUILTIN_FLAG_HIDDEN = 1 << 2,
   RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS = 1 << 3,
+  RPM_OSTREE_BUILTIN_FLAG_CONTAINER_CAPABLE = 1 << 4,
 } RpmOstreeBuiltinFlags;
 
 typedef struct RpmOstreeCommand RpmOstreeCommand;

--- a/src/app/rpmostree-clientlib.h
+++ b/src/app/rpmostree-clientlib.h
@@ -54,6 +54,7 @@ public:
 };
 
 void client_require_root ();
+gboolean client_throw_non_ostree_host_error (GError **error);
 
 std::unique_ptr<ClientConnection> new_client_connection ();
 


### PR DESCRIPTION
ci: Be verbose for tar extraction

I want to verify we're doing the right thing.

---

cli: Opt-in some CLI verbs to working inside ostree containers

The work to progress having some rpm-ostree functionality work inside
(ostree based) containers is great, but in the current shuffle
we lost an essential check.  Only a few CLI commands today work,
and they need to opt-in.

Before this patch, all the other CLI verbs, e.g. `rpm-ostree status`
just crash and burn inside an ostree container.

xref https://github.com/coreos/rpm-ostree/issues/3540

---

