### PR TITLE
fixes for "the world changed underneath us" CI failures

### DIFF
--- a/tests/compose/test-install-langs.sh
+++ b/tests/compose/test-install-langs.sh
@@ -36,6 +36,6 @@ assert_file_has_content out.txt 'opérande de fichier manquant'
 if ostree --repo=${repo} ls ${treeref} /usr/bin/rpmostree-postprocess-lang-test.sh 2>err.txt; then
     assert_not_reached "we failed to unlink?"
 fi
-assert_file_has_content err.txt "error: No such file or directory"
+assert_file_has_content err.txt "error:.*No such file or directory"
 
 echo "ok install-langs"

--- a/tests/kolainst/destructive/apply-live
+++ b/tests/kolainst/destructive/apply-live
@@ -34,6 +34,9 @@ if rpm -q foo 2>/dev/null; then
   fatal "found foo"
 fi
 
+# Turn off zincati since we're rebasing
+systemctl mask --now zincati
+
 rpm -qa | sort > original-rpmdb.txt
 
 rpm-ostree install foo

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -41,6 +41,9 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     checksum=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
     rm ${image_dir} -rf
     
+    # Since we're switching OS update stream, turn off zincati
+    systemctl mask --now zincati
+
     rpm-ostree ex-container 'export' --repo=/ostree/repo ${checksum} "${image}"
     rpm-ostree rebase "$image_pull" --experimental | tee out.txt
     assert_file_has_content out.txt 'Importing.*'"$image_pull"

--- a/tests/kolainst/destructive/layering-local
+++ b/tests/kolainst/destructive/layering-local
@@ -33,6 +33,8 @@ fi
 
 # Disable repos, no Internet access should be required
 rm -rf /etc/yum.repos.d/
+# Also disable zincati since we're rebasing
+systemctl mask --now zincati
 booted_commit=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
 ostree refs ${booted_commit} --create vmcheck
 rpm-ostree rebase :vmcheck


### PR DESCRIPTION
This is like https://github.com/coreos/coreos-assembler/pull/2814
but for our tests, required now that
https://github.com/coreos/coreos-assembler/pull/2810
merged into coreos-assembler.
