### PR TITLE
diff: Drop use of Pin<&mut T> for ostree repo

### DIFF
--- a/rust/src/builtins/apply_live.rs
+++ b/rust/src/builtins/apply_live.rs
@@ -87,8 +87,8 @@ pub(crate) fn applylive_finish(mut sysroot: Pin<&mut crate::ffi::OstreeSysroot>)
     let pkgdiff = {
         cxx::let_cxx_string!(from = booted_commit);
         cxx::let_cxx_string!(to = live_state.commit.as_str());
-        let repo = repo.gobj_rewrap();
-        crate::ffi::rpmdb_diff(repo, &from, &to, false).map_err(anyhow::Error::msg)?
+        crate::ffi::rpmdb_diff(repo.reborrow_cxx(), &from, &to, false)
+            .map_err(anyhow::Error::msg)?
     };
     pkgdiff.print();
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -772,7 +772,7 @@ pub mod ffi {
         fn n_added(&self) -> i32;
         fn n_modified(&self) -> i32;
         fn rpmdb_diff(
-            repo: Pin<&mut OstreeRepo>,
+            repo: &OstreeRepo,
             src: &CxxString,
             dest: &CxxString,
             allow_noent: bool,

--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -431,8 +431,8 @@ pub(crate) fn transaction_apply_live(
     let pkgdiff = {
         cxx::let_cxx_string!(from = source_commit);
         cxx::let_cxx_string!(to = &*target_commit);
-        let repo = repo.gobj_rewrap();
-        crate::ffi::rpmdb_diff(repo, &from, &to, false).map_err(anyhow::Error::msg)?
+        crate::ffi::rpmdb_diff(repo.reborrow_cxx(), &from, &to, false)
+            .map_err(anyhow::Error::msg)?
     };
     if !allow_replacement {
         if pkgdiff.n_removed() > 0 {

--- a/src/libpriv/rpmostree-diff.cxx
+++ b/src/libpriv/rpmostree-diff.cxx
@@ -43,7 +43,8 @@ RPMDiff::~RPMDiff ()
 }
 
 std::unique_ptr<RPMDiff>
-rpmdb_diff (OstreeRepo &repo, const std::string &from, const std::string &to, bool allow_noent)
+rpmdb_diff (const OstreeRepo &repo, const std::string &from, const std::string &to,
+            bool allow_noent)
 {
   g_autoptr (GPtrArray) removed = NULL;
   g_autoptr (GPtrArray) added = NULL;
@@ -55,8 +56,9 @@ rpmdb_diff (OstreeRepo &repo, const std::string &from, const std::string &to, bo
   if (allow_noent)
     flags |= RPM_OSTREE_DB_DIFF_EXT_ALLOW_NOENT;
 
-  if (!rpm_ostree_db_diff_ext (&repo, from.c_str (), to.c_str (), (RpmOstreeDbDiffExtFlags)flags,
-                               &removed, &added, &modified_old, &modified_new, NULL, &local_error))
+  if (!rpm_ostree_db_diff_ext (&const_cast<OstreeRepo &> (repo), from.c_str (), to.c_str (),
+                               (RpmOstreeDbDiffExtFlags)flags, &removed, &added, &modified_old,
+                               &modified_new, NULL, &local_error))
     util::throw_gerror (local_error);
   return std::make_unique<RPMDiff> (removed, added, modified_old, modified_new);
 }

--- a/src/libpriv/rpmostree-diff.hpp
+++ b/src/libpriv/rpmostree-diff.hpp
@@ -60,7 +60,7 @@ private:
   GPtrArray *modified_new_;
 };
 
-std::unique_ptr<RPMDiff> rpmdb_diff (OstreeRepo &repo, const std::string &src,
+std::unique_ptr<RPMDiff> rpmdb_diff (const OstreeRepo &repo, const std::string &src,
                                      const std::string &dest, bool allow_noent);
 
 } /* namespace */


### PR DESCRIPTION
This one is subtle.  Again here, cxx.rs wants to try to match up
rust `&` and `&mut` with C++ `const &` vs `&`.

However...on the C side, we take raw `OstreeRepo *` pointers that
all implicitly support "interior mutability".

We can then (safely AIUI) use `const_cast` to cast away the `const`
that cxx wants to get a reference, which we then turn into a raw
C pointer which is passed to the C side.
