### PR TITLE
daemon: Handle rebasing back from container to ostree

### DIFF
--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -54,6 +54,10 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     rpm-ostree status | tee out.txt
     assert_file_has_content_literal out.txt 'Digest: sha256:'
 
+    # Test rebasing back to ostree https://github.com/coreos/rpm-ostree/issues/3677
+    rpm-ostree rebase "$checksum"
+    rpm-ostree rebase "$image_pull" --experimental
+
     /tmp/autopkgtest-reboot 1
     ;;
   1)


### PR DESCRIPTION
Since the container flow is experimental, we need to handle
rebasing back to ostree.

There's still an issue here in that we're not pruning container image
refs when rebasing, but that's also true of rebasing between
container images today.

Closes: https://github.com/coreos/rpm-ostree/issues/3677
