### PR TITLE
daemon: Move tokio handle reference into daemon

### DIFF
--- a/src/daemon/rpmostreed-daemon.cxx
+++ b/src/daemon/rpmostreed-daemon.cxx
@@ -77,6 +77,8 @@ struct _RpmostreedDaemon
 
   GDBusConnection *connection;
   GDBusObjectManagerServer *object_manager;
+
+  std::optional<rust::Box<rpmostreecxx::TokioHandle> > tokio_handle;
 };
 
 struct _RpmostreedDaemonClass
@@ -164,6 +166,8 @@ daemon_finalize (GObject *object)
   g_clear_object (&self->sysroot);
   g_clear_object (&self->bus_proxy);
 
+  self->tokio_handle.~optional ();
+
   g_object_unref (self->connection);
   g_hash_table_unref (self->bus_clients);
   g_clear_pointer (&self->idle_exit_source, (GDestroyNotify)g_source_unref);
@@ -224,6 +228,8 @@ rpmostreed_daemon_init (RpmostreedDaemon *self)
   self->sysroot = NULL;
   self->bus_clients = g_hash_table_new_full (g_str_hash, g_str_equal, NULL,
                                              (GDestroyNotify)rpmostree_client_free);
+
+  self->tokio_handle = rpmostreecxx::tokio_handle_get ();
 }
 
 static void
@@ -354,6 +360,15 @@ get_config_uint64 (GKeyFile *keyfile, const char *key, guint64 default_val)
                           local_error->message);
     }
   return default_val;
+}
+
+namespace rpmostreecxx
+{
+rust::Box<TokioEnterGuard>
+rpmostreed_daemon_tokio_enter (RpmostreedDaemon *self)
+{
+  return (*self->tokio_handle)->enter ();
+}
 }
 
 RpmostreedAutomaticUpdatePolicy

--- a/src/daemon/rpmostreed-daemon.h
+++ b/src/daemon/rpmostreed-daemon.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "rpmostree-cxxrs.h"
 #include "rpmostree-util.h"
 #include "rpmostreed-types.h"
 
@@ -62,3 +63,8 @@ gboolean rpmostreed_authorize_method_for_uid0 (GDBusMethodInvocation *invocation
 RpmostreedAutomaticUpdatePolicy rpmostreed_get_automatic_update_policy (RpmostreedDaemon *self);
 
 G_END_DECLS
+
+namespace rpmostreecxx
+{
+rust::Box<TokioEnterGuard> rpmostreed_daemon_tokio_enter (RpmostreedDaemon *self);
+}


### PR DESCRIPTION
We got a panic inside `rpmostreed_transaction_new_cleanup` because
there was no tokio handle associated with the current thread.

The goal of the original PR here was to grab the tokio context
from the main (initial) thread.  Now, in that stack trace
GDBus is clearly executing the callback on a worker thread.

As best I can tell from looking at the GDBus source, this can
happen in cases where method authorization is in play; there's a
whole dance where that bit gets dispatched to a worker, then we
try to schedule the callback on the original main context.

(Also, one can configure all GDBus method invocations to run
 in a thread, but we're not doing that)

I am not totally sure why this isn't *always* crashing - it might
only occur in situations where the main context is not idle?

Anyways, I think it will be more reliable instead to have the C++
global daemon context hold a reference to the tokio handle.  All
our GDBus stuff on the daemon side uses that, and we know that
object is constructed on the main thread.
