### PR TITLE
libpriv/origin: Finish thinning out RpmOstreeOrigin

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -150,7 +150,7 @@ INSTALL_EXEC_HOOKS += install-rpmostree-hook
 # the main thing here is we still drop the `target` dir in our build
 # directory, since we nominally support srcdir != builddir.
 rust-test: $(binding_generated_sources) $(dbus_built_sources) $(librpmostree_rust_path) librpmostreecxxrs.la librpmostreeinternals.la
-	LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:@abs_top_builddir@/.libs/" cargo test
+	LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:@abs_top_builddir@/.libs/" cargo test --workspace
 rust-test-%: $(binding_generated_sources) $(dbus_built_sources) $(librpmostree_rust_path) librpmostreecxxrs.la librpmostreeinternals.la
-	LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:@abs_top_builddir@/.libs/" cargo test -- $*
+	LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:@abs_top_builddir@/.libs/" cargo test --workspace -- $*
 .PHONY: rust-test rust-test-%

--- a/Makefile.am
+++ b/Makefile.am
@@ -90,7 +90,7 @@ CARGO_RELEASE_ARGS=--release
 endif
 
 check-local-cargo:
-	cargo test
+	cargo test --workspace
 CHECK_LOCAL_HOOKS += check-local-cargo
 
 clean-local-cargo:

