### PR TITLE
rpmostreed-sysroot: Use G_IO_ERROR_BUSY for "Transaction in progress" error

### DIFF
--- a/src/daemon/rpmostreed-sysroot.cxx
+++ b/src/daemon/rpmostreed-sysroot.cxx
@@ -813,10 +813,11 @@ rpmostreed_sysroot_prep_for_txn (RpmostreedSysroot *self, GDBusMethodInvocation 
         }
       const char *title
           = rpmostree_transaction_get_title ((RPMOSTreeTransaction *)(self->transaction));
-      return glnx_throw (error,
-                         "Transaction in progress: %s\n You can cancel the current transaction "
-                         "with `rpm-ostree cancel`",
-                         title);
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_BUSY,
+                   "Transaction in progress: %s\n You can cancel the current transaction "
+                   "with `rpm-ostree cancel`",
+                   title);
+      return FALSE;
     }
   *out_compat_txn = NULL;
   return TRUE;


### PR DESCRIPTION
Use G_IO_ERROR_BUSY for "Transaction in progress" error, thus the caller
can do specific actions when something else is ongoing.

Closes https://github.com/coreos/rpm-ostree/issues/3070