### PR TITLE
core: Two small oxidation patches

### DIFF
--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -116,7 +116,7 @@ cxxrs_bind!(
     Ostree,
     ostree,
     ostree::ffi,
-    [Deployment, Repo, RepoTransactionStats, Sysroot]
+    [Deployment, Repo, RepoTransactionStats, SePolicy, Sysroot]
 );
 cxxrs_bind!(G, glib, glib::gobject_ffi, [Object]);
 cxxrs_bind!(G, gio, gio::ffi, [Cancellable, DBusConnection, FileInfo]);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -217,6 +217,8 @@ pub mod ffi {
 
         fn commit_has_matching_sepolicy(commit: &GVariant, policy: &OstreeSePolicy)
             -> Result<bool>;
+
+        fn get_header_variant(repo: &OstreeRepo, cachebranch: &str) -> Result<*mut GVariant>;
     }
 
     // composepost.rs

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -52,6 +52,7 @@ pub mod ffi {
         type OstreeRepo = crate::FFIOstreeRepo;
         type OstreeRepoTransactionStats = crate::FFIOstreeRepoTransactionStats;
         type OstreeSysroot = crate::FFIOstreeSysroot;
+        type OstreeSePolicy = crate::FFIOstreeSePolicy;
         type GObject = crate::FFIGObject;
         type GCancellable = crate::FFIGCancellable;
         type GDBusConnection = crate::FFIGDBusConnection;
@@ -191,6 +192,7 @@ pub mod ffi {
         Container,
     }
 
+    // core.rs
     extern "Rust" {
         type TempEtcGuard;
         type FilesystemScriptPrep;
@@ -212,6 +214,9 @@ pub mod ffi {
 
         fn stage_container_rpms(rpms: Vec<String>) -> Result<Vec<String>>;
         fn stage_container_rpm_raw_fds(fds: Vec<i32>) -> Result<Vec<String>>;
+
+        fn commit_has_matching_sepolicy(commit: &GVariant, policy: &OstreeSePolicy)
+            -> Result<bool>;
     }
 
     // composepost.rs

--- a/src/libpriv/rpmostree-cxxrs-prelude.h
+++ b/src/libpriv/rpmostree-cxxrs-prelude.h
@@ -30,6 +30,7 @@ typedef ::OstreeDeployment OstreeDeployment;
 typedef ::OstreeRepo OstreeRepo;
 typedef ::OstreeRepoTransactionStats OstreeRepoTransactionStats;
 typedef ::OstreeSysroot OstreeSysroot;
+typedef ::OstreeSePolicy OstreeSePolicy;
 typedef ::GObject GObject;
 typedef ::GCancellable GCancellable;
 typedef ::GDBusConnection GDBusConnection;


### PR DESCRIPTION
core: Oxidize commit_has_matching_sepolicy

No specific motivation, just noticed that this one is relatively
easy (no libdnf bits).

---

core: Oxidize get_header_variant

No specific motivation, just keeping up momentum.

---

