### PR TITLE
rust/libdnf: fix some implicit pointer conversions

### DIFF
--- a/rust/libdnf-sys/cxx/libdnf.cxx
+++ b/rust/libdnf-sys/cxx/libdnf.cxx
@@ -28,13 +28,13 @@ namespace dnfcxx
 std::unique_ptr<DnfPackage>
 dnf_package_from_ptr (FFIDnfPackage *pkg) noexcept
 {
-  return std::make_unique<DnfPackage> (g_object_ref (pkg));
+  return std::make_unique<DnfPackage> ((FFIDnfPackage *)g_object_ref (pkg));
 }
 
 std::unique_ptr<DnfRepo>
 dnf_repo_from_ptr (FFIDnfRepo *repo) noexcept
 {
-  return std::make_unique<DnfRepo> (g_object_ref (repo));
+  return std::make_unique<DnfRepo> ((FFIDnfRepo *)g_object_ref (repo));
 }
 
 std::unique_ptr<DnfSack>


### PR DESCRIPTION
This fixes two void-to-type implicit pointer conversions, which gcc
reports as warnings like this:

```
cxx/libdnf.hpp:77:24: note:   initializing argument 1 of ‘dnfcxx::DnfRepo::DnfRepo(dnfcxx::FFIDnfRepo*)’
    77 |   DnfRepo (FFIDnfRepo *repo) : repo (repo) {}
[...]
invalid conversion from ‘void*’ to ‘dnfcxx::FFIDnfRepo*’ {aka ‘_DnfRepo*’} [-fpermissive]
```

Follow up to https://github.com/coreos/rpm-ostree/pull/3670.

/cc @jlebon 
