### PR TITLE
cliwrap/dracut: Don't intercept if we're running in systemd

### DIFF
--- a/rust/src/cliwrap/dracut.rs
+++ b/rust/src/cliwrap/dracut.rs
@@ -6,6 +6,11 @@ use crate::cliwrap::cliutil;
 
 /// Primary entrypoint to running our wrapped `dracut` handling.
 pub(crate) fn main(argv: &[&str]) -> Result<()> {
+    // At least kdump.service runs dracut to generate a separate initramfs.
+    // We need to continue supporting that.
+    if crate::utils::running_in_systemd() {
+        return cliutil::exec_real_binary("dracut", argv);
+    }
     eprintln!(
         "This system is rpm-ostree based; initramfs handling is
 integrated with the underlying ostree transaction mechanism.

--- a/tests/kolainst/destructive/cliwrap
+++ b/tests/kolainst/destructive/cliwrap
@@ -45,7 +45,7 @@ if rpm -e bash 2>out.txt; then
 fi
 assert_file_has_content out.txt 'Dropping privileges as `rpm` was executed with not "known safe" arguments'
 
-if dracut --blah 2>out.txt; then
+if env -u INVOCATION_ID dracut 2>out.txt; then
     fatal "dracut worked"
 fi
 assert_file_has_content out.txt 'This system is rpm-ostree based'


### PR DESCRIPTION
This should fix `kdump.service` which we test in FCOS at least.
