### PR TITLE
rust/scripts: Ignore `kernel-automotive-core.posttrans`

### DIFF
--- a/rust/src/scripts.rs
+++ b/rust/src/scripts.rs
@@ -18,9 +18,11 @@ use phf::phf_set;
 static IGNORED_PKG_SCRIPTS: phf::Set<&'static str> = phf_set! {
     "glibc.prein",
     // We take over depmod/dracut etc.  It's `kernel` in C7 and kernel-core in F25+
+    // XXX: we should probably change this to instead ignore based on the kernel virtual Provides
     "kernel.posttrans",
     "kernel-core.posttrans",
     "kernel-debug-core.posttrans",
+    "kernel-automotive-core.posttrans",
     // Additionally ignore posttrans scripts for the Oracle Linux `kernel-uek` package
     "kernel-uek.posttrans",
     // Legacy workaround


### PR DESCRIPTION
Yet another kernel package variant whose %posttrans we want to ignore.

As mentioned in there, I think we should change the strategy so that we
detect kernel packages like we do in the core based on its `Provides` to
know to ignore %posttrans.

Alternatively/additionally, we should work with kernel and systemd teams
so that e.g. it short-circuits if it detects an "offline" system. That
would also benefit containers, which AFAIK even today runs dracut on
kernel installs.

Closes: #3720