### PR TITLE
Migrate source of truth for override-commit and initramfs-etc files

### DIFF
--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -17,7 +17,7 @@ use glib::prelude::*;
 use ostree_ext::{gio, glib, ostree};
 use rustix::fd::BorrowedFd;
 use rustix::fs::MetadataExt;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Read;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
@@ -57,6 +57,12 @@ fn vdict_insert_optvec(dict: &glib::VariantDict, k: &str, v: Option<&Vec<String>
 /// Insert keys from the provided map into the target `dict` with key `k`.
 fn vdict_insert_optmap(dict: &glib::VariantDict, k: &str, v: Option<&BTreeMap<String, String>>) {
     let v = v.iter().map(|s| s.keys()).flatten().map(|s| s.as_str());
+    vdict_insert_strv(dict, k, v);
+}
+
+/// Insert keys from the provided map into the target `dict` with key `k`.
+fn vdict_insert_optset(dict: &glib::VariantDict, k: &str, v: Option<&BTreeSet<String>>) {
+    let v = v.iter().map(|s| s.iter()).flatten().map(|s| s.as_str());
     vdict_insert_strv(dict, k, v);
 }
 
@@ -107,7 +113,7 @@ fn deployment_populate_variant_origin(
     if let Some(initramfs) = tf.derive.initramfs.as_ref() {
         dict.insert("regenerate-initramfs", &initramfs.regenerate);
         vdict_insert_optvec(dict, "initramfs-args", initramfs.args.as_ref());
-        vdict_insert_optvec(dict, "initramfs-etc", initramfs.etc.as_ref());
+        vdict_insert_optset(dict, "initramfs-etc", initramfs.etc.as_ref());
     } else {
         // This key is also always injected.
         dict.insert("regenerate-initramfs", &false);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -498,6 +498,7 @@ pub mod ffi {
         fn has_initramfs_etc_files(&self) -> bool;
         fn initramfs_etc_files_track(&mut self, files: Vec<String>) -> bool;
         fn initramfs_etc_files_untrack(&mut self, files: Vec<String>) -> bool;
+        fn initramfs_etc_files_untrack_all(&mut self) -> bool;
         fn get_initramfs_regenerate(&self) -> bool;
         fn get_initramfs_args(&self) -> Vec<String>;
         fn get_unconfigured_state(&self) -> String;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -493,6 +493,7 @@ pub mod ffi {
         fn get_origin_custom_url(&self) -> String;
         fn get_origin_custom_description(&self) -> String;
         fn get_override_commit(&self) -> String;
+        fn set_override_commit(&mut self, checksum: &str);
         fn get_initramfs_etc_files(&self) -> Vec<String>;
         fn has_initramfs_etc_files(&self) -> bool;
         fn get_initramfs_regenerate(&self) -> bool;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -496,6 +496,7 @@ pub mod ffi {
         fn set_override_commit(&mut self, checksum: &str);
         fn get_initramfs_etc_files(&self) -> Vec<String>;
         fn has_initramfs_etc_files(&self) -> bool;
+        fn initramfs_etc_files_track(&mut self, files: Vec<String>) -> bool;
         fn get_initramfs_regenerate(&self) -> bool;
         fn get_initramfs_args(&self) -> Vec<String>;
         fn get_unconfigured_state(&self) -> String;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -497,6 +497,7 @@ pub mod ffi {
         fn get_initramfs_etc_files(&self) -> Vec<String>;
         fn has_initramfs_etc_files(&self) -> bool;
         fn initramfs_etc_files_track(&mut self, files: Vec<String>) -> bool;
+        fn initramfs_etc_files_untrack(&mut self, files: Vec<String>) -> bool;
         fn get_initramfs_regenerate(&self) -> bool;
         fn get_initramfs_args(&self) -> Vec<String>;
         fn get_unconfigured_state(&self) -> String;

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -188,7 +188,7 @@ fn treefile_to_origin_inner(tf: &Treefile) -> Result<glib::KeyFile> {
         if initramfs.regenerate {
             kf.set_boolean(RPMOSTREE, "regenerate-initramfs", true);
         }
-        if let Some(etc) = initramfs.etc.as_deref() {
+        if let Some(etc) = initramfs.etc.as_ref() {
             let etc = etc.iter().map(|s| s.as_str());
             kf_set_string_list(&kf, RPMOSTREE, "initramfs-etc", etc)
         }

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -29,7 +29,7 @@ use ostree_ext::{glib, ostree};
 use regex::Regex;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
 use std::fs::{read_dir, File};
 use std::io::prelude::*;
@@ -1135,7 +1135,7 @@ impl Treefile {
             .derive
             .initramfs
             .as_ref()
-            .and_then(|i| i.etc.clone())
+            .and_then(|i| i.etc.as_ref().map(|h| h.iter().cloned().collect()))
             .unwrap_or_default()
     }
 
@@ -1905,7 +1905,7 @@ pub(crate) struct DeriveCustom {
 pub(crate) struct DeriveInitramfs {
     pub(crate) regenerate: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) etc: Option<Vec<String>>,
+    pub(crate) etc: Option<BTreeSet<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) args: Option<Vec<String>>,
 }

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1180,6 +1180,18 @@ impl Treefile {
         changed
     }
 
+    // Returns true if files were removed.
+    pub(crate) fn initramfs_etc_files_untrack_all(&mut self) -> bool {
+        self.parsed
+            .derive
+            .initramfs
+            .ext_get_or_insert_default()
+            .etc
+            .take()
+            .map(|set| !set.is_empty())
+            .unwrap_or_default()
+    }
+
     pub(crate) fn get_initramfs_regenerate(&self) -> bool {
         self.parsed
             .derive
@@ -3180,6 +3192,16 @@ conditional-include:
             .unwrap();
         assert!(!etc.contains("/etc/new"));
         assert!(!etc.contains("/etc/boo"));
+        assert!(treefile.initramfs_etc_files_untrack_all());
+        assert!(!treefile.initramfs_etc_files_untrack_all());
+        assert!(treefile
+            .parsed
+            .derive
+            .initramfs
+            .as_ref()
+            .unwrap()
+            .etc
+            .is_none());
         assert!(treefile.get_initramfs_regenerate());
         assert_eq!(treefile.get_initramfs_args(), &["-I", "/usr/lib/foo"]);
         assert_eq!(

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1123,6 +1123,13 @@ impl Treefile {
             .unwrap_or_default()
     }
 
+    pub(crate) fn set_override_commit(&mut self, checksum: &str) {
+        let _ = self.parsed.derive.override_commit.take();
+        if !checksum.is_empty() {
+            self.parsed.derive.override_commit = Some(checksum.into());
+        }
+    }
+
     pub(crate) fn get_initramfs_etc_files(&self) -> Vec<String> {
         self.parsed
             .derive
@@ -3081,7 +3088,7 @@ conditional-include:
             unconfigured-state: First register your instance with corpy-tool
             cliwrap: true
         "};
-        let treefile = Treefile::new_from_string(utils::InputFormat::YAML, buf).unwrap();
+        let mut treefile = Treefile::new_from_string(utils::InputFormat::YAML, buf).unwrap();
         assert!(treefile.has_packages());
         assert_eq!(treefile.get_packages(), &["foobar"]);
         assert!(treefile.has_modules_enable());
@@ -3101,6 +3108,15 @@ conditional-include:
             treefile.get_override_commit(),
             "d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1"
         );
+        treefile.set_override_commit(
+            "9763c41704cedf0321ce591e16b3c7ddc8d8789b3f0084ee83236677864ab1cf",
+        );
+        assert_eq!(
+            treefile.get_override_commit(),
+            "9763c41704cedf0321ce591e16b3c7ddc8d8789b3f0084ee83236677864ab1cf"
+        );
+        treefile.set_override_commit("");
+        assert!(treefile.parsed.derive.override_commit.is_none());
         assert!(treefile.has_initramfs_etc_files());
         assert_eq!(treefile.get_initramfs_etc_files(), &["/etc/asdf"]);
         assert!(treefile.get_initramfs_regenerate());

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1853,9 +1853,8 @@ initramfs_etc_transaction_execute (RpmostreedTransaction *transaction, GCancella
 
   if (self->track)
     {
-      gboolean subchanged = FALSE;
-      rpmostree_origin_initramfs_etc_files_track (origin, self->track, &subchanged);
-      changed = changed || subchanged;
+      auto files = util::rust_stringvec_from_strv (self->track);
+      changed = rpmostree_origin_initramfs_etc_files_track (origin, files) || changed;
     }
 
   if (!changed && !self->force_sync)

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1166,7 +1166,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
           || rpmostree_origin_has_initramfs_etc_files (origin)))
     {
       rpmostree_origin_set_regenerate_initramfs (origin, FALSE, NULL);
-      rpmostree_origin_initramfs_etc_files_untrack_all (origin, NULL);
+      rpmostree_origin_initramfs_etc_files_untrack_all (origin);
       changed = TRUE;
     }
 
@@ -1840,9 +1840,7 @@ initramfs_etc_transaction_execute (RpmostreedTransaction *transaction, GCancella
   gboolean changed = FALSE;
   if (self->untrack_all)
     {
-      gboolean subchanged = FALSE;
-      rpmostree_origin_initramfs_etc_files_untrack_all (origin, &subchanged);
-      changed = changed || subchanged;
+      changed = rpmostree_origin_initramfs_etc_files_untrack_all (origin) || changed;
     }
   else if (self->untrack)
     {

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1846,9 +1846,8 @@ initramfs_etc_transaction_execute (RpmostreedTransaction *transaction, GCancella
     }
   else if (self->untrack)
     {
-      gboolean subchanged = FALSE;
-      rpmostree_origin_initramfs_etc_files_untrack (origin, self->untrack, &subchanged);
-      changed = changed || subchanged;
+      auto files = util::rust_stringvec_from_strv (self->untrack);
+      changed = rpmostree_origin_initramfs_etc_files_untrack (origin, files) || changed;
     }
 
   if (self->track)

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -97,9 +97,7 @@ static void
 sync_treefile (RpmOstreeOrigin *self)
 {
   self->treefile.reset ();
-  g_autoptr (GError) local_error = NULL;
-  self->treefile = ROSCXX_VAL (origin_to_treefile (*self->kf), &local_error);
-  g_assert_no_error (local_error);
+  self->treefile = CXX_MUST_VAL (rpmostreecxx::origin_to_treefile (*self->kf));
 }
 
 static GKeyFile *

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -93,14 +93,13 @@ rpmostree_origin_unref (RpmOstreeOrigin *origin)
   g_free (origin);
 }
 
-static gboolean
+static void
 sync_treefile (RpmOstreeOrigin *self)
 {
   self->treefile.reset ();
   g_autoptr (GError) local_error = NULL;
   self->treefile = ROSCXX_VAL (origin_to_treefile (*self->kf), &local_error);
   g_assert_no_error (local_error);
-  return TRUE;
 }
 
 static GKeyFile *

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -464,21 +464,25 @@ rpmostree_origin_initramfs_etc_files_track (RpmOstreeOrigin *origin, rust::Vec<r
 }
 
 /* Mutability: setter */
-void
-rpmostree_origin_initramfs_etc_files_untrack (RpmOstreeOrigin *origin, char **paths,
-                                              gboolean *out_changed)
+bool
+rpmostree_origin_initramfs_etc_files_untrack (RpmOstreeOrigin *origin,
+                                              rust::Vec<rust::String> paths)
 {
   gboolean changed = FALSE;
-  for (char **path = paths; path && *path; path++)
-    changed = (g_hash_table_remove (origin->cached_initramfs_etc_files, *path) || changed);
+  for (auto &path : paths)
+    {
+      changed
+          = (g_hash_table_remove (origin->cached_initramfs_etc_files, path.c_str ()) || changed);
+    }
 
   if (changed)
-    update_string_list_from_hash_table (origin, "rpmostree", "initramfs-etc",
-                                        origin->cached_initramfs_etc_files);
-  if (out_changed)
-    *out_changed = changed;
+    {
+      update_string_list_from_hash_table (origin, "rpmostree", "initramfs-etc",
+                                          origin->cached_initramfs_etc_files);
+      g_assert ((*origin->treefile)->initramfs_etc_files_untrack (paths));
+    }
 
-  sync_treefile (origin);
+  return changed;
 }
 
 /* Mutability: setter */

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -292,9 +292,8 @@ rpmostree_origin_remove_transient_state (RpmOstreeOrigin *origin)
   ostree_deployment_origin_remove_transient_state (origin->kf);
 
   /* this is already covered by the above, but the below also updates the cached value */
+  /* NB: this also updates the treefile */
   rpmostree_origin_set_override_commit (origin, NULL);
-
-  sync_treefile (origin);
 }
 
 /* Mutability: getter */
@@ -549,7 +548,7 @@ rpmostree_origin_set_override_commit (RpmOstreeOrigin *origin, const char *check
   g_free (origin->cached_override_commit);
   origin->cached_override_commit = g_strdup (checksum);
 
-  sync_treefile (origin);
+  (*origin->treefile)->set_override_commit (checksum ?: "");
 }
 
 /* Mutability: getter */

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -100,6 +100,14 @@ sync_treefile (RpmOstreeOrigin *self)
   self->treefile = CXX_MUST_VAL (rpmostreecxx::origin_to_treefile (*self->kf));
 }
 
+static void
+sync_origin (RpmOstreeOrigin *self)
+{
+  g_autoptr (GKeyFile) kf = CXX_MUST_VAL (rpmostreecxx::treefile_to_origin (**self->treefile));
+  g_clear_pointer (&self->kf, g_key_file_unref);
+  self->kf = g_key_file_ref (kf);
+}
+
 static GKeyFile *
 keyfile_dup (GKeyFile *kf)
 {

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -486,18 +486,18 @@ rpmostree_origin_initramfs_etc_files_untrack (RpmOstreeOrigin *origin,
 }
 
 /* Mutability: setter */
-void
-rpmostree_origin_initramfs_etc_files_untrack_all (RpmOstreeOrigin *origin, gboolean *out_changed)
+bool
+rpmostree_origin_initramfs_etc_files_untrack_all (RpmOstreeOrigin *origin)
 {
   const gboolean changed = (g_hash_table_size (origin->cached_initramfs_etc_files) > 0);
   g_hash_table_remove_all (origin->cached_initramfs_etc_files);
   if (changed)
-    update_string_list_from_hash_table (origin, "rpmostree", "initramfs-etc",
-                                        origin->cached_initramfs_etc_files);
-  if (out_changed)
-    *out_changed = changed;
-
-  sync_treefile (origin);
+    {
+      update_string_list_from_hash_table (origin, "rpmostree", "initramfs-etc",
+                                          origin->cached_initramfs_etc_files);
+      g_assert ((*origin->treefile)->initramfs_etc_files_untrack_all ());
+    }
+  return changed;
 }
 
 /* Mutability: setter */

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -443,21 +443,24 @@ update_string_list_from_hash_table (RpmOstreeOrigin *origin, const char *group, 
 }
 
 /* Mutability: setter */
-void
-rpmostree_origin_initramfs_etc_files_track (RpmOstreeOrigin *origin, char **paths,
-                                            gboolean *out_changed)
+bool
+rpmostree_origin_initramfs_etc_files_track (RpmOstreeOrigin *origin, rust::Vec<rust::String> paths)
 {
   gboolean changed = FALSE;
-  for (char **path = paths; path && *path; path++)
-    changed = (g_hash_table_add (origin->cached_initramfs_etc_files, g_strdup (*path)) || changed);
+  for (auto &path : paths)
+    {
+      changed = (g_hash_table_add (origin->cached_initramfs_etc_files, g_strdup (path.c_str ()))
+                 || changed);
+    }
 
   if (changed)
-    update_string_list_from_hash_table (origin, "rpmostree", "initramfs-etc",
-                                        origin->cached_initramfs_etc_files);
-  if (out_changed)
-    *out_changed = changed;
+    {
+      update_string_list_from_hash_table (origin, "rpmostree", "initramfs-etc",
+                                          origin->cached_initramfs_etc_files);
+      g_assert ((*origin->treefile)->initramfs_etc_files_track (paths));
+    }
 
-  sync_treefile (origin);
+  return changed;
 }
 
 /* Mutability: setter */

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -79,8 +79,8 @@ GKeyFile *rpmostree_origin_dup_keyfile (RpmOstreeOrigin *origin);
 bool rpmostree_origin_initramfs_etc_files_track (RpmOstreeOrigin *origin,
                                                  rust::Vec<rust::String> paths);
 
-void rpmostree_origin_initramfs_etc_files_untrack (RpmOstreeOrigin *origin, char **paths,
-                                                   gboolean *out_changed);
+bool rpmostree_origin_initramfs_etc_files_untrack (RpmOstreeOrigin *origin,
+                                                   rust::Vec<rust::String> paths);
 
 void rpmostree_origin_initramfs_etc_files_untrack_all (RpmOstreeOrigin *origin,
                                                        gboolean *out_changed);

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -82,8 +82,7 @@ bool rpmostree_origin_initramfs_etc_files_track (RpmOstreeOrigin *origin,
 bool rpmostree_origin_initramfs_etc_files_untrack (RpmOstreeOrigin *origin,
                                                    rust::Vec<rust::String> paths);
 
-void rpmostree_origin_initramfs_etc_files_untrack_all (RpmOstreeOrigin *origin,
-                                                       gboolean *out_changed);
+bool rpmostree_origin_initramfs_etc_files_untrack_all (RpmOstreeOrigin *origin);
 
 void rpmostree_origin_set_regenerate_initramfs (RpmOstreeOrigin *origin, gboolean regenerate,
                                                 char **args);

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -76,8 +76,8 @@ bool rpmostree_origin_has_any_packages (RpmOstreeOrigin *origin);
 
 GKeyFile *rpmostree_origin_dup_keyfile (RpmOstreeOrigin *origin);
 
-void rpmostree_origin_initramfs_etc_files_track (RpmOstreeOrigin *origin, char **paths,
-                                                 gboolean *out_changed);
+bool rpmostree_origin_initramfs_etc_files_track (RpmOstreeOrigin *origin,
+                                                 rust::Vec<rust::String> paths);
 
 void rpmostree_origin_initramfs_etc_files_untrack (RpmOstreeOrigin *origin, char **paths,
                                                    gboolean *out_changed);

--- a/tests/kolainst/destructive/initramfs-etc
+++ b/tests/kolainst/destructive/initramfs-etc
@@ -85,8 +85,8 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     rpm-ostree status --json > status.json
     assert_jq status.json \
       '.deployments[0]["initramfs-etc"]|length == 2' \
-      '.deployments[0]["initramfs-etc"][0] == "/etc/foo/bar/baz/boo"' \
-      '.deployments[0]["initramfs-etc"][1] == "/etc/cmdline.d"'
+      '.deployments[0]["initramfs-etc"][0] == "/etc/cmdline.d"' \
+      '.deployments[0]["initramfs-etc"][1] == "/etc/foo/bar/baz/boo"'
 
     /tmp/autopkgtest-reboot-prepare 3
     rpm-ostree finalize-deployment --allow-missing-checksum


### PR DESCRIPTION
Now that we have all getters backed by the treefile, we can start migrating the setters. Do this for the override commit and initramfs-etc files to get the ball rolling. More to come.