### PR TITLE
rust: Tighten `unsafe` scope to just `from_glib_full`

### DIFF
--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -213,15 +213,13 @@ pub async fn container_encapsulate(args: &[&str]) -> Result<()> {
     let pkglist = {
         let repo = repo.gobj_rewrap();
         let cancellable = gio::Cancellable::new();
-        unsafe {
-            let r = crate::ffi::package_variant_list_for_commit(
-                repo,
-                rev.as_str(),
-                cancellable.gobj_rewrap(),
-            )?;
-            let r: glib::Variant = glib::translate::from_glib_full(r as *mut _);
-            r
-        }
+        let r = crate::ffi::package_variant_list_for_commit(
+            repo,
+            rev.as_str(),
+            cancellable.gobj_rewrap(),
+        )?;
+        let r: glib::Variant = unsafe { glib::translate::from_glib_full(r as *mut _) };
+        r
     };
 
     // Open the RPM database for this commit.

--- a/rust/src/fedora_integration.rs
+++ b/rust/src/fedora_integration.rs
@@ -237,15 +237,13 @@ fn get_base_package_list() -> Result<HashSet<String>> {
         let repo = repo.gobj_rewrap();
         let pkglist = {
             let cancellable = gio::Cancellable::new();
-            unsafe {
-                let r = crate::ffi::package_variant_list_for_commit(
-                    repo,
-                    checksum.as_str(),
-                    cancellable.gobj_rewrap(),
-                )?;
-                let r: glib::Variant = glib::translate::from_glib_full(r as *mut _);
-                r
-            }
+            let r = crate::ffi::package_variant_list_for_commit(
+                repo,
+                checksum.as_str(),
+                cancellable.gobj_rewrap(),
+            )?;
+            let r: glib::Variant = unsafe { glib::translate::from_glib_full(r as *mut _) };
+            r
         };
         Ok(pkglist
             .iter()


### PR DESCRIPTION
The rest isn't unsafe.