### PR TITLE
libpriv/importer: move importer flags to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,6 +2060,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "binread",
+ "bitflags",
  "c_utf8",
  "camino",
  "cap-std-ext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ rpm = "4"
 [dependencies]
 anyhow = "1.0.57"
 binread = "2.2.0"
+bitflags = "1.3"
 c_utf8 = "0.1.0"
 camino = "1.0.7"
 cap-std-ext = "0.24.3"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -337,12 +337,14 @@ pub mod ffi {
 
     // importer.rs
     extern "Rust" {
-        type RpmImporter;
+        type RpmImporterFlags;
+        fn rpm_importer_flags_new_empty() -> Box<RpmImporterFlags>;
 
+        type RpmImporter;
         fn rpm_importer_new(
             pkg_name: &str,
             ostree_branch: &str,
-            doc_files_are_filtered: bool,
+            flags: &RpmImporterFlags,
         ) -> Result<Box<RpmImporter>>;
         fn handle_translate_pathname(self: &mut RpmImporter, path: &str) -> String;
         fn ostree_branch(self: &RpmImporter) -> String;
@@ -351,19 +353,20 @@ pub mod ffi {
         fn doc_files_are_filtered(self: &RpmImporter) -> bool;
         fn doc_files_insert(self: &mut RpmImporter, path: &str);
         fn doc_files_contains(self: &RpmImporter, path: &str) -> bool;
-
-        fn importer_compose_filter(
+        fn is_ima_enabled(self: &RpmImporter) -> bool;
+        fn tweak_imported_file_info(self: &RpmImporter, mut file_info: Pin<&mut GFileInfo>);
+        fn is_file_filtered(
+            self: &RpmImporter,
             path: &str,
             mut file_info: Pin<&mut GFileInfo>,
-            skip_extraneous: bool,
         ) -> Result<bool>;
+
         fn tmpfiles_translate(
             abs_path: &str,
             mut file_info: Pin<&mut GFileInfo>,
             username: &str,
             groupname: &str,
         ) -> Result<String>;
-        fn tweak_imported_file_info(mut file_info: Pin<&mut GFileInfo>, ro_executables: bool);
     }
 
     // initramfs.rs
@@ -552,6 +555,7 @@ pub mod ffi {
         fn print_deprecation_warnings(&self);
         fn print_experimental_notices(&self);
         fn sanitycheck_externals(&self) -> Result<()>;
+        fn importer_flags(&self, pkg_name: &str) -> Box<RpmImporterFlags>;
 
         // these functions are more related to derivation
         fn validate_for_container(&self) -> Result<()>;

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -567,8 +567,9 @@ static gboolean
 import_local_rpm (OstreeRepo *repo, OstreeSePolicy *policy, int *fd, char **out_sha256_nevra,
                   GCancellable *cancellable, GError **error)
 {
-  g_autoptr (RpmOstreeImporter) unpacker = rpmostree_importer_new_take_fd (
-      fd, repo, NULL, static_cast<RpmOstreeImporterFlags> (0), policy, error);
+  auto flags = rpmostreecxx::rpm_importer_flags_new_empty ();
+  g_autoptr (RpmOstreeImporter) unpacker
+      = rpmostree_importer_new_take_fd (fd, repo, NULL, *flags, policy, error);
   if (unpacker == NULL)
     return FALSE;
 

--- a/src/libpriv/rpmostree-importer.h
+++ b/src/libpriv/rpmostree-importer.h
@@ -39,24 +39,8 @@ GType rpmostree_importer_get_type (void);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (RpmOstreeImporter, g_object_unref)
 
-/**
- * RpmOstreeImporterFlags:
- * @RPMOSTREE_IMPORTER_FLAGS_SKIP_EXTRANEOUS: Skip files/directories outside of supported
- * ostree-compliant paths rather than erroring out
- * @RPMOSTREE_IMPORTER_FLAGS_NODOCS: Skip documentation files
- * @RPMOSTREE_IMPORTER_FLAGS_RO_EXECUTABLES: Make executable files readonly
- * @RPMOSTREE_IMPORTER_FLAGS_IMA: Enable IMA
- */
-typedef enum
-{
-  RPMOSTREE_IMPORTER_FLAGS_SKIP_EXTRANEOUS = (1 << 0),
-  RPMOSTREE_IMPORTER_FLAGS_NODOCS = (1 << 1),
-  RPMOSTREE_IMPORTER_FLAGS_RO_EXECUTABLES = (1 << 2),
-  RPMOSTREE_IMPORTER_FLAGS_IMA = (1 << 3),
-} RpmOstreeImporterFlags;
-
 RpmOstreeImporter *rpmostree_importer_new_take_fd (int *fd, OstreeRepo *repo, DnfPackage *pkg,
-                                                   RpmOstreeImporterFlags flags,
+                                                   rpmostreecxx::RpmImporterFlags &flags,
                                                    OstreeSePolicy *sepolicy, GError **error);
 
 gboolean rpmostree_importer_read_metainfo (int fd, Header *out_header, gsize *out_cpio_offset,


### PR DESCRIPTION
This moves the RPM importer flags to Rust, backed by `bitflags`.