### PR TITLE
extensions: Validate we don't have `--repo` and `--rootfs`

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -25,6 +25,10 @@ file describing OS extensions (packages) and a base OSTree
 commit. After performing a depsolve, it downloads the
 extension packages and places them in an output directory.
 
+This can then be used as part of the same (or related)
+pipeline that runs `rpm-ostree compose tree` to ship
+extension packages.
+
 ## extensions.yaml
 
 The format of the `extensions.yaml` file is as follow:

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1478,6 +1478,12 @@ rpmostree_compose_builtin_extensions (int argc, char **argv, RpmOstreeCommandInv
       return FALSE;
     }
 
+  if (opt_repo && opt_extensions_rootfs)
+    {
+      rpmostree_usage_error (context, "--repo must not be specified with --rootfs", error);
+      return FALSE;
+    }
+
   const char *treefile_path = argv[1];
   const char *extensions_path = argv[2];
 
@@ -1491,6 +1497,7 @@ rpmostree_compose_builtin_extensions (int argc, char **argv, RpmOstreeCommandInv
   // If we're in a running rootfs, we don't need a repo, so make up a fake one for now.
   if (opt_extensions_rootfs)
     {
+      g_assert (!opt_repo);
       if (!glnx_mkdtempat (AT_FDCWD, "/tmp/tmprepo.XXXXX", 0700, &tmp_repo, error))
         return glnx_prefix_error (error, "Creating temporary repo dir");
       repo = ostree_repo_create_at (tmp_repo.fd, tmp_repo.path, OSTREE_REPO_MODE_BARE_USER, NULL,


### PR DESCRIPTION
Came up in code review.  Also while I'm here add a tweak to the
doc.
