### PR TITLE
partial, tree-wide: Switch to using inline variables in `format!`

### DIFF
--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -165,7 +165,7 @@ impl Bubblewrap {
 
         let lang = std::env::var_os("LANG");
         let lang = lang.as_ref().and_then(|s| s.to_str()).unwrap_or("C");
-        let lang_var = format!("LANG={}", lang);
+        let lang_var = format!("LANG={lang}");
         let lang_var = Path::new(&lang_var);
 
         let launcher = gio::SubprocessLauncher::new(gio::SubprocessFlags::NONE);
@@ -247,8 +247,8 @@ impl Bubblewrap {
                 }
 
                 argv.push("--symlink".to_string());
-                argv.push(format!("usr/{}", name));
-                argv.push(format!("/{}", name));
+                argv.push(format!("usr/{name}"));
+                argv.push(format!("/{name}"));
             }
         }
 

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -246,9 +246,9 @@ pub(crate) fn client_render_download_progress(
             )
         }
     } else if outstanding_writes > 0 {
-        format!("Writing objects: {}", outstanding_writes)
+        format!("Writing objects: {outstanding_writes}")
     } else {
-        format!("Scanning metadata: {}", n_scanned_metadata)
+        format!("Scanning metadata: {n_scanned_metadata}")
     }
 }
 

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -85,13 +85,13 @@ fn compose_init_rootfs(rootfs_dfd: &cap_std::fs::Dir, tmp_is_dir: bool) -> Resul
     TOPLEVEL_DIRS.par_iter().try_for_each(|&d| {
         rootfs_dfd
             .ensure_dir_with(d, default_dirbuilder)
-            .with_context(|| format!("Creating {}", d))
+            .with_context(|| format!("Creating {d}"))
             .map(|_: bool| ())
     })?;
     TOPLEVEL_SYMLINKS.par_iter().try_for_each(|&(dest, src)| {
         rootfs_dfd
             .symlink(dest, src)
-            .with_context(|| format!("Creating {}", src))
+            .with_context(|| format!("Creating {src}"))
     })?;
 
     if tmp_is_dir {
@@ -292,7 +292,7 @@ fn compose_postprocess_units(rootfs_dfd: &openat::Dir, treefile: &mut Treefile) 
         }
 
         println!("Adding {} to multi-user.target.wants", unit);
-        let target = format!("/usr/lib/systemd/system/{}", unit);
+        let target = format!("/usr/lib/systemd/system/{unit}");
         rootfs_dfd.symlink(&dest, &target)?;
     }
     Ok(())
@@ -307,7 +307,7 @@ fn compose_postprocess_default_target(rootfs_dfd: &openat::Dir, target: &str) ->
      */
     let default_target_path = "usr/lib/systemd/system/default.target";
     rootfs_dfd.remove_file_optional(default_target_path)?;
-    let dest = format!("/usr/lib/systemd/system/{}", target);
+    let dest = format!("/usr/lib/systemd/system/{target}");
     rootfs_dfd.symlink(default_target_path, dest)?;
 
     Ok(())
@@ -519,11 +519,11 @@ fn compose_postprocess_mutate_os_release(
     println!("Updating {}", path);
     let contents = rootfs_dfd
         .read_to_string(path)
-        .with_context(|| format!("Reading {}", path))?;
+        .with_context(|| format!("Reading {path}"))?;
     let new_contents = mutate_os_release_contents(&contents, base_version, next_version);
     rootfs_dfd
         .write_file_contents(path, 0o644, new_contents.as_bytes())
-        .with_context(|| format!("Writing {}", path))?;
+        .with_context(|| format!("Writing {path}"))?;
     Ok(())
 }
 
@@ -1372,9 +1372,9 @@ OSTREE_VERSION='33.4'
 
         let mut metas = vec![];
         for fname in files {
-            let binpath = format!("{}/{}.bin", PREFIX, fname);
+            let binpath = format!("{PREFIX}/{fname}.bin");
             rootfs.new_file(&binpath, 0o755).unwrap();
-            let fpath = format!("{}/{}", PREFIX, fname);
+            let fpath = format!("{PREFIX}/{fname}");
             rootfs.new_file(&fpath, 0o755).unwrap();
             let before_meta = rootfs.metadata(fpath).unwrap();
             metas.push(before_meta);

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -457,7 +457,7 @@ pub fn generate_baselayer_refs(
     });
     for (index, base_rev) in bases.enumerate() {
         let base_rev = base_rev?;
-        let ref_name = format!("rpmostree/base/{}", index);
+        let ref_name = format!("rpmostree/base/{index}");
         repo.transaction_set_refspec(&ref_name, Some(&base_rev));
     }
 

--- a/rust/src/lockfile.rs
+++ b/rust/src/lockfile.rs
@@ -380,7 +380,7 @@ pub(crate) fn lockfile_write(
         output_pkgs.insert(
             name.as_str().to_string(),
             LockedPackage::Evra {
-                evra: format!("{}.{}", evr.as_str(), arch.as_str()),
+                evra: format!("{evr}.{arch}"),
                 digest: Some(chksum),
                 metadata: None,
             },

--- a/rust/src/nameservice/shadow.rs
+++ b/rust/src/nameservice/shadow.rs
@@ -88,7 +88,7 @@ pub(crate) fn parse_shadow_content(content: impl BufRead) -> Result<Vec<ShadowEn
     let mut entries = vec![];
     for (line_num, line) in content.lines().enumerate() {
         let input =
-            line.with_context(|| format!("failed to read shadow entry at line {}", line_num))?;
+            line.with_context(|| format!("failed to read shadow entry at line {line_num}"))?;
 
         // Skip empty and comment lines
         if input.is_empty() || input.starts_with('#') {

--- a/rust/src/passwd.rs
+++ b/rust/src/passwd.rs
@@ -51,7 +51,7 @@ pub fn prepare_rpm_layering(rootfs_dfd: i32, merge_passwd_dir: &str) -> CxxResul
     // Break hardlinks for the shadow files, since shadow-utils currently uses
     // O_RDWR unconditionally.
     for filename in PWGRP_SHADOW_FILES {
-        let src = format!("etc/{}", filename);
+        let src = format!("etc/{filename}");
         if rootfs.exists(&src)? {
             ostree::break_hardlink(rootfs.as_raw_fd(), &src, true, gio::NONE_CANCELLABLE)?;
         };

--- a/rust/src/testutils.rs
+++ b/rust/src/testutils.rs
@@ -188,7 +188,7 @@ fn update_os_tree(opts: &SyntheticUpgradeOpts) -> Result<()> {
                     notepath.to_str().unwrap(),
                     have_objcopy,
                 )
-                .with_context(|| format!("Replacing binaries in {}", v))?;
+                .with_context(|| format!("Replacing binaries in {v}"))?;
             }
         }
     }


### PR DESCRIPTION
I didn't try to convert everything, just did some to start the ball
rolling, avoid having a flag day that would conflict with other outstanding
PRs etc.
