### PR TITLE
tree-wide: Rework C++ try/catch to GError bridging

### DIFF
--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -265,7 +265,7 @@ rpmostree_option_context_parse (GOptionContext *context, const GOptionEntry *mai
   if ((flags & RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT) > 0)
     ROSCXX_TRY (client_require_root (), error);
 
-  auto is_ostree_container = ROSCXX_TRY_VAL (is_ostree_container (), error);
+  CXX_TRY_VAR (is_ostree_container, rpmostreecxx::is_ostree_container (), error);
   bool container_capable = (flags & RPM_OSTREE_BUILTIN_FLAG_CONTAINER_CAPABLE) > 0;
   if (use_daemon && !(is_ostree_container && container_capable))
     {

--- a/src/app/rpmostree-builtin-cleanup.cxx
+++ b/src/app/rpmostree-builtin-cleanup.cxx
@@ -81,7 +81,7 @@ rpmostree_builtin_cleanup (int argc, char **argv, RpmOstreeCommandInvocation *in
       return FALSE;
     }
 
-  auto is_ostree_container = ROSCXX_TRY_VAL (is_ostree_container (), error);
+  CXX_TRY_VAR (is_ostree_container, rpmostreecxx::is_ostree_container (), error);
   if (is_ostree_container)
     {
       if (cleanup_types->len == 1 && opt_repomd)

--- a/src/app/rpmostree-builtin-rebuild.cxx
+++ b/src/app/rpmostree-builtin-rebuild.cxx
@@ -44,14 +44,14 @@ rpmostree_ex_builtin_rebuild (int argc, char **argv, RpmOstreeCommandInvocation 
   bool in_container = false;
   if (rpmostreecxx::running_in_container ())
     {
-      auto is_ostree_container = ROSCXX_TRY_VAL (is_ostree_container (), error);
+      CXX_TRY_VAR (is_ostree_container, rpmostreecxx::is_ostree_container (), error);
       if (!is_ostree_container)
         return glnx_throw (error, "This command can only run in an OSTree container.");
       in_container = true;
     }
 
   auto basearch = rpmostreecxx::get_rpm_basearch ();
-  auto treefile = ROSCXX_TRY_VAL (treefile_new_client_from_etc (basearch), error);
+  CXX_TRY_VAR (treefile, rpmostreecxx::treefile_new_client_from_etc (basearch), error);
 
   /* This is the big switch: we support running this command in two modes:
    * "client containers", where the effect takes place in the active rootfs, and
@@ -64,7 +64,7 @@ rpmostree_ex_builtin_rebuild (int argc, char **argv, RpmOstreeCommandInvocation 
 
       /* In the container flow, we effectively "consume" the treefiles after
        * modifying the rootfs. */
-      auto n = ROSCXX_TRY_VAL (treefile_delete_client_etc (), error);
+      CXX_TRY_VAR (n, rpmostreecxx::treefile_delete_client_etc (), error);
       if (n == 0)
         {
           g_print ("No changes to apply.\n");

--- a/src/app/rpmostree-builtin-shlib-backend.cxx
+++ b/src/app/rpmostree-builtin-shlib-backend.cxx
@@ -105,7 +105,7 @@ rpmostree_builtin_shlib_backend (int argc, char **argv, RpmOstreeCommandInvocati
       const char *src = argv[2];
       g_autoptr (DnfContext) ctx = dnf_context_new ();
       auto varsubsts = rpmostree_dnfcontext_get_varsubsts (ctx);
-      auto rets = ROSCXX_TRY_VAL (varsubstitute (src, *varsubsts), error);
+      CXX_TRY_VAR (rets, rpmostreecxx::varsubstitute (src, *varsubsts), error);
       ret = g_variant_new_string (rets.c_str ());
     }
   else if (g_str_equal (arg, "packagelist-from-commit"))
@@ -123,7 +123,7 @@ rpmostree_builtin_shlib_backend (int argc, char **argv, RpmOstreeCommandInvocati
 
   rust::Slice<const uint8_t> dataslice{ (guint8 *)g_variant_get_data (ret),
                                         g_variant_get_size (ret) };
-  glnx_fd_close int ret_memfd
-      = ROSCXX_TRY_VAL (sealed_memfd ("rpm-ostree-shlib-backend", dataslice), error);
-  return send_memfd_result (ipc_sock, glnx_steal_fd (&ret_memfd), error);
+  CXX_TRY_VAR (ret_memfd, rpmostreecxx::sealed_memfd ("rpm-ostree-shlib-backend", dataslice),
+               error);
+  return send_memfd_result (ipc_sock, ret_memfd, error);
 }

--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -1372,14 +1372,14 @@ rpmostree_ex_builtin_history (int argc, char **argv, RpmOstreeCommandInvocation 
   /* initiate a history context, then iterate over each (boot time, deploy time), then print */
 
   /* XXX: enhance with option for going in reverse (oldest first) */
-  auto history_ctx = ROSCXX_TRY_VAL (history_ctx_new (), error);
+  CXX_TRY_VAR (history_ctx, rpmostreecxx::history_ctx_new (), error);
 
   /* XXX: use pager here */
 
   gboolean at_least_one = FALSE;
   while (opt_all || opt_limit--)
     {
-      auto entry = CXX_TRY_VAL (history_ctx->next_entry (), error);
+      CXX_TRY_VAR (entry, history_ctx->next_entry (), error);
       if (entry.eof)
         break;
       if (!print_history_entry (entry, error))

--- a/src/app/rpmostree-clientlib.cxx
+++ b/src/app/rpmostree-clientlib.cxx
@@ -848,7 +848,7 @@ rpmostree_sort_pkgs_strv (const char *const *pkgs, GUnixFDList *fd_list, GPtrArr
   for (const char *const *pkgiter = pkgs; pkgiter && *pkgiter; pkgiter++)
     {
       auto pkg = *pkgiter;
-      auto fds = ROSCXX_TRY_VAL (client_handle_fd_argument (pkg, basearch), error);
+      CXX_TRY_VAR (fds, rpmostreecxx::client_handle_fd_argument (pkg, basearch), error);
       if (fds.size () > 0)
         {
           for (const auto &fd : fds)

--- a/src/app/rpmostree-composeutil.cxx
+++ b/src/app/rpmostree-composeutil.cxx
@@ -53,7 +53,7 @@ rpmostree_composeutil_checksum (HyGoal goal, OstreeRepo *repo, const rpmostreecx
 
   /* Hash in the treefile inputs (this includes all externals like postprocess, add-files,
    * etc... and the final flattened treefile -- see treefile.rs for more details). */
-  auto tf_checksum = CXX_TRY_VAL (tf.get_checksum (*repo), error);
+  CXX_TRY_VAR (tf_checksum, tf.get_checksum (*repo), error);
   g_checksum_update (checksum, (const guint8 *)tf_checksum.data (), tf_checksum.size ());
 
   /* Hash in each package */

--- a/src/app/rpmostree-db-builtin-diff.cxx
+++ b/src/app/rpmostree-db-builtin-diff.cxx
@@ -99,8 +99,8 @@ print_diff (OstreeRepo *repo, const char *from_desc, const char *from_checksum, 
 
   if (opt_advisories)
     {
-      auto diff
-          = ROSCXX_TRY_VAL (calculate_advisories_diff (*repo, from_checksum, to_checksum), error);
+      CXX_TRY_VAR (
+          diff, rpmostreecxx::calculate_advisories_diff (*repo, from_checksum, to_checksum), error);
       g_print ("\n");
       rpmostree_print_advisories (diff, TRUE, 0);
     }
@@ -257,8 +257,9 @@ rpmostree_db_builtin_diff (int argc, char **argv, RpmOstreeCommandInvocation *in
                                        error))
         return FALSE;
       g_variant_builder_add (&builder, "{sv}", "pkgdiff", diffv);
-      auto adv_diff
-          = ROSCXX_TRY_VAL (calculate_advisories_diff (*repo, from_checksum, to_checksum), error);
+      CXX_TRY_VAR (adv_diff,
+                   rpmostreecxx::calculate_advisories_diff (*repo, from_checksum, to_checksum),
+                   error);
       g_variant_builder_add (&builder, "{sv}", "advisories", adv_diff);
       g_autoptr (GVariant) metadata = g_variant_builder_end (&builder);
 

--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -221,10 +221,10 @@ rpmostree_override_builtin_replace (int argc, char **argv, RpmOstreeCommandInvoc
   argc--;
   argv[argc] = NULL;
 
-  auto is_ostree_container = ROSCXX_TRY_VAL (is_ostree_container (), error);
+  CXX_TRY_VAR (is_ostree_container, rpmostreecxx::is_ostree_container (), error);
   if (is_ostree_container)
     {
-      auto treefile = ROSCXX_TRY_VAL (treefile_new_empty (), error);
+      CXX_TRY_VAR (treefile, rpmostreecxx::treefile_new_empty (), error);
       treefile->set_packages_override_remove (util::rust_stringvec_from_strv (opt_remove_pkgs));
       treefile->set_packages_override_replace_local_rpms (util::rust_stringvec_from_strv (argv));
       return rpmostree_container_rebuild (*treefile, cancellable, error);
@@ -262,10 +262,10 @@ rpmostree_override_builtin_remove (int argc, char **argv, RpmOstreeCommandInvoca
   argc--;
   argv[argc] = NULL;
 
-  auto is_ostree_container = ROSCXX_TRY_VAL (is_ostree_container (), error);
+  CXX_TRY_VAR (is_ostree_container, rpmostreecxx::is_ostree_container (), error);
   if (is_ostree_container)
     {
-      auto treefile = ROSCXX_TRY_VAL (treefile_new_empty (), error);
+      CXX_TRY_VAR (treefile, rpmostreecxx::treefile_new_empty (), error);
       treefile->set_packages_override_replace_local_rpms (
           util::rust_stringvec_from_strv (opt_replace_pkgs));
       treefile->set_packages_override_remove (util::rust_stringvec_from_strv (argv));

--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -179,10 +179,10 @@ rpmostree_builtin_install (int argc, char **argv, RpmOstreeCommandInvocation *in
   argc--;
   argv[argc] = NULL;
 
-  auto is_ostree_container = ROSCXX_TRY_VAL (is_ostree_container (), error);
+  CXX_TRY_VAR (is_ostree_container, rpmostreecxx::is_ostree_container (), error);
   if (is_ostree_container)
     {
-      auto treefile = ROSCXX_TRY_VAL (treefile_new_empty (), error);
+      CXX_TRY_VAR (treefile, rpmostreecxx::treefile_new_empty (), error);
       treefile->set_packages (util::rust_stringvec_from_strv (argv));
       return rpmostree_container_rebuild (*treefile, cancellable, error);
     }

--- a/src/daemon/rpmostree-sysroot-core.cxx
+++ b/src/daemon/rpmostree-sysroot-core.cxx
@@ -131,7 +131,8 @@ generate_pkgcache_refs (OstreeSysroot *sysroot, OstreeRepo *repo, guint *out_n_f
           const char *nevra = nevra_v.c_str ();
           if (!rpmostree_decompose_sha256_nevra (&nevra, NULL, error))
             return FALSE;
-          auto cachebranch = ROSCXX_TRY_VAL (nevra_to_cache_branch (std::string (nevra)), error);
+          CXX_TRY_VAR (cachebranch, rpmostreecxx::nevra_to_cache_branch (std::string (nevra)),
+                       error);
           g_hash_table_add (referenced_pkgs, g_strdup (cachebranch.c_str ()));
         }
     }
@@ -343,7 +344,7 @@ rpmostree_syscore_write_deployment (OstreeSysroot *sysroot, OstreeDeployment *ne
       OstreeDeployment *booted = ostree_sysroot_get_booted_deployment (sysroot);
       if (booted)
         {
-          auto is_live = ROSCXX_TRY_VAL (has_live_apply_state (*sysroot, *booted), error);
+          CXX_TRY_VAR (is_live, rpmostreecxx::has_live_apply_state (*sysroot, *booted), error);
           if (is_live)
             flags = static_cast<OstreeSysrootSimpleWriteDeploymentFlags> (
                 flags | OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_RETAIN_ROLLBACK);

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -434,7 +434,8 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader *self, const char
           return glnx_throw (error, "Specifying commit overrides for container-image-reference "
                                     "type refspecs is not supported");
 
-        auto import = ROSCXX_TRY_VAL (pull_container (*self->repo, *cancellable, refspec), error);
+        CXX_TRY_VAR (import, rpmostreecxx::pull_container (*self->repo, *cancellable, refspec),
+                     error);
         // Note this duplicates
         // https://github.com/ostreedev/ostree-rs-ext/blob/22a663f64e733e7ba8382f11f853ce4202652254/lib/src/container/store.rs#L64
         if (import->is_layered)
@@ -579,15 +580,17 @@ static gboolean
 try_load_base_rsack_from_pending (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable,
                                   GError **error)
 {
-  auto is_live = ROSCXX_TRY_VAL (
-      has_live_apply_state (*self->sysroot, *self->origin_merge_deployment), error);
+  CXX_TRY_VAR (is_live,
+               rpmostreecxx::has_live_apply_state (*self->sysroot, *self->origin_merge_deployment),
+               error);
   /* livefs invalidates the deployment */
   if (is_live)
     return TRUE;
 
   auto repo = ostree_sysroot_repo (self->sysroot);
-  auto layeredmeta
-      = ROSCXX_TRY_VAL (deployment_layeredmeta_load (*repo, *self->origin_merge_deployment), error);
+  CXX_TRY_VAR (layeredmeta,
+               rpmostreecxx::deployment_layeredmeta_load (*repo, *self->origin_merge_deployment),
+               error);
   /* older client layers have a bug blocking us from using their base rpmdb:
    * https://github.com/projectatomic/rpm-ostree/pull/1560 */
   if (layeredmeta.is_layered && layeredmeta.clientlayer_version < 4)
@@ -918,7 +921,8 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable, 
 
   {
     g_autoptr (GKeyFile) computed_origin_kf = rpmostree_origin_dup_keyfile (self->computed_origin);
-    self->treefile = ROSCXX_TRY_VAL (origin_to_treefile (*computed_origin_kf), error);
+    CXX_TRY_VAR (tf, rpmostreecxx::origin_to_treefile (*computed_origin_kf), error);
+    self->treefile = std::move (tf);
   }
   rpmostree_context_set_treefile (self->ctx, **self->treefile);
 
@@ -1344,9 +1348,9 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
   const char *overlay_v[] = { NULL, NULL };
   if (rpmostree_origin_has_initramfs_etc_files (self->computed_origin))
     {
-      glnx_fd_close int fd = -1;
       auto etc_files = rpmostree_origin_get_initramfs_etc_files (self->computed_origin);
-      fd = ROSCXX_TRY_VAL (initramfs_overlay_generate (etc_files, *cancellable), error);
+      CXX_TRY_VAR (fdv, rpmostreecxx::initramfs_overlay_generate (etc_files, *cancellable), error);
+      glnx_fd_close int fd = fdv;
       if (!ostree_sysroot_stage_overlay_initrd (self->sysroot, fd, &overlay_initrd_checksum,
                                                 cancellable, error))
         return glnx_prefix_error (error, "Staging initramfs overlay");

--- a/src/daemon/rpmostreed-daemon.cxx
+++ b/src/daemon/rpmostreed-daemon.cxx
@@ -286,8 +286,9 @@ rpmostreed_daemon_initable_init (GInitable *initable, GCancellable *cancellable,
   if (!rpmostreed_daemon_reload_config (self, NULL, error))
     return FALSE;
 
-  auto path = ROSCXX_TRY_VAL (
-      generate_object_path (rust::Str (BASE_DBUS_PATH), rust::Str ("Sysroot")), error);
+  CXX_TRY_VAR (
+      path, rpmostreecxx::generate_object_path (rust::Str (BASE_DBUS_PATH), rust::Str ("Sysroot")),
+      error);
 
   self->sysroot = (RpmostreedSysroot *)g_object_new (RPMOSTREED_TYPE_SYSROOT, "path",
                                                      self->sysroot_path, NULL);

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -204,7 +204,7 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot, OstreeDeployment
     case rpmostreecxx::RefspecType::Container:
       {
         g_variant_dict_insert (dict, "container-image-reference", "s", refspec.c_str ());
-        auto state = ROSCXX_TRY_VAL (query_container_image (*repo, refspec.c_str ()), error);
+        CXX_TRY_VAR (state, rpmostreecxx::query_container_image (*repo, refspec.c_str ()), error);
         g_variant_dict_insert (dict, "container-image-reference-digest", "s",
                                state->image_digest.c_str ());
       }

--- a/src/daemon/rpmostreed-os-experimental.cxx
+++ b/src/daemon/rpmostreed-os-experimental.cxx
@@ -209,7 +209,7 @@ prepare_download_pkgs_txn (const gchar *const *queries, const char *source,
     return glnx_prefix_error (error, "Downloading metadata");
 
   DnfSack *sack = dnf_context_get_sack (rpmostree_context_get_dnf (ctx));
-  auto parsed_source = ROSCXX_TRY_VAL (parse_override_source (source), error);
+  CXX_TRY_VAR (parsed_source, rpmostreecxx::parse_override_source (source), error);
 
   if (parsed_source.kind == rpmostreecxx::PackageOverrideSourceKind::Repo)
     {
@@ -300,8 +300,9 @@ rpmostreed_osexperimental_new (OstreeSysroot *sysroot, OstreeRepo *repo, const c
   g_assert (OSTREE_IS_SYSROOT (sysroot));
   g_assert (name != NULL);
 
-  auto path
-      = ROSCXX_TRY_VAL (generate_object_path (rust::Str (BASE_DBUS_PATH), rust::Str (name)), error);
+  CXX_TRY_VAR (path,
+               rpmostreecxx::generate_object_path (rust::Str (BASE_DBUS_PATH), rust::Str (name)),
+               error);
 
   auto obj = (RpmostreedOSExperimental *)g_object_new (RPMOSTREED_TYPE_OSEXPERIMENTAL, NULL);
 

--- a/src/daemon/rpmostreed-os.cxx
+++ b/src/daemon/rpmostreed-os.cxx
@@ -350,10 +350,10 @@ get_deployments_rpm_diff (const char *arg_deployid0, const char *arg_deployid1,
   ot_repo = rpmostreed_sysroot_get_repo (global_sysroot);
 
   rust::Str deploy_id0 (arg_deployid0 ?: "");
-  auto ref0 = ROSCXX_TRY_VAL (deployment_checksum_for_id (*ot_sysroot, deploy_id0), error);
+  CXX_TRY_VAR (ref0, rpmostreecxx::deployment_checksum_for_id (*ot_sysroot, deploy_id0), error);
 
   rust::Str deploy_id1 (arg_deployid1 ?: "");
-  auto ref1 = ROSCXX_TRY_VAL (deployment_checksum_for_id (*ot_sysroot, deploy_id1), error);
+  CXX_TRY_VAR (ref1, rpmostreecxx::deployment_checksum_for_id (*ot_sysroot, deploy_id1), error);
 
   if (!rpm_ostree_db_diff_variant (ot_repo, ref0.c_str (), ref1.c_str (), FALSE, &value,
                                    cancellable, error))
@@ -392,7 +392,6 @@ get_cached_update_rpm_diff (const gchar *name, const char *arg_deployid, GVarian
   g_autoptr (RpmOstreeOrigin) origin = NULL;
   OstreeSysroot *ot_sysroot = NULL;
   OstreeRepo *ot_repo = NULL;
-  glnx_unref_object OstreeDeployment *base_deployment = NULL;
   GCancellable *cancellable = NULL;
   g_autoptr (GVariant) value = NULL;
   g_autoptr (GVariant) details = NULL;
@@ -404,7 +403,9 @@ get_cached_update_rpm_diff (const gchar *name, const char *arg_deployid, GVarian
 
   rust::Str os_name (name ?: "");
   rust::Str deploy_id (arg_deployid ?: "");
-  base_deployment = ROSCXX_TRY_VAL (deployment_get_base (*ot_sysroot, deploy_id, os_name), error);
+  CXX_TRY_VAR (base_deploymentv,
+               rpmostreecxx::deployment_get_base (*ot_sysroot, deploy_id, os_name), error);
+  glnx_unref_object OstreeDeployment *base_deployment = base_deploymentv;
 
   origin = rpmostree_origin_parse_deployment (base_deployment, error);
   if (!origin)
@@ -1450,7 +1451,7 @@ get_cached_deploy_rpm_diff (RPMOSTreeOS *interface, const char *arg_revision, GV
   const char *base_checksum = ostree_deployment_get_csum (base_deployment);
 
   auto refspec = rpmostree_origin_get_refspec (origin);
-  auto parsed_revision = ROSCXX_TRY_VAL (parse_revision (arg_revision), error);
+  CXX_TRY_VAR (parsed_revision, rpmostreecxx::parse_revision (arg_revision), error);
   g_autofree char *checksum = NULL;
   switch (parsed_revision.kind)
     {
@@ -1727,8 +1728,9 @@ rpmostreed_os_new (OstreeSysroot *sysroot, OstreeRepo *repo, const char *name, G
   g_assert (OSTREE_IS_SYSROOT (sysroot));
   g_assert (name != NULL);
 
-  auto path
-      = ROSCXX_TRY_VAL (generate_object_path (rust::Str (BASE_DBUS_PATH), rust::Str (name)), error);
+  CXX_TRY_VAR (path,
+               rpmostreecxx::generate_object_path (rust::Str (BASE_DBUS_PATH), rust::Str (name)),
+               error);
 
   auto obj = (RpmostreedOS *)g_object_new (RPMOSTREED_TYPE_OS, "name", name, NULL);
 

--- a/src/daemon/rpmostreed-sysroot.cxx
+++ b/src/daemon/rpmostreed-sysroot.cxx
@@ -267,8 +267,9 @@ sysroot_populate_deployments_unlocked (RpmostreedSysroot *self, gboolean *out_ch
     {
       auto os = ostree_deployment_get_osname (booted);
 
-      auto path = ROSCXX_TRY_VAL (generate_object_path (rust::Str (BASE_DBUS_PATH), rust::Str (os)),
-                                  error);
+      CXX_TRY_VAR (path,
+                   rpmostreecxx::generate_object_path (rust::Str (BASE_DBUS_PATH), rust::Str (os)),
+                   error);
 
       rpmostree_sysroot_set_booted (RPMOSTREE_SYSROOT (self), path.c_str ());
       auto bootedid_v = rpmostreecxx::deployment_generate_id (*booted);

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -171,7 +171,7 @@ apply_revision_override (RpmostreedTransaction *transaction, OstreeRepo *repo,
   if (refspectype != rpmostreecxx::RefspecType::Ostree)
     return glnx_throw (error, "Invalid refspec type");
 
-  auto parsed_revision = ROSCXX_TRY_VAL (parse_revision (revision), error);
+  CXX_TRY_VAR (parsed_revision, rpmostreecxx::parse_revision (revision), error);
   switch (parsed_revision.kind)
     {
     case rpmostreecxx::ParsedRevisionKind::Version:
@@ -1440,7 +1440,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
 
           OstreeDeployment *deployment = rpmostree_sysroot_upgrader_get_merge_deployment (upgrader);
 
-          auto is_live = ROSCXX_TRY_VAL (has_live_apply_state (*sysroot, *deployment), error);
+          CXX_TRY_VAR (is_live, rpmostreecxx::has_live_apply_state (*sysroot, *deployment), error);
           if (is_live)
             changed = TRUE;
         }
@@ -2490,8 +2490,8 @@ finalize_deployment_transaction_execute (RpmostreedTransaction *transaction,
   if (!g_str_equal (ostree_deployment_get_osname (default_deployment), self->osname))
     return glnx_throw (error, "Staged deployment is not for osname '%s'", self->osname);
 
-  auto layeredmeta
-      = ROSCXX_TRY_VAL (deployment_layeredmeta_load (*repo, *default_deployment), error);
+  CXX_TRY_VAR (layeredmeta, rpmostreecxx::deployment_layeredmeta_load (*repo, *default_deployment),
+               error);
   const char *checksum = layeredmeta.base_commit.c_str ();
 
   auto expected_checksum = (char *)vardict_lookup_ptr (self->options, "checksum", "&s");

--- a/src/libpriv/rpmostree-importer.cxx
+++ b/src/libpriv/rpmostree-importer.cxx
@@ -408,7 +408,7 @@ build_metadata_variant (RpmOstreeImporter *self, GVariant **out_variant, GCancel
 
       /* include a checksum of the RPM as a whole; the actual algo used depends
        * on how the repodata was created, so just keep a repr */
-      auto chksum_repr = ROSCXX_TRY_VAL (get_repodata_chksum_repr (*self->pkg), error);
+      CXX_TRY_VAR (chksum_repr, rpmostreecxx::get_repodata_chksum_repr (*self->pkg), error);
       g_variant_builder_add (&metadata_builder, "{sv}", "rpmostree.repodata_checksum",
                              g_variant_new_string (chksum_repr.c_str ()));
     }

--- a/src/libpriv/rpmostree-kernel.cxx
+++ b/src/libpriv/rpmostree-kernel.cxx
@@ -464,9 +464,9 @@ rpmostree_run_dracut (int rootfs_dfd, const char *const *argv, const char *kver,
    * today.  Though maybe in the future we should add it, but
    * in the end we want to use systemd-sysusers of course.
    **/
-  auto etc_guard = ROSCXX_TRY_VAL (prepare_tempetc_guard (rootfs_dfd), error);
+  CXX_TRY_VAR (etc_guard, rpmostreecxx::prepare_tempetc_guard (rootfs_dfd), error);
 
-  gboolean have_passwd = ROSCXX_TRY_VAL (prepare_rpm_layering (rootfs_dfd, ""), error);
+  CXX_TRY_VAR (have_passwd, rpmostreecxx::prepare_rpm_layering (rootfs_dfd, ""), error);
 
   /* Note rebuild_from_initramfs now is only used as a fallback in the client-side regen
    * path when we can't fetch the canonical initramfs args to use. */
@@ -508,7 +508,7 @@ rpmostree_run_dracut (int rootfs_dfd, const char *const *argv, const char *kver,
   if (!glnx_open_tmpfile_linkable_at (rootfs_dfd, ".", O_RDWR | O_CLOEXEC, &tmpf, error))
     return FALSE;
 
-  auto bwrap = ROSCXX_TRY_VAL (bubblewrap_new (rootfs_dfd), error);
+  CXX_TRY_VAR (bwrap, rpmostreecxx::bubblewrap_new (rootfs_dfd), error);
   if (use_root_etc)
     {
       bwrap->bind_read ("/etc", "/etc");

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -92,13 +92,14 @@ static void
 sync_treefile (RpmOstreeOrigin *self)
 {
   self->treefile.reset ();
-  self->treefile = CXX_MUST_VAL (rpmostreecxx::origin_to_treefile (*self->kf));
+  // Note this may throw a C++ exception
+  self->treefile = rpmostreecxx::origin_to_treefile (*self->kf);
 }
 
 static void
 sync_origin (RpmOstreeOrigin *self)
 {
-  g_autoptr (GKeyFile) kf = CXX_MUST_VAL (rpmostreecxx::treefile_to_origin (**self->treefile));
+  g_autoptr (GKeyFile) kf = rpmostreecxx::treefile_to_origin (**self->treefile);
   g_clear_pointer (&self->kf, g_key_file_unref);
   self->kf = g_key_file_ref (kf);
 }
@@ -422,7 +423,7 @@ GKeyFile *
 rpmostree_origin_dup_keyfile (RpmOstreeOrigin *origin)
 {
   // XXX: we should be able to make this conversion infallible
-  return CXX_MUST_VAL (rpmostreecxx::treefile_to_origin (**origin->treefile));
+  return rpmostreecxx::treefile_to_origin (**origin->treefile);
 }
 
 static void

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -786,7 +786,7 @@ rpmostree_compose_commit (int rootfs_fd, OstreeRepo *repo, const char *parent_re
   if (devino_cache)
     ostree_repo_commit_modifier_set_devino_cache (commit_modifier, devino_cache);
 
-  auto n_bytes = ROSCXX_TRY_VAL (directory_size (rootfs_fd, *cancellable), error);
+  CXX_TRY_VAR (n_bytes, rpmostreecxx::directory_size (rootfs_fd, *cancellable), error);
 
   tdata.n_bytes = n_bytes;
   tdata.repo = repo;

--- a/src/libpriv/rpmostree-util.cxx
+++ b/src/libpriv/rpmostree-util.cxx
@@ -505,8 +505,8 @@ rpmostree_deployment_get_layered_info (OstreeRepo *repo, OstreeDeployment *deplo
   if (!ostree_repo_load_commit (repo, csum, &commit, NULL, error))
     return FALSE;
 
-  auto layeredmeta
-      = ROSCXX_TRY_VAL (deployment_layeredmeta_from_commit (*deployment, *commit), error);
+  CXX_TRY_VAR (layeredmeta, rpmostreecxx::deployment_layeredmeta_from_commit (*deployment, *commit),
+               error);
 
   g_autoptr (GVariant) metadata = g_variant_get_child_value (commit, 0);
   g_autoptr (GVariantDict) dict = g_variant_dict_new (metadata);


### PR DESCRIPTION


clang's `scan-build` static analyzer says that our current pattern
is not safe.  Replace our usage of `CXX_TRY_VAL` with `CXX_TRY_VAR`
that moves the type declaration into the macro.  Crucially, the
variable is only created on the success path.

I think C++ has special handling for exceptions and things like
`auto var = somefunc();` where if `somefunc()` throws it knows that
`var` is not initialized.  But this doesn't work with the GCC statement-expression
extension.

Note that we can no longer do e.g.:
`self->treefile_rs = CXX_TRY(...)`
so the new pattern is:
```
CXX_TRY_VAR(tf, ...);
self->treefile_rs = std::move (tf);
```

Also, while I'm here I honestly find the `ROS` thing was a bit *too*
magic.  So I ported everything to explicitly say `rpmostreecxx::`
for the namespace.

Eventually, we will likely want to have multiple cxx.rs bridges,
in which case namespacing would need to be explicit anyways.

---

