### PR TITLE
rpmutil: Factor out helper for fcaps to single variant

### DIFF
--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -131,6 +131,7 @@ G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC (RpmSighandlerResetCleanup, rpmostree_sighandle
     0,                                                                                             \
   };
 
+GVariant *rpmostree_fcap_to_ostree_xattr (const char *fcap);
 GVariant *rpmostree_fcap_to_xattr_variant (const char *fcap);
 
 typedef enum


### PR DESCRIPTION
Prep for use in IMA work, where we need to merge fcap xattrs
with IMA xattrs.
