### PR TITLE
Enable compilation with librhsm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,9 @@ debug = true
 lto = "thin"
 
 [features]
+# Note: If you add a feature here, you also probably want to update utils.rs:get_features()
 fedora-integration = []
+rhsm = ["libdnf-sys/rhsm"]
 bin-unit-tests = []
 # ASAN+UBSAN
 sanitizers = []

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -99,6 +99,8 @@ if BUILDOPT_ASAN
 cargo_build += --features sanitizers
 endif
 
+cargo_build += $(if $(RUST_FEATURES),--features $(RUST_FEATURES))
+
 if RUST_DEBUG
 cargo_target_dir=debug
 else

--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,12 @@ AS_IF([test x$enable_bin_unit_tests = xyes], [
 ])
 AM_CONDITIONAL(BUILDOPT_BIN_UNIT_TESTS, [test x$enable_bin_unit_tests = xyes])
 
+AC_ARG_ENABLE(featuresrs,
+              AS_HELP_STRING([--enable-featuresrs],
+                             [Rust features, see Cargo.toml for more information]),,
+              [enable_featuresrs=])
+AC_SUBST([RUST_FEATURES], $enable_featuresrs)
+
 # Initialize libtool
 LT_PREREQ([2.2.4])
 LT_INIT([disable-static])
@@ -143,5 +149,6 @@ echo "
     ASAN + UBSAN:                            ${enable_sanitizers:-no}
     gtk-doc:                                 $enable_gtk_doc
     rust:                                    $rust_debug_release
+    rust features:                           $enable_featuresrs
     bdb rpmdb default:                       ${enable_bdb_rpmdb_default}
 "

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -27,6 +27,13 @@ BuildRequires: rust
 # Embedded unit tests
 %bcond_with bin_unit_tests
 
+# This is copied from the libdnf spec
+%if 0%{?rhel} && ! 0%{?centos}
+%bcond_without rhsm
+%else
+%bcond_with rhsm
+%endif
+
 # RHEL (8,9) doesn't ship zchunk today.  Keep this in sync
 # with libdnf: https://gitlab.com/redhat/centos-stream/rpms/libdnf/-/blob/762f631e36d1e42c63a794882269d26c156b68c1/libdnf.spec#L45
 %if 0%{?rhel}
@@ -111,6 +118,9 @@ BuildRequires:  gpgme-devel
 # not in RHEL8.  Missing this package breaks -znow.
 BuildRequires:  libassuan-devel
 %endif
+%if %{with rhsm}
+BuildRequires:  pkgconfig(librhsm) >= 0.0.3
+%endif
 
 Requires:       libmodulemd%{?_isa} >= %{libmodulemd_version}
 Requires:       libsolv%{?_isa} >= %{libsolv_version}
@@ -169,7 +179,8 @@ env NOCONFIGURE=1 ./autogen.sh
 %if 0%{?build_rustflags:1}
 export RUSTFLAGS="%{build_rustflags}"
 %endif
-%configure --disable-silent-rules --enable-gtk-doc %{?rpmdb_default} %{?with_sanitizers:--enable-sanitizers}  %{?with_bin_unit_tests:--enable-bin-unit-tests}
+%configure --disable-silent-rules --enable-gtk-doc %{?rpmdb_default} %{?with_sanitizers:--enable-sanitizers}  %{?with_bin_unit_tests:--enable-bin-unit-tests} \
+  %{?with_rhsm:--enable-featuresrs=rhsm}
 
 %make_build
 

--- a/rust/libdnf-sys/Cargo.toml
+++ b/rust/libdnf-sys/Cargo.toml
@@ -34,3 +34,8 @@ modulemd = { name = "modulemd-2.0", version = "2" }
 jsonc = { name = "json-c", version = "0" }
 glib = { name = "glib-2.0", version = "2" }
 zck = { version = "0.9", optional = true }
+librhsm = { version = "0.0.3", feature = "rhsm" }
+
+[features]
+rhsm = []
+default = []

--- a/rust/libdnf-sys/build.rs
+++ b/rust/libdnf-sys/build.rs
@@ -5,6 +5,7 @@ fn main() -> Result<()> {
     let libs = system_deps::Config::new().probe()?;
     let has_gpgme_pkgconfig = libs.get_by_name("gpgme").is_some();
     let with_zck: u8 = libs.get_by_name("zck").is_some().into();
+    let with_rhsm = std::env::var_os("CARGO_FEATURE_RHSM").is_some();
 
     // first, the submodule proper
     let libdnf = cmake::Config::new("../../libdnf")
@@ -25,6 +26,10 @@ fn main() -> Result<()> {
         // We don't need docs
         .define("WITH_HTML:BOOL", "0")
         .define("WITH_MAN:BOOL", "0")
+        .define(
+            "ENABLE_RHSM_SUPPORT:BOOL",
+            if with_rhsm { "1" } else { "0" },
+        )
         // Auto-enable zchunk, if present
         .define("WITH_ZCHUNK:BOOL", format!("{}", with_zck))
         // Don't need bindings

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -549,12 +549,15 @@ pub(crate) fn varsubstitute(s: &str, subs: &Vec<crate::ffi::StringMapping>) -> C
 pub(crate) fn get_features() -> Vec<String> {
     // These constant features were originally set in configure.ac, but have migrated to
     // Rust in the interest in having less logic in autoconf.
-    let mut r: Vec<_> = ["rust", "compose"].iter().map(|&x| x.to_string()).collect();
+    let mut r = vec!["rust".to_string(), "compose".to_string()];
     if cfg!(feature = "fedora-integration") {
         r.push("fedora-integration".to_string());
     }
     if cfg!(feature = "bin-unit-tests") {
         r.push("bin-unit-tests".to_string());
+    }
+    if cfg!(feature = "rhsm") {
+        r.push("rhsm".to_string());
     }
     r
 }


### PR DESCRIPTION


Enable compilation with librhsm

First, add a generic `--enable-featuresrs=$x` autoconf bit which just passes
through to `cargo build --features $x` so we don't need to mirror all
future options in autoconf.

Use this to add `--enable-featuresrs=rhsm` which basically boils
down to passing `-DENABLE_RHSM_SUPPORT=1` to the libdnf cmake bits.

This is important for subscriptions on RHEL.

---

spec: Add bcond for rhsm mirroring libdnf

Do the same thing the libdnf spec is doing to enable the feature.

---

