### PR TITLE
lib: Drop the last remaining use of `goto` in our code

### DIFF
--- a/ci/codestyle.sh
+++ b/ci/codestyle.sh
@@ -35,3 +35,10 @@ git ls-files '*.rs' | while read f; do
     fi
 done
 echo "ok"
+
+echo 'checking for goto...'
+if git grep 'goto [a-z]*;' '*.c' '*.cxx'; then
+    echo "error: found goto usage" 1>&2
+    exit 1
+fi
+echo "ok"

--- a/src/lib/rpmver-private.c
+++ b/src/lib/rpmver-private.c
@@ -106,8 +106,7 @@ rpmverOverlap (rpmver v1, rpmsenseFlags f1, rpmver v2, rpmsenseFlags f2)
               if ((v1->r && *v1->r && (f2 & RPMSENSE_EQUAL))
                   || (v2->r && *v2->r && (f1 & RPMSENSE_EQUAL)))
                 {
-                  result = 1;
-                  goto exit;
+                  return 1;
                 }
             }
         }
@@ -130,7 +129,6 @@ rpmverOverlap (rpmver v1, rpmsenseFlags f1, rpmver v2, rpmsenseFlags f2)
       result = 1;
     }
 
-exit:
   return result;
 }
 


### PR DESCRIPTION
lib: Drop the last remaining use of `goto` in our code

Luca removed all matches for `goto out` in our codebase, but a quick
`git grep 'goto [a-z]+` found this last `goto`.

---

ci: Verify we have no `goto` usage in C/C++

This is important for conversion to Rust, but also interacts
better with C++ exceptions.

---

