### PR TITLE
spec: BR `libassuan-devel` on rhel8

### DIFF
--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -107,6 +107,11 @@ BuildRequires:  pkgconfig(modulemd-2.0) >= %{libmodulemd_version}
 BuildRequires:  pkgconfig(smartcols)
 BuildRequires:  gettext
 BuildRequires:  gpgme-devel
+%if 0%{?rhel} <= 8
+# In current Fedora, this is a dependency of gpgme-devel, but
+# not in RHEL8.  Missing this package breaks -znow.
+BuildRequires:  libassuan-devel
+%endif
 
 Requires:       libmodulemd%{?_isa} >= %{libmodulemd_version}
 Requires:       libsolv%{?_isa} >= %{libsolv_version}


### PR DESCRIPTION
Trying to build current git in COPR for C8S, we get:

```
  = note: /usr/bin/ld: cannot find -lassuan
          collect2: error: ld returned 1 exit status
```

(As part of a *huge* linker invocation)

I am pretty sure this is because
`/usr/lib/rpm/macros.d/macros.rust:  -Clink-arg=-Wl,-z,relro,-z,now`
specifically `-znow` requires all shared libraries present at build
time.

In current Fedora 35 we have:
```
$ grep Requires /usr/lib64/pkgconfig/gpgme.pc
Requires: gpg-error, libassuan
$
```
Which causes `gpgme-devel` to `Require` `libassuan-devel`, but
this `Requires` is missing in C8S gpgme.
