### PR TITLE
copr: Mark git checkout as safe

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,4 +1,6 @@
 srpm:
+	# similar to https://github.com/actions/checkout/issues/760, but for COPR
+	git config --global --add safe.directory $(shell pwd)
 	./ci/installdeps.sh
 	# fetch tags so `git describe` gives a nice NEVRA when building the RPM
 	git fetch origin --tags


### PR DESCRIPTION
This is similar to 8c6ea612 ("ci: Mark git checkout as safe") but for
COPR. It seems the git checkout is mounted in.

For more information, see:
https://github.com/actions/checkout/issues/760