### PR TITLE
rust/fedora-integration: Only download valid packages to replace

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -126,9 +126,13 @@ pub(crate) fn is_src_rpm_arg(arg: &str) -> bool {
 /// RPM URLs we need to fetch, and if so download those URLs and return file
 /// descriptors for the content.
 /// TODO(cxx-rs): This would be slightly more elegant as Result<Option<Vec<i32>>>
-pub(crate) fn client_handle_fd_argument(arg: &str, arch: &str) -> CxxResult<Vec<i32>> {
+pub(crate) fn client_handle_fd_argument(
+    arg: &str,
+    arch: &str,
+    is_replace: bool,
+) -> CxxResult<Vec<i32>> {
     #[cfg(feature = "fedora-integration")]
-    if let Some(fds) = crate::fedora_integration::handle_cli_arg(arg, arch)? {
+    if let Some(fds) = crate::fedora_integration::handle_cli_arg(arg, arch, is_replace)? {
         return Ok(fds.into_iter().map(|f| f.into_raw_fd()).collect());
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -92,7 +92,7 @@ pub mod ffi {
         fn require_system_host_type(t: SystemHostType) -> Result<()>;
         fn is_rpm_arg(arg: &str) -> bool;
         fn client_start_daemon() -> Result<()>;
-        fn client_handle_fd_argument(arg: &str, arch: &str) -> Result<Vec<i32>>;
+        fn client_handle_fd_argument(arg: &str, arch: &str, is_replace: bool) -> Result<Vec<i32>>;
         fn client_render_download_progress(progress: Pin<&mut GVariant>) -> String;
         fn running_in_container() -> bool;
     }
@@ -821,6 +821,7 @@ pub mod ffi {
         fn nevra_to_cache_branch(nevra: &CxxString) -> Result<String>;
         fn get_repodata_chksum_repr(pkg: &mut FFIDnfPackage) -> Result<String>;
         fn rpmts_for_commit(repo: Pin<&mut OstreeRepo>, rev: &str) -> Result<UniquePtr<RpmTs>>;
+        fn rpmdb_package_name_list(dfd: i32, path: String) -> Result<Vec<String>>;
 
         // Methods on RpmTs
         fn packages_providing_file(self: &RpmTs, path: &str) -> Result<Vec<String>>;

--- a/src/app/rpmostree-clientlib.h
+++ b/src/app/rpmostree-clientlib.h
@@ -96,8 +96,8 @@ void rpmostree_print_gpg_info (GVariant *signatures, gboolean verbose, guint max
 void rpmostree_print_package_diffs (GVariant *variant);
 
 gboolean rpmostree_sort_pkgs_strv (const char *const *pkgs, GUnixFDList *fd_list,
-                                   GPtrArray **out_repo_pkgs, GVariant **out_fd_idxs,
-                                   GError **error);
+                                   gboolean is_replace, GPtrArray **out_repo_pkgs,
+                                   GVariant **out_fd_idxs, GError **error);
 
 gboolean rpmostree_update_deployment (
     RPMOSTreeOS *os_proxy, const char *set_refspec, const char *set_revision,

--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -231,7 +231,7 @@ rpmostree_override_builtin_replace (int argc, char **argv, RpmOstreeCommandInvoc
       for (char **it = argv; it && *it; it++)
         {
           auto pkg = *it;
-          CXX_TRY_VAR (fds, rpmostreecxx::client_handle_fd_argument (pkg, basearch), error);
+          CXX_TRY_VAR (fds, rpmostreecxx::client_handle_fd_argument (pkg, basearch, true), error);
           if (fds.size () > 0)
             {
               CXX_TRY_VAR (pkgs, rpmostreecxx::stage_container_rpm_raw_fds (fds), error);

--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -189,7 +189,7 @@ rpmostree_builtin_install (int argc, char **argv, RpmOstreeCommandInvocation *in
       for (char **it = argv; it && *it; it++)
         {
           auto pkg = *it;
-          CXX_TRY_VAR (fds, rpmostreecxx::client_handle_fd_argument (pkg, basearch), error);
+          CXX_TRY_VAR (fds, rpmostreecxx::client_handle_fd_argument (pkg, basearch, false), error);
           if (fds.size () > 0)
             {
               CXX_TRY_VAR (pkgs, rpmostreecxx::stage_container_rpm_raw_fds (fds), error);

--- a/src/libpriv/rpmostree-rpm-util.cxx
+++ b/src/libpriv/rpmostree-rpm-util.cxx
@@ -1266,6 +1266,30 @@ rpmostree_create_rpmdb_pkglist_variant (int dfd, const char *path, GVariant **ou
   return TRUE;
 }
 
+namespace rpmostreecxx
+{
+rust::Vec<rust::String>
+rpmdb_package_name_list (gint32 dfd, rust::String path)
+{
+  g_autoptr (GError) local_error = NULL;
+  g_autoptr (RpmOstreeRefSack) refsack
+      = rpmostree_get_refsack_for_root (dfd, path.c_str (), &local_error);
+  if (!refsack)
+    throw std::runtime_error (local_error->message);
+
+  rust::Vec<rust::String> r;
+  g_autoptr (GPtrArray) pkglist = rpmostree_sack_get_sorted_packages (refsack->sack);
+  const guint n = pkglist->len;
+  for (guint i = 0; i < n; i++)
+    {
+      auto pkg = static_cast<DnfPackage *> (pkglist->pdata[i]);
+      r.push_back (rust::String (dnf_package_get_name (pkg)));
+    }
+
+  return r;
+}
+}
+
 /* Simple wrapper around hy_split_nevra() that adds allow-none and GError convention */
 gboolean
 rpmostree_decompose_nevra (const char *nevra, char **out_name, /* allow-none */

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -39,6 +39,7 @@ namespace rpmostreecxx
 rust::String nevra_to_cache_branch (const std::string &nevra);
 rust::String get_repodata_chksum_repr (DnfPackage &pkg);
 std::unique_ptr<RpmTs> rpmts_for_commit (OstreeRepo &repo, rust::Str rev);
+rust::Vec<rust::String> rpmdb_package_name_list (gint32 dfd, rust::String path);
 }
 
 // C code follows

--- a/tests/kolainst/destructive/layering-fedorainfra
+++ b/tests/kolainst/destructive/layering-fedorainfra
@@ -18,4 +18,14 @@ rpm-ostree cleanup -p
 # *or* injecting it from the build container)
 rpm-ostree override replace https://koji.fedoraproject.org/koji/buildinfo?buildID=1671410
 
+n_systemd_installed=$(rpm -qa | grep ^systemd | wc -l)
+rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2022-0bbb402870 |& tee out.txt
+n_systemd_downloaded=$(grep Downloading out.txt | wc -l)
+n_systemd_replaced=$(rpm-ostree db diff | grep systemd | wc -l)
+if [[ $n_systemd_installed != $n_systemd_downloaded ]]; then
+  fatal "Found $n_systemd_installed installed systemd pkgs, but $n_systemd_downloaded downloaded"
+elif [[ $n_systemd_installed != $n_systemd_replaced ]]; then
+  fatal "Found $n_systemd_installed installed systemd pkgs, but $n_systemd_replaced replaced"
+fi
+
 echo "ok"


### PR DESCRIPTION
Right now, when applying overrides from Bodhi or Koji, we just download
all the packages, regardless of whether they're valid replacements or
not. This leads to lots of wasted I/O and inactive overrides.

Enhance things so that override replacements are now filtered down so
that only RPMs that are applicable to the base are downloaded. Implement
this for both the client-side and container paths.