### PR TITLE
libpriv/json-parsing: port one helper to Rust

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -469,6 +469,7 @@ pub mod ffi {
         fn get_all_ostree_layers(&self) -> Vec<String>;
         fn get_repos(&self) -> Vec<String>;
         fn get_packages(&self) -> Vec<String>;
+        fn get_automatic_version_prefix(&self) -> Result<String>;
         fn add_packages(&mut self, packages: Vec<String>, allow_existing: bool) -> Result<bool>;
         fn has_packages(&self) -> bool;
         fn set_packages(&mut self, packages: Vec<String>);

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -713,6 +713,15 @@ impl Treefile {
             .unwrap_or_default()
     }
 
+    /// Return the `automatic-version-prefix` field, or an error if missing.
+    pub fn get_automatic_version_prefix(&self) -> CxxResult<String> {
+        self.parsed
+            .base
+            .automatic_version_prefix
+            .clone()
+            .ok_or_else(|| anyhow!("Member 'automatic-version-prefix' not found").into())
+    }
+
     // The list of packages is really a list of provides, so string equality
     // is a bit weird here. Multiple provides can resolve to the same package
     // and we allow that. But still, let's make sure that silly users don't

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -897,10 +897,7 @@ impl_install_tree (RpmOstreeTreeComposeContext *self, gboolean *out_changed,
       /* let --add-metadata-string=version=... take precedence */
       !g_hash_table_contains (self->metadata, OSTREE_COMMIT_META_KEY_VERSION))
     {
-      const char *ver_prefix = _rpmostree_jsonutil_object_require_string_member (
-          self->treefile, "automatic-version-prefix", error);
-      if (!ver_prefix)
-        return FALSE;
+      CXX_TRY_VAR (ver_prefix, (*self->treefile_rs)->get_automatic_version_prefix (), error);
       const char *ver_suffix = NULL;
       if (!_rpmostree_jsonutil_object_get_optional_string_member (
               self->treefile, "automatic-version-suffix", &ver_suffix, error))
@@ -919,10 +916,10 @@ impl_install_tree (RpmOstreeTreeComposeContext *self, gboolean *out_changed,
                                   &last_version);
         }
 
-      CXX_TRY_VAR (
-          next_versionv,
-          rpmostreecxx::util_next_version (ver_prefix, ver_suffix ?: "", last_version ?: ""),
-          error);
+      CXX_TRY_VAR (next_versionv,
+                   rpmostreecxx::util_next_version (ver_prefix.c_str (), ver_suffix ?: "",
+                                                    last_version ?: ""),
+                   error);
       next_version = std::move (next_versionv);
       g_hash_table_insert (self->metadata, g_strdup (OSTREE_COMMIT_META_KEY_VERSION),
                            g_variant_ref_sink (g_variant_new_string (next_version.c_str ())));

--- a/src/libpriv/rpmostree-json-parsing.cxx
+++ b/src/libpriv/rpmostree-json-parsing.cxx
@@ -46,18 +46,6 @@ _rpmostree_jsonutil_object_get_optional_string_member (JsonObject *object, const
   return TRUE;
 }
 
-const char *
-_rpmostree_jsonutil_object_require_string_member (JsonObject *object, const char *member_name,
-                                                  GError **error)
-{
-  const char *ret;
-  if (!_rpmostree_jsonutil_object_get_optional_string_member (object, member_name, &ret, error))
-    return NULL;
-  if (!ret)
-    return (char *)glnx_null_throw (error, "Member '%s' not found", member_name);
-  return ret;
-}
-
 gboolean
 _rpmostree_jsonutil_object_get_optional_boolean_member (JsonObject *object, const char *member_name,
                                                         gboolean *out_value, GError **error)

--- a/src/libpriv/rpmostree-json-parsing.h
+++ b/src/libpriv/rpmostree-json-parsing.h
@@ -30,10 +30,6 @@ gboolean _rpmostree_jsonutil_object_get_optional_string_member (JsonObject *obje
                                                                 const char **out_value,
                                                                 GError **error);
 
-const char *_rpmostree_jsonutil_object_require_string_member (JsonObject *object,
-                                                              const char *member_name,
-                                                              GError **error);
-
 gboolean _rpmostree_jsonutil_object_get_optional_boolean_member (JsonObject *object,
                                                                  const char *member_name,
                                                                  gboolean *out_value,


### PR DESCRIPTION
This oxidizes one JSON parsing helper.