### PR TITLE
ci: Reduce parallelism of vmcheck tests to 5

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -24,7 +24,7 @@ codestyle: {
 }
 }
 
-def nhosts = 6
+def nhosts = 5
 def mem = (nhosts * 1024) + 512
 cosaPod(runAsUser: 0, memory: "${mem}Mi", cpu: "${nhosts}") {
   stage("Unit Tests") {


### PR DESCRIPTION
We're seeing issues where CI sometimes hits EAGAIN on `fork`:

https://github.com/coreos/fedora-coreos-tracker/issues/1186

It's possible something changed recently that made rpm-ostree use more
threads than before and more likely to hit this.

There's no way for us control the PID limit from our side (it's a
node setting), so let's just lower parallelism here. (Another approach
is splitting it into multiple pods, but it doesn't seem worth the
complexity yet.)