### PR TITLE
Release 2022.9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2022])
-m4_define([release_version], [8])
+m4_define([release_version], [9])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2022.8
+Version: 2022.9
 Release: 1%{?dist}
 License: LGPLv2+
 URL: https://github.com/coreos/rpm-ostree
@@ -83,7 +83,7 @@ BuildRequires: jq
 #########################################################################
 
 
-%global libsolv_version 0.7.17
+%global libsolv_version 0.7.21
 %global libmodulemd_version 2.13.0
 %global librepo_version 1.13.1
 
@@ -95,14 +95,13 @@ BuildRequires:  pkgconfig(librepo) >= %{librepo_version}
 BuildRequires:  pkgconfig(check)
 BuildRequires:  pkgconfig(gio-unix-2.0) >= 2.46.0
 BuildRequires:  pkgconfig(gtk-doc)
-BuildRequires:  rpm-devel >= 4.11.0
+BuildRequires:  rpm-devel >= 4.15.0
 %if %{with zchunk}
 BuildRequires:  pkgconfig(zck) >= 0.9.11
 %endif
 BuildRequires:  pkgconfig(sqlite3)
 BuildRequires:  pkgconfig(json-c)
 BuildRequires:  pkgconfig(cppunit)
-BuildRequires:  pkgconfig(libcrypto)
 BuildRequires:  pkgconfig(modulemd-2.0) >= %{libmodulemd_version}
 BuildRequires:  pkgconfig(smartcols)
 BuildRequires:  gettext


### PR DESCRIPTION
Compose:

- Add support for propagating RPM IMA signatures

Container:

- We now support `yum install foo`
- Fix `override replace` and `override remove` support
- Support whitespace-separated packages in `ex-override-replace` key

Internals:

- Bump libdnf submodule to latest, which should fix https://bugzilla.redhat.com/show_bug.cgi?id=2083715
- Oxidize more bits in the origin and importer code
- Move testing to Fedora 36

```
Colin Walters (19):
      lib: Add an API to get "system host"
      cliwrap: add install verb, support being run in a container
      cliwrap: Enable `yum install foo` in a container
      core: Check for errors from `hy_subject_get_best_solution`
      treefile: Handle whitespace splitting for remote override packages
      treefile: Simplify code for whitespace-splitting repo packages
      postprocess: Move rpmdb cleanup into Rust
      cliwrap: Use `Utf8Path` to drop an `unwrap()` also `ok_or_else`
      cliwrap: More Utf8Path usage
      rpmutil: Factor out helper for fcaps to single variant
      core: Add constants for IMA
      postprocess: Automatically propagate user.ostreemeta xattrs in commit
      build: Add support for propagating RPM IMA signatures
      tests: Add a compose IMA test
      testdeps: Install rpm-sign
      history: Port to cap-std
      treefile: Remove unused workdir
      Update to ostree-ext 0.7.2
      tree-wide: Update to cap-std 0.25

Jonathan Lebon (36):
      libpriv/origin: Back add_modules() by treefile
      libpriv/origin: Back remove_modules() by treefile
      libpriv/origin: Back remove_all_packages() by treefile
      libpriv/origin: Stop caching module-related keys
      rust/treefile: Fix has_modules_enable() check
      rust/origin: Don't add empty string lists in origin
      rust/treefile: Rename `modules` variable for clarity
      rust/treefile: Make override-remove field a BTreeSet
      libpriv/origin: Back add_overrides() by treefile
      libpriv/origin: Back remove_override() by treefile
      libpriv/origin: Back remove_all_overrides() by treefile
      libpriv/origin: Stop caching override-related keys
      rust/treefile: Separately assert override didn't exist
      libpriv/origin: Drop unused RpmOstreeOriginOverrideType enum
      rust/libdnf-sys: Rename libdnf.hxx to libdnf.hpp and reformat
      rust/libdnf-sys: Bridge hy_split_nevra()
      Use `--workspace` when running `cargo test`
      libpriv/origin: Fix change setting in `add_*_packages`
      rust/treefile: Add more testing for `add_packages`
      libpriv/origin: Back remove_packages() by treefile
      libpriv/origin: Stop caching package-related keys
      libpriv/origin: Stop caching unconfigured state
      libpriv/origin: Drop unused functions
      libpriv/origin: Drop GKeyFile member from RpmOstreeOrigin
      libpriv/origin: Free treefile when dropping RpmOstreeOrigin
      ci: Reduce parallelism of vmcheck tests to 5
      rust/treefile: Drop `set_packages_override_remove`
      core: Include expected SHA256 in mismatch error
      core: Hint at warnings when dnf_sack_add_cmdline_package fails
      app/override: Mark `replace` and `remove` as container capable
      tests: Adapt for Fedora 36 rebase
      ci: Mark git checkout as safe
      ci: Consistently use app.ci over quay.io for cosa and fcos-buildroot images
      tests/container-image: Build derived image with --net=host
      tests/vmcheck/db: Bump fake glibc.i686 version
      Release 2022.9

Luca BRUNO (15):
      libpriv/importer: simplify ostree branch handling
      libpriv/importer: avoid caching header digest
      libpriv/import: move result formatting out of core logic
      libpriv/importer: port logic for /var/lib/ symlinks to Rust
      libpriv/importer: port logic for /opt symlinks to Rust
      importer: minor code tweaks
      libpriv/importer: port path translation to Rust
      libpriv/core: workaround libdnf vars path lookup
      libpriv/core: canonicalize install_root
      libpriv/importer: move ostree branch caching to Rust
      libpriv/importer: cache package name
      libpriv/importer: port docs filtering to Rust
      cargo: add bitflags
      lockfile: refresh after changes
      libpriv/importer: move importer flags to Rust

dependabot[bot] (13):
      build(deps): bump nix from 0.23.1 to 0.24.1
      build(deps): bump anyhow from 1.0.56 to 1.0.57
      build(deps): bump libc from 0.2.124 to 0.2.125
      build(deps): bump cxx from 1.0.66 to 1.0.67
      build(deps): bump cxx-build from 1.0.66 to 1.0.67
      build(deps): bump serde_json from 1.0.79 to 1.0.80
      build(deps): bump serde from 1.0.136 to 1.0.137
      build(deps): bump serde_yaml from 0.8.23 to 0.8.24
      build(deps): bump indoc from 1.0.4 to 1.0.6
      build(deps): bump cap-tempfile from 0.24.2 to 0.24.3
      build(deps): bump openssl from 0.10.38 to 0.10.40
      build(deps): bump serde_json from 1.0.80 to 1.0.81
      build(deps): bump libdnf from `e5ecbc1` to `1742be5`
```