### PR TITLE
service: Don't fail if `/var/lib/containers` doesn't exist

### DIFF
--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -19,7 +19,7 @@ ProtectHome=true
 # Explicitly list paths here which we should never access.  The initial
 # entry here ensures that the skopeo process we fork won't interact with
 # application containers.
-InaccessiblePaths=/var/lib/containers
+InaccessiblePaths=-/var/lib/containers
 NotifyAccess=main
 @SYSTEMD_ENVIRON@
 ExecStart=@bindir@/rpm-ostree start-daemon


### PR DESCRIPTION
Hit in CentOS Automotive work apparently.
