### PR TITLE
libpriv/origin: Move overrides-related bits to treefile

### DIFF
--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -98,7 +98,7 @@ fn deployment_populate_variant_origin(
         "requested-local-fileoverride-packages",
         tf.derive.packages_local_fileoverride.as_ref(),
     );
-    vdict_insert_optvec(
+    vdict_insert_optset(
         dict,
         "requested-base-removals",
         tf.derive.override_remove.as_ref(),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -487,9 +487,11 @@ pub mod ffi {
         ) -> Result<bool>;
         fn get_packages_override_replace(&self) -> Vec<OverrideReplacement>;
         fn get_packages_override_replace_local(&self) -> Vec<String>;
+        fn add_packages_override_replace_local(&mut self, packages: Vec<String>) -> Result<()>;
         fn get_packages_override_replace_local_rpms(&self) -> Vec<String>;
         fn set_packages_override_replace_local_rpms(&mut self, packages: Vec<String>);
         fn get_packages_override_remove(&self) -> Vec<String>;
+        fn add_packages_override_remove(&mut self, packages: Vec<String>) -> Result<()>;
         fn has_packages_override_remove_name(&self, name: &str) -> bool;
         fn set_packages_override_remove(&mut self, packages: Vec<String>);
         fn get_modules_enable(&self) -> Vec<String>;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -488,10 +488,12 @@ pub mod ffi {
         fn get_packages_override_replace(&self) -> Vec<OverrideReplacement>;
         fn get_packages_override_replace_local(&self) -> Vec<String>;
         fn add_packages_override_replace_local(&mut self, packages: Vec<String>) -> Result<()>;
+        fn remove_package_override_replace_local(&mut self, package: &str) -> bool;
         fn get_packages_override_replace_local_rpms(&self) -> Vec<String>;
         fn set_packages_override_replace_local_rpms(&mut self, packages: Vec<String>);
         fn get_packages_override_remove(&self) -> Vec<String>;
         fn add_packages_override_remove(&mut self, packages: Vec<String>) -> Result<()>;
+        fn remove_package_override_remove(&mut self, package: &str) -> bool;
         fn has_packages_override_remove_name(&self, name: &str) -> bool;
         fn set_packages_override_remove(&mut self, packages: Vec<String>);
         fn get_modules_enable(&self) -> Vec<String>;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -496,6 +496,7 @@ pub mod ffi {
         fn remove_package_override_remove(&mut self, package: &str) -> bool;
         fn has_packages_override_remove_name(&self, name: &str) -> bool;
         fn set_packages_override_remove(&mut self, packages: Vec<String>);
+        fn remove_all_overrides(&mut self) -> bool;
         fn get_modules_enable(&self) -> Vec<String>;
         fn has_modules_enable(&self) -> bool;
         fn get_modules_install(&self) -> Vec<String>;

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -33,6 +33,7 @@ static UNORDERED_LIST_KEYS: phf::Set<&'static str> = phf::phf_set! {
     "packages/local-fileoverride",
     "modules/enable",
     "modules/install",
+    "overrides/remove",
     "overrides/replace-local"
 };
 
@@ -182,7 +183,7 @@ fn treefile_to_origin_inner(tf: &Treefile) -> Result<glib::KeyFile> {
     if let Some(pkgs) = tf.derive.packages_local_fileoverride.as_ref() {
         set_sha256_nevra_pkgs(&kf, PACKAGES, "requested-local-fileoverride", pkgs)
     }
-    if let Some(pkgs) = tf.derive.override_remove.as_deref() {
+    if let Some(pkgs) = tf.derive.override_remove.as_ref() {
         let pkgs = pkgs.iter().map(|s| s.as_str());
         kf_set_string_list_optional(&kf, OVERRIDES, "remove", pkgs)
     }

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -983,6 +983,15 @@ impl Treefile {
         Ok(())
     }
 
+    pub(crate) fn remove_package_override_replace_local(&mut self, package: &str) -> bool {
+        self.parsed
+            .derive
+            .override_replace_local
+            .as_mut()
+            .and_then(|map| Some(map.remove(package).is_some()))
+            .unwrap_or_default()
+    }
+
     pub(crate) fn get_packages_override_replace_local_rpms(&self) -> Vec<String> {
         self.parsed
             .derive
@@ -1022,6 +1031,15 @@ impl Treefile {
                 .insert(pkg));
         }
         Ok(())
+    }
+
+    pub(crate) fn remove_package_override_remove(&mut self, package: &str) -> bool {
+        self.parsed
+            .derive
+            .override_remove
+            .as_mut()
+            .and_then(|set| Some(set.remove(package)))
+            .unwrap_or_default()
     }
 
     pub(crate) fn remove_all_packages(&mut self) -> bool {
@@ -3536,6 +3554,9 @@ conditional-include:
             .add_packages_override_remove(vec!["systemd".into()])
             .unwrap();
         assert!(treefile.has_packages_override_remove_name("systemd"));
+        assert!(treefile.remove_package_override_remove("systemd"));
+        assert!(!treefile.has_packages_override_remove_name("systemd"));
+        assert!(!treefile.remove_package_override_remove("systemd"));
         treefile
             .add_packages_override_replace_local(vec![
                 "d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1:foo-1.0-1.x86_64"
@@ -3549,6 +3570,10 @@ conditional-include:
                     .to_string(),
             ]
         );
+        assert!(treefile.remove_package_override_replace_local("foo-1.0-1.x86_64"));
+        assert!(!treefile.remove_package_override_replace_local("foo-1.0-1.x86_64"));
+        assert!(!treefile.remove_package_override_replace_local("enoent"));
+        assert!(treefile.get_packages_override_replace_local().is_empty());
         assert!(treefile.get_packages().is_empty());
         assert!(treefile.get_local_packages().is_empty());
         assert!(treefile.get_local_fileoverride_packages().is_empty());

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1042,6 +1042,35 @@ impl Treefile {
             .unwrap_or_default()
     }
 
+    pub(crate) fn remove_all_overrides(&mut self) -> bool {
+        let mut changed = false;
+        changed = self
+            .parsed
+            .derive
+            .override_remove
+            .take()
+            .map(|x| !x.is_empty())
+            .unwrap_or_default()
+            || changed;
+        changed = self
+            .parsed
+            .derive
+            .override_replace
+            .take()
+            .map(|x| !x.is_empty())
+            .unwrap_or_default()
+            || changed;
+        changed = self
+            .parsed
+            .derive
+            .override_replace_local
+            .take()
+            .map(|x| !x.is_empty())
+            .unwrap_or_default()
+            || changed;
+        changed
+    }
+
     pub(crate) fn remove_all_packages(&mut self) -> bool {
         let mut changed = false;
         changed = self
@@ -3701,6 +3730,20 @@ conditional-include:
         assert!(treefile.get_cliwrap());
         treefile.set_cliwrap(false);
         assert!(!treefile.get_cliwrap());
+        // test this after has_any_packages() test above since it nukes everything
+        treefile
+            .add_packages_override_remove(vec!["systemd".into()])
+            .unwrap();
+        treefile
+            .add_packages_override_replace_local(vec![
+                "d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1:foo-1.0-1.x86_64"
+                    .to_string(),
+            ])
+            .unwrap();
+        assert!(treefile.remove_all_overrides());
+        assert!(treefile.get_packages_override_remove().is_empty());
+        assert!(treefile.get_packages_override_replace_local().is_empty());
+        assert!(!treefile.remove_all_overrides());
 
         // test some negatives
         let treefile = treefile_new_empty().unwrap();

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -907,7 +907,8 @@ impl Treefile {
         self.parsed
             .derive
             .override_remove
-            .clone()
+            .as_ref()
+            .map(|h| h.iter().cloned().collect())
             .unwrap_or_default()
     }
 
@@ -916,7 +917,7 @@ impl Treefile {
             .derive
             .override_remove
             .as_ref()
-            .map(|v| v.iter().any(|e| e == name))
+            .map(|set| set.contains(name))
             .unwrap_or_default()
     }
 
@@ -2284,7 +2285,7 @@ pub(crate) struct DeriveConfigFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) packages_local_fileoverride: Option<BTreeMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) override_remove: Option<Vec<String>>,
+    pub(crate) override_remove: Option<BTreeSet<String>>,
     #[serde(rename = "ex-override-replace")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) override_replace: Option<Vec<RemoteOverrideReplace>>,
@@ -2756,8 +2757,8 @@ pub(crate) mod tests {
         "});
         let v = treefile.derive.override_remove.unwrap();
         assert_eq!(v.len(), 2);
-        assert_eq!(v[0], "foo");
-        assert_eq!(v[1], "bar");
+        assert!(v.contains("foo"));
+        assert!(v.contains("bar"));
     }
 
     #[test]

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -891,15 +891,15 @@ impl Treefile {
     }
 
     pub(crate) fn remove_modules(&mut self, modules: Vec<String>, enable_only: bool) -> bool {
+        let modules_to_remove: BTreeSet<String> = modules.into_iter().collect();
         let modules_cfg = self.parsed.modules.ext_get_or_insert_default();
         let map = if enable_only {
             modules_cfg.enable.ext_get_or_insert_default()
         } else {
             modules_cfg.install.ext_get_or_insert_default()
         };
-        let modules: BTreeSet<String> = modules.into_iter().collect();
         let n = map.len();
-        map.retain(|module| !modules.contains(module));
+        map.retain(|module| !modules_to_remove.contains(module));
         n != map.len()
     }
 

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -670,8 +670,7 @@ finalize_removal_overrides (RpmOstreeSysrootUpgrader *self, GCancellable *cancel
         {
           const char *item = (const char *)inactive_removals->pdata[i];
           rpmostree_output_message ("  %s", item);
-          rpmostree_origin_remove_override (self->computed_origin, item,
-                                            RPMOSTREE_ORIGIN_OVERRIDE_REMOVE);
+          rpmostree_origin_remove_override_remove (self->computed_origin, item);
         }
     }
 
@@ -714,8 +713,7 @@ finalize_replacement_overrides (RpmOstreeSysrootUpgrader *self, GCancellable *ca
         {
           const char *item = (const char *)inactive_replacements->pdata[i];
           rpmostree_output_message ("  %s", item);
-          rpmostree_origin_remove_override (self->computed_origin, item,
-                                            RPMOSTREE_ORIGIN_OVERRIDE_REPLACE_LOCAL);
+          rpmostree_origin_remove_override_replace_local (self->computed_origin, item);
         }
     }
 

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1418,8 +1418,8 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
           if (pkgs->len > 0)
             {
               g_ptr_array_add (pkgs, NULL);
-              if (!rpmostree_origin_add_overrides (origin, (char **)pkgs->pdata,
-                                                   RPMOSTREE_ORIGIN_OVERRIDE_REPLACE_LOCAL, error))
+              auto pkgsv = util::rust_stringvec_from_strv ((char **)pkgs->pdata);
+              if (!rpmostree_origin_add_override_replace_local (origin, pkgsv, error))
                 return FALSE;
             }
         }
@@ -1497,8 +1497,8 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
         }
 
       g_ptr_array_add (pkgnames, NULL);
-      if (!rpmostree_origin_add_overrides (origin, (char **)pkgnames->pdata,
-                                           RPMOSTREE_ORIGIN_OVERRIDE_REMOVE, error))
+      auto pkgnamesv = util::rust_stringvec_from_strv ((char **)pkgnames->pdata);
+      if (!rpmostree_origin_add_override_remove (origin, pkgnamesv, error))
         return FALSE;
 
       rpmostree_sysroot_upgrader_set_origin (upgrader, origin);

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1379,11 +1379,10 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
               g_assert_not_reached ();
             }
 
-          if (rpmostree_origin_remove_override (origin, name, RPMOSTREE_ORIGIN_OVERRIDE_REMOVE))
+          if (rpmostree_origin_remove_override_remove (origin, name))
             continue; /* override found; move on to the next one */
 
-          if (rpmostree_origin_remove_override (origin, nevra,
-                                                RPMOSTREE_ORIGIN_OVERRIDE_REPLACE_LOCAL))
+          if (rpmostree_origin_remove_override_replace_local (origin, nevra))
             continue; /* override found; move on to the next one */
 
           return glnx_throw (error, "No overrides for package '%s'", name_or_nevra);
@@ -1412,8 +1411,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
               auto nevra = static_cast<const char *> (g_hash_table_lookup (name_to_nevra, name));
 
               if (nevra)
-                rpmostree_origin_remove_override (origin, nevra,
-                                                  RPMOSTREE_ORIGIN_OVERRIDE_REPLACE_LOCAL);
+                rpmostree_origin_remove_override_replace_local (origin, nevra);
             }
           if (pkgs->len > 0)
             {

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1291,8 +1291,8 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
 
   if (no_overrides)
     {
-      if (!rpmostree_origin_remove_all_overrides (origin, &changed, error))
-        return FALSE;
+      if (rpmostree_origin_remove_all_overrides (origin))
+        changed = TRUE;
     }
   else if (override_reset_pkgs || override_replace_local_pkgs)
     {

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -638,28 +638,21 @@ rpmostree_origin_add_override_replace_local (RpmOstreeOrigin *origin,
 /* Returns FALSE if the override does not exist. */
 /* Mutability: setter */
 gboolean
-rpmostree_origin_remove_override (RpmOstreeOrigin *origin, const char *package,
-                                  RpmOstreeOriginOverrideType type)
+rpmostree_origin_remove_override_remove (RpmOstreeOrigin *origin, const char *package)
 {
-  if (type == RPMOSTREE_ORIGIN_OVERRIDE_REPLACE_LOCAL)
-    {
-      if (!g_hash_table_remove (origin->cached_overrides_local_replace, package))
-        return FALSE;
-      update_keyfile_pkgs_from_cache (origin, "overrides", "replace-local",
-                                      origin->cached_overrides_local_replace, TRUE);
-    }
-  else if (type == RPMOSTREE_ORIGIN_OVERRIDE_REMOVE)
-    {
-      if (!g_hash_table_remove (origin->cached_overrides_remove, package))
-        return FALSE;
-      update_keyfile_pkgs_from_cache (origin, "overrides", "remove",
-                                      origin->cached_overrides_remove, FALSE);
-    }
-  else
-    g_assert_not_reached ();
+  auto changed = (*origin->treefile)->remove_package_override_remove (package);
+  if (changed)
+    sync_origin (origin);
+  return changed;
+}
 
-  sync_treefile (origin);
-  return TRUE;
+gboolean
+rpmostree_origin_remove_override_replace_local (RpmOstreeOrigin *origin, const char *package)
+{
+  auto changed = (*origin->treefile)->remove_package_override_replace_local (package);
+  if (changed)
+    sync_origin (origin);
+  return changed;
 }
 
 /* Mutability: setter */

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -657,25 +657,10 @@ rpmostree_origin_remove_override_replace_local (RpmOstreeOrigin *origin, const c
 
 /* Mutability: setter */
 gboolean
-rpmostree_origin_remove_all_overrides (RpmOstreeOrigin *origin, gboolean *out_changed,
-                                       GError **error)
+rpmostree_origin_remove_all_overrides (RpmOstreeOrigin *origin)
 {
-  gboolean remove_changed = (g_hash_table_size (origin->cached_overrides_remove) > 0);
-  g_hash_table_remove_all (origin->cached_overrides_remove);
-
-  gboolean local_replace_changed = (g_hash_table_size (origin->cached_overrides_local_replace) > 0);
-  g_hash_table_remove_all (origin->cached_overrides_local_replace);
-
-  if (remove_changed)
-    update_keyfile_pkgs_from_cache (origin, "overrides", "remove", origin->cached_overrides_remove,
-                                    FALSE);
-  if (local_replace_changed)
-    update_keyfile_pkgs_from_cache (origin, "overrides", "replace-local",
-                                    origin->cached_overrides_local_replace, TRUE);
-
-  const gboolean any_changed = remove_changed || local_replace_changed;
-  set_changed (out_changed, any_changed);
-  if (any_changed)
-    sync_treefile (origin);
-  return TRUE;
+  auto changed = (*origin->treefile)->remove_all_overrides ();
+  if (changed)
+    sync_origin (origin);
+  return changed;
 }

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -138,5 +138,4 @@ gboolean rpmostree_origin_remove_override_remove (RpmOstreeOrigin *origin, const
 gboolean rpmostree_origin_remove_override_replace_local (RpmOstreeOrigin *origin,
                                                          const char *package);
 
-gboolean rpmostree_origin_remove_all_overrides (RpmOstreeOrigin *origin, gboolean *out_changed,
-                                                GError **error);
+gboolean rpmostree_origin_remove_all_overrides (RpmOstreeOrigin *origin);

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -133,8 +133,10 @@ gboolean rpmostree_origin_add_override_replace_local (RpmOstreeOrigin *origin,
                                                       rust::Vec<rust::String> packages,
                                                       GError **error);
 
-gboolean rpmostree_origin_remove_override (RpmOstreeOrigin *origin, const char *package,
-                                           RpmOstreeOriginOverrideType type);
+gboolean rpmostree_origin_remove_override_remove (RpmOstreeOrigin *origin, const char *package);
+
+gboolean rpmostree_origin_remove_override_replace_local (RpmOstreeOrigin *origin,
+                                                         const char *package);
 
 gboolean rpmostree_origin_remove_all_overrides (RpmOstreeOrigin *origin, gboolean *out_changed,
                                                 GError **error);

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -127,8 +127,11 @@ typedef enum
   RPMOSTREE_ORIGIN_OVERRIDE_REMOVE
 } RpmOstreeOriginOverrideType;
 
-gboolean rpmostree_origin_add_overrides (RpmOstreeOrigin *origin, char **packages,
-                                         RpmOstreeOriginOverrideType type, GError **error);
+gboolean rpmostree_origin_add_override_remove (RpmOstreeOrigin *origin,
+                                               rust::Vec<rust::String> packages, GError **error);
+gboolean rpmostree_origin_add_override_replace_local (RpmOstreeOrigin *origin,
+                                                      rust::Vec<rust::String> packages,
+                                                      GError **error);
 
 gboolean rpmostree_origin_remove_override (RpmOstreeOrigin *origin, const char *package,
                                            RpmOstreeOriginOverrideType type);


### PR DESCRIPTION
See individual commits. Part of the work to thin out `RpmOstreeOrigin`.