### PR TITLE
rust: Add "reborrow" API, use for live path (+1 cancellable bit)

### DIFF
--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -662,10 +662,10 @@ pub fn composepost_nsswitch_altfiles(rootfs_dfd: i32) -> CxxResult<()> {
 /// few rpm-ostree compat symlinks just directly write tmpfiles.d dropins.
 pub fn convert_var_to_tmpfiles_d(
     rootfs_dfd: i32,
-    mut cancellable: Pin<&mut crate::FFIGCancellable>,
+    cancellable: &crate::FFIGCancellable,
 ) -> CxxResult<()> {
     let rootfs = unsafe { crate::ffiutil::ffi_dirfd(rootfs_dfd)? };
-    let cancellable = &cancellable.gobj_wrap();
+    let cancellable = &cancellable.glib_reborrow();
 
     // TODO(lucab): unify this logic with the one in rpmostree-importer.cxx.
     var_to_tmpfiles(&rootfs, Some(cancellable))?;

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -153,7 +153,7 @@ pub(crate) fn deployment_populate_variant(
     dict.insert("booted", &booted);
 
     let live_state =
-        crate::live::get_live_apply_state(sysroot.gobj_rewrap(), deployment.gobj_rewrap())?;
+        crate::live::get_live_apply_state(sysroot.reborrow_cxx(), deployment.reborrow_cxx())?;
     if !live_state.inprogress.is_empty() {
         dict.insert("live-inprogress", &live_state.inprogress.as_str());
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -229,10 +229,7 @@ pub mod ffi {
             unified_core: bool,
         ) -> Result<()>;
         fn compose_postprocess_final(rootfs_dfd: i32) -> Result<()>;
-        fn convert_var_to_tmpfiles_d(
-            rootfs_dfd: i32,
-            cancellable: Pin<&mut GCancellable>,
-        ) -> Result<()>;
+        fn convert_var_to_tmpfiles_d(rootfs_dfd: i32, cancellable: &GCancellable) -> Result<()>;
         fn rootfs_prepare_links(rootfs_dfd: i32) -> Result<()>;
         fn workaround_selinux_cross_labeling(
             rootfs_dfd: i32,
@@ -614,18 +611,15 @@ pub mod ffi {
     // live.rs
     extern "Rust" {
         fn get_live_apply_state(
-            sysroot: Pin<&mut OstreeSysroot>,
-            deployment: Pin<&mut OstreeDeployment>,
+            sysroot: &OstreeSysroot,
+            deployment: &OstreeDeployment,
         ) -> Result<LiveApplyState>;
         fn has_live_apply_state(
-            sysroot: Pin<&mut OstreeSysroot>,
-            deployment: Pin<&mut OstreeDeployment>,
+            sysroot: &OstreeSysroot,
+            deployment: &OstreeDeployment,
         ) -> Result<bool>;
         fn applylive_sync_ref(sysroot: Pin<&mut OstreeSysroot>) -> Result<()>;
-        fn transaction_apply_live(
-            sysroot: Pin<&mut OstreeSysroot>,
-            target: Pin<&mut GVariant>,
-        ) -> Result<()>;
+        fn transaction_apply_live(sysroot: &OstreeSysroot, target: &GVariant) -> Result<()>;
     }
 
     // passwd.rs

--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -338,11 +338,11 @@ fn rerun_tmpfiles() -> Result<()> {
 
 /// Implementation of `rpm-ostree ex apply-live`.
 pub(crate) fn transaction_apply_live(
-    mut sysroot: Pin<&mut crate::ffi::OstreeSysroot>,
-    mut options: Pin<&mut crate::ffi::GVariant>,
+    sysroot: &crate::ffi::OstreeSysroot,
+    options: &crate::ffi::GVariant,
 ) -> CxxResult<()> {
-    let sysroot = &sysroot.gobj_wrap();
-    let options = &options.gobj_wrap();
+    let sysroot = &sysroot.glib_reborrow();
+    let options = &options.glib_reborrow();
     let options = &glib::VariantDict::new(Some(options));
     let target = &options
         .lookup::<String>(OPT_TARGET)
@@ -543,11 +543,11 @@ mod test {
 }
 
 pub(crate) fn get_live_apply_state(
-    mut sysroot: Pin<&mut crate::ffi::OstreeSysroot>,
-    mut deployment: Pin<&mut crate::ffi::OstreeDeployment>,
+    sysroot: &crate::ffi::OstreeSysroot,
+    deployment: &crate::ffi::OstreeDeployment,
 ) -> CxxResult<LiveApplyState> {
-    let sysroot = sysroot.gobj_wrap();
-    let deployment = deployment.gobj_wrap();
+    let sysroot = sysroot.glib_reborrow();
+    let deployment = deployment.glib_reborrow();
     let repo = &sysroot.repo().unwrap();
     if let Some(state) = get_live_state(repo, &deployment)? {
         Ok(state)
@@ -557,8 +557,8 @@ pub(crate) fn get_live_apply_state(
 }
 
 pub(crate) fn has_live_apply_state(
-    sysroot: Pin<&mut crate::ffi::OstreeSysroot>,
-    deployment: Pin<&mut crate::ffi::OstreeDeployment>,
+    sysroot: &crate::ffi::OstreeSysroot,
+    deployment: &crate::ffi::OstreeDeployment,
 ) -> CxxResult<bool> {
     let state = get_live_apply_state(sysroot, deployment)?;
     Ok(!(state.commit.is_empty() && state.inprogress.is_empty()))


### PR DESCRIPTION
I was going to do some further oxidation and as I was typing out the
whole `Pin<&mut T>` thing again I was thinking about how in other
places we were passing plain Rust references i.e. `&Foo` not
`Pin<&mut Foo>`.

With this, it works fine to pass borrowed glib-rs types across via
cxx-rs.  I am not totally sure how I got it into my head originally
that we needed `Pin<&mut T>` here.

In particular, this case of C/C++ → Rust is basically the same as
the use case of GObject signals (e.g. Rust GTK+ application catching
a resize signal).  We can use
https://docs.rs/glib/latest/glib/translate/trait.FromGlibPtrBorrow.html
which is designed for this.

Another way to look at this is: We don't need to bump the gobject
reference count here - we have the Rust lifetime rules to protect us.

The `Pin<&mut T>` bits for cxx-rs are designed to map to
C++ mutable vs `const`, but that doesn't apply at all to plain C where
`const` is even more useless than in C++, and hence the glib-rs Rust
code just passes everything as shared `&` references and not `&mut`.

After this lands I think we can slowly convert the rest of our FFI
to use this, and drop most of the `Pin<&mut T>` bits.

I started out testing this by changing one random `GCancellable` bit
in composepost, but then decided to try a full port of the `live.rs`
API.
