### PR TITLE
compose: Make a default treefile instead of using `std::optional`

### DIFF
--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -44,7 +44,6 @@ G_END_DECLS
 
 namespace rpmostreecxx
 {
-gboolean postprocess_final (int rootfs_dfd,
-                            std::optional<std::reference_wrapper<Treefile> > treefile_rs,
-                            gboolean unified_core_mode, GCancellable *cancellable, GError **error);
+gboolean postprocess_final (int rootfs_dfd, Treefile &treefile, gboolean unified_core_mode,
+                            GCancellable *cancellable, GError **error);
 }


### PR DESCRIPTION
For one thing, I nearly fell into the trap that `std::optional<Treefile&>`
is undefined behavior and one needs this weird `reference_wrapper`
thing.

But better, this means that we only have the default values in
*one place* - in `treefile.rs`.  Previously e.g. the code had the
default of `true` for `machineid-compat` in the postprocess bits too.
