### PR TITLE
3 small CI patches

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -30,6 +30,18 @@ jobs:
         with:
           name: install.tar
           path: install.tar
+  build-clang:
+    name: "Build (clang)"
+    runs-on: ubuntu-latest
+    container: registry.ci.openshift.org/coreos/fcos-buildroot:testing-devel
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      # https://github.com/actions/checkout/issues/760
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Build
+        run: ./ci/clang-build-check.sh
   integration:
     name: "Container Integration"
     needs: build

--- a/ci/codestyle.sh
+++ b/ci/codestyle.sh
@@ -35,3 +35,10 @@ git ls-files '*.rs' | while read f; do
     fi
 done
 echo "ok"
+
+echo 'checking for goto...'
+if git grep 'goto [a-z]*;' '*.c' '*.cxx'; then
+    echo "error: found goto usage" 1>&2
+    exit 1
+fi
+echo "ok"


### PR DESCRIPTION
ci: Verify we have no `goto` usage in C/C++

This is important for conversion to Rust, but also interacts
better with C++ exceptions.

---

tests: Fix dependency on uid/gid in compose tests

Trying to do a build in GH actions, I was really confused initially
why `test_tmpfiles_d_translation()` was failing there.  It turns
out the test was indirectly depending on the uid being 4 characters
long (1000, from coreos-assembler) because we end up writing the
current uid into the filesystem, and then the test asserts on the
total size of all regular files.

Fix the test to dynamically compute the expected size.

---

ci: Also build clang in Github Actions

Let's leave the Prow workloads to things that want nested virt
basically.

---

