### PR TITLE
app/override: Support remote overrides

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -68,4 +68,24 @@ if [[ $n_downloaded != 1 ]]; then
   fatal "Expected 1 'Downloading', but got $n_downloaded"
 fi
 
+(cd /etc/yum.repos.d/ && curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-coreos-pool.repo)
+(cd /etc/yum.repos.d/ && curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/ci/continuous/fcos-continuous.repo)
+
+# test repo override by NEVRA
+rpm-ostree override replace --experimental --from repo=fedora-coreos-pool \
+  afterburn-5.2.0-4.fc36.x86_64 \
+  afterburn-dracut-5.2.0-4.fc36.x86_64
+
+rpm -q afterburn-5.2.0-4.fc36.x86_64 afterburn-dracut-5.2.0-4.fc36.x86_64
+
+# test repo override by pkgname
+rpm-ostree override replace --experimental \
+  --from repo=copr:copr.fedorainfracloud.org:group_CoreOS:continuous \
+  afterburn \
+  afterburn-dracut
+
+# the continuous build's version has the git rev, prefixed with g
+rpm -q afterburn | grep g
+rpm -q afterburn-dracut | grep g
+
 echo ok

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -108,6 +108,13 @@ fn deployment_populate_variant_origin(
         "requested-base-local-replacements",
         tf.derive.override_replace_local.as_ref(),
     );
