### PR TITLE
cliwrap: Enable `yum install foo` in a container

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -28,4 +28,13 @@ fi
 rm "${origindir}/clienterror.yaml"
 rpm-ostree ex rebuild
 
+if ! test -x /usr/bin/yum; then
+    rpm-ostree cliwrap install-to-root /
+fi
+
+# Test a critical path package
+yum install cowsay && yum clean all
+cowsay "It worked"
+test '!' -d /var/cache/rpm-ostree
+
 echo ok

--- a/rust/src/cliwrap.rs
+++ b/rust/src/cliwrap.rs
@@ -37,6 +37,7 @@ pub(crate) enum RunDisposition {
     Ok,
     Warn,
     Notice(String),
+    Unsupported,
 }
 
 /// Main entrypoint for cliwrap
@@ -68,8 +69,8 @@ pub fn entrypoint(args: &[&str]) -> Result<()> {
         SystemHostType::OstreeHost | SystemHostType::OstreeContainer
     ) {
         match name {
-            "rpm" => Ok(self::rpm::main(args)?),
-            "yum" | "dnf" => Ok(self::yumdnf::main(args)?),
+            "rpm" => Ok(self::rpm::main(host_type, args)?),
+            "yum" | "dnf" => Ok(self::yumdnf::main(host_type, args)?),
             "dracut" => Ok(self::dracut::main(args)?),
             "grubby" => Ok(self::grubby::main(args)?),
             _ => Err(anyhow!("Unknown wrapped binary: {}", name)),

--- a/rust/src/cliwrap/cliutil.rs
+++ b/rust/src/cliwrap/cliutil.rs
@@ -4,16 +4,9 @@ use anyhow::Result;
 use cap_std_ext::rustix;
 use nix::sys::statvfs;
 use std::os::unix::process::CommandExt;
-use std::{path, thread, time};
+use std::{thread, time};
 
 use crate::cliwrap;
-
-use crate::core::OSTREE_BOOTED;
-
-/// Returns true if the current process is booted via ostree.
-pub fn is_ostree_booted() -> bool {
-    path::Path::new(OSTREE_BOOTED).exists()
-}
 
 /// Returns true if /usr is not a read-only bind mount
 pub fn is_unlocked() -> Result<bool> {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -77,11 +77,21 @@ pub mod ffi {
         v: String,
     }
 
+    /// Classify the running system.
+    #[derive(Clone, Debug)]
+    enum SystemHostType {
+        OstreeContainer,
+        OstreeHost,
+        Unknown,
+    }
+
     // client.rs
     extern "Rust" {
         fn is_bare_split_xattrs() -> Result<bool>;
         fn is_http_arg(arg: &str) -> bool;
         fn is_ostree_container() -> Result<bool>;
+        fn get_system_host_type() -> Result<SystemHostType>;
+        fn require_system_host_type(t: SystemHostType) -> Result<()>;
         fn is_rpm_arg(arg: &str) -> bool;
         fn client_start_daemon() -> Result<()>;
         fn client_handle_fd_argument(arg: &str, arch: &str) -> Result<Vec<i32>>;


### PR DESCRIPTION
lib: Add an API to get "system host"

I think we in the future will want to more carefully dispatch
on the type.

---

cliwrap: add install verb, support being run in a container

This is preparatory work for actually having e.g. `yum install`
do what we want in a container.

---

cliwrap: Enable `yum install foo` in a container

For the "ostree native container" bits, the goal is to make things
*extremely obvious* to someone who is using a `Dockerfile` to build
derived images.

Another way to say this is that a goal is for ostree to
"fade into the background".  It's still there - just not something
everyone needs to learn or care about.

This makes it so that typing `yum install usbguard && yum clean all`
Just Works as one would expect.

---

