### PR TITLE
libpriv/origin: Move module-related bits to treefile

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -496,6 +496,7 @@ pub mod ffi {
         fn has_modules_enable(&self) -> bool;
         fn get_modules_install(&self) -> Vec<String>;
         fn add_modules(&mut self, modules: Vec<String>, enable_only: bool) -> bool;
+        fn remove_modules(&mut self, modules: Vec<String>, enable_only: bool) -> bool;
         fn get_exclude_packages(&self) -> Vec<String>;
         fn get_platform_module(&self) -> String;
         fn get_install_langs(&self) -> Vec<String>;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -495,6 +495,7 @@ pub mod ffi {
         fn get_modules_enable(&self) -> Vec<String>;
         fn has_modules_enable(&self) -> bool;
         fn get_modules_install(&self) -> Vec<String>;
+        fn add_modules(&mut self, modules: Vec<String>, enable_only: bool) -> bool;
         fn get_exclude_packages(&self) -> Vec<String>;
         fn get_platform_module(&self) -> String;
         fn get_install_langs(&self) -> Vec<String>;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -497,6 +497,7 @@ pub mod ffi {
         fn get_modules_install(&self) -> Vec<String>;
         fn add_modules(&mut self, modules: Vec<String>, enable_only: bool) -> bool;
         fn remove_modules(&mut self, modules: Vec<String>, enable_only: bool) -> bool;
+        fn remove_all_packages(&mut self) -> bool;
         fn get_exclude_packages(&self) -> Vec<String>;
         fn get_platform_module(&self) -> String;
         fn get_install_langs(&self) -> Vec<String>;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -863,7 +863,7 @@ impl Treefile {
         self.parsed
             .modules
             .as_ref()
-            .map(|m| m.enable.is_some())
+            .map(|m| m.enable.as_ref().map(|e| !e.is_empty()).unwrap_or_default())
             .unwrap_or_default()
     }
 

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -890,6 +890,19 @@ impl Treefile {
         n != map.len()
     }
 
+    pub(crate) fn remove_modules(&mut self, modules: Vec<String>, enable_only: bool) -> bool {
+        let modules_cfg = self.parsed.modules.ext_get_or_insert_default();
+        let map = if enable_only {
+            modules_cfg.enable.ext_get_or_insert_default()
+        } else {
+            modules_cfg.install.ext_get_or_insert_default()
+        };
+        let modules: BTreeSet<String> = modules.into_iter().collect();
+        let n = map.len();
+        map.retain(|module| !modules.contains(module));
+        n != map.len()
+    }
+
     pub(crate) fn get_packages_override_remove(&self) -> Vec<String> {
         self.parsed
             .derive
@@ -3410,6 +3423,12 @@ conditional-include:
         assert!(!treefile.add_modules(vec!["baz:boo/minimal".into()], false));
         assert_eq!(treefile.get_modules_enable(), &["foo:bar", "nodejs:latest"]);
         assert_eq!(treefile.get_modules_install(), &["baz:boo/minimal"]);
+        assert!(treefile.remove_modules(vec!["foo:bar".into()], true));
+        assert!(!treefile.remove_modules(vec!["foo:bar".into()], true));
+        assert!(treefile.remove_modules(vec!["baz:boo/minimal".into()], false));
+        assert!(!treefile.remove_modules(vec!["baz:boo/minimal".into()], false));
+        assert_eq!(treefile.get_modules_enable(), &["nodejs:latest"]);
+        assert!(treefile.get_modules_install().is_empty());
         assert!(treefile.has_packages_override_remove_name("glibc"));
         assert!(!treefile.has_packages_override_remove_name("enoent"));
         assert_eq!(

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1195,10 +1195,12 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
       if (!rpmostree_origin_remove_packages (origin, uninstall_pkgs, idempotent_layering, &changed,
                                              error))
         return FALSE;
-      if (!rpmostree_origin_remove_modules (origin, disable_modules, TRUE, &changed, error))
-        return FALSE;
-      if (!rpmostree_origin_remove_modules (origin, uninstall_modules, FALSE, &changed, error))
-        return FALSE;
+      if (rpmostree_origin_remove_modules (origin, util::rust_stringvec_from_strv (disable_modules),
+                                           TRUE))
+        changed = TRUE;
+      if (rpmostree_origin_remove_modules (
+              origin, util::rust_stringvec_from_strv (uninstall_modules), FALSE))
+        changed = TRUE;
     }
 
   /* lazily loaded cache that's used in a few conditional blocks */

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1184,8 +1184,8 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
 
   if (no_layering)
     {
-      if (!rpmostree_origin_remove_all_packages (origin, &changed, error))
-        return FALSE;
+      if (rpmostree_origin_remove_all_packages (origin))
+        changed = TRUE;
     }
   else
     {

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1242,10 +1242,11 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
         return FALSE;
     }
 
-  if (!rpmostree_origin_add_modules (origin, enable_modules, TRUE, &changed, error))
-    return FALSE;
-  if (!rpmostree_origin_add_modules (origin, install_modules, FALSE, &changed, error))
-    return FALSE;
+  if (rpmostree_origin_add_modules (origin, util::rust_stringvec_from_strv (enable_modules), TRUE))
+    changed = TRUE;
+  if (rpmostree_origin_add_modules (origin, util::rust_stringvec_from_strv (install_modules),
+                                    FALSE))
+    changed = TRUE;
 
   if (install_local_pkgs != NULL)
     {

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -41,8 +41,6 @@ struct RpmOstreeOrigin
 
   char *cached_unconfigured_state;
   GHashTable *cached_packages;                    /* set of reldeps */
-  GHashTable *cached_modules_enable;              /* set of module specs to enable */
-  GHashTable *cached_modules_install;             /* set of module specs to install */
   GHashTable *cached_local_packages;              /* NEVRA --> header sha256 */
   GHashTable *cached_local_fileoverride_packages; /* NEVRA --> header sha256 */
   /* GHashTable *cached_overrides_replace;         XXX: NOT IMPLEMENTED YET */
@@ -69,8 +67,6 @@ rpmostree_origin_unref (RpmOstreeOrigin *origin)
   g_key_file_unref (origin->kf);
   g_free (origin->cached_unconfigured_state);
   g_clear_pointer (&origin->cached_packages, g_hash_table_unref);
-  g_clear_pointer (&origin->cached_modules_enable, g_hash_table_unref);
-  g_clear_pointer (&origin->cached_modules_install, g_hash_table_unref);
   g_clear_pointer (&origin->cached_local_packages, g_hash_table_unref);
   g_clear_pointer (&origin->cached_local_fileoverride_packages, g_hash_table_unref);
   g_clear_pointer (&origin->cached_overrides_local_replace, g_hash_table_unref);
@@ -146,8 +142,6 @@ rpmostree_origin_parse_keyfile (GKeyFile *origin, GError **error)
   ret->kf = std::move (kfv);
 
   ret->cached_packages = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
-  ret->cached_modules_enable = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
-  ret->cached_modules_install = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
   ret->cached_local_packages = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
   ret->cached_local_fileoverride_packages
       = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
@@ -167,13 +161,6 @@ rpmostree_origin_parse_keyfile (GKeyFile *origin, GError **error)
 
   if (!parse_packages_strv (ret->kf, "packages", "requested-local-fileoverride", TRUE,
                             ret->cached_local_fileoverride_packages, error))
-    return FALSE;
-
-  if (!parse_packages_strv (ret->kf, "modules", "enable", FALSE, ret->cached_modules_enable, error))
-    return FALSE;
-
-  if (!parse_packages_strv (ret->kf, "modules", "install", FALSE, ret->cached_modules_install,
-                            error))
     return FALSE;
 
   if (!parse_packages_strv (ret->kf, "overrides", "remove", FALSE, ret->cached_overrides_remove,

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -609,25 +609,13 @@ rpmostree_origin_add_modules (RpmOstreeOrigin *origin, rust::Vec<rust::String> m
 
 /* Mutability: setter */
 gboolean
-rpmostree_origin_remove_modules (RpmOstreeOrigin *origin, char **modules, gboolean enable_only,
-                                 gboolean *out_changed, GError **error)
+rpmostree_origin_remove_modules (RpmOstreeOrigin *origin, rust::Vec<rust::String> modules,
+                                 gboolean enable_only)
 {
-  if (!modules)
-    return TRUE;
-  const char *key = enable_only ? "enable" : "install";
-  GHashTable *target = enable_only ? origin->cached_modules_enable : origin->cached_modules_install;
-  gboolean changed = FALSE;
-  for (char **mod = modules; mod && *mod; mod++)
-    changed = (g_hash_table_remove (target, *mod) || changed);
-
+  auto changed = (*origin->treefile)->remove_modules (modules, enable_only);
   if (changed)
-    {
-      update_string_list_from_hash_table (origin, "modules", key, target);
-      sync_treefile (origin);
-    }
-
-  set_changed (out_changed, changed);
-  return TRUE;
+    sync_origin (origin);
+  return changed;
 }
 
 /* Mutability: setter */

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -620,67 +620,12 @@ rpmostree_origin_remove_modules (RpmOstreeOrigin *origin, rust::Vec<rust::String
 
 /* Mutability: setter */
 gboolean
-rpmostree_origin_remove_all_packages (RpmOstreeOrigin *origin, gboolean *out_changed,
-                                      GError **error)
+rpmostree_origin_remove_all_packages (RpmOstreeOrigin *origin)
 {
-  gboolean changed = FALSE;
-  gboolean local_changed = FALSE;
-  gboolean local_fileoverride_changed = FALSE;
-  gboolean modules_enable_changed = FALSE;
-  gboolean modules_install_changed = FALSE;
-
-  if (g_hash_table_size (origin->cached_packages) > 0)
-    {
-      g_hash_table_remove_all (origin->cached_packages);
-      changed = TRUE;
-    }
-
-  if (g_hash_table_size (origin->cached_local_packages) > 0)
-    {
-      g_hash_table_remove_all (origin->cached_local_packages);
-      local_changed = TRUE;
-    }
-
-  if (g_hash_table_size (origin->cached_local_fileoverride_packages) > 0)
-    {
-      g_hash_table_remove_all (origin->cached_local_fileoverride_packages);
-      local_fileoverride_changed = TRUE;
-    }
-
-  if (g_hash_table_size (origin->cached_modules_enable) > 0)
-    {
-      g_hash_table_remove_all (origin->cached_modules_enable);
-      modules_enable_changed = TRUE;
-    }
-
-  if (g_hash_table_size (origin->cached_modules_install) > 0)
-    {
-      g_hash_table_remove_all (origin->cached_modules_install);
-      modules_install_changed = TRUE;
-    }
-
+  auto changed = (*origin->treefile)->remove_all_packages ();
   if (changed)
-    update_keyfile_pkgs_from_cache (origin, "packages", "requested", origin->cached_packages,
-                                    FALSE);
-  if (local_changed)
-    update_keyfile_pkgs_from_cache (origin, "packages", "requested-local",
-                                    origin->cached_local_packages, TRUE);
-  if (local_fileoverride_changed)
-    update_keyfile_pkgs_from_cache (origin, "packages", "requested-local-fileoverride",
-                                    origin->cached_local_fileoverride_packages, TRUE);
-  if (modules_enable_changed)
-    update_keyfile_pkgs_from_cache (origin, "modules", "enable", origin->cached_modules_enable,
-                                    FALSE);
-  if (modules_install_changed)
-    update_keyfile_pkgs_from_cache (origin, "modules", "install", origin->cached_modules_install,
-                                    FALSE);
-
-  changed = changed || local_changed || local_fileoverride_changed || modules_enable_changed
-            || modules_install_changed;
-  set_changed (out_changed, changed);
-  if (changed)
-    sync_treefile (origin);
-  return TRUE;
+    sync_origin (origin);
+  return changed;
 }
 
 /* Mutability: setter */

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -598,25 +598,13 @@ rpmostree_origin_remove_packages (RpmOstreeOrigin *origin, char **packages, gboo
 
 /* Mutability: setter */
 gboolean
-rpmostree_origin_add_modules (RpmOstreeOrigin *origin, char **modules, gboolean enable_only,
-                              gboolean *out_changed, GError **error)
+rpmostree_origin_add_modules (RpmOstreeOrigin *origin, rust::Vec<rust::String> modules,
+                              gboolean enable_only)
 {
-  if (!modules)
-    return TRUE;
-  const char *key = enable_only ? "enable" : "install";
-  GHashTable *target = enable_only ? origin->cached_modules_enable : origin->cached_modules_install;
-  gboolean changed = FALSE;
-  for (char **mod = modules; mod && *mod; mod++)
-    changed = (g_hash_table_add (target, g_strdup (*mod)) || changed);
-
+  auto changed = (*origin->treefile)->add_modules (modules, enable_only);
   if (changed)
-    {
-      update_string_list_from_hash_table (origin, "modules", key, target);
-      sync_treefile (origin);
-    }
-
-  set_changed (out_changed, changed);
-  return TRUE;
+    sync_origin (origin);
+  return changed;
 }
 
 /* Mutability: setter */

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -118,9 +118,8 @@ gboolean rpmostree_origin_remove_all_packages (RpmOstreeOrigin *origin, gboolean
 gboolean rpmostree_origin_add_modules (RpmOstreeOrigin *origin, rust::Vec<rust::String> modules,
                                        gboolean enable_only);
 
-gboolean rpmostree_origin_remove_modules (RpmOstreeOrigin *origin, char **modules,
-                                          gboolean enable_only, gboolean *out_changed,
-                                          GError **error);
+gboolean rpmostree_origin_remove_modules (RpmOstreeOrigin *origin, rust::Vec<rust::String> modules,
+                                          gboolean enable_only);
 
 typedef enum
 {

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -112,8 +112,7 @@ gboolean rpmostree_origin_add_local_fileoverride_packages (RpmOstreeOrigin *orig
 gboolean rpmostree_origin_remove_packages (RpmOstreeOrigin *origin, char **packages,
                                            gboolean allow_noent, gboolean *out_changed,
                                            GError **error);
-gboolean rpmostree_origin_remove_all_packages (RpmOstreeOrigin *origin, gboolean *out_changed,
-                                               GError **error);
+gboolean rpmostree_origin_remove_all_packages (RpmOstreeOrigin *origin);
 
 gboolean rpmostree_origin_add_modules (RpmOstreeOrigin *origin, rust::Vec<rust::String> modules,
                                        gboolean enable_only);

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -115,8 +115,8 @@ gboolean rpmostree_origin_remove_packages (RpmOstreeOrigin *origin, char **packa
 gboolean rpmostree_origin_remove_all_packages (RpmOstreeOrigin *origin, gboolean *out_changed,
                                                GError **error);
 
-gboolean rpmostree_origin_add_modules (RpmOstreeOrigin *origin, char **modules,
-                                       gboolean enable_only, gboolean *out_changed, GError **error);
+gboolean rpmostree_origin_add_modules (RpmOstreeOrigin *origin, rust::Vec<rust::String> modules,
+                                       gboolean enable_only);
 
 gboolean rpmostree_origin_remove_modules (RpmOstreeOrigin *origin, char **modules,
                                           gboolean enable_only, gboolean *out_changed,


### PR DESCRIPTION
See individual commits. Part of the work to thin out `RpmOstreeOrigin`.