### PR TITLE
Various remote override handling tweaks

### DIFF
--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -105,7 +105,7 @@ handle_override (RPMOSTreeSysroot *sysroot_proxy, RpmOstreeCommandInvocation *in
   if (!opt_experimental && (opt_freeze || opt_from))
     return glnx_throw (error, "Must specify --experimental to use --freeze or --from");
 
-  if (override_replace && opt_freeze && opt_from)
+  if (override_replace && opt_from)
     {
       override_replace_final = g_ptr_array_new_with_free_func (free);
       g_autoptr (GPtrArray) queries = g_ptr_array_new ();
@@ -117,11 +117,15 @@ handle_override (RPMOSTreeSysroot *sysroot_proxy, RpmOstreeCommandInvocation *in
           if (rpmostreecxx::is_http_arg (pkg) || rpmostreecxx::is_rpm_arg (pkg))
             {
               g_ptr_array_add (override_replace_final, (gpointer)g_strdup (pkg));
-              continue;
+            }
+          // if the pkg is a valid nevra, then treat it as frozen
+          else if (opt_freeze || rpmostree_is_valid_nevra (pkg))
+            {
+              g_ptr_array_add (queries, (gpointer)pkg);
             }
           else
             {
-              g_ptr_array_add (queries, (gpointer)pkg);
+              return glnx_throw (error, "CLI remote overrides not supported yet");
             }
         }
       if (queries->len > 0)

--- a/src/daemon/rpmostreed-os-experimental.cxx
+++ b/src/daemon/rpmostreed-os-experimental.cxx
@@ -252,8 +252,11 @@ prepare_download_pkgs_txn (const gchar *const *queries, const char *source,
       if (g_unix_fd_list_append (fd_list, fd, error) < 0)
         return FALSE;
 
-      if (!glnx_unlinkat (AT_FDCWD, path, 0, error))
-        return FALSE;
+      if (!rpmostree_pkg_is_local (pkg))
+        {
+          if (!glnx_unlinkat (AT_FDCWD, path, 0, error))
+            return FALSE;
+        }
     }
 
   *out_fd_list = util::move_nullify (fd_list);

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1368,6 +1368,10 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
 
       for (char **it = override_reset_pkgs; it && *it; it++)
         {
+          /* remote overrides support only pkgnames and no nevras are mapped, so try it first */
+          if (rpmostree_origin_remove_override_replace (origin, *it))
+            continue; /* override found; move on to the next one */
+
           const char *name_or_nevra = *it;
           auto name
               = static_cast<const char *> (g_hash_table_lookup (nevra_to_name, name_or_nevra));
@@ -1396,9 +1400,6 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
             continue; /* override found; move on to the next one */
 
           if (rpmostree_origin_remove_override_replace_local (origin, nevra))
-            continue; /* override found; move on to the next one */
-
-          if (rpmostree_origin_remove_override_replace (origin, name))
             continue; /* override found; move on to the next one */
 
           return glnx_throw (error, "No overrides for package '%s'", name_or_nevra);

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -1984,32 +1984,26 @@ rpmostree_context_prepare (RpmOstreeContext *self, GCancellable *cancellable, GE
         case rpmostreecxx::OverrideReplacementType::Repo:
           {
             const char *repo = override_replace.from.c_str ();
-            for (auto &pkg : override_replace.packages)
+            for (auto &pkgname_s : override_replace.packages)
               {
-                g_auto (HySubject) subject = hy_subject_create (pkg.c_str ());
-                HyNevra nevra = NULL;
-                // We don't support provides or filenames: we need a concrete package name that
-                // matches the base. Nevras or partial nevras (e.g. foobar.x86_64 or foobar-1.2) are
-                // supported.
-                hy_autoquery HyQuery query = hy_subject_get_best_solution (
-                    subject, sack, NULL, &nevra, FALSE, TRUE, FALSE, FALSE, FALSE);
-                if (!nevra)
-                  return glnx_throw (error, "Failed to parse selector: %s", pkg.c_str ());
-                auto pkgname = nevra->getName ();
-                // this should never happen, but just in case
-                if (pkgname.empty ())
-                  return glnx_throw (error, "Invalid subject '%s': no package name found",
-                                     pkg.c_str ());
+                // We only support pkgnames here. The use case for partial names (e.g. foo-1.2-3) is
+                // dubious; once the repo is updated past that, upgrades would fail. It also
+                // complicates inactive override handling and the UX for resetting overrides.
+                // Instead we should look at in the future implementing "smart remote overrides"
+                // which automatically drop out once a pkg reached a certain version.
+                const char *pkgname = pkgname_s.c_str ();
+                hy_autoquery HyQuery query = hy_query_create (sack);
                 hy_query_filter (query, HY_PKG_REPONAME, HY_EQ, repo);
+                hy_query_filter (query, HY_PKG_NAME, HY_EQ, pkgname);
                 g_autoptr (DnfPackageSet) pset = hy_query_run_set (query);
                 if (dnf_packageset_count (pset) == 0)
-                  return glnx_throw (error, "No matches for '%s' in repo '%s'", pkg.c_str (), repo);
+                  return glnx_throw (error, "No matches for '%s' in repo '%s'", pkgname, repo);
                 g_auto (HySelector) selector = hy_selector_create (sack);
                 hy_selector_pkg_set (selector, pset);
                 if (!hy_goal_install_selector (goal, selector, error))
                   return FALSE;
                 map_or (pinned_pkgs_map, dnf_packageset_get_map (pset));
-                g_ptr_array_add (replaced_pkgnames, g_strdup (pkgname.c_str ()));
+                g_ptr_array_add (replaced_pkgnames, g_strdup (pkgname));
               }
           }
           break;

--- a/src/libpriv/rpmostree-rpm-util.cxx
+++ b/src/libpriv/rpmostree-rpm-util.cxx
@@ -1322,6 +1322,12 @@ rpmostree_decompose_nevra (const char *nevra, char **out_name, /* allow-none */
   return TRUE;
 }
 
+gboolean
+rpmostree_is_valid_nevra (const char *subject)
+{
+  return rpmostree_decompose_nevra (subject, NULL, NULL, NULL, NULL, NULL, NULL);
+}
+
 /* translates NEVRA to its cache branch */
 namespace rpmostreecxx
 {

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -179,6 +179,8 @@ gboolean rpmostree_decompose_nevra (const char *nevra, char **out_name, /* allow
                                     char **out_arch,                    /* allow-none */
                                     GError **error);
 
+gboolean rpmostree_is_valid_nevra (const char *subject);
+
 gboolean rpmostree_nevra_to_cache_branch (const char *nevra, char **cache_branch, GError **error);
 
 GPtrArray *rpmostree_get_enabled_rpmmd_repos (DnfContext *dnfctx, DnfRepoEnabled enablement);

--- a/tests/kolainst/destructive/override-pinning
+++ b/tests/kolainst/destructive/override-pinning
@@ -45,6 +45,15 @@ assert_file_has_content status.txt 'ReplacedBasePackages: zincati .* -> 99.99-3'
 rpmostree_assert_status \
   '.deployments[0]["base-local-replacements"]|length == 1' \
   '.deployments[0]["requested-base-local-replacements"]|length == 1'
+# try it again, but using its NEVRA
+# this also tests that we didn't delete the RPM
+rpm-ostree cleanup -p
+rpm-ostree override replace zincati-99.99-3.x86_64 --experimental --from repo=test-repo
+rpm-ostree status > status.txt
+assert_file_has_content status.txt 'ReplacedBasePackages: zincati .* -> 99.99-3'
+rpmostree_assert_status \
+  '.deployments[0]["base-local-replacements"]|length == 1' \
+  '.deployments[0]["requested-base-local-replacements"]|length == 1'
 /tmp/autopkgtest-reboot "1"
 ;;
 "1")

--- a/tests/vmcheck/install.sh
+++ b/tests/vmcheck/install.sh
@@ -24,7 +24,10 @@ pkgs="libsolv libmodulemd"
 if rpm -q zchunk-libs 2>/dev/null; then
     pkgs="${pkgs} zchunk-libs"
 fi
-for pkg in ostree{,-libs,-grub2} ${pkgs}; do
+if rpm -q ostree-grub2 2>/dev/null; then
+    pkgs="${pkgs} ostree-grub2"
+fi
+for pkg in ostree{,-libs} ${pkgs}; do
 
     rpm -q $pkg
 


### PR DESCRIPTION
```
commit 5b3cee5a8a5b95f85c38d4ce5ab8a2768a1b8f49
Date:   Fri Jun 10 13:31:24 2022 -0400

    app/override: Always treat NEVRA as frozen

    If we're given a NEVRA and `--from`, handle it right away as a frozen
    local override instead of converting it to a remote override (which
    we'll add client-side support for soon).

    A NEVRA pin is functionally the same as a local override after the repo
    fetching, and it's silly to always try to refetch the same NEVRA from
    the remote every upgrade.
```
---
```
commit 11eb8054b9207e6a54dba782a74106d49c34f8d5
Date:   Fri Jun 10 13:31:25 2022 -0400

    core: Support package names only for remote overrides

    Initially, I wanted to support remote overrides with partial package
    names, e.g. NEVR and NEV. However, I don't think the use case is strong
    enough combining with remote overrides to warrant the additional
    complexity it involves.

    Validation and inactive override handling will be much simpler if we
    just require the exact package name to be overridden to be passed.

    Note that NEVRAs are supported and translated into local overrides (see
    previous patch).
```