### PR TITLE
tree-wide: Update to cap-std 0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3430d1b5ba78fa381eb227525578d2b85d77b42ff49be85d1e72a94f305e603c"
+checksum = "5d684df5773e4af5c343c466f47151db7e7a4366daab609b4a6bb7a75aecf732"
 dependencies = [
  "cap-primitives",
  "io-extras",
@@ -186,13 +186,13 @@ dependencies = [
 
 [[package]]
 name = "cap-std-ext"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35542c3139ae910606e9de752706b6ebd676ae31f35c963d6e64dd07f8f18c7c"
+checksum = "b1dcfdda606dc44a9bf48efc76bbe48a49a4e9ccf84cbbaafbe7e5a6d891d3e6"
 dependencies = [
  "cap-std",
+ "cap-tempfile",
  "rustix 0.33.0",
- "uuid 0.8.2",
 ]
 
 [[package]]
@@ -204,7 +204,7 @@ dependencies = [
  "cap-std",
  "rand",
  "rustix 0.33.0",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2744,15 +2744,6 @@ name = "utf8-cstr"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = "1.0.57"
 binread = "2.2.0"
 c_utf8 = "0.1.0"
 camino = "1.0.7"
-cap-std-ext = "0.24.3"
+cap-std-ext = "0.25"
 cap-tempfile = "0.24.3"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = "2.34.0"

--- a/rust/src/builtins/compose/mod.rs
+++ b/rust/src/builtins/compose/mod.rs
@@ -25,7 +25,7 @@ pub fn composeutil_legacy_prep_dev_and_run(rootfs_dfd: i32) -> CxxResult<()> {
     let rootfs = unsafe { crate::ffiutil::ffi_dirfd(rootfs_dfd)? };
     legacy_prepare_dev(&rootfs)?;
     rootfs.create_dir_with("run", DirBuilder::new().mode(0o755))?;
-    rootfs.replace_contents_with_perms(&OSTREE_BOOTED[1..], b"", Permissions::from_mode(0o755))?;
+    rootfs.atomic_write_with_perms(&OSTREE_BOOTED[1..], b"", Permissions::from_mode(0o755))?;
     Ok(())
 }
 

--- a/rust/src/cliwrap.rs
+++ b/rust/src/cliwrap.rs
@@ -104,7 +104,8 @@ fn write_one_wrapper(rootfs_dfd: &Dir, binpath: &Utf8Path, allow_noent: bool) ->
     if exists {
         let destpath = format!("{}/{}", CLIWRAP_DESTDIR, name);
         rootfs_dfd.rename(binpath, rootfs_dfd, destpath.as_str())?;
-        rootfs_dfd.replace_file_with_perms(binpath, perms, |w| {
+        rootfs_dfd.atomic_replace_with(binpath, |w| {
+            w.get_mut().as_file_mut().set_permissions(perms)?;
             indoc::writedoc! {w, r#"
 #!/bin/sh
 # Wrapper created by rpm-ostree to override
@@ -115,7 +116,8 @@ exec /usr/bin/rpm-ostree cliwrap $0 "$@"
 "#,  destpath }
         })?;
     } else {
-        rootfs_dfd.replace_file_with_perms(binpath, perms, |w| {
+        rootfs_dfd.atomic_replace_with(binpath, |w| {
+            w.get_mut().as_file_mut().set_permissions(perms)?;
             indoc::writedoc! {w, r#"
 #!/bin/sh
 # Wrapper created by rpm-ostree to implement this CLI interface.

--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -350,7 +350,7 @@ pub async fn container_encapsulate(args: &[&str]) -> Result<()> {
     if let Some(v) = opt.write_contentmeta_json {
         let v = v.strip_prefix("/").unwrap_or(&v);
         let root = Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
-        root.replace_file_with(v, |w| {
+        root.atomic_replace_with(v, |w| {
             serde_json::to_writer(w, &meta.sizes).map_err(anyhow::Error::msg)
         })?;
     }

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -143,7 +143,7 @@ impl FilesystemScriptPrep {
             let saved = &Self::saved_name(path);
             if rootfs.try_exists(path)? {
                 rootfs.rename(path, &rootfs, saved)?;
-                rootfs.replace_contents_with_perms(path, contents, mode)?;
+                rootfs.atomic_write_with_perms(path, contents, mode)?;
             }
         }
         Ok(Box::new(Self { rootfs }))
@@ -216,7 +216,7 @@ fn verify_kernel_hmac_impl(moddir: &Dir) -> Result<()> {
     }
 
     let perms = Permissions::from_mode(0o644);
-    moddir.replace_contents_with_perms(hmac_path, new_contents, perms)?;
+    moddir.atomic_write_with_perms(hmac_path, new_contents, perms)?;
 
     Ok(())
 }
@@ -265,9 +265,9 @@ mod test {
         db.recursive(true);
         d.ensure_dir_with("usr/bin", &db)?;
         d.ensure_dir_with("usr/sbin", &db)?;
-        d.replace_contents_with_perms(super::SSS_CACHE_PATH, "sss binary", mode.clone())?;
+        d.atomic_write_with_perms(super::SSS_CACHE_PATH, "sss binary", mode.clone())?;
         let original_systemctl = "original systemctl";
-        d.replace_contents_with_perms(super::SYSTEMCTL_PATH, original_systemctl, mode.clone())?;
+        d.atomic_write_with_perms(super::SYSTEMCTL_PATH, original_systemctl, mode.clone())?;
         // Replaced systemctl
         {
             assert!(d.try_exists(super::SSS_CACHE_PATH)?);

--- a/rust/src/countme/cookie.rs
+++ b/rust/src/countme/cookie.rs
@@ -3,12 +3,10 @@
 use anyhow::{bail, Result};
 use cap_std::fs::Dir;
 use cap_std_ext::cap_std;
-use cap_std_ext::cap_std::fs::Permissions;
 use cap_std_ext::dirext::CapStdExtDirExt;
 use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::io::Read;
-use std::os::unix::prelude::PermissionsExt;
 
 /// State directory used to store the countme cookie
 const STATE_DIR: &str = "var/lib/rpm-ostree-countme";
@@ -146,8 +144,7 @@ impl Cookie {
             window: self.now,
         };
         let statedir = Dir::open_ambient_dir(STATE_DIR, cap_std::ambient_authority())?;
-        let perms = Permissions::from_mode(0o644);
-        statedir.replace_file_with_perms(COUNTME_COOKIE, perms, |w| -> Result<_> {
+        statedir.atomic_replace_with(COUNTME_COOKIE, |w| -> Result<_> {
             Ok(serde_json::to_writer(w, &cookie)?)
         })
     }

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -354,7 +354,7 @@ fn get_cached_signatures_variant(
 
     let v = glib::Variant::from_array::<glib::Variant>(&sigs);
     let perms = cap_std::fs::Permissions::from_mode(0o600);
-    cachedir.replace_contents_with_perms(&cached_relpath, &v.data_as_bytes(), perms)?;
+    cachedir.atomic_write_with_perms(&cached_relpath, &v.data_as_bytes(), perms)?;
     Ok(v)
 }
 

--- a/rust/src/extensions.rs
+++ b/rust/src/extensions.rs
@@ -166,7 +166,7 @@ impl Extensions {
     pub(crate) fn update_state_checksum(&self, chksum: &str, output_dir: &str) -> CxxResult<()> {
         let output_dir = Dir::open_ambient_dir(output_dir, cap_std::ambient_authority())?;
         Ok(output_dir
-            .replace_contents_with_perms(
+            .atomic_write_with_perms(
                 RPMOSTREE_EXTENSIONS_STATE_FILE,
                 chksum,
                 Permissions::from_mode(0o644),
@@ -177,11 +177,9 @@ impl Extensions {
     pub(crate) fn serialize_to_dir(&self, output_dir: &str) -> CxxResult<()> {
         let output_dir = Dir::open_ambient_dir(output_dir, cap_std::ambient_authority())?;
         Ok(output_dir
-            .replace_file_with_perms(
-                "extensions.json",
-                Permissions::from_mode(0o644),
-                |w| -> Result<_> { Ok(serde_json::to_writer_pretty(w, self)?) },
-            )
+            .atomic_replace_with("extensions.json", |w| -> Result<_> {
+                Ok(serde_json::to_writer_pretty(w, self)?)
+            })
             .context("while serializing")?)
     }
 

--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -12,7 +12,7 @@ use crate::ffi::LiveApplyState;
 use crate::isolation;
 use crate::progress::progress_task;
 use anyhow::{anyhow, Context, Result};
-use cap_std::fs::{Dir, Permissions};
+use cap_std::fs::Dir;
 use cap_std_ext::cap_std;
 use cap_std_ext::dirext::CapStdExtDirExt;
 use fn_error_context::context;
@@ -24,7 +24,6 @@ use ostree_ext::{gio, glib, ostree};
 use rayon::prelude::*;
 use std::borrow::Cow;
 use std::os::unix::io::AsRawFd;
-use std::os::unix::prelude::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 
@@ -102,8 +101,7 @@ fn write_live_state(
 
     // Ensure the stamp file exists
     if !found_live_stamp && commit.or(inprogress_commit).is_some() {
-        let perms = Permissions::from_mode(0o644);
-        rundir.replace_contents_with_perms(LIVE_STATE_NAME, b"", perms)?;
+        rundir.atomic_write(LIVE_STATE_NAME, b"")?;
     }
 
     Ok(())

--- a/rust/src/lockfile.rs
+++ b/rust/src/lockfile.rs
@@ -13,7 +13,6 @@
 pub use self::ffi::*;
 use crate::utils;
 use anyhow::{anyhow, bail, Result};
-use cap_std::fs::Permissions;
 use cap_std_ext::cap_std;
 use cap_std_ext::dirext::CapStdExtDirExt;
 use chrono::prelude::*;
@@ -22,7 +21,6 @@ use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::io;
 use std::iter::Extend;
-use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::pin::Pin;
 
@@ -420,7 +418,7 @@ pub(crate) fn lockfile_write(
 
     let (dir, path) =
         crate::capstdext::open_dir_of(Path::new(filename), cap_std::ambient_authority())?;
-    dir.replace_file_with_perms(path, Permissions::from_mode(0o644), |w| -> Result<()> {
+    dir.atomic_replace_with(path, |w| -> Result<()> {
         Ok(serde_json::to_writer_pretty(w, &lockfile)?)
     })?;
     Ok(())


### PR DESCRIPTION
I mostly aimed to be conservative and continue to explicitly set
file permissions.  But not in all cases - in a few I chose to
just explicitly rely on us getting `0644`, relying on a reasonable
umask.
