### PR TITLE
Two minor container-split prep patches

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -47,7 +47,6 @@ parallel insttests: {
           # include our built rpm-ostree in the image
           mkdir -p overrides/rpm
           mv *.rpm overrides/rpm
-          ${env.WORKSPACE}/ci/cosa-overrides.sh
           coreos-assembler fetch
           coreos-assembler build
            ${env.WORKSPACE}/ci/composepost-checks.sh

--- a/ci/cosa-overrides.sh
+++ b/ci/cosa-overrides.sh
@@ -2,5 +2,3 @@
 # Inject ideally temporary overrides into our cosa build
 # skopeo for containers https://github.com/containers/skopeo/pull/1476
 cd overrides/rpm
-curl -L --remote-name-all \
-  https://kojipkgs.fedoraproject.org//packages/skopeo/1.5.1/1.fc35/x86_64/skopeo-1.5.1-1.fc35.x86_64.rpm

--- a/ci/prow/fcos-e2e.sh
+++ b/ci/prow/fcos-e2e.sh
@@ -10,7 +10,6 @@ rpm-ostree --version
 cd $(mktemp -d)
 cosa init https://github.com/coreos/fedora-coreos-config/
 rsync -rlv /cosa/component-install/ overrides/rootfs/
-/ci/cosa-overrides.sh
 cosa fetch
 cosa build
 cosa kola run 'ext.rpm-ostree.*'

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -43,7 +43,7 @@ pub(crate) static COMPAT_VARLIB_SYMLINKS: &[&str] = &["alternatives", "vagrant"]
 
 /* See rpmostree-core.h */
 const RPMOSTREE_BASE_RPMDB: &str = "usr/lib/sysimage/rpm-ostree-base-db";
-const RPMOSTREE_RPMDB_LOCATION: &str = "usr/share/rpm";
+pub(crate) const RPMOSTREE_RPMDB_LOCATION: &str = "usr/share/rpm";
 const RPMOSTREE_SYSIMAGE_RPMDB: &str = "usr/lib/sysimage/rpm";
 pub(crate) const TRADITIONAL_RPMDB_LOCATION: &str = "var/lib/rpm";
 


### PR DESCRIPTION
ci: Drop skopeo override

It's actively downgrading things now.

---

composepost: Make rpmdb location `pub(crate)`

Prep for supporting ostree-container layer splitting work.

---

