### PR TITLE
Add support for repo overrides in container flow

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -432,6 +432,19 @@ pub mod ffi {
         refspec: String,
     }
 
+    // This is an awkward almost duplicate of the types in treefile.rs, but cxx.rs-compatible.
+    #[derive(Debug)]
+    enum OverrideReplacementType {
+        Repo,
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct OverrideReplacement {
+        from: String,
+        from_kind: OverrideReplacementType,
+        packages: Vec<String>,
+    }
+
     extern "Rust" {
         type Treefile;
 
@@ -471,6 +484,7 @@ pub mod ffi {
             packages: Vec<String>,
             allow_existing: bool,
         ) -> Result<bool>;
+        fn get_packages_override_replace(&self) -> Vec<OverrideReplacement>;
         fn get_packages_override_replace_local(&self) -> Vec<String>;
         fn get_packages_override_replace_local_rpms(&self) -> Vec<String>;
         fn set_packages_override_replace_local_rpms(&mut self, packages: Vec<String>);

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -115,6 +115,7 @@ EOF
     cat >baz.yaml << 'EOF'
 packages:
   - baz-1.0
+  - boo-1.0
 EOF
     cat >testdaemon-query.yaml << 'EOF'
 repo-packages:
@@ -131,6 +132,11 @@ EOF
     cat >replace-baz.yaml <<EOF
 override-replace-local-rpms:
   - /var/tmp/baz-2.0-1.x86_64.rpm
+ex-override-replace:
+  - from:
+      repo: local
+    packages:
+      - boo
 EOF
 cat > Dockerfile << 'EOF'
 FROM localhost/fcos

--- a/tests/kolainst/kolainst-build.sh
+++ b/tests/kolainst/kolainst-build.sh
@@ -22,6 +22,8 @@ build_rpm foo version 1.2 release 3
 build_rpm bar
 build_rpm baz
 build_rpm baz version 2.0
+build_rpm boo
+build_rpm boo version 2.0
 # And from here we lose our creativity and name things starting
 # with `testpkg` and grow more content.
 # This one has various files in /etc


### PR DESCRIPTION
This implements the semantics discussed in
https://github.com/coreos/rpm-ostree/issues/1265.

For now, it's only supported in treefile format. Will wire it up to
`override replace` soon.

Also for now, this only works in the container flow. The client-side
will come soon, but it still needs more cleanups there to avoid having
to wire this through a non-trivial number of APIs.