### PR TITLE
kernel: Stop hardcoding `dracut --gzip`

### DIFF
--- a/src/libpriv/rpmostree-kernel.cxx
+++ b/src/libpriv/rpmostree-kernel.cxx
@@ -450,7 +450,7 @@ rpmostree_run_dracut (int rootfs_dfd, const char *const *argv, const char *kver,
                          "set -euo pipefail\n"
                          "export PATH=%s:${PATH}\n"
                          "extra_argv=; if (dracut --help; true) | grep -q -e --reproducible; then "
-                         "extra_argv=\"--reproducible --gzip\"; fi\n"
+                         "extra_argv=\"--reproducible\"; fi\n"
                          "mkdir -p /tmp/dracut && dracut $extra_argv -v --add ostree "
                          "--tmpdir=/tmp/dracut -f /tmp/initramfs.img \"$@\"\n"
                          "cat /tmp/initramfs.img >/proc/self/fd/3\n",


### PR DESCRIPTION
I want to test out using zstd for the initramfs; so let's allow
configuring that by dropping a config file in `/etc/dracut.conf.d`
as intended.

Also, we should default to whatever dracut defaults to; and if
someone e.g. wants to force on something else, they can do that
via injecting `/etc/dracut.conf.d` too.

In current Fedora, the dracut default is still gzip, but compressed
in parallel via `pigz`.
