### PR TITLE
libpriv/rpm-util: remove dead code for signal handling

### DIFF
--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -200,7 +200,6 @@ rpmostree_context_new_base (OstreeRepo *repo)
   rpmsqSetInterruptSafety (FALSE);
 
   self->dnfctx = dnf_context_new ();
-  DECLARE_RPMSIGHANDLER_RESET;
   dnf_context_set_http_proxy (self->dnfctx, g_getenv ("http_proxy"));
 
   dnf_context_set_repo_dir (self->dnfctx, "/etc/yum.repos.d");
@@ -1036,7 +1035,6 @@ rpmostree_context_download_metadata (RpmOstreeContext *self, DnfContextSetupSack
     /* This will check the metadata again, but it *should* hit the cache; down
      * the line we should really improve the libdnf API around all of this.
      */
-    DECLARE_RPMSIGHANDLER_RESET;
     if (!dnf_context_setup_sack_with_flags (self->dnfctx, hifstate, flags, error))
       return FALSE;
     g_signal_handler_disconnect (hifstate, progress_sigid);
@@ -4014,10 +4012,7 @@ rpmostree_context_assemble (RpmOstreeContext *self, GCancellable *cancellable, G
         setup_package = (DnfPackage *)g_object_ref (pkg);
     }
 
-  {
-    DECLARE_RPMSIGHANDLER_RESET;
-    rpmtsOrder (ordering_ts);
-  }
+  rpmtsOrder (ordering_ts);
 
   guint overrides_total = overrides_remove->len + overrides_replace->len;
   const char *progress_msg = "Checking out packages";

--- a/src/libpriv/rpmostree-importer.cxx
+++ b/src/libpriv/rpmostree-importer.cxx
@@ -116,7 +116,6 @@ rpmostree_importer_read_metainfo (int fd, Header *out_header, gsize *out_cpio_of
   gsize ret_cpio_offset;
   g_autofree char *abspath = g_strdup_printf ("/proc/self/fd/%d", fd);
 
-  DECLARE_RPMSIGHANDLER_RESET;
   ts = rpmtsCreate ();
   rpmtsSetVSFlags (ts, _RPMVSF_NOSIGNATURES);
 

--- a/src/libpriv/rpmostree-rpm-util.cxx
+++ b/src/libpriv/rpmostree-rpm-util.cxx
@@ -994,12 +994,6 @@ rpmostree_pkg_array_compare (DnfPackage **p_pkg1, DnfPackage **p_pkg2)
   return dnf_package_cmp (*p_pkg1, *p_pkg2);
 }
 
-void
-rpmostree_sighandler_reset_cleanup (RpmSighandlerResetCleanup *cleanup)
-{
-  /* No-op now that we have rpmsqSetInterruptSafety_ */
-}
-
 static void
 print_pkglist (GPtrArray *pkglist)
 {

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -117,21 +117,6 @@ gint rpmostree_pkg_array_compare (DnfPackage **p_pkg1, DnfPackage **p_pkg2);
 
 void rpmostree_print_transaction (DnfContext *context);
 
-/* This cleanup struct wraps _rpmostree_reset_rpm_sighandlers(). We have a dummy
- * variable to pacify clang's unused variable detection.
- */
-typedef struct
-{
-  gboolean v;
-} RpmSighandlerResetCleanup;
-void rpmostree_sighandler_reset_cleanup (RpmSighandlerResetCleanup *cleanup);
-G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC (RpmSighandlerResetCleanup, rpmostree_sighandler_reset_cleanup);
-
-#define DECLARE_RPMSIGHANDLER_RESET                                                                \
-  __attribute__ ((unused)) g_auto (RpmSighandlerResetCleanup) sigcleanup = {                       \
-    0,                                                                                             \
-  };
-
 GVariant *rpmostree_fcap_to_ostree_xattr (const char *fcap);
 GVariant *rpmostree_fcap_to_xattr_variant (const char *fcap);
 


### PR DESCRIPTION
This removes some dead code related to a signal handling workaround
which was required for older librpm versions. It got altered at the
time when RHEL 7 support got dropped, and what remains of that logic
seems to be effectively a no-op.

Ref: https://github.com/coreos/rpm-ostree/pull/1794