### PR TITLE
use basename when cleaning up the .vmlinuz.hmac file

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -198,6 +198,8 @@ pub mod ffi {
 
         fn is_container_image_reference(refspec: &str) -> bool;
         fn refspec_classify(refspec: &str) -> RefspecType;
+
+        fn verify_kernel_hmac(rootfs: i32, moddir: &str) -> Result<()>;
     }
 
     // composepost.rs


### PR DESCRIPTION
Prior to this commit, the .vmlinuz.hmac file was assumed to be:

```
<hmac>  /boot/vmlinuz-<version>
```

This is because the ARK kernel.spec so-happens to run hmac512sum on that path while building the RPM. Because absolute paths to the kernel don't make sense for Core-OS, `/boot/` was removed from the start of the path. This means that the prior emergent behavior was a `basename`, where supported. Unfortunately, some custom kernels build with a path other than `/boot/`, and the prior behavior would log an error and abort.

At the time of this commit, using the basename is under consideration in ARK. However, there are many existing custom kernels that rpm-ostree users may want to use.

Given that a basename was being performed (when no error is encountered), this change reflects that behavior. While this is still a hack, it is likely a more robust hack.

Two spaces are expected to delimit the hash and the path. The path is split by `/`, and the final item in the resulting array is used as the path.

Closes #3546