### PR TITLE
build: Add support for propagating RPM IMA signatures

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -32,6 +32,9 @@ It supports the following parameters:
  * `selinux`: boolean, optional: Defaults to `true`.  If `false`, then
    no SELinux labeling will be performed on the server side.
 
+ * `ima`: boolean, optional: Defaults to `false`.  Propagate any
+   IMA signatures in input RPMs into the final OSTree commit.
+
  * `boot-location` (or `boot_location`): string, optional:
     There are 2 possible values:
     * "new": A misnomer, this value is no longer "new".  Kernel data

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -534,6 +534,7 @@ pub mod ffi {
         fn get_documentation(&self) -> bool;
         fn get_recommends(&self) -> bool;
         fn get_selinux(&self) -> bool;
+        fn get_ima(&self) -> bool;
         fn get_releasever(&self) -> String;
         fn get_repo_metadata_target(&self) -> RepoMetadataTarget;
         fn rpmdb_backend_is_target(&self) -> bool;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -404,6 +404,7 @@ fn treefile_merge(dest: &mut TreeComposeConfig, src: &mut TreeComposeConfig) {
         basearch,
         rojig,
         selinux,
+        ima,
         gpg_key,
         include,
         container,
@@ -1255,6 +1256,10 @@ impl Treefile {
 
     pub(crate) fn get_selinux(&self) -> bool {
         self.parsed.base.selinux.unwrap_or(true)
+    }
+
+    pub(crate) fn get_ima(&self) -> bool {
+        self.parsed.base.ima.unwrap_or(false)
     }
 
     pub(crate) fn get_releasever(&self) -> String {
@@ -2276,6 +2281,8 @@ pub(crate) struct BaseComposeConfigFields {
     pub(crate) lockfile_repos: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) selinux: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) ima: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) gpg_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -2425,6 +2425,9 @@ start_async_import_one_package (RpmOstreeContext *self, DnfPackage *pkg, GCancel
   if (self->treefile_rs->get_readonly_executables ())
     flags |= RPMOSTREE_IMPORTER_FLAGS_RO_EXECUTABLES;
 
+  if (self->treefile_rs->get_ima ())
+    flags |= RPMOSTREE_IMPORTER_FLAGS_IMA;
+
   /* TODO - tweak the unpacker flags for containers */
   OstreeRepo *ostreerepo = get_pkgcache_repo (self);
   g_autoptr (RpmOstreeImporter) unpacker = rpmostree_importer_new_take_fd (

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -40,6 +40,10 @@ G_BEGIN_DECLS
 #define RPMOSTREE_DIR_CACHE_SOLV "solv"
 #define RPMOSTREE_DIR_LOCK "lock"
 
+// Extended attribute used at build time.
+#define RPMOSTREE_USER_IMA "user.ima"
+#define RPMOSTREE_SYSTEM_IMA "security.ima"
+
 /* See http://lists.rpm.org/pipermail/rpm-maint/2017-October/006681.html */
 /* This is also defined on the Rust side. */
 #define RPMOSTREE_RPMDB_LOCATION "usr/share/rpm"

--- a/src/libpriv/rpmostree-importer.h
+++ b/src/libpriv/rpmostree-importer.h
@@ -45,12 +45,14 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (RpmOstreeImporter, g_object_unref)
  * ostree-compliant paths rather than erroring out
  * @RPMOSTREE_IMPORTER_FLAGS_NODOCS: Skip documentation files
  * @RPMOSTREE_IMPORTER_FLAGS_RO_EXECUTABLES: Make executable files readonly
+ * @RPMOSTREE_IMPORTER_FLAGS_IMA: Enable IMA
  */
 typedef enum
 {
   RPMOSTREE_IMPORTER_FLAGS_SKIP_EXTRANEOUS = (1 << 0),
   RPMOSTREE_IMPORTER_FLAGS_NODOCS = (1 << 1),
   RPMOSTREE_IMPORTER_FLAGS_RO_EXECUTABLES = (1 << 2),
+  RPMOSTREE_IMPORTER_FLAGS_IMA = (1 << 3),
 } RpmOstreeImporterFlags;
 
 RpmOstreeImporter *rpmostree_importer_new_take_fd (int *fd, OstreeRepo *repo, DnfPackage *pkg,


### PR DESCRIPTION
The alignment between ostree and IMA is actually quite good.  IMA
signatures are just extended attributes, and ostree has first-class
native support for those.

RPM represents IMA signatures in an ad-hoc way, and then a plugin
pulls bits from the header and does the `lsetxattr` call.

One thing that ostree is pretty good at is that one can synthesize
data in memory into the final ostree commit, without actually needing
it to hit the physical filesystem at build time.  This is crucial
for SELinux, where we want to be able to set security contexts
in the resulting build without actually requiring matching SELinux
policy on the *build* server.

IMA has similar issues; we don't want to blindly use `rpm-plugin-ima`
at *build* time.  That would potentially conflict with IMA policy
set up for the host system.

Add a treefile option `ima: true` that if set, causes the importer
to propagate the RPM IMA signatures into the proper `security.ima`
extended attribute.

Now, while working on this I made a fundamental realization that
all along, we should have supported committing `bare-user` checkouts
directly into `archive` repositories.

This is how it works in coreos-assembler today.  It'd make a ton
of sense to add something like `ostree commit --from-bare-user` that
would honor the `ostree.usermeta` xattr.  (Tempting to do it by default
but the compatibility hazard seems high)

So for now...hack in code in our commit phase to do this.

Note there was previous work here to automatically translate the
`user.ima` xattr to `security.ima` (because it was apparently easier
than patching rpm-ostree core?).  This code kind of obsoletes that,
but on the other hand one could today be writing `user.ima` attributes
during a build process for things that are not from RPM, and that's
kind of useful to continue to support.  Though, I think we should
handle that in a more principled way (that's a bigger topic).

Note that Fedora and CentOS do not ship native IMA signatures by
default.  And in fact, there was a *huge* mess around the representation
of IMA signatures in rpm - so patches to fix that landed in C9S/RHEL9
but not in at least Fedora 35 I believe.

Which means: actually using this functionality for e.g. RHEL9 IMA
signatures requires using rpm-ostree (and really, librpm) from
a RHEL9 host system - it won't work today to "cross build" as
we do with coreos-assembler.

Also, testing this out with RHEL9 content I needed to do:
```
remove-from-packages:
  - - systemd-libs
    - /usr/share/licenses/systemd/LICENSE.LGPL2.1
```

because there are two copies of that file, but they apparently
have separate IMA signatures and only when IMA is enabled, ostree
(correctly) reports them as conflicting.

Closes: https://github.com/coreos/rpm-ostree/issues/3547
