### PR TITLE
daemon: Handle `org.freedesktop.DBus.Error.ServiceUnknown` too

### DIFF
--- a/src/daemon/rpmostreed-os.cxx
+++ b/src/daemon/rpmostreed-os.cxx
@@ -247,7 +247,8 @@ os_authorize_method (GDBusInterfaceSkeleton *interface, GDBusMethodInvocation *i
           if (g_dbus_error_is_remote_error (error))
             {
               g_autofree char *remote_err = g_dbus_error_get_remote_error (error);
-              if (g_str_equal (remote_err, "org.freedesktop.DBus.Error.NameHasNoOwner"))
+              if (g_str_equal (remote_err, "org.freedesktop.DBus.Error.NameHasNoOwner")
+                  || g_str_equal (remote_err, "org.freedesktop.DBus.Error.ServiceUnknown"))
                 {
                   return rpmostreed_authorize_method_for_uid0 (invocation);
                 }

--- a/src/daemon/rpmostreed-sysroot.cxx
+++ b/src/daemon/rpmostreed-sysroot.cxx
@@ -611,7 +611,8 @@ sysroot_authorize_method (GDBusInterfaceSkeleton *interface, GDBusMethodInvocati
           if (g_dbus_error_is_remote_error (local_error))
             {
               g_autofree char *remote_err = g_dbus_error_get_remote_error (local_error);
-              if (g_str_equal (remote_err, "org.freedesktop.DBus.Error.NameHasNoOwner"))
+              if (g_str_equal (remote_err, "org.freedesktop.DBus.Error.NameHasNoOwner")
+                  || g_str_equal (remote_err, "org.freedesktop.DBus.Error.ServiceUnknown"))
                 {
                   return rpmostreed_authorize_method_for_uid0 (invocation);
                 }


### PR DESCRIPTION
For some reason on at least current C9S, dbus-broker is returning
a different error when polkit is not available.  Looking at it,
the two errors come from here
https://github.com/bus1/dbus-broker/blob/92142f321fc80c76ab1cc973ce2defa1039cac4a/src/bus/driver.c#L743

But I don't quite understand the circumstances in which one is sent
versus the other.

In any case, this should be a very safe and targeted change to
ensure we handle both errors.

Closes: https://github.com/coreos/rpm-ostree/issues/3554
