### PR TITLE
libpriv/importer: simplify ostree branch handling

### DIFF
--- a/src/libpriv/rpmostree-importer.h
+++ b/src/libpriv/rpmostree-importer.h
@@ -60,8 +60,6 @@ RpmOstreeImporter *rpmostree_importer_new_take_fd (int *fd, OstreeRepo *repo, Dn
 gboolean rpmostree_importer_read_metainfo (int fd, Header *out_header, gsize *out_cpio_offset,
                                            rpmfi *out_fi, GError **error);
 
-const char *rpmostree_importer_get_ostree_branch (RpmOstreeImporter *unpacker);
-
 gboolean rpmostree_importer_run (RpmOstreeImporter *unpacker, char **out_commit,
                                  GCancellable *cancellable, GError **error);
 


### PR DESCRIPTION
This reworks the initialization logic for the ostree branch member
in the RPM importer. Branch name can be derived from the RPM header,
and both of them can be directly set in the constructor.
It seems safe to assert that both are populated, and drop further
conditional logic.
