### PR TITLE
ci: Move legacy compose tests to GH actions

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -75,35 +75,4 @@ parallel insttests: {
         }
       }
     }
-},
-compose: {
-    def jobs = 5
-    def mem = (jobs * 2048) + 512
-    cosaPod(runAsUser: 0, memory: "${mem}Mi", cpu: "${jobs}") {
-        checkout scm
-        unstash 'rpms'
-        stage("Install Deps") {
-          shwrap("""
-            ci/install-test-deps.sh
-            dnf install -y *.rpm  # install our built rpm-ostree
-          """)
-        }
-        stage("Run") {
-          try {
-            timeout(time: 60, unit: 'MINUTES') {
-              shwrap("""
-                mkdir -p compose-logs /srv/tmpdir
-                TMPDIR=/srv/tmpdir JOBS=${jobs} ./tests/compose.sh
-              """)
-            }
-          } finally {
-            shwrap("""
-              if [ -d compose-logs ]; then
-                tar -C compose-logs -cf- . | xz -c9 > compose-logs.tar.xz
-              fi
-            """)
-            archiveArtifacts allowEmptyArchive: true, artifacts: 'compose-logs.tar.xz'
-          }
-        }
-    }
 }}

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,5 +1,5 @@
 ---
-name: Container
+name: Container and legacy compose
 
 on:
   push:
@@ -26,7 +26,7 @@ jobs:
           name: install.tar
           path: install.tar
   integration:
-    name: "Integration"
+    name: "Container Integration"
     needs: build
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos:testing-devel
@@ -41,3 +41,23 @@ jobs:
         run: tar -C / -xzvf install.tar
       - name: Integration tests
         run: ./ci/test-container.sh
+  legacy-compose:
+    name: "Legacy compose tests"
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/coreos-assembler/coreos-assembler:latest
+      options: "--user root --privileged -v /var/tmp:/var/tmp"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install test dependencies
+        run: ./ci/install-test-deps.sh
+      - name: Download build
+        uses: actions/download-artifact@v2
+        with:
+          name: install.tar
+      - name: Install
+        run: tar -C / -xzvf install.tar
+      - name: Integration tests
+        run: env TMPDIR=/var/tmp JOBS=3 ./tests/compose.sh


### PR DESCRIPTION
The compose tests keep flaking out in FCOS CI/Jenkins.  I am not
totally sure why, but I think it's related to the fact it's on
bare metal (which is great) but that Kubernetes uses CPU shares
and most tools which try to count processors are confused by that.

We have 3 CI systems, and actually I think GH actions is a good
match for our legacy compose tests.  It gives us a VM, in which
we can easily run a privileged container.

Further, GH actions is nicer here in that the legacy compose tests
can appear as a separate check status.
