### PR TITLE
Wrap kernel-install calls on containers

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -45,11 +45,17 @@ case $versionid in
     url_suffix=2.13.0/5.fc35/x86_64/ignition-2.13.0-5.fc35.x86_64.rpm
     # 2.14.0
     koji_url=https://koji.fedoraproject.org/koji/buildinfo?buildID=1967838
+    koji_kernel_url=https://koji.fedoraproject.org/koji/buildinfo?buildID=1970751
+    kver=5.17.11
+    krev=200
     ;;
   36)
     url_suffix=2.13.0/5.fc36/x86_64/ignition-2.13.0-5.fc36.x86_64.rpm
     # 2.14.0
     koji_url=https://koji.fedoraproject.org/koji/buildinfo?buildID=1967836
+    koji_kernel_url=https://koji.fedoraproject.org/koji/buildinfo?buildID=1970749
+    kver=5.17.11
+    krev=300
     ;;
   *) fatal "Unsupported Fedora version: $versionid";;
 esac
@@ -87,5 +93,9 @@ rpm-ostree override replace --experimental \
 # the continuous build's version has the git rev, prefixed with g
 rpm -q afterburn | grep g
 rpm -q afterburn-dracut | grep g
+
+rpm-ostree override replace $koji_kernel_url
+# test that the new initramfs was generated
+test -f /usr/lib/modules/${kver}-${krev}.fc${versionid}.x86_64/initramfs.img
 
 echo ok

--- a/rust/src/cliwrap.rs
+++ b/rust/src/cliwrap.rs
@@ -16,6 +16,7 @@ use std::os::unix::prelude::PermissionsExt;
 mod cliutil;
 mod dracut;
 mod grubby;
+mod kernel_install;
 mod rpm;
 mod yumdnf;
 use crate::cxxrsutil::CxxResult;
@@ -29,7 +30,7 @@ pub const CLIWRAP_DESTDIR: &str = "usr/libexec/rpm-ostree/wrapped";
 static WRAPPED_BINARIES: &[&str] = &["usr/bin/rpm", "usr/bin/dracut", "usr/sbin/grubby"];
 
 /// Binaries we will wrap, or create if they don't exist.
-static MUSTWRAP_BINARIES: &[&str] = &["usr/bin/yum", "usr/bin/dnf"];
+static MUSTWRAP_BINARIES: &[&str] = &["usr/bin/yum", "usr/bin/dnf", "usr/bin/kernel-install"];
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum RunDisposition {
@@ -69,6 +70,7 @@ pub fn entrypoint(args: &[&str]) -> Result<()> {
             "yum" | "dnf" => Ok(self::yumdnf::main(host_type, args)?),
             "dracut" => Ok(self::dracut::main(args)?),
             "grubby" => Ok(self::grubby::main(args)?),
+            "kernel-install" => Ok(self::kernel_install::main(args)?),
             _ => Err(anyhow!("Unknown wrapped binary: {}", name)),
         }
     } else {

--- a/rust/src/cliwrap/kernel_install.rs
+++ b/rust/src/cliwrap/kernel_install.rs
@@ -1,0 +1,84 @@
+// If not running on container continue the current path.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+use crate::cliwrap;
+use crate::cliwrap::cliutil;
+use anyhow::{anyhow, Context, Result};
+use camino::Utf8Path;
+use cap_std::fs::FileType;
+use cap_std::fs_utf8::Dir as Utf8Dir;
+use cap_std_ext::cap_std;
+use std::process::Command;
+
+/// Primary entrypoint to running our wrapped `kernel-install` handling.
+pub(crate) fn main(argv: &[&str]) -> Result<()> {
+    if !ostree_ext::container_utils::is_ostree_container()? {
+        return cliutil::exec_real_binary("kernel-install", argv);
+    }
+    let is_install = matches!(argv.get(0), Some(&"add"));
+
+    let modules_path = Utf8Dir::open_ambient_dir("lib/modules", cap_std::ambient_authority())?;
+    //kernel-install is called by kernel-core and kernel-modules cleanup let's make sure we just call dracut once.
+    let mut new_kernel: Option<_> = None;
+
+    //finds which the kernel to remove and which to generate the initramfs for.
+    for entry in modules_path.entries()? {
+        let entry = entry?;
+        let kernel_dir = entry.file_name()?;
+        let kernel_binary_path = Utf8Path::new(&kernel_dir).join("vmlinuz");
+
+        if entry.file_type()? == FileType::dir() {
+            if modules_path.exists(kernel_binary_path) {
+                if is_install {
+                    new_kernel = Some(kernel_dir);
+                }
+            } else {
+                new_kernel = None;
+                modules_path.remove_dir_all(kernel_dir)?;
+            }
+        }
+    }
+    if let Some(k) = new_kernel {
+        run_dracut(&k)?;
+    }
+    Ok(())
+}
+
+fn run_dracut(kernel_dir: &str) -> Result<()> {
+    let root_fs = Utf8Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
+    let tmp_dir = tempfile::tempdir()?;
+    let tmp_initramfs_path = tmp_dir.path().join("initramfs.img");
+
+    let cliwrap_dracut = Utf8Path::new(cliwrap::CLIWRAP_DESTDIR).join("dracut");
+    let dracut_path = cliwrap_dracut
+        .exists()
+        .then(|| cliwrap_dracut)
+        .unwrap_or_else(|| Utf8Path::new("dracut").to_owned());
+    // If changing this, also look at changing rpmostree-kernel.cxx
+    let res = Command::new(dracut_path)
+        .args(&[
+            "--no-hostonly",
+            "--kver",
+            kernel_dir,
+            "--reproducible",
+            "-v",
+            "--add",
+            "ostree",
+            "-f",
+        ])
+        .arg(tmp_initramfs_path)
+        .status()?;
+    if !res.success() {
+        return Err(anyhow!(
+            "Failed to generate initramfs (via dracut) for for kernel: {kernel_dir}: {:?}",
+            res
+        ));
+    }
+    let utf8_tmp_dir_path = Utf8Path::from_path(tmp_dir.path().strip_prefix("/")?)
+        .context("Error turning Path to Utf8Path")?;
+    root_fs.rename(
+        utf8_tmp_dir_path.join("initramfs.img"),
+        &root_fs,
+        (Utf8Path::new("lib/modules").join(kernel_dir)).join("initramfs.img"),
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
Adds kernel-install wrap to properly override replace the kernel packages on container builds.