### PR TITLE
treefile: rename one method

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -469,7 +469,7 @@ pub mod ffi {
         fn get_all_ostree_layers(&self) -> Vec<String>;
         fn get_repos(&self) -> Vec<String>;
         fn get_packages(&self) -> Vec<String>;
-        fn get_automatic_version_prefix(&self) -> Result<String>;
+        fn require_automatic_version_prefix(&self) -> Result<String>;
         fn add_packages(&mut self, packages: Vec<String>, allow_existing: bool) -> Result<bool>;
         fn has_packages(&self) -> bool;
         fn set_packages(&mut self, packages: Vec<String>);

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -714,7 +714,7 @@ impl Treefile {
     }
 
     /// Return the `automatic-version-prefix` field, or an error if missing.
-    pub fn get_automatic_version_prefix(&self) -> CxxResult<String> {
+    pub fn require_automatic_version_prefix(&self) -> CxxResult<String> {
         self.parsed
             .base
             .automatic_version_prefix

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -897,7 +897,7 @@ impl_install_tree (RpmOstreeTreeComposeContext *self, gboolean *out_changed,
       /* let --add-metadata-string=version=... take precedence */
       !g_hash_table_contains (self->metadata, OSTREE_COMMIT_META_KEY_VERSION))
     {
-      CXX_TRY_VAR (ver_prefix, (*self->treefile_rs)->get_automatic_version_prefix (), error);
+      CXX_TRY_VAR (ver_prefix, (*self->treefile_rs)->require_automatic_version_prefix (), error);
       const char *ver_suffix = NULL;
       if (!_rpmostree_jsonutil_object_get_optional_string_member (
               self->treefile, "automatic-version-suffix", &ver_suffix, error))


### PR DESCRIPTION
This renames one fallible getter method, using a more explicit
'require' wording.
