### PR TITLE
rust/origin: Drop unnecessary `Pin<&mut T>`

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -716,9 +716,9 @@ pub mod ffi {
 
     // origin.rs
     extern "Rust" {
-        fn origin_to_treefile(kf: Pin<&mut GKeyFile>) -> Result<Box<Treefile>>;
+        fn origin_to_treefile(kf: &GKeyFile) -> Result<Box<Treefile>>;
         fn treefile_to_origin(tf: &Treefile) -> Result<*mut GKeyFile>;
-        fn origin_validate_roundtrip(mut kf: Pin<&mut GKeyFile>);
+        fn origin_validate_roundtrip(kf: &GKeyFile);
     }
 
     // rpmutils.rs

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -15,7 +15,6 @@ use glib::KeyFile;
 use ostree_ext::glib;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::pin::Pin;
 use std::result::Result as StdResult;
 
 use ostree_ext::container::deploy::ORIGIN_CONTAINER;
@@ -108,11 +107,8 @@ pub(crate) fn origin_to_treefile_inner(kf: &KeyFile) -> Result<Box<Treefile>> {
 /// For historical reasons, rpm-ostree has two file formats to represent
 /// state.  This bridges parts of an origin file to a treefile that
 /// is understood by the core.
-pub(crate) fn origin_to_treefile(
-    mut kf: Pin<&mut crate::ffi::GKeyFile>,
-) -> CxxResult<Box<Treefile>> {
-    let kf = kf.gobj_wrap();
-    Ok(origin_to_treefile_inner(&kf)?)
+pub(crate) fn origin_to_treefile(kf: &crate::ffi::GKeyFile) -> CxxResult<Box<Treefile>> {
+    Ok(origin_to_treefile_inner(&kf.glib_reborrow())?)
 }
 
 /// Convert a treefile config to an origin keyfile.
@@ -308,9 +304,8 @@ fn origin_validate_roundtrip_inner(kf: &glib::KeyFile) -> Result<()> {
 /// For historical reasons, rpm-ostree has two file formats to represent
 /// state.  This bridges parts of an origin file to a treefile that
 /// is understood by the core.
-pub(crate) fn origin_validate_roundtrip(mut kf: Pin<&mut crate::ffi::GKeyFile>) {
-    let kf = kf.gobj_wrap();
-    if let Some(e) = origin_validate_roundtrip_inner(&kf).err() {
+pub(crate) fn origin_validate_roundtrip(kf: &crate::ffi::GKeyFile) {
+    if let Some(e) = origin_validate_roundtrip_inner(&kf.glib_reborrow()).err() {
         tracing::debug!("Failed to roundtrip origin: {}", e);
     }
 }


### PR DESCRIPTION
A minor ongoing cleanup.