+    if let Some(remote_overrides) = tf.derive.override_replace.as_ref() {
+        let v: Vec<(String, Vec<&String>)> = remote_overrides
+            .iter()
+            .map(|ovr| (ovr.from.to_string(), ovr.packages.iter().collect()))
+            .collect();
+        dict.insert_value("requested-base-remote-replacements", &v.to_variant());
+    }
 
     // Initramfs data.
     if let Some(initramfs) = tf.derive.initramfs.as_ref() {

--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -571,7 +571,7 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy, GVariant *child, gboolean
 {
   /* Add the long keys here */
   const guint max_key_len
-      = MAX (strlen ("InactiveLocalOverrides"), strlen ("InterruptedLiveCommit"));
+      = MAX (strlen ("InactiveRemoteOverrides"), strlen ("InterruptedLiveCommit"));
 
   g_autoptr (GVariantDict) dict = g_variant_dict_new (child);
 
@@ -602,11 +602,13 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy, GVariant *child, gboolean
   g_autofree const gchar **origin_requested_local_fileoverride_packages = NULL;
   g_autofree const gchar **origin_requested_base_removals = NULL;
   g_autofree const gchar **origin_requested_base_local_replacements = NULL;
+  g_autoptr (GVariant) origin_requested_base_remote_replacements = NULL;
   /* these come from commit metadata; they represent what *actually* happened */
   g_autofree const gchar **packages = NULL;
   g_autofree const gchar **modules = NULL;
   g_autoptr (GVariant) base_removals = NULL;
   g_autoptr (GVariant) base_local_replacements = NULL;
+  g_autoptr (GVariant) base_remote_replacements = NULL;
   if (g_variant_dict_lookup (dict, "origin", "&s", &origin_refspec)
       || g_variant_dict_lookup (dict, "container-image-reference", "&s", &origin_refspec))
     {
@@ -615,6 +617,8 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy, GVariant *child, gboolean
       base_removals = g_variant_dict_lookup_value (dict, "base-removals", G_VARIANT_TYPE ("av"));
       base_local_replacements
           = g_variant_dict_lookup_value (dict, "base-local-replacements", G_VARIANT_TYPE ("a(vv)"));
+      base_remote_replacements = g_variant_dict_lookup_value (dict, "base-remote-replacements",
+                                                              G_VARIANT_TYPE ("a{sv}"));
       origin_requested_modules_enabled
           = lookup_array_and_canonicalize (dict, "requested-modules-enabled");
       origin_requested_packages = lookup_array_and_canonicalize (dict, "requested-packages");
@@ -627,6 +631,8 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy, GVariant *child, gboolean
           = lookup_array_and_canonicalize (dict, "requested-base-removals");
       origin_requested_base_local_replacements
           = lookup_array_and_canonicalize (dict, "requested-base-local-replacements");
+      origin_requested_base_remote_replacements = g_variant_dict_lookup_value (
+          dict, "requested-base-remote-replacements", G_VARIANT_TYPE ("a(sas)"));
     }
 
   const gchar *version_string;
@@ -948,6 +954,61 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy, GVariant *child, gboolean
   if (origin_requested_base_local_replacements && opt_verbose)
     print_values ("InactiveLocalOverrides", max_key_len, origin_requested_base_local_replacements,
                   (const char *const *)active_replacements->pdata, TRUE, NULL);
+
+  g_autoptr (GPtrArray) active_remote_replacements = g_ptr_array_new_with_free_func (g_free);
+  if (base_remote_replacements)
+    {
+      g_autoptr (GVariantIter) viter = g_variant_iter_new (base_remote_replacements);
+      const char *source;
+      GVariant *vreplaced;
+      g_autoptr (GString) buf = g_string_new ("");
+      while (g_variant_iter_loop (viter, "{&sv}", &source, &vreplaced))
+        {
+          const guint n = g_variant_n_children (vreplaced);
+          if (n == 0)
+            continue;
+
+          g_autoptr (GPtrArray) vals = g_ptr_array_new_with_free_func (g_free);
+          for (guint i = 0; i < n; i++)
+            {
+              g_autoptr (GVariant) gv_nevra_new;
+              g_autoptr (GVariant) gv_nevra_old;
+              g_variant_get_child (vreplaced, i, "(vv)", &gv_nevra_new, &gv_nevra_old);
+              const char *name;
+              g_variant_get_child (gv_nevra_new, 1, "&s", &name);
+
+              g_string_truncate (buf, 0);
+              g_string_append (buf, name);
+              g_string_append (buf, " ");
+              gv_nevra_to_evr (buf, gv_nevra_old);
+              g_string_append (buf, " -> ");
+              gv_nevra_to_evr (buf, gv_nevra_new);
+
+              g_ptr_array_add (active_remote_replacements, g_strdup (name));
+              g_ptr_array_add (vals, g_strdup (buf->str));
+            }
+          g_ptr_array_add (vals, NULL);
+          print_values ("RemoteOverrides", max_key_len, (const char *const *)vals->pdata, NULL,
+                        FALSE, source);
+        }
+
+      g_ptr_array_add (active_remote_replacements, NULL);
+    }
+
+  if (origin_requested_base_remote_replacements && opt_verbose)
+    {
+      g_autoptr (GVariantIter) viter
+          = g_variant_iter_new (origin_requested_base_remote_replacements);
+      const char *source;
+      g_autofree char **packages = NULL;
+      gboolean printed_key = FALSE;
+      while (g_variant_iter_loop (viter, "(&s^a&s)", &source, &packages))
+        {
+          if (print_values (printed_key ? "" : "InactiveRemoteOverrides", max_key_len, packages,
+                            (const char *const *)active_remote_replacements->pdata, FALSE, source))
+            printed_key = TRUE;
+        }
+    }
 
   /* only print inactive layering requests in verbose mode */
   if (origin_requested_packages && opt_verbose)

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -135,6 +135,8 @@ filter_commit_meta (GVariant *commit_meta)
   g_variant_dict_remove (&dict, "rpmostree.spec");     /* old way of getting packages */
   g_variant_dict_remove (&dict, "rpmostree.removed-base-packages");  /* 'base-removals' */
   g_variant_dict_remove (&dict, "rpmostree.replaced-base-packages"); /* 'base-local-replacements' */
+  g_variant_dict_remove (
+      &dict, "rpmostree.replaced-base-remote-packages"); /* 'base-remote-replacements' */
   return g_variant_dict_end (&dict);
 }
 
@@ -166,9 +168,10 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot, OstreeDeployment
   g_auto (GStrv) layered_modules = NULL;
   g_autoptr (GVariant) removed_base_pkgs = NULL;
   g_autoptr (GVariant) replaced_base_local_pkgs = NULL;
-  if (!rpmostree_deployment_get_layered_info (repo, deployment, &is_layered, NULL, &base_checksum,
-                                              &layered_pkgs, &layered_modules, &removed_base_pkgs,
-                                              &replaced_base_local_pkgs, error))
+  g_autoptr (GVariant) replaced_base_remote_pkgs = NULL;
+  if (!rpmostree_deployment_get_layered_info (
+          repo, deployment, &is_layered, NULL, &base_checksum, &layered_pkgs, &layered_modules,
+          &removed_base_pkgs, &replaced_base_local_pkgs, &replaced_base_remote_pkgs, error))
     return FALSE;
 
   g_autoptr (GVariant) base_commit = NULL;
@@ -255,6 +258,7 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot, OstreeDeployment
   g_variant_dict_insert (dict, "modules", "^as", layered_modules);
   g_variant_dict_insert_value (dict, "base-removals", removed_base_pkgs);
   g_variant_dict_insert_value (dict, "base-local-replacements", replaced_base_local_pkgs);
+  g_variant_dict_insert_value (dict, "base-remote-replacements", replaced_base_remote_pkgs);
 
   *out_variant = g_variant_dict_end (dict);
   return TRUE;

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1318,7 +1318,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
       g_autoptr (GVariant) removed = NULL;
       g_autoptr (GVariant) replaced_local = NULL;
       if (!rpmostree_deployment_get_layered_info (repo, merge_deployment, NULL, NULL, NULL, NULL,
-                                                  NULL, &removed, &replaced_local, error))
+                                                  NULL, &removed, &replaced_local, NULL, error))
         return FALSE;
 
       g_autoptr (GHashTable) nevra_to_name = g_hash_table_new (g_str_hash, g_str_equal);

