### PR TITLE
Two more: Drop unnecessary `Pin<&mut T>`

### DIFF
--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -210,12 +210,11 @@ pub async fn container_encapsulate(args: &[&str]) -> Result<()> {
     let repo = &opt.repo;
     let (root, rev) = repo.read_commit(opt.ostree_ref.as_str(), gio::NONE_CANCELLABLE)?;
     let pkglist = {
-        let repo = repo.gobj_rewrap();
         let cancellable = gio::Cancellable::new();
         let r = crate::ffi::package_variant_list_for_commit(
-            repo,
+            repo.reborrow_cxx(),
             rev.as_str(),
-            cancellable.gobj_rewrap(),
+            cancellable.reborrow_cxx(),
         )?;
         let r: glib::Variant = unsafe { glib::translate::from_glib_full(r as *mut _) };
         r

--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -222,7 +222,7 @@ pub async fn container_encapsulate(args: &[&str]) -> Result<()> {
     };
 
     // Open the RPM database for this commit.
-    let q = crate::ffi::rpmts_for_commit(repo.gobj_rewrap(), rev.as_str())?;
+    let q = crate::ffi::rpmts_for_commit(repo.reborrow_cxx(), rev.as_str())?;
 
     let mut state = MappingBuilder {
         unpackaged_id: Rc::from(MappingBuilder::UNPACKAGED_ID),

--- a/rust/src/fedora_integration.rs
+++ b/rust/src/fedora_integration.rs
@@ -234,13 +234,12 @@ fn get_base_package_list() -> Result<HashSet<String>> {
             .ok_or_else(|| anyhow::anyhow!("No deployments found"))?;
         let checksum = default.csum().unwrap();
         let repo = sysroot.repo().unwrap();
-        let repo = repo.gobj_rewrap();
         let pkglist = {
             let cancellable = gio::Cancellable::new();
             let r = crate::ffi::package_variant_list_for_commit(
-                repo,
+                repo.reborrow_cxx(),
                 checksum.as_str(),
-                cancellable.gobj_rewrap(),
+                cancellable.reborrow_cxx(),
             )?;
             let r: glib::Variant = unsafe { glib::translate::from_glib_full(r as *mut _) };
             r

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -828,7 +828,7 @@ pub mod ffi {
         #[allow(dead_code)]
         fn nevra_to_cache_branch(nevra: &CxxString) -> Result<String>;
         fn get_repodata_chksum_repr(pkg: &mut FFIDnfPackage) -> Result<String>;
-        fn rpmts_for_commit(repo: Pin<&mut OstreeRepo>, rev: &str) -> Result<UniquePtr<RpmTs>>;
+        fn rpmts_for_commit(repo: &OstreeRepo, rev: &str) -> Result<UniquePtr<RpmTs>>;
         fn rpmdb_package_name_list(dfd: i32, path: String) -> Result<Vec<String>>;
 
         // Methods on RpmTs

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -845,9 +845,9 @@ pub mod ffi {
     unsafe extern "C++" {
         include!("rpmostree-package-variants.h");
         fn package_variant_list_for_commit(
-            repo: Pin<&mut OstreeRepo>,
+            repo: &OstreeRepo,
             rev: &str,
-            cancellable: Pin<&mut GCancellable>,
+            cancellable: &GCancellable,
         ) -> Result<*mut GVariant>;
     }
 }

--- a/rust/src/testutils.rs
+++ b/rust/src/testutils.rs
@@ -278,11 +278,13 @@ pub(crate) fn testutils_entrypoint(args: Vec<String>) -> CxxResult<()> {
 }
 
 fn test_pkg_variants(repo: &ostree::Repo, booted_commit: &str) -> Result<()> {
-    let repo = repo.gobj_rewrap();
     let cancellable = gio::Cancellable::new();
-    let cancellable = cancellable.gobj_rewrap();
     // This returns an a(sssss) as a raw value
-    let v = crate::ffi::package_variant_list_for_commit(repo, booted_commit, cancellable)?;
+    let v = crate::ffi::package_variant_list_for_commit(
+        repo.reborrow_cxx(),
+        booted_commit,
+        cancellable.reborrow_cxx(),
+    )?;
     let v: glib::Variant = unsafe { glib::translate::from_glib_full(v as *mut _) };
     for p in v.iter() {
         let n = p.child_value(0);

--- a/src/daemon/rpmostree-package-variants.cxx
+++ b/src/daemon/rpmostree-package-variants.cxx
@@ -191,13 +191,15 @@ rpm_ostree_db_diff_variant (OstreeRepo *repo, const char *from_rev, const char *
 namespace rpmostreecxx
 {
 GVariant *
-package_variant_list_for_commit (OstreeRepo &repo, rust::Str rev, GCancellable &cancellable)
+package_variant_list_for_commit (const OstreeRepo &repo, rust::Str rev,
+                                 const GCancellable &cancellable)
 {
   g_autoptr (GError) local_error = NULL;
   auto rev_c = std::string (rev);
   g_autoptr (GVariant) ret_v = NULL;
-  if (!_rpm_ostree_package_variant_list_for_commit (&repo, rev_c.c_str (), FALSE, &ret_v,
-                                                    &cancellable, &local_error))
+  if (!_rpm_ostree_package_variant_list_for_commit (
+          &const_cast<OstreeRepo &> (repo), rev_c.c_str (), FALSE, &ret_v,
+          &const_cast<GCancellable &> (cancellable), &local_error))
     util::throw_gerror (local_error);
   return util::move_nullify (ret_v);
 }

--- a/src/daemon/rpmostree-package-variants.h
+++ b/src/daemon/rpmostree-package-variants.h
@@ -45,7 +45,7 @@ G_END_DECLS
 #include "rust/cxx.h"
 namespace rpmostreecxx
 {
-GVariant *package_variant_list_for_commit (OstreeRepo &repo, rust::Str rev,
-                                           GCancellable &cancellable);
+GVariant *package_variant_list_for_commit (const OstreeRepo &repo, rust::Str rev,
+                                           const GCancellable &cancellable);
 }
 #endif

--- a/src/libpriv/rpmostree-rpm-util.cxx
+++ b/src/libpriv/rpmostree-rpm-util.cxx
@@ -1656,12 +1656,13 @@ namespace rpmostreecxx
 {
 
 std::unique_ptr<RpmTs>
-rpmts_for_commit (OstreeRepo &repo, rust::Str rev)
+rpmts_for_commit (const OstreeRepo &repo, rust::Str rev)
 {
   g_autoptr (GError) local_error = NULL;
   RpmOstreeRefTs *refts = NULL;
   auto rev_c = std::string (rev);
-  if (!rpmostree_get_refts_for_commit (&repo, rev_c.c_str (), &refts, NULL, &local_error))
+  if (!rpmostree_get_refts_for_commit (&const_cast<OstreeRepo &> (repo), rev_c.c_str (), &refts,
+                                       NULL, &local_error))
     util::throw_gerror (local_error);
 
   return std::make_unique<RpmTs> (refts);

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -38,7 +38,7 @@ namespace rpmostreecxx
 {
 rust::String nevra_to_cache_branch (const std::string &nevra);
 rust::String get_repodata_chksum_repr (DnfPackage &pkg);
-std::unique_ptr<RpmTs> rpmts_for_commit (OstreeRepo &repo, rust::Str rev);
+std::unique_ptr<RpmTs> rpmts_for_commit (const OstreeRepo &repo, rust::Str rev);
 rust::Vec<rust::String> rpmdb_package_name_list (gint32 dfd, rust::String path);
 }
 


### PR DESCRIPTION
rpmutil: Drop unnecessary `Pin<&mut T>`

Minor ongoing cleanup.

---

lib: Drop unnecessary `Pin<&mut T>` from package variant API

Minor ongoing cleanup.

---

