### PR TITLE
libpriv/origin: Migrate source of truth for more fields to treefile

### DIFF
--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -77,13 +77,13 @@ fn deployment_populate_variant_origin(
     let tf = &tf.parsed;
 
     // Package mappings.  Note these are inserted unconditionally, even if empty.
-    vdict_insert_optvec(dict, "requested-packages", tf.packages.as_ref());
-    vdict_insert_optvec(
+    vdict_insert_optset(dict, "requested-packages", tf.packages.as_ref());
+    vdict_insert_optset(
         dict,
         "requested-modules",
         tf.modules.as_ref().and_then(|m| m.install.as_ref()),
     );
-    vdict_insert_optvec(
+    vdict_insert_optset(
         dict,
         "modules-enabled",
         tf.modules.as_ref().and_then(|m| m.enable.as_ref()),

--- a/rust/src/extensions.rs
+++ b/rust/src/extensions.rs
@@ -195,7 +195,7 @@ impl Extensions {
                 releasever: src.parsed.base.releasever.clone(),
                 ..Default::default()
             },
-            packages: Some(self.get_os_extension_packages()),
+            packages: Some(self.get_os_extension_packages().into_iter().collect()),
             modules: self.modules.clone(),
             ..Default::default()
         };
@@ -336,7 +336,7 @@ extensions:
         assert_eq!(extensions.get_repos().len(), 2);
         assert_eq!(extensions.get_repos()[1], "bazboo-repo");
         let modules = extensions.modules.unwrap();
-        assert_eq!(modules.enable.unwrap(), vec!["virt:av"]);
+        assert!(modules.enable.unwrap().contains("virt:av"));
         assert!(modules.install.is_none());
 
         let mut input = std::io::BufReader::new(buf.as_bytes());
@@ -351,7 +351,8 @@ extensions:
         assert_eq!(extensions.get_repos().len(), 2);
         assert_eq!(extensions.get_repos()[1], "foo-repo");
         let modules = extensions.modules.unwrap();
-        assert_eq!(modules.enable.unwrap(), vec!["foo:stable", "virt:av"]);
+        assert!(modules.enable.as_ref().unwrap().contains("foo:stable"));
+        assert!(modules.enable.as_ref().unwrap().contains("virt:av"));
         assert!(modules.install.is_none());
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -458,8 +458,8 @@ pub mod ffi {
         fn get_packages(&self) -> Vec<String>;
         fn has_packages(&self) -> bool;
         fn set_packages(&mut self, packages: &Vec<String>);
-        fn get_packages_local(&self) -> Vec<String>;
-        fn get_packages_local_fileoverride(&self) -> Vec<String>;
+        fn get_local_packages(&self) -> Vec<String>;
+        fn get_local_fileoverride_packages(&self) -> Vec<String>;
         fn get_packages_override_replace_local(&self) -> Vec<String>;
         fn get_packages_override_replace_local_rpms(&self) -> Vec<String>;
         fn set_packages_override_replace_local_rpms(&mut self, packages: &Vec<String>);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -476,6 +476,7 @@ pub mod ffi {
         fn get_lockfile_repos(&self) -> Vec<String>;
         fn get_ref(&self) -> &str;
         fn get_cliwrap(&self) -> bool;
+        fn set_cliwrap(&mut self, enabled: bool);
         fn get_container_cmd(&self) -> Vec<String>;
         fn get_readonly_executables(&self) -> bool;
         fn get_documentation(&self) -> bool;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -456,10 +456,21 @@ pub mod ffi {
         fn get_all_ostree_layers(&self) -> Vec<String>;
         fn get_repos(&self) -> Vec<String>;
         fn get_packages(&self) -> Vec<String>;
+        fn add_packages(&mut self, packages: Vec<String>, allow_existing: bool) -> Result<bool>;
         fn has_packages(&self) -> bool;
         fn set_packages(&mut self, packages: Vec<String>);
         fn get_local_packages(&self) -> Vec<String>;
+        fn add_local_packages(
+            &mut self,
+            packages: Vec<String>,
+            allow_existing: bool,
+        ) -> Result<bool>;
         fn get_local_fileoverride_packages(&self) -> Vec<String>;
+        fn add_local_fileoverride_packages(
+            &mut self,
+            packages: Vec<String>,
+            allow_existing: bool,
+        ) -> Result<bool>;
         fn get_packages_override_replace_local(&self) -> Vec<String>;
         fn get_packages_override_replace_local_rpms(&self) -> Vec<String>;
         fn set_packages_override_replace_local_rpms(&mut self, packages: Vec<String>);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -176,7 +176,7 @@ pub mod ffi {
     }
 
     // core.rs
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq, Eq)]
     enum RefspecType {
         Ostree,
         Checksum,
@@ -426,6 +426,12 @@ pub mod ffi {
         Disabled,
     }
 
+    #[derive(Debug, PartialEq, Eq)]
+    struct Refspec {
+        kind: RefspecType,
+        refspec: String,
+    }
+
     extern "Rust" {
         type Treefile;
 
@@ -491,7 +497,7 @@ pub mod ffi {
 
         // these functions are more related to derivation
         fn validate_for_container(&self) -> Result<()>;
-        fn get_base_refspec(&self) -> String;
+        fn get_base_refspec(&self) -> Refspec;
         fn get_origin_custom_url(&self) -> String;
         fn get_origin_custom_description(&self) -> String;
         fn get_override_commit(&self) -> String;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -515,6 +515,7 @@ pub mod ffi {
         fn initramfs_etc_files_untrack_all(&mut self) -> bool;
         fn get_initramfs_regenerate(&self) -> bool;
         fn get_initramfs_args(&self) -> Vec<String>;
+        fn set_initramfs_regenerate(&mut self, enabled: bool, args: Vec<String>);
         fn get_unconfigured_state(&self) -> String;
         fn may_require_local_assembly(&self) -> bool;
         fn has_any_packages(&self) -> bool;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -527,7 +527,7 @@ pub mod ffi {
         type RepoPackage;
 
         fn get_repo(&self) -> &str;
-        fn get_packages(&self) -> &[String];
+        fn get_packages(&self) -> Vec<String>;
     }
 
     // utils.rs

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -498,6 +498,12 @@ pub mod ffi {
         // these functions are more related to derivation
         fn validate_for_container(&self) -> Result<()>;
         fn get_base_refspec(&self) -> Refspec;
+        fn rebase(
+            &mut self,
+            new_refspec: &str,
+            custom_origin_url: &str,
+            custom_origin_description: &str,
+        );
         fn get_origin_custom_url(&self) -> String;
         fn get_origin_custom_description(&self) -> String;
         fn get_override_commit(&self) -> String;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -457,15 +457,15 @@ pub mod ffi {
         fn get_repos(&self) -> Vec<String>;
         fn get_packages(&self) -> Vec<String>;
         fn has_packages(&self) -> bool;
-        fn set_packages(&mut self, packages: &Vec<String>);
+        fn set_packages(&mut self, packages: Vec<String>);
         fn get_local_packages(&self) -> Vec<String>;
         fn get_local_fileoverride_packages(&self) -> Vec<String>;
         fn get_packages_override_replace_local(&self) -> Vec<String>;
         fn get_packages_override_replace_local_rpms(&self) -> Vec<String>;
-        fn set_packages_override_replace_local_rpms(&mut self, packages: &Vec<String>);
+        fn set_packages_override_replace_local_rpms(&mut self, packages: Vec<String>);
         fn get_packages_override_remove(&self) -> Vec<String>;
         fn has_packages_override_remove_name(&self, name: &str) -> bool;
-        fn set_packages_override_remove(&mut self, packages: &Vec<String>);
+        fn set_packages_override_remove(&mut self, packages: Vec<String>);
         fn get_modules_enable(&self) -> Vec<String>;
         fn has_modules_enable(&self) -> bool;
         fn get_modules_install(&self) -> Vec<String>;

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -18,6 +18,8 @@ use std::collections::BTreeSet;
 use std::pin::Pin;
 use std::result::Result as StdResult;
 
+use ostree_ext::container::deploy::ORIGIN_CONTAINER;
+
 const ORIGIN: &str = "origin";
 const RPMOSTREE: &str = "rpmostree";
 const PACKAGES: &str = "packages";
@@ -45,17 +47,13 @@ pub(crate) fn origin_to_treefile_inner(kf: &KeyFile) -> Result<Box<Treefile>> {
         None
     };
 
-    let container_image_reference =
-        keyfile_get_optional_string(kf, ORIGIN, ostree_ext::container::deploy::ORIGIN_CONTAINER)?;
+    let container_image_reference = keyfile_get_optional_string(kf, ORIGIN, ORIGIN_CONTAINER)?;
 
     match (base_refspec, container_image_reference) {
-        (Some(_), Some(_)) => bail!(
-            "Found both refspec/baserefspec and {}",
-            ostree_ext::container::deploy::ORIGIN_CONTAINER
-        ),
+        (Some(_), Some(_)) => bail!("Found both refspec/baserefspec and {}", ORIGIN_CONTAINER),
         (None, None) => bail!(
             "Failed to find refspec/baserefspec/{} in origin",
-            ostree_ext::container::deploy::ORIGIN_CONTAINER
+            ORIGIN_CONTAINER
         ),
         (Some(s), None) => cfg.derive.base_refspec = Some(s),
         (None, Some(s)) => cfg.derive.container_image_reference = Some(s),
@@ -166,7 +164,7 @@ fn treefile_to_origin_inner(tf: &Treefile) -> Result<glib::KeyFile> {
         };
         kf.set_string(ORIGIN, k, r);
     } else if let Some(r) = tf.derive.container_image_reference.as_deref() {
-        kf.set_string(ORIGIN, ostree_ext::container::deploy::ORIGIN_CONTAINER, r);
+        kf.set_string(ORIGIN, ORIGIN_CONTAINER, r);
     } else {
         unreachable!();
     }

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -253,7 +253,10 @@ fn kf_diff(kf: &glib::KeyFile, newkf: &glib::KeyFile) -> Result<()> {
             match newkf.value(grp, k) {
                 Ok(newv) => {
                     if !kf_diff_value(grp, k, origv.as_str(), newv.as_str()) {
-                        errs.push(format!("Mismatched value for {}/{}: {}", grp, k, newv));
+                        errs.push(format!(
+                            "Mismatched value for {}/{}: {} vs {}",
+                            grp, k, origv, newv
+                        ));
                     }
                 }
                 Err(e) => errs.push(format!("Fetching {}/{}: {}", grp, k, e)),

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -142,15 +142,16 @@ fn set_sha256_nevra_pkgs(
 /// Convert a treefile to an origin file.
 #[context("Parsing treefile origin")]
 fn treefile_to_origin_inner(tf: &Treefile) -> Result<glib::KeyFile> {
+    let may_require_local_assembly = tf.may_require_local_assembly();
     let tf = &tf.parsed;
     let kf = glib::KeyFile::new();
 
-    // refspec (note special handling right now for layering)
-    let deriving = tf.packages.is_some()
-        || tf.derive.packages_local.is_some()
-        || tf.derive.packages_local_fileoverride.is_some();
     if let Some(r) = tf.derive.base_refspec.as_deref() {
-        let k = if deriving { "baserefspec" } else { "refspec" };
+        let k = if may_require_local_assembly {
+            "baserefspec"
+        } else {
+            "refspec"
+        };
         kf.set_string(ORIGIN, k, r)
     };
 

--- a/rust/src/passwd.rs
+++ b/rust/src/passwd.rs
@@ -830,7 +830,7 @@ impl PasswdEntries {
         &self,
         old_subset: &PasswdEntries,
         rootfs: i32,
-        ignored_users: &Option<HashSet<String>>,
+        ignored_users: &Option<BTreeSet<String>>,
     ) -> Result<()> {
         let old_user_names: BTreeSet<&str> = old_subset.users.keys().map(|s| s.as_str()).collect();
         let new_keys: BTreeSet<&str> = self.users.keys().map(|s| s.as_str()).collect();
@@ -908,7 +908,7 @@ impl PasswdEntries {
         &self,
         old_subset: &PasswdEntries,
         rootfs: i32,
-        ignored_groups: &Option<HashSet<String>>,
+        ignored_groups: &Option<BTreeSet<String>>,
     ) -> Result<()> {
         let old_group_names: BTreeSet<&str> =
             old_subset.groups.keys().map(|s| s.as_str()).collect();

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1269,6 +1269,20 @@ impl Treefile {
             .unwrap_or_default()
     }
 
+    pub(crate) fn set_initramfs_regenerate(&mut self, enabled: bool, args: Vec<String>) {
+        if !enabled {
+            // implicitly leaves empty if already empty
+            if let Some(ref mut initrd) = self.parsed.derive.initramfs {
+                initrd.regenerate = false;
+                initrd.args = None;
+            }
+        } else {
+            let initrd = self.parsed.derive.initramfs.ext_get_or_insert_default();
+            initrd.regenerate = true;
+            initrd.args = Some(args);
+        }
+    }
+
     pub(crate) fn get_unconfigured_state(&self) -> String {
         self.parsed
             .derive
@@ -3307,6 +3321,12 @@ conditional-include:
             .is_none());
         assert!(treefile.get_initramfs_regenerate());
         assert_eq!(treefile.get_initramfs_args(), &["-I", "/usr/lib/foo"]);
+        treefile.set_initramfs_regenerate(false, vec![]);
+        assert!(!treefile.get_initramfs_regenerate());
+        assert!(treefile.get_initramfs_args().is_empty());
+        treefile.set_initramfs_regenerate(true, vec!["-a".to_string(), "40foo".to_string()]);
+        assert!(treefile.get_initramfs_regenerate());
+        assert_eq!(treefile.get_initramfs_args(), &["-a", "40foo"]);
         assert_eq!(
             treefile.get_unconfigured_state(),
             "First register your instance with corpy-tool"

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -705,10 +705,10 @@ impl Treefile {
             .unwrap_or_default()
     }
 
-    pub(crate) fn set_packages(&mut self, packages: &Vec<String>) {
+    pub(crate) fn set_packages(&mut self, packages: Vec<String>) {
         let _ = self.parsed.packages.take();
         if !packages.is_empty() {
-            self.parsed.packages = Some(packages.iter().cloned().collect());
+            self.parsed.packages = Some(packages.into_iter().collect());
         }
     }
 
@@ -779,10 +779,10 @@ impl Treefile {
             .unwrap_or_default()
     }
 
-    pub(crate) fn set_packages_override_remove(&mut self, packages: &Vec<String>) {
+    pub(crate) fn set_packages_override_remove(&mut self, packages: Vec<String>) {
         let _ = self.parsed.derive.override_remove.take();
         if !packages.is_empty() {
-            self.parsed.derive.override_remove = Some(packages.clone());
+            self.parsed.derive.override_remove = Some(packages.into_iter().collect());
         }
     }
 
@@ -804,10 +804,10 @@ impl Treefile {
             .unwrap_or_default()
     }
 
-    pub(crate) fn set_packages_override_replace_local_rpms(&mut self, packages: &Vec<String>) {
+    pub(crate) fn set_packages_override_replace_local_rpms(&mut self, packages: Vec<String>) {
         let _ = self.parsed.derive.override_replace_local_rpms.take();
         if !packages.is_empty() {
-            self.parsed.derive.override_replace_local_rpms = Some(packages.clone());
+            self.parsed.derive.override_replace_local_rpms = Some(packages.into_iter().collect());
         }
     }
 

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -712,7 +712,7 @@ impl Treefile {
         }
     }
 
-    pub(crate) fn get_packages_local(&self) -> Vec<String> {
+    pub(crate) fn get_local_packages(&self) -> Vec<String> {
         self.parsed
             .derive
             .packages_local
@@ -722,7 +722,7 @@ impl Treefile {
             .collect()
     }
 
-    pub(crate) fn get_packages_local_fileoverride(&self) -> Vec<String> {
+    pub(crate) fn get_local_fileoverride_packages(&self) -> Vec<String> {
         self.parsed
             .derive
             .packages_local_fileoverride

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -848,6 +848,13 @@ impl Treefile {
         self.parsed.cliwrap.unwrap_or(false)
     }
 
+    pub(crate) fn set_cliwrap(&mut self, enabled: bool) {
+        let _ = self.parsed.cliwrap.take();
+        if enabled {
+            self.parsed.cliwrap = Some(true);
+        }
+    }
+
     pub(crate) fn get_readonly_executables(&self) -> bool {
         self.parsed.base.readonly_executables.unwrap_or(false)
     }
@@ -3334,6 +3341,8 @@ conditional-include:
         assert!(treefile.may_require_local_assembly());
         assert!(treefile.has_any_packages());
         assert!(treefile.get_cliwrap());
+        treefile.set_cliwrap(false);
+        assert!(!treefile.get_cliwrap());
 
         // test some negatives
         let treefile = treefile_new_empty().unwrap();

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1095,7 +1095,13 @@ impl Treefile {
     }
 
     pub(crate) fn get_base_refspec(&self) -> String {
-        self.parsed.derive.base_refspec.clone().unwrap_or_default()
+        self.parsed
+            .derive
+            .base_refspec
+            .as_deref()
+            .or(self.parsed.derive.container_image_reference.as_deref())
+            .unwrap_or_default()
+            .to_string()
     }
 
     pub(crate) fn get_origin_custom_url(&self) -> String {
@@ -1959,8 +1965,12 @@ pub(crate) struct DeriveInitramfs {
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct DeriveConfigFields {
+    // this is used for ref types ostree/checksum
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) base_refspec: Option<String>,
+    // this is used for ref types ostree/checksum
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) container_image_reference: Option<String>,
 
     // Packages
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -421,12 +421,11 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader *self, const char
   if (!override_commit_s.empty ())
     override_commit = override_commit_s.c_str ();
 
-  auto refspec = rpmostree_origin_get_refspec (self->computed_origin);
-  auto refspec_type = rpmostreecxx::refspec_classify (refspec.c_str ());
+  auto r = rpmostree_origin_get_refspec (self->computed_origin);
 
   g_autofree char *new_base_rev = NULL;
 
-  switch (refspec_type)
+  switch (r.kind)
     {
     case rpmostreecxx::RefspecType::Container:
       {
@@ -434,7 +433,8 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader *self, const char
           return glnx_throw (error, "Specifying commit overrides for container-image-reference "
                                     "type refspecs is not supported");
 
-        CXX_TRY_VAR (import, rpmostreecxx::pull_container (*self->repo, *cancellable, refspec),
+        CXX_TRY_VAR (import,
+                     rpmostreecxx::pull_container (*self->repo, *cancellable, r.refspec.c_str ()),
                      error);
         // Note this duplicates
         // https://github.com/ostreedev/ostree-rs-ext/blob/22a663f64e733e7ba8382f11f853ce4202652254/lib/src/container/store.rs#L64
@@ -449,7 +449,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader *self, const char
       {
         g_autofree char *origin_remote = NULL;
         g_autofree char *origin_ref = NULL;
-        if (!ostree_parse_refspec (refspec.c_str (), &origin_remote, &origin_ref, error))
+        if (!ostree_parse_refspec (r.refspec.c_str (), &origin_remote, &origin_ref, error))
           return FALSE;
 
         const gboolean is_commit = ostree_validate_checksum_string (origin_ref, NULL);
@@ -501,7 +501,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader *self, const char
           new_base_rev = g_strdup (override_commit);
         else
           {
-            if (!ostree_repo_resolve_rev (self->repo, refspec.c_str (), FALSE, &new_base_rev,
+            if (!ostree_repo_resolve_rev (self->repo, r.refspec.c_str (), FALSE, &new_base_rev,
                                           error))
               return FALSE;
           }
@@ -1262,14 +1262,14 @@ write_history (RpmOstreeSysrootUpgrader *self, OstreeDeployment *new_deployment,
     version = rpmostree_checksum_version (commit);
   }
 
-  auto refspec = rpmostree_origin_get_refspec (self->computed_origin);
+  auto r = rpmostree_origin_get_refspec (self->computed_origin);
   sd_journal_send (
       "MESSAGE_ID=" SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL (RPMOSTREE_NEW_DEPLOYMENT_MSG),
       "MESSAGE=Created new deployment /%s", deployment_dirpath, "DEPLOYMENT_PATH=/%s",
       deployment_dirpath, "DEPLOYMENT_TIMESTAMP=%" PRIu64, (uint64_t)stbuf.st_ctime,
       "DEPLOYMENT_DEVICE=%" PRIu64, (uint64_t)stbuf.st_dev, "DEPLOYMENT_INODE=%" PRIu64,
       (uint64_t)stbuf.st_ino, "DEPLOYMENT_CHECKSUM=%s", ostree_deployment_get_csum (new_deployment),
-      "DEPLOYMENT_REFSPEC=%s", refspec.c_str (),
+      "DEPLOYMENT_REFSPEC=%s", r.refspec.c_str (),
       /* we could use iovecs here and sd_journal_sendv to make these truly
        * conditional, but meh, empty field works fine too */
       "DEPLOYMENT_VERSION=%s", version ?: "", "COMMAND_LINE=%s", self->command_line ?: "",

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -141,7 +141,7 @@ parse_origin_deployment (RpmOstreeSysrootUpgrader *self, OstreeDeployment *deplo
   self->original_origin = rpmostree_origin_parse_deployment (deployment, error);
   if (!self->original_origin)
     return FALSE;
-  rpmostree_origin_remove_transient_state (self->original_origin);
+  rpmostree_origin_set_override_commit (self->original_origin, NULL);
 
   auto unconfigured = rpmostree_origin_get_unconfigured_state (self->original_origin);
   if (!unconfigured.empty ()

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1237,8 +1237,8 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
             }
         }
 
-      if (!rpmostree_origin_add_packages (origin, install_pkgs, FALSE, FALSE, idempotent_layering,
-                                          &changed, error))
+      auto pkgsv = util::rust_stringvec_from_strv (install_pkgs);
+      if (!rpmostree_origin_add_packages (origin, pkgsv, idempotent_layering, &changed, error))
         return FALSE;
     }
 
@@ -1257,8 +1257,9 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
         {
           g_ptr_array_add (pkgs, NULL);
 
-          if (!rpmostree_origin_add_packages (origin, (char **)pkgs->pdata, TRUE, FALSE,
-                                              idempotent_layering, &changed, error))
+          auto pkgsv = util::rust_stringvec_from_strv ((char **)pkgs->pdata);
+          if (!rpmostree_origin_add_local_packages (origin, pkgsv, idempotent_layering, &changed,
+                                                    error))
             return FALSE;
         }
     }
@@ -1274,8 +1275,9 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
         {
           g_ptr_array_add (pkgs, NULL);
 
-          if (!rpmostree_origin_add_packages (origin, (char **)pkgs->pdata, TRUE, TRUE,
-                                              idempotent_layering, &changed, error))
+          auto pkgsv = util::rust_stringvec_from_strv ((char **)pkgs->pdata);
+          if (!rpmostree_origin_add_local_fileoverride_packages (origin, pkgsv, idempotent_layering,
+                                                                 &changed, error))
             return FALSE;
         }
     }

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -600,6 +600,8 @@ unixfdlist_to_ptrarray (GUnixFDList *fdl)
   return ret;
 }
 
+// XXX: Convert out_pkgs to return a rust::Vec<StringMapping> once all the related origin fields
+// have migrated to the treefile. Then simplify related treefile APIs.
 static gboolean
 import_many_local_rpms (OstreeRepo *repo, GUnixFDList *fdl, GPtrArray **out_pkgs,
                         GCancellable *cancellable, GError **error)

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1164,7 +1164,8 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
       && (rpmostree_origin_get_regenerate_initramfs (origin)
           || rpmostree_origin_has_initramfs_etc_files (origin)))
     {
-      rpmostree_origin_set_regenerate_initramfs (origin, FALSE, NULL);
+      auto argsv = util::rust_stringvec_from_strv (NULL);
+      rpmostree_origin_set_regenerate_initramfs (origin, FALSE, argsv);
       rpmostree_origin_initramfs_etc_files_untrack_all (origin);
       changed = TRUE;
     }
@@ -1988,7 +1989,8 @@ initramfs_state_transaction_execute (RpmostreedTransaction *transaction, GCancel
       return FALSE;
     }
 
-  rpmostree_origin_set_regenerate_initramfs (origin, self->regenerate, self->args);
+  auto argsv = util::rust_stringvec_from_strv (self->args);
+  rpmostree_origin_set_regenerate_initramfs (origin, self->regenerate, argsv);
   rpmostree_sysroot_upgrader_set_origin (upgrader, origin);
   rpmostree_sysroot_upgrader_set_caller_info (
       upgrader, command_line, rpmostreed_transaction_get_agent_id (RPMOSTREED_TRANSACTION (self)),

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -1701,8 +1701,8 @@ rpmostree_context_prepare (RpmOstreeContext *self, GCancellable *cancellable, GE
   DnfContext *dnfctx = self->dnfctx;
 
   auto packages = self->treefile_rs->get_packages ();
-  auto packages_local = self->treefile_rs->get_packages_local ();
-  auto packages_local_fileoverride = self->treefile_rs->get_packages_local_fileoverride ();
+  auto packages_local = self->treefile_rs->get_local_packages ();
+  auto packages_local_fileoverride = self->treefile_rs->get_local_fileoverride_packages ();
   auto packages_override_replace_local = self->treefile_rs->get_packages_override_replace_local ();
   auto packages_override_replace_local_rpms
       = self->treefile_rs->get_packages_override_replace_local_rpms ();

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -259,21 +259,6 @@ rpmostree_origin_dup (RpmOstreeOrigin *origin)
   return ret;
 }
 
-/* This is useful if the origin is meant to be used to generate a *new* deployment, as
- * opposed to simply gathering information about an existing one. In such cases, there are
- * some things that we do not generally want to apply to a new deployment. */
-/* Mutability: setter */
-void
-rpmostree_origin_remove_transient_state (RpmOstreeOrigin *origin)
-{
-  /* first libostree-known things */
-  ostree_deployment_origin_remove_transient_state (origin->kf);
-
-  /* this is already covered by the above, but the below also updates the cached value */
-  /* NB: this also updates the treefile */
-  rpmostree_origin_set_override_commit (origin, NULL);
-}
-
 /* Mutability: getter */
 rust::String
 rpmostree_origin_get_refspec (RpmOstreeOrigin *origin)

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -245,14 +245,14 @@ rpmostree_origin_has_modules_enable (RpmOstreeOrigin *origin)
 rust::Vec<rust::String>
 rpmostree_origin_get_local_packages (RpmOstreeOrigin *origin)
 {
-  return (*origin->treefile)->get_packages_local ();
+  return (*origin->treefile)->get_local_packages ();
 }
 
 /* Mutability: getter */
 rust::Vec<rust::String>
 rpmostree_origin_get_local_fileoverride_packages (RpmOstreeOrigin *origin)
 {
-  return (*origin->treefile)->get_packages_local_fileoverride ();
+  return (*origin->treefile)->get_local_fileoverride_packages ();
 }
 
 /* Mutability: getter */

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -404,16 +404,10 @@ rpmostree_origin_get_cliwrap (RpmOstreeOrigin *origin)
 
 /* Mutability: setter */
 void
-rpmostree_origin_set_cliwrap (RpmOstreeOrigin *origin, gboolean cliwrap)
+rpmostree_origin_set_cliwrap (RpmOstreeOrigin *origin, bool cliwrap)
 {
-  const char k[] = "rpmostree";
-  const char v[] = "ex-cliwrap";
-  if (cliwrap)
-    g_key_file_set_boolean (origin->kf, k, v, TRUE);
-  else
-    g_key_file_remove_key (origin->kf, k, v, NULL);
-
-  sync_treefile (origin);
+  (*origin->treefile)->set_cliwrap (cliwrap);
+  sync_origin (origin);
 }
 
 /* Mutability: setter */

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -260,15 +260,10 @@ rpmostree_origin_dup (RpmOstreeOrigin *origin)
 }
 
 /* Mutability: getter */
-rust::String
+rpmostreecxx::Refspec
 rpmostree_origin_get_refspec (RpmOstreeOrigin *origin)
 {
-  // This is awkward: the treefile supports no base refspec being set since none is in the compose
-  // case. But in the derive case, there should *always* be a base refspec, so verify this. Ideally
-  // we'd have a different type for derivation treefiles. It's not the right time to fix this yet.
-  auto r = (*origin->treefile)->get_base_refspec ();
-  g_assert_cmpstr (r.c_str (), !=, "");
-  return r;
+  return (*origin->treefile)->get_base_refspec ();
 }
 
 rust::String

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -34,7 +34,7 @@ RpmOstreeOrigin *rpmostree_origin_parse_deployment (OstreeDeployment *deployment
 
 RpmOstreeOrigin *rpmostree_origin_dup (RpmOstreeOrigin *origin);
 
-rust::String rpmostree_origin_get_refspec (RpmOstreeOrigin *origin);
+rpmostreecxx::Refspec rpmostree_origin_get_refspec (RpmOstreeOrigin *origin);
 
 rust::String rpmostree_origin_get_custom_url (RpmOstreeOrigin *origin);
 

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -83,7 +83,7 @@ bool rpmostree_origin_initramfs_etc_files_untrack (RpmOstreeOrigin *origin,
 bool rpmostree_origin_initramfs_etc_files_untrack_all (RpmOstreeOrigin *origin);
 
 void rpmostree_origin_set_regenerate_initramfs (RpmOstreeOrigin *origin, gboolean regenerate,
-                                                char **args);
+                                                rust::Vec<rust::String> args);
 
 void rpmostree_origin_set_override_commit (RpmOstreeOrigin *origin, const char *checksum);
 

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -34,8 +34,6 @@ RpmOstreeOrigin *rpmostree_origin_parse_deployment (OstreeDeployment *deployment
 
 RpmOstreeOrigin *rpmostree_origin_dup (RpmOstreeOrigin *origin);
 
-void rpmostree_origin_remove_transient_state (RpmOstreeOrigin *origin);
-
 rust::String rpmostree_origin_get_refspec (RpmOstreeOrigin *origin);
 
 rust::String rpmostree_origin_get_custom_url (RpmOstreeOrigin *origin);

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -95,9 +95,19 @@ void rpmostree_origin_set_rebase_custom (RpmOstreeOrigin *origin, const char *ne
                                          const char *custom_origin_url,
                                          const char *custom_origin_description);
 
-gboolean rpmostree_origin_add_packages (RpmOstreeOrigin *origin, char **packages, gboolean local,
-                                        gboolean fileoverride, gboolean allow_existing,
-                                        gboolean *out_changed, GError **error);
+gboolean rpmostree_origin_add_packages (RpmOstreeOrigin *origin, rust::Vec<rust::String> packages,
+                                        gboolean allow_existing, gboolean *out_changed,
+                                        GError **error);
+
+gboolean rpmostree_origin_add_local_packages (RpmOstreeOrigin *origin,
+                                              rust::Vec<rust::String> packages,
+                                              gboolean allow_existing, gboolean *out_changed,
+                                              GError **error);
+
+gboolean rpmostree_origin_add_local_fileoverride_packages (RpmOstreeOrigin *origin,
+                                                           rust::Vec<rust::String> packages,
+                                                           gboolean allow_existing,
+                                                           gboolean *out_changed, GError **error);
 
 gboolean rpmostree_origin_remove_packages (RpmOstreeOrigin *origin, char **packages,
                                            gboolean allow_noent, gboolean *out_changed,

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -88,7 +88,7 @@ void rpmostree_origin_set_regenerate_initramfs (RpmOstreeOrigin *origin, gboolea
 void rpmostree_origin_set_override_commit (RpmOstreeOrigin *origin, const char *checksum);
 
 bool rpmostree_origin_get_cliwrap (RpmOstreeOrigin *origin);
-void rpmostree_origin_set_cliwrap (RpmOstreeOrigin *origin, gboolean cliwrap);
+void rpmostree_origin_set_cliwrap (RpmOstreeOrigin *origin, bool cliwrap);
 
 void rpmostree_origin_set_rebase (RpmOstreeOrigin *origin, const char *new_refspec);
 void rpmostree_origin_set_rebase_custom (RpmOstreeOrigin *origin, const char *new_refspec,


### PR DESCRIPTION
This starts with initramfs regeneration and args, but more will be added.
Works on top of https://github.com/coreos/rpm-ostree/pull/3561.