### PR TITLE
Downgrade tracing-subscriber to 0.3.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2622,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.10"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9df98b037d039d03400d9dd06b0f8ce05486b5f25e9a2d7d36196e142ebbc52"
+checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
 dependencies = [
  "ansi_term",
  "lazy_static",


### PR DESCRIPTION
We managed to ship this bug in the current 2022.6 release:
https://github.com/tokio-rs/tracing/issues/2046

Which is definitely embarassing enough to cut a new release.  (For both them and us, but I explicitly mean we should cut an rpm-ostree 2022.7 with this downgrade)

Closes: #3589 