### PR TITLE
libpriv/importer: port path translation to Rust

### DIFF
--- a/rust/src/importer.rs
+++ b/rust/src/importer.rs
@@ -48,6 +48,12 @@ impl RpmImporter {
         }
     }
 
+    /// Callback for ostree importer `translate_pathname`.
+    pub fn handle_translate_pathname(&mut self, path: &str) -> String {
+        self.inspect_path_for_symlink_translation(path);
+        utils::translate_path_for_ostree(path)
+    }
+
     /// Process special paths which need symlink translation.
     ///
     /// This detects cases where an RPM does ship content under `/opt` or `/var`.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -329,7 +329,7 @@ pub mod ffi {
         type RpmImporter;
 
         fn rpm_importer_new() -> Box<RpmImporter>;
-        fn inspect_path_for_symlink_translation(self: &mut RpmImporter, path: &str) -> bool;
+        fn handle_translate_pathname(self: &mut RpmImporter, path: &str) -> String;
         fn tmpfiles_symlink_entries(self: &RpmImporter) -> Vec<String>;
 
         fn importer_compose_filter(
@@ -583,6 +583,7 @@ pub mod ffi {
             checksum_from: &str,
             checksum_to: &str,
         ) -> Result<*mut GVariant>;
+        fn translate_path_for_ostree(path: &str) -> String;
     }
 
     #[derive(Debug, Default)]

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -2503,11 +2503,16 @@ rpmostree_context_consume_package (RpmOstreeContext *self, DnfPackage *pkg, int 
 static char *
 canonicalize_rpmfi_path (const char *path)
 {
+  g_assert (path != NULL);
+
   /* this is a bit awkward; we relativize for the translation, but then make it absolute
    * again to match libostree */
   path += strspn (path, "/");
-  g_autofree char *translated = rpmostree_translate_path_for_ostree (path) ?: g_strdup (path);
-  return g_build_filename ("/", translated, NULL);
+  auto translated = rpmostreecxx::translate_path_for_ostree (path);
+  if (translated.size () != 0)
+    return g_build_filename ("/", translated.c_str (), NULL);
+  else
+    return g_build_filename ("/", path, NULL);
 }
 
 /* Convert e.g. lib/foo/bar → usr/lib/foo/bar */

--- a/src/libpriv/rpmostree-importer.cxx
+++ b/src/libpriv/rpmostree-importer.cxx
@@ -509,22 +509,23 @@ xattr_cb (OstreeRepo *repo, const char *path, GFileInfo *file_info, gpointer use
   return NULL;
 }
 
-/* Given a path in an RPM archive, possibly translate it
- * for ostree convention.
- */
+/* Given a path in an RPM archive, possibly translate it for ostree convention. */
 static char *
-handle_translate_pathname (OstreeRepo *repo, const struct stat *stbuf, const char *path,
+handle_translate_pathname (OstreeRepo *_repo, const struct stat *_stbuf, const char *path,
                            gpointer user_data)
 {
-  // Sanity check that path is relative (i.e. no leading slash).
+  // Sanity checks: path is relative (i.e. no leading slash), data pointer is ok.
   g_assert (path != NULL);
   g_assert (*path != '/');
+  g_assert (user_data != NULL);
 
   auto self = static_cast<RpmOstreeImporter *> (user_data);
 
-  self->importer_rs->inspect_path_for_symlink_translation (path);
-
-  return rpmostree_translate_path_for_ostree (path);
+  auto translated = self->importer_rs->handle_translate_pathname (path);
+  if (translated.size () != 0)
+    return g_strdup (translated.c_str ());
+  else
+    return NULL;
 }
 
 static gboolean

--- a/src/libpriv/rpmostree-util.cxx
+++ b/src/libpriv/rpmostree-util.cxx
@@ -116,33 +116,6 @@ rpmostree_check_size_within_limit (guint64 actual, guint64 limit, const char *su
                      found_formatted);
 }
 
-/* Convert a "traditional" path (normally from e.g. an RPM) into its final location in
- * ostree */
-char *
-rpmostree_translate_path_for_ostree (const char *path)
-{
-  if (g_str_has_prefix (path, "etc/"))
-    return g_strconcat ("usr/", path, NULL);
-  else if (g_str_has_prefix (path, "boot/"))
-    return g_strconcat ("usr/lib/ostree-boot/", path + strlen ("boot/"), NULL);
-  /* Special hack for https://bugzilla.redhat.com/show_bug.cgi?id=1290659
-   * See also commit 4a86bdd19665700fa308461510c9decd63e31a03
-   * and rpmostree_postprocess_selinux_policy_store_location().
-   */
-  else if (g_str_has_prefix (path, VAR_SELINUX_TARGETED_PATH))
-    return g_strconcat ("usr/etc/selinux/targeted/", path + strlen (VAR_SELINUX_TARGETED_PATH),
-                        NULL);
-  else if (g_str_has_prefix (path, "opt/"))
-    return g_strconcat ("usr/lib/", path, NULL);
-  else if ((strcmp (path, "var/lib/alternatives/") == 0)
-           || g_str_has_prefix (path, "var/lib/alternatives")
-           || (strcmp (path, "var/lib/vagrant/") == 0)
-           || g_str_has_prefix (path, "var/lib/vagrant"))
-    return g_strconcat ("usr/", path + strlen ("var/"), NULL);
-
-  return NULL;
-}
-
 /* Replace [match_start, match_end) in version with rendered date_fmt.
  *
  * Returns TRUE on success, FALSE otherwise.

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -193,8 +193,6 @@ G_BEGIN_DECLS
 #define _N(single, plural, n) ((n) == 1 ? (single) : (plural))
 #define _NS(n) _N ("", "s", n)
 
-#define VAR_SELINUX_TARGETED_PATH "var/lib/selinux/targeted/"
-
 int rpmostree_ptrarray_sort_compare_strings (gconstpointer ap, gconstpointer bp);
 
 GVariant *_rpmostree_vardict_lookup_value_required (GVariantDict *dict, const char *key,
@@ -210,8 +208,6 @@ char *rpmostree_pkg_get_local_path (DnfPackage *pkg);
 
 gboolean rpmostree_check_size_within_limit (guint64 actual, guint64 limit, const char *subject,
                                             GError **error);
-
-char *rpmostree_translate_path_for_ostree (const char *path);
 
 char *rpmostree_str_replace (const char *buf, const char *old, const char *newval, GError **error);
 


### PR DESCRIPTION
This moves the logic for path translation and the ostree importing
callback to Rust.