### PR TITLE
container: Cleanup rpmdb after installs

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -15,4 +15,8 @@ if rpm-ostree ex rebuild 2>err.txt; then
    fatal "did rebuild with base-refspec"
 fi
 
+# Test the no-op rebuild path
+rm "${origindir}/clienterror.yaml"
+rpm-ostree ex rebuild
+
 echo ok

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -533,6 +533,7 @@ cleanup_leftover_files (int rootfs_fd, const char *subpath, const char *files[],
 }
 
 static const char *selinux_leftover_files[] = { "semanage.trans.LOCK", "semanage.read.LOCK", NULL };
+// TODO: move cleanup API into librpm
 static const char *rpmdb_leftover_files[] = { ".dbenv.lock", ".rpm.lock", NULL };
 static const char *rpmdb_leftover_prefixes[] = { "__db.", NULL };
 


### PR DESCRIPTION
container: Cleanup rpmdb after installs

Really, we should get this API down into librpm.

Closes: https://github.com/coreos/rpm-ostree/issues/3540
