### PR TITLE
postprocess: Move rpmdb cleanup into Rust 

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -242,6 +242,7 @@ pub mod ffi {
             cancellable: Pin<&mut GCancellable>,
         ) -> Result<()>;
         fn compose_postprocess_rpm_macro(rootfs_dfd: i32) -> Result<()>;
+        fn postprocess_cleanup_rpmdb(rootfs_dfd: i32) -> Result<()>;
         fn rewrite_rpmdb_for_target(rootfs_dfd: i32, normalize: bool) -> Result<()>;
         fn directory_size(dfd: i32, mut cancellable: Pin<&mut GCancellable>) -> Result<u64>;
     }

--- a/src/libpriv/rpmostree-container.cxx
+++ b/src/libpriv/rpmostree-container.cxx
@@ -28,6 +28,7 @@
 
 #include "rpmostree-container.h"
 #include "rpmostree-postprocess.h"
+#include "rpmostree-util.h"
 
 #include <libglnx.h>
 
@@ -62,8 +63,7 @@ rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile, GCancellable *can
   glnx_autofd int rootfs_fd = -1;
   if (!glnx_opendirat (AT_FDCWD, "/", TRUE, &rootfs_fd, error))
     return FALSE;
-  if (!rpmostree_cleanup_leftover_rpmdb_files (rootfs_fd, cancellable, error))
-    return FALSE;
+  CXX_TRY (rpmostreecxx::postprocess_cleanup_rpmdb (rootfs_fd), error);
 
   return TRUE;
 }

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -4577,9 +4577,7 @@ rpmostree_context_commit (RpmOstreeContext *self, const char *parent,
     g_variant_builder_add (&metadata_builder, "{sv}", "rpmostree.state-sha512",
                            g_variant_new_string (state_checksum));
 
-    /* And finally, make sure we clean up rpmdb left over files */
-    if (!rpmostree_cleanup_leftover_rpmdb_files (self->tmprootfs_dfd, cancellable, error))
-      return FALSE;
+    CXX_TRY (rpmostreecxx::postprocess_cleanup_rpmdb (self->tmprootfs_dfd), error);
 
     auto modflags
         = static_cast<OstreeRepoCommitModifierFlags> (OSTREE_REPO_COMMIT_MODIFIER_FLAGS_NONE);

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -26,9 +26,6 @@
 
 G_BEGIN_DECLS
 
-gboolean rpmostree_cleanup_leftover_rpmdb_files (int rootfs_fd, GCancellable *cancellable,
-                                                 GError **error);
-
 gboolean rpmostree_rootfs_postprocess_common (int rootfs_fd, GCancellable *cancellable,
                                               GError **error);
 


### PR DESCRIPTION


Prep for calling it from Rust code.