--- a/rust/libdnf-sys/build.rs
+++ b/rust/libdnf-sys/build.rs
@@ -50,7 +50,7 @@ fn main() -> Result<()> {
     libdnfcxx
         .file("cxx/libdnf.cxx")
         .flag("-std=c++17")
-        .include("cxx") // this is needed for cxx.rs' `include!("libdnf.hxx")` to work
+        .include("cxx") // this is needed for cxx.rs' `include!("libdnf.hpp")` to work
         .include("../../libdnf");
     libdnfcxx.includes(libs.all_include_paths());
     libdnfcxx.compile("libdnfcxx.a");

--- a/rust/libdnf-sys/build.rs
+++ b/rust/libdnf-sys/build.rs
@@ -44,6 +44,7 @@ fn main() -> Result<()> {
         libdnf.display()
     );
     println!("cargo:rustc-link-lib=static=dnf");
+    println!("cargo:rustc-link-lib=glib-2.0");
 
     // now, our thin cxx.rs bridge wrapper
     let mut libdnfcxx = cxx_build::bridge("lib.rs");

--- a/rust/libdnf-sys/cxx/libdnf.cxx
+++ b/rust/libdnf-sys/cxx/libdnf.cxx
@@ -18,7 +18,7 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#include "libdnf.hxx"
+#include "libdnf.hpp"
 
 namespace dnfcxx
 {

--- a/rust/libdnf-sys/cxx/libdnf.cxx
+++ b/rust/libdnf-sys/cxx/libdnf.cxx
@@ -18,6 +18,9 @@
  * Boston, MA 02111-1307, USA.
  */
 
+#include <glib-unix.h>
+
+#include "libdnf-sys/lib.rs.h"
 #include "libdnf.hpp"
 
 namespace dnfcxx
@@ -53,5 +56,26 @@ guint64
 dnf_repo_get_timestamp_generated (DnfRepo &repo)
 {
   return ::dnf_repo_get_timestamp_generated (&repo);
+}
+// XXX: dedupe with rpmostree_decompose_nevra
+Nevra
+hy_split_nevra (rust::Str nevra)
+{
+  g_autofree char *name = NULL;
+  int epoch;
+  g_autofree char *version = NULL;
+  g_autofree char *release = NULL;
+  g_autofree char *arch = NULL;
+
+  g_autofree char *nevra_c = g_strndup (nevra.data (), nevra.length ());
+  if (::hy_split_nevra (nevra_c, &name, &epoch, &version, &release, &arch) != 0)
+    throw std::runtime_error (std::string ("Failed to decompose NEVRA string: ") + nevra_c);
+
+  Nevra r = {
+    rust::String (name),    (guint64)epoch,      rust::String (version),
+    rust::String (release), rust::String (arch),
+  };
+  // the copy here *should* get elided
+  return r;
 }
 }

--- a/rust/libdnf-sys/cxx/libdnf.hpp
+++ b/rust/libdnf-sys/cxx/libdnf.hpp
@@ -25,14 +25,15 @@
 
 #include "rust/cxx.h"
 
-namespace dnfcxx {
-  typedef ::DnfPackage DnfPackage;
-  rust::String dnf_package_get_nevra(DnfPackage &pkg);
-  rust::String dnf_package_get_name(DnfPackage &pkg);
-  rust::String dnf_package_get_evr(DnfPackage &pkg);
-  rust::String dnf_package_get_arch(DnfPackage &pkg);
+namespace dnfcxx
+{
+typedef ::DnfPackage DnfPackage;
+rust::String dnf_package_get_nevra (DnfPackage &pkg);
+rust::String dnf_package_get_name (DnfPackage &pkg);
+rust::String dnf_package_get_evr (DnfPackage &pkg);
+rust::String dnf_package_get_arch (DnfPackage &pkg);
 
-  typedef ::DnfRepo DnfRepo;
-  rust::String dnf_repo_get_id(DnfRepo &repo);
-  guint64 dnf_repo_get_timestamp_generated(DnfRepo &repo);
+typedef ::DnfRepo DnfRepo;
+rust::String dnf_repo_get_id (DnfRepo &repo);
+guint64 dnf_repo_get_timestamp_generated (DnfRepo &repo);
 }

--- a/rust/libdnf-sys/cxx/libdnf.hpp
+++ b/rust/libdnf-sys/cxx/libdnf.hpp
@@ -27,6 +27,8 @@
 
 namespace dnfcxx
 {
+struct Nevra;
+
 typedef ::DnfPackage DnfPackage;
 rust::String dnf_package_get_nevra (DnfPackage &pkg);
 rust::String dnf_package_get_name (DnfPackage &pkg);
@@ -36,4 +38,6 @@ rust::String dnf_package_get_arch (DnfPackage &pkg);
 typedef ::DnfRepo DnfRepo;
 rust::String dnf_repo_get_id (DnfRepo &repo);
 guint64 dnf_repo_get_timestamp_generated (DnfRepo &repo);
+
+Nevra hy_split_nevra (rust::Str nevra);
 }

--- a/rust/libdnf-sys/lib.rs
+++ b/rust/libdnf-sys/lib.rs
@@ -29,7 +29,7 @@ unsafe impl ExternType for DnfRepo {
 #[cxx::bridge(namespace = "dnfcxx")]
 pub mod ffi {
     unsafe extern "C++" {
-        include!("libdnf.hxx");
+        include!("libdnf.hpp");
 
         type DnfPackage = crate::DnfPackage;
         fn dnf_package_get_nevra(pkg: &mut DnfPackage) -> Result<String>;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -485,6 +485,7 @@ pub mod ffi {
             packages: Vec<String>,
             allow_existing: bool,
         ) -> Result<bool>;
+        fn remove_packages(&mut self, packages: Vec<String>, allow_noent: bool) -> Result<bool>;
         fn get_packages_override_replace(&self) -> Vec<OverrideReplacement>;
         fn get_packages_override_replace_local(&self) -> Vec<String>;
         fn add_packages_override_replace_local(&mut self, packages: Vec<String>) -> Result<()>;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -972,13 +972,13 @@ impl Treefile {
             if self.has_override(nevra) {
                 bail!("Override already exists for package '{}'", pkg);
             }
-            assert!(self
+            let prev = self
                 .parsed
                 .derive
                 .override_replace_local
                 .ext_get_or_insert_default()
-                .insert(nevra.into(), sha256.into())
-                .is_none());
+                .insert(nevra.into(), sha256.into());
+            assert!(prev.is_none()); // otherwise, `has_override()` would've triggered
         }
         Ok(())
     }
@@ -1023,12 +1023,13 @@ impl Treefile {
             if self.has_override(&pkg) {
                 bail!("Override already exists for package '{}'", &pkg);
             }
-            assert!(self
+            let is_new = self
                 .parsed
                 .derive
                 .override_remove
                 .ext_get_or_insert_default()
-                .insert(pkg));
+                .insert(pkg);
+            assert!(is_new); // otherwise, `has_override()` would've triggered
         }
         Ok(())
     }

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -3766,6 +3766,74 @@ conditional-include:
     }
 
     #[test]
+    fn test_add_package_filtering() {
+        let buf = indoc! {"
+            packages:
+              - foobar-1.0-1.x86_64
+            packages-local:
+              bazboo-1.0-1.x86_64: d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1
+            packages-local-fileoverride:
+              dodo-1.0-1.x86_64: d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1
+        "};
+        let mut treefile = Treefile::new_from_string(utils::InputFormat::YAML, buf).unwrap();
+        assert!(treefile.has_packages());
+        assert!(treefile
+            .add_packages(vec!["foobar-1.0-1.x86_64".into()], false)
+            .is_err());
+        assert!(treefile
+            .add_packages(vec!["bazboo-1.0-1.x86_64".into()], false)
+            .is_err());
+        assert!(treefile
+            .add_packages(vec!["dodo-1.0-1.x86_64".into()], false)
+            .is_err());
+        assert!(!treefile
+            .add_packages(vec!["foobar-1.0-1.x86_64".into()], true)
+            .unwrap());
+        assert!(!treefile
+            .add_packages(vec!["bazboo-1.0-1.x86_64".into()], true)
+            .unwrap());
+        assert!(!treefile
+            .add_packages(vec!["dodo-1.0-1.x86_64".into()], true)
+            .unwrap());
+        assert!(treefile
+            .add_local_packages(vec!["d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1:foobar-1.0-1.x86_64".into()], false)
+            .is_err());
+        assert!(treefile
+            .add_local_packages(vec!["d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1:bazboo-1.0-1.x86_64".into()], false)
+            .is_err());
+        assert!(treefile
+            .add_local_packages(vec!["d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1:dodo-1.0-1.x86_64".into()], false)
+            .is_err());
+        assert!(!treefile
+            .add_local_packages(vec!["d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1:foobar-1.0-1.x86_64".into()], true)
+            .unwrap());
+        assert!(!treefile
+            .add_local_packages(vec!["d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1:bazboo-1.0-1.x86_64".into()], true)
+            .unwrap());
+        assert!(!treefile
+            .add_local_packages(vec!["d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1:dodo-1.0-1.x86_64".into()], true)
+            .unwrap());
+        assert!(treefile
+            .add_local_fileoverride_packages(vec!["d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1:foobar-1.0-1.x86_64".into()], false)
+            .is_err());
+        assert!(treefile
+            .add_local_fileoverride_packages(vec!["d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1:bazboo-1.0-1.x86_64".into()], false)
+            .is_err());
+        assert!(treefile
+            .add_local_fileoverride_packages(vec!["d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1:dodo-1.0-1.x86_64".into()], false)
+            .is_err());
+        assert!(!treefile
+            .add_local_fileoverride_packages(vec!["d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1:foobar-1.0-1.x86_64".into()], true)
+            .unwrap());
+        assert!(!treefile
+            .add_local_fileoverride_packages(vec!["d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1:bazboo-1.0-1.x86_64".into()], true)
+            .unwrap());
+        assert!(!treefile
+            .add_local_fileoverride_packages(vec!["d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1:dodo-1.0-1.x86_64".into()], true)
+            .unwrap());
+    }
+
+    #[test]
     fn test_override_replace() {
         let buf = indoc! {"
             base-refspec: fedora:fedora/35/x86_64/silverblue

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -859,8 +859,9 @@ finalize_overlays (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable, GE
           const char *pkgs[] = { req, NULL };
           g_autoptr (GError) local_error = NULL;
           rpmostree_output_message ("  %s (already provided by %s)", req, nevra);
-          if (!rpmostree_origin_remove_packages (self->computed_origin, (char **)pkgs, FALSE,
-                                                 &changed, &local_error))
+          if (!rpmostree_origin_remove_packages (self->computed_origin,
+                                                 util::rust_stringvec_from_strv ((char **)pkgs),
+                                                 FALSE, &changed, &local_error))
             g_error ("%s", local_error->message);
           g_assert (changed);
           changed = FALSE;

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1196,8 +1196,9 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
       /* In reality, there may not be any new layer required even if `remove_changed` is TRUE
        * (if e.g. we're removing a duplicate provides). But the origin has changed so we need to
        * create a new deployment; see https://github.com/projectatomic/rpm-ostree/issues/753 */
-      if (!rpmostree_origin_remove_packages (origin, uninstall_pkgs, idempotent_layering, &changed,
-                                             error))
+      if (!rpmostree_origin_remove_packages (origin,
+                                             util::rust_stringvec_from_strv (uninstall_pkgs),
+                                             idempotent_layering, &changed, error))
         return FALSE;
       if (rpmostree_origin_remove_modules (origin, util::rust_stringvec_from_strv (disable_modules),
                                            TRUE))

--- a/src/libpriv/rpmostree-cxxrs-prelude.h
+++ b/src/libpriv/rpmostree-cxxrs-prelude.h
@@ -39,7 +39,7 @@ typedef ::GVariantDict GVariantDict;
 typedef ::GKeyFile GKeyFile;
 }
 
-// XXX: really should just include! libdnf.hxx in the bridge
+// XXX: really should just include! libdnf.hpp in the bridge
 #include <libdnf/libdnf.h>
 namespace dnfcxx
 {

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -53,6 +53,7 @@ rpmostree_origin_unref (RpmOstreeOrigin *origin)
   origin->refcount--;
   if (origin->refcount > 0)
     return;
+  origin->treefile.reset ();
   g_free (origin);
 }
 

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -38,8 +38,6 @@ struct RpmOstreeOrigin
 
   /* this is used for convenience while we migrate; we always sync back to the treefile */
   GKeyFile *kf;
-
-  char *cached_unconfigured_state;
 };
 
 RpmOstreeOrigin *
@@ -59,7 +57,6 @@ rpmostree_origin_unref (RpmOstreeOrigin *origin)
   if (origin->refcount > 0)
     return;
   g_key_file_unref (origin->kf);
-  g_free (origin->cached_unconfigured_state);
   g_free (origin);
 }
 
@@ -129,9 +126,6 @@ rpmostree_origin_parse_keyfile (GKeyFile *origin, GError **error)
   ret->treefile = ROSCXX_VAL (origin_to_treefile (*origin), error);
   CXX_TRY_VAR (kfv, rpmostreecxx::treefile_to_origin (**ret->treefile), error);
   ret->kf = std::move (kfv);
-
-  ret->cached_unconfigured_state
-      = g_key_file_get_string (ret->kf, "origin", "unconfigured-state", NULL);
 
   // We will eventually start converting origin to treefile, this helps us
   // debug cases that may fail currently.

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -442,8 +442,7 @@ rpmostree_origin_add_packages (RpmOstreeOrigin *origin, rust::Vec<rust::String> 
   CXX_TRY_VAR (changed, (*origin->treefile)->add_packages (packages, allow_existing), error);
   if (changed)
     sync_origin (origin);
-  if (out_changed)
-    *out_changed = changed;
+  set_changed (out_changed, changed);
   return TRUE;
 }
 
@@ -455,8 +454,7 @@ rpmostree_origin_add_local_packages (RpmOstreeOrigin *origin, rust::Vec<rust::St
   CXX_TRY_VAR (changed, (*origin->treefile)->add_local_packages (packages, allow_existing), error);
   if (changed)
     sync_origin (origin);
-  if (out_changed)
-    *out_changed = changed;
+  set_changed (out_changed, changed);
   return TRUE;
 }
 
@@ -472,8 +470,7 @@ rpmostree_origin_add_local_fileoverride_packages (RpmOstreeOrigin *origin,
                error);
   if (changed)
     sync_origin (origin);
-  if (out_changed)
-    *out_changed = changed;
+  set_changed (out_changed, changed);
   return TRUE;
 }
 

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -109,9 +109,9 @@ gboolean rpmostree_origin_add_local_fileoverride_packages (RpmOstreeOrigin *orig
                                                            gboolean allow_existing,
                                                            gboolean *out_changed, GError **error);
 
-gboolean rpmostree_origin_remove_packages (RpmOstreeOrigin *origin, char **packages,
-                                           gboolean allow_noent, gboolean *out_changed,
-                                           GError **error);
+gboolean rpmostree_origin_remove_packages (RpmOstreeOrigin *origin,
+                                           rust::Vec<rust::String> packages, gboolean allow_noent,
+                                           gboolean *out_changed, GError **error);
 gboolean rpmostree_origin_remove_all_packages (RpmOstreeOrigin *origin);
 
 gboolean rpmostree_origin_add_modules (RpmOstreeOrigin *origin, rust::Vec<rust::String> modules,

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -120,13 +120,6 @@ gboolean rpmostree_origin_add_modules (RpmOstreeOrigin *origin, rust::Vec<rust::
 gboolean rpmostree_origin_remove_modules (RpmOstreeOrigin *origin, rust::Vec<rust::String> modules,
                                           gboolean enable_only);
 
-typedef enum
-{
-  /* RPMOSTREE_ORIGIN_OVERRIDE_REPLACE, */
-  RPMOSTREE_ORIGIN_OVERRIDE_REPLACE_LOCAL,
-  RPMOSTREE_ORIGIN_OVERRIDE_REMOVE
-} RpmOstreeOriginOverrideType;
-
 gboolean rpmostree_origin_add_override_remove (RpmOstreeOrigin *origin,
                                                rust::Vec<rust::String> packages, GError **error);
 gboolean rpmostree_origin_add_override_replace_local (RpmOstreeOrigin *origin,


### PR DESCRIPTION
We're finally there! Quoting the before last commit:

```
libpriv/origin: Drop GKeyFile member from RpmOstreeOrigin

Everything is backed by the treefile now, so we no longer need to also
maintain a `GKeyFile` copy in sync.

This completes the hollowing of `RpmOstreeOrigin`.

The next phase will be to make callers use the treefile APIs directly so
that we can delete `RpmOstreeOrigin` entirely.
```