--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -69,7 +69,7 @@ struct _RpmOstreeContext
   guint n_async_pkgs_relabeled;
 
   GHashTable *pkgs_to_remove;  /* pkgname --> gv_nevra */
-  GHashTable *pkgs_to_replace; /* new gv_nevra --> old gv_nevra */
+  GHashTable *pkgs_to_replace; /* source -> (new gv_nevra --> old gv_nevra) */
 
   GHashTable *fileoverride_pkgs; /* set of nevras */
 

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -267,6 +267,7 @@ gboolean rpmostree_deployment_get_layered_info (OstreeRepo *repo, OstreeDeployme
                                                 char ***out_layered_modules,
                                                 GVariant **out_removed_base_pkgs,
                                                 GVariant **out_replaced_base_local_pkgs,
+                                                GVariant **out_replaced_base_remote_pkgs,
                                                 GError **error);
 
 /* simpler version of the above */

--- a/tests/kolainst/destructive/override-replace-repo
+++ b/tests/kolainst/destructive/override-replace-repo
@@ -1,0 +1,100 @@
+#!/bin/bash
+set -euo pipefail
+
+. ${KOLA_EXT_DATA}/libtest.sh
+cd $(mktemp -d)
+
+set -x
+
+rm -rf /etc/yum.repos.d/*
+cat > /etc/yum.repos.d/vmcheck.repo << EOF
+[test-repo]
+name=test-repo
+baseurl=file:///${KOLA_EXT_DATA}/rpm-repos/0
+gpgcheck=0
+enabled=1
+EOF
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+"")
+
+# switch to a local ref so that `upgrade` later on works
+booted_commit=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
+ostree refs --create "localref" ${booted_commit}
+rpm-ostree rebase :localref
+
+# start with a simple repo override
+rpm-ostree override replace zincati --experimental --from repo=test-repo
+rpmostree_assert_status \
+  '.deployments[0]["base-remote-replacements"]["repo=test-repo"]|length == 1' \
+  '.deployments[0]["base-remote-replacements"]["repo=test-repo"][0][0][0] == "zincati-99.99-3.x86_64"' \
+  '.deployments[0]["requested-base-remote-replacements"]|length == 1' \
+  '.deployments[0]["requested-base-remote-replacements"][0][0] == "repo=test-repo"' \
+  '.deployments[0]["requested-base-remote-replacements"][0][1]|length == 1' \
+  '.deployments[0]["requested-base-remote-replacements"][0][1][0] == "zincati"'
+/tmp/autopkgtest-reboot "1"
+
+;;
+"1")
+
+# check zincati was actually installed
+zincati > zincati_version.txt
+assert_file_has_content_literal zincati_version.txt '99.99-3'
+rm -f zincati_version.txt
+rpm-ostree status > status.txt
+assert_file_has_content status.txt 'RemoteOverrides: repo=test-repo'
+assert_file_has_content status.txt 'zincati .* -> 99.99-3'
+echo "ok override replace from repos"
+
+# let's try updating now
+sed -i -e 's,rpm-repos/0,rpm-repos/1,' /etc/yum.repos.d/vmcheck.repo
+rpm-ostree upgrade
+rpmostree_assert_status \
+  '.deployments[0]["base-remote-replacements"]["repo=test-repo"]|length == 1' \
+  '.deployments[0]["base-remote-replacements"]["repo=test-repo"][0][0][0] == "zincati-99.99-4.x86_64"'
+rpm-ostree status > status.txt
+assert_file_has_content status.txt 'RemoteOverrides: repo=test-repo'
+assert_file_has_content status.txt 'zincati .* -> 99.99-4'
+echo "ok override replace update from repos"
+
+# disable repo and check that upgrading fails
+rpm-ostree cleanup -p
+sed -i -e 's,enabled=1,enabled=0,' /etc/yum.repos.d/vmcheck.repo
+if rpm-ostree upgrade; then
+  assert_not_reached "successfully upgraded without repo enabled?"
+fi
+
+# enabled repo, but package not there
+sed -i -e 's,enabled=0,enabled=1,' /etc/yum.repos.d/vmcheck.repo
+sed -i -e 's,rpm-repos/1,rpm-repos/2,' /etc/yum.repos.d/vmcheck.repo
+if rpm-ostree upgrade; then
+  assert_not_reached "successfully upgraded with empty repo?"
+fi
+
+# revert because all the other pkgs are in rpm-repos/0
+sed -i -e 's,rpm-repos/2,rpm-repos/0,' /etc/yum.repos.d/vmcheck.repo
+
+# try inactive overrides
+rpm-ostree override replace foo --experimental --from repo=test-repo
+rpmostree_assert_status \
+  '.deployments[0]["base-remote-replacements"]["repo=test-repo"]|length == 1' \
+  '.deployments[0]["base-remote-replacements"]["repo=test-repo"][0][0][0] == "zincati-99.99-3.x86_64"' \
+  '.deployments[0]["requested-base-remote-replacements"]|length == 2'
+rpm-ostree status -v > status.txt
+# awkward way of testing that foo is listed under InactiveRemoteOverrides
+if ! grep -A1 -e 'InactiveRemoteOverrides: repo=test-repo' status.txt | grep 'foo'; then
+  cat status.txt
+  assert_not_reached "failed to find inactive override in status output"
+fi
+echo "ok inactive overrides"
+
+# reset everything
+rpm-ostree override reset --all
+rpmostree_assert_status \
+  '.deployments[0]["base-remote-replacements"]|length == 0' \
+  '.deployments[0]["requested-base-remote-replacements"]|length == 0'
+echo "ok reset all overrides"
+
+;;
+*) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac

--- a/tests/kolainst/kolainst-build.sh
+++ b/tests/kolainst/kolainst-build.sh
@@ -80,13 +80,25 @@ build_module foomodular \
 build_module_defaults foomodular \
   defprofile with-default-profile:default
 
-# Test override replace --ex-pin-from-repos
+# To test remote override replace
 build_rpm zincati version 99.99 release 3
 
 mv ${test_tmpdir}/yumrepo/* ${test_tmpdir}/rpm-repos/${repover}
 
+# To test remote override replace update
+repover=1
+mkdir ${test_tmpdir}/rpm-repos/${repover}
+build_rpm zincati version 99.99 release 4
+mv ${test_tmpdir}/yumrepo/* ${test_tmpdir}/rpm-repos/${repover}
+
+# Create an empty repo when we want to test inability to find a package
+repover=2
+mkdir ${test_tmpdir}/rpm-repos/${repover}
+(cd ${test_tmpdir}/rpm-repos/${repover} && createrepo_c --no-database .)
+
 # Other repo versions here e.g.
-# repover=1
+# repover=3
+# mkdir ${test_tmpdir}/rpm-repos/${repover}
 # ...
 # mv ${test_tmpdir}/yumrepo/* ${test_tmpdir}/rpm-repos/${repover}
 


### PR DESCRIPTION
This add support for specifying remote overrides from the CLI in both
the host and the container paths.

This is pretty straightforward since the treefile and core already
support it. We just wrap the requests into a treefile and feed it to the
lower levels.