### PR TITLE
rust: Drop a few more `Pin<&mut T>`

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -539,7 +539,7 @@ pub mod ffi {
         fn rpmdb_backend_is_target(&self) -> bool;
         fn should_normalize_rpmdb(&self) -> bool;
         fn get_files_remove_regex(&self, package: &str) -> Vec<String>;
-        fn get_checksum(&self, repo: Pin<&mut OstreeRepo>) -> Result<String>;
+        fn get_checksum(&self, repo: &OstreeRepo) -> Result<String>;
         fn get_ostree_ref(&self) -> String;
         fn get_repo_packages(&self) -> &[RepoPackage];
         fn clear_repo_packages(&mut self);
@@ -592,7 +592,7 @@ pub mod ffi {
         fn sealed_memfd(description: &str, content: &[u8]) -> Result<i32>;
         fn running_in_systemd() -> bool;
         fn calculate_advisories_diff(
-            repo: Pin<&mut OstreeRepo>,
+            repo: &OstreeRepo,
             checksum_from: &str,
             checksum_to: &str,
         ) -> Result<*mut GVariant>;
@@ -618,7 +618,7 @@ pub mod ffi {
             sysroot: &OstreeSysroot,
             deployment: &OstreeDeployment,
         ) -> Result<bool>;
-        fn applylive_sync_ref(sysroot: Pin<&mut OstreeSysroot>) -> Result<()>;
+        fn applylive_sync_ref(sysroot: &OstreeSysroot) -> Result<()>;
         fn transaction_apply_live(sysroot: &OstreeSysroot, target: &GVariant) -> Result<()>;
     }
 

--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -25,7 +25,6 @@ use rayon::prelude::*;
 use std::borrow::Cow;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
 
 /// GVariant `s`: Choose a specific commit
 pub(crate) const OPT_TARGET: &str = "target";
@@ -507,10 +506,8 @@ pub(crate) fn transaction_apply_live(
 /// Writing a ref for the live-apply state can get out of sync
 /// if we upgrade.  This prunes the ref if the booted deployment
 /// doesn't have a live apply state in /run.
-pub(crate) fn applylive_sync_ref(
-    mut sysroot: Pin<&mut crate::ffi::OstreeSysroot>,
-) -> CxxResult<()> {
-    let sysroot = sysroot.gobj_wrap();
+pub(crate) fn applylive_sync_ref(sysroot: &crate::ffi::OstreeSysroot) -> CxxResult<()> {
+    let sysroot = sysroot.glib_reborrow();
     let repo = &sysroot.repo().unwrap();
     let booted = if let Some(b) = sysroot.booted_deployment() {
         b

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -35,7 +35,6 @@ use std::io::prelude::*;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
 use std::str::FromStr;
 use std::{fs, io};
 use tracing::{event, instrument, Level};
@@ -1417,11 +1416,8 @@ impl Treefile {
         print_experimental_notice(self.parsed.base.lockfile_repos.is_some(), "lockfile-repos");
     }
 
-    pub(crate) fn get_checksum(
-        &self,
-        mut repo: Pin<&mut crate::ffi::OstreeRepo>,
-    ) -> CxxResult<String> {
-        let repo = &repo.gobj_wrap();
+    pub(crate) fn get_checksum(&self, repo: &crate::ffi::OstreeRepo) -> CxxResult<String> {
+        let repo = &repo.glib_reborrow();
         // Notice we hash the *reserialization* of the final flattened treefile only so that e.g.
         // comments/whitespace/hash table key reorderings don't trigger a respin. We could take
         // this further by using a custom `serialize_with` for Vecs where ordering doesn't matter


### PR DESCRIPTION
Cleanup followup to https://github.com/coreos/rpm-ostree/pull/3723/commits/b2c7bf7fc46de45ef0b0f47e48e9f068e2b81210
