### PR TITLE
more Drop use of `Pin<&mut T>`

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -11,7 +11,6 @@ use cap_std_ext::rustix;
 use gio::prelude::*;
 use ostree_ext::{gio, glib};
 use std::os::unix::io::IntoRawFd;
-use std::pin::Pin;
 use std::process::Command;
 
 /// The well-known bus name.
@@ -197,11 +196,9 @@ pub(crate) fn client_start_daemon() -> CxxResult<()> {
 }
 
 /// Convert the GVariant parameters from the DownloadProgress DBus API to a human-readable English string.
-pub(crate) fn client_render_download_progress(
-    mut progress: Pin<&mut crate::ffi::GVariant>,
-) -> String {
-    let progress = progress.gobj_wrap();
+pub(crate) fn client_render_download_progress(progress: &crate::ffi::GVariant) -> String {
     let progress = progress
+        .glib_reborrow()
         .get::<(
             (u64, u64),
             (u32, u32),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -356,16 +356,12 @@ pub mod ffi {
         fn rpmfi_overrides_contains(self: &RpmImporter, path: &str) -> bool;
         fn rpmfi_overrides_get(self: &RpmImporter, path: &str) -> u64;
         fn is_ima_enabled(self: &RpmImporter) -> bool;
-        fn tweak_imported_file_info(self: &RpmImporter, mut file_info: Pin<&mut GFileInfo>);
-        fn is_file_filtered(
-            self: &RpmImporter,
-            path: &str,
-            mut file_info: Pin<&mut GFileInfo>,
-        ) -> Result<bool>;
+        fn tweak_imported_file_info(self: &RpmImporter, mut file_info: &GFileInfo);
+        fn is_file_filtered(self: &RpmImporter, path: &str, file_info: &GFileInfo) -> Result<bool>;
         fn translate_to_tmpfiles_entry(
             self: &mut RpmImporter,
             abs_path: &str,
-            mut file_info: Pin<&mut GFileInfo>,
+            file_info: &GFileInfo,
             username: &str,
             groupname: &str,
         ) -> Result<()>;
@@ -374,7 +370,7 @@ pub mod ffi {
 
         fn tmpfiles_translate(
             abs_path: &str,
-            mut file_info: Pin<&mut GFileInfo>,
+            file_info: &GFileInfo,
             username: &str,
             groupname: &str,
         ) -> Result<String>;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -94,7 +94,7 @@ pub mod ffi {
         fn is_rpm_arg(arg: &str) -> bool;
         fn client_start_daemon() -> Result<()>;
         fn client_handle_fd_argument(arg: &str, arch: &str, is_replace: bool) -> Result<Vec<i32>>;
-        fn client_render_download_progress(progress: Pin<&mut GVariant>) -> String;
+        fn client_render_download_progress(progress: &GVariant) -> String;
         fn running_in_container() -> bool;
     }
 


### PR DESCRIPTION
rust/client: Drop use of Pin<&mut T>

Part of an ongoing cleanup.

---

rust/importer: Drop use of `Pin<&mut T>`

Part of an ongoing cleanup.

---

