### PR TITLE
copr: Disable git repo ownership security

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,11 +1,10 @@
 srpm:
 	./ci/installdeps.sh
 	# similar to https://github.com/actions/checkout/issues/760, but for COPR
-	git config --global --add safe.directory $(shell pwd)
+	git config --global --add safe.directory '*'
 	# fetch tags so `git describe` gives a nice NEVRA when building the RPM
 	git fetch origin --tags
 	git submodule update --init --recursive
-	ci/installdeps.sh
 	# Our primary CI build goes via RPM rather than direct to binaries
 	# to better test that path, including our vendored spec file, etc.
 	# The RPM build expects pre-generated bindings, so do that now.


### PR DESCRIPTION
Adding the checkout as a safe directory is not enough. The same issue
happens again for each submodule we have. Rather than listing those
explicitly, let's just disable this security check.

While we're here, drop the duplicate `ci/installdeps.sh` call.