### PR TITLE
compose: Fix handling of base rev

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1547,8 +1547,6 @@ rpmostree_compose_builtin_extensions (int argc, char **argv, RpmOstreeCommandInv
 
   auto packages_mapping = std::make_unique<rust::Vec<rpmostreecxx::StringMapping> > ();
   g_autofree char *base_rev = NULL;
-  if (!ostree_repo_resolve_rev (repo, opt_extensions_base_rev, FALSE, &base_rev, error))
-    return FALSE;
 
   if (opt_extensions_rootfs)
     {
@@ -1568,6 +1566,9 @@ rpmostree_compose_builtin_extensions (int argc, char **argv, RpmOstreeCommandInv
     }
   else
     {
+      if (!ostree_repo_resolve_rev (repo, opt_extensions_base_rev, FALSE, &base_rev, error))
+        return FALSE;
+
       g_autoptr (GVariant) commit = NULL;
       if (!ostree_repo_load_commit (repo, base_rev, &commit, NULL, error))
         return FALSE;


### PR DESCRIPTION
I definitely tested the previous patch (and so did Joseph)
but I am fearing that I did further cleanup before pushing
that broke it.

What we're seeing right now is a segfault trying to use this with
RHCOS (which notably doesn't have a `ref` in the treefile).

Anyways, we should only be trying to resolve the base rev in
the "outside" path, not the in-container path.  (Right now, but
once we can depend on a newer ostree inside the container we can
actually make this all work symmetrically)
