### PR TITLE
treefile: Handle whitespace splitting for remote override packages

### DIFF
--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -176,6 +176,7 @@ fn treefile_parse_stream<R: io::Read>(
         treefile.modules = Some(modules);
     }
 
+    // Whitespace split repo packages
     if let Some(repo_packages) = treefile.repo_packages.take() {
         treefile.repo_packages = Some(
             repo_packages
@@ -188,6 +189,11 @@ fn treefile_parse_stream<R: io::Read>(
                 })
                 .collect::<Result<Vec<RepoPackage>>>()?,
         );
+    }
+    if let Some(repo_packages) = treefile.derive.override_replace.as_mut() {
+        for rp in repo_packages {
+            rp.packages = whitespace_split_packages(&rp.packages)?;
+        }
     }
 
     treefile.packages = Some(pkgs);
@@ -3975,6 +3981,7 @@ conditional-include:
                   packages:
                     - foo
                     - bar
+                    - baz blah
         "};
         let treefile = Treefile::new_from_string(utils::InputFormat::YAML, buf).unwrap();
         assert!(treefile.parsed.derive.override_replace.is_some());
@@ -3984,7 +3991,12 @@ conditional-include:
             replacements[0],
             RemoteOverrideReplace {
                 from: RemoteOverrideReplaceFrom::Repo("foobar".into()),
-                packages: maplit::btreeset!["foo".into(), "bar".into()],
+                packages: maplit::btreeset![
+                    "foo".into(),
+                    "bar".into(),
+                    "baz".into(),
+                    "blah".into()
+                ],
             }
         );
     }

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -177,18 +177,10 @@ fn treefile_parse_stream<R: io::Read>(
     }
 
     // Whitespace split repo packages
-    if let Some(repo_packages) = treefile.repo_packages.take() {
-        treefile.repo_packages = Some(
-            repo_packages
-                .into_iter()
-                .map(|rp| -> Result<RepoPackage> {
-                    Ok(RepoPackage {
-                        repo: rp.repo,
-                        packages: whitespace_split_packages(&rp.packages)?,
-                    })
-                })
-                .collect::<Result<Vec<RepoPackage>>>()?,
-        );
+    if let Some(repo_packages) = treefile.repo_packages.as_mut() {
+        for rp in repo_packages {
+            rp.packages = whitespace_split_packages(&rp.packages)?;
+        }
     }
     if let Some(repo_packages) = treefile.derive.override_replace.as_mut() {
         for rp in repo_packages {

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -1963,6 +1963,8 @@ rpmostree_context_prepare (RpmOstreeContext *self, GCancellable *cancellable, GE
           HyNevra nevra = NULL;
           hy_autoquery HyQuery query = hy_subject_get_best_solution (
               subject, sack, NULL, &nevra, FALSE, TRUE, TRUE, TRUE, FALSE);
+          if (!nevra)
+            return glnx_throw (error, "Failed to parse selector: %s", pkg.c_str ());
           hy_query_filter (query, HY_PKG_REPONAME, HY_EQ, repo.c_str ());
           g_autoptr (DnfPackageSet) pset = hy_query_run_set (query);
           if (dnf_packageset_count (pset) == 0)
@@ -1993,6 +1995,8 @@ rpmostree_context_prepare (RpmOstreeContext *self, GCancellable *cancellable, GE
                 // supported.
                 hy_autoquery HyQuery query = hy_subject_get_best_solution (
                     subject, sack, NULL, &nevra, FALSE, TRUE, FALSE, FALSE, FALSE);
+                if (!nevra)
+                  return glnx_throw (error, "Failed to parse selector: %s", pkg.c_str ());
                 auto pkgname = nevra->getName ();
                 // this should never happen, but just in case
                 if (pkgname.empty ())


### PR DESCRIPTION
core: Check for errors from `hy_subject_get_best_solution`

In https://github.com/coreos/fedora-coreos-config/pull/1710 I originally
tried to do:

```
    packages:
      - ostree ostree-libs
      - rpm-ostree rpm-ostree-libs
```

And I got a segfault.  This is because e.g. `hy_subject_get_best_solution`
will return a `NULL` nevra if it fails to parse.

Hooray for inconsistent C/C++ error handling.

---

treefile: Handle whitespace splitting for remote override packages

It's just more friendly and consistent.

---

treefile: Simplify code for whitespace-splitting repo packages

Lots of unnecessary complexity.

---

