### PR TITLE
refts: Correctly canonicalize explicit zero epoch

### DIFF
--- a/src/libpriv/rpmostree-rpm-util.cxx
+++ b/src/libpriv/rpmostree-rpm-util.cxx
@@ -138,6 +138,20 @@ pkg_nevra_strdup (Header h1)
       (RpmOstreePkgNevraFlags)(PKG_NEVRA_FLAGS_NAME | PKG_NEVRA_FLAGS_EVR | PKG_NEVRA_FLAGS_ARCH));
 }
 
+namespace rpmostreecxx
+{
+
+// Return a canonicalized NEVRA string.  Crucially this differs from the librpm
+// version which may or may not return an explicit `0` epoch.  This version
+// always omits both unset and zero epoch.
+rust::String
+header_get_nevra (Header h)
+{
+  g_autofree char *v = pkg_nevra_strdup (h);
+  return rust::String (v);
+}
+}
+
 static char *
 pkg_na_strdup (Header h1)
 {

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -199,3 +199,8 @@ GPtrArray *rpmostree_get_enabled_rpmmd_repos (DnfContext *dnfctx, DnfRepoEnabled
 GVariant *rpmostree_advisories_variant (DnfSack *sack, GPtrArray *pkgs);
 
 G_END_DECLS
+
+namespace rpmostreecxx
+{
+rust::String header_get_nevra (Header h);
+}


### PR DESCRIPTION
Ye olde "librpm treats explicit epoch 0 differently than unset"
bites us again when I tried `rpm-ostree container-encapsulate fedora/35/x86_64/silverblue`.

`perl-NDBM_File` has an explicit `0` epoch, and this causes
an assertion error because the nevra we get from our pkglist is
different than what librpm returns.
