### PR TITLE
daemon: Add `treefile` modifier to `UpdateDeployment`

### DIFF
--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -2543,6 +2543,14 @@ pub(crate) enum RemoteOverrideReplaceFrom {
     Repo(String),
 }
 
+impl std::fmt::Display for RemoteOverrideReplaceFrom {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            RemoteOverrideReplaceFrom::Repo(r) => write!(f, "repo={}", r),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct RemoteOverrideReplace {

--- a/src/app/rpmostree-builtin-deploy.cxx
+++ b/src/app/rpmostree-builtin-deploy.cxx
@@ -174,6 +174,7 @@ rpmostree_builtin_deploy (int argc, char **argv, RpmOstreeCommandInvocation *inv
                                             NULL,                 /* override remove */
                                             NULL,                 /* override reset */
                                             NULL,                 /* local_repo_remote */
+                                            NULL,                 /* treefile */
                                             options, &transaction_address, cancellable, error))
             return FALSE;
         }

--- a/src/app/rpmostree-builtin-rebase.cxx
+++ b/src/app/rpmostree-builtin-rebase.cxx
@@ -196,12 +196,12 @@ rpmostree_builtin_rebase (int argc, char **argv, RpmOstreeCommandInvocation *inv
   if (install_pkgs || uninstall_pkgs || local_repo_remote)
     {
       if (!rpmostree_update_deployment (os_proxy, new_provided_refspec, revision, install_pkgs,
-                                        NULL,                 /* install_fileoverride_pkgs */
-                                        uninstall_pkgs, NULL, /* override replace */
-                                        NULL,                 /* override remove */
-                                        NULL,                 /* override reset */
-                                        local_repo_remote, options, &transaction_address,
-                                        cancellable, error))
+                                        NULL,                    /* install_fileoverride_pkgs */
+                                        uninstall_pkgs, NULL,    /* override replace */
+                                        NULL,                    /* override remove */
+                                        NULL,                    /* override reset */
+                                        local_repo_remote, NULL, /* treefile */
+                                        options, &transaction_address, cancellable, error))
         return FALSE;
     }
   else

--- a/src/app/rpmostree-builtin-reset.cxx
+++ b/src/app/rpmostree-builtin-reset.cxx
@@ -97,8 +97,8 @@ rpmostree_builtin_reset (int argc, char **argv, RpmOstreeCommandInvocation *invo
   g_autoptr (GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
   if (!rpmostree_update_deployment (os_proxy, NULL, NULL, install_pkgs, NULL, uninstall_pkgs, NULL,
-                                    NULL, NULL, NULL, options, &transaction_address, cancellable,
-                                    error))
+                                    NULL, NULL, NULL, NULL, options, &transaction_address,
+                                    cancellable, error))
     return FALSE;
 
   return rpmostree_transaction_client_run (invocation, sysroot_proxy, os_proxy, options, FALSE,

--- a/src/app/rpmostree-builtin-upgrade.cxx
+++ b/src/app/rpmostree-builtin-upgrade.cxx
@@ -183,6 +183,7 @@ rpmostree_builtin_upgrade (int argc, char **argv, RpmOstreeCommandInvocation *in
                                             NULL,                 /* override remove */
                                             NULL,                 /* override reset */
                                             NULL,                 /* local_repo_remote */
+                                            NULL,                 /* treefile */
                                             options, &transaction_address, cancellable, error))
             return FALSE;
         }

--- a/src/app/rpmostree-clientlib.h
+++ b/src/app/rpmostree-clientlib.h
@@ -104,8 +104,8 @@ gboolean rpmostree_update_deployment (
     const char *const *install_pkgs, const char *const *install_fileoverride_pkgs,
     const char *const *uninstall_pkgs, const char *const *override_replace_pkgs,
     const char *const *override_remove_pkgs, const char *const *override_reset_pkgs,
-    const char *local_repo_remote, GVariant *options, char **out_transaction_address,
-    GCancellable *cancellable, GError **error);
+    const char *local_repo_remote, const char *treefile, GVariant *options,
+    char **out_transaction_address, GCancellable *cancellable, GError **error);
 
 gboolean rpmostree_print_diff_advisories (GVariant *rpm_diff, GVariant *advisories,
                                           gboolean verbose, gboolean verbose_advisories,

--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -160,7 +160,7 @@ handle_override (RPMOSTreeSysroot *sysroot_proxy, RpmOstreeCommandInvocation *in
                                     NULL,               /* set-revision */
                                     install_pkgs, NULL, /* install_fileoverride_pkgs */
                                     uninstall_pkgs, override_replace, override_remove,
-                                    override_reset, NULL, options, &transaction_address,
+                                    override_reset, NULL, NULL, options, &transaction_address,
                                     cancellable, error))
     return FALSE;
 

--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -137,6 +137,7 @@ pkg_change (RpmOstreeCommandInvocation *invocation, RPMOSTreeSysroot *sysroot_pr
                                         NULL, /* override remove */
                                         NULL, /* override reset */
                                         NULL, /* local_repo_remote */
+                                        NULL, /* treefile */
                                         options, &transaction_address, cancellable, error))
         return FALSE;
     }

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -345,6 +345,7 @@
          "override-replace-packages" (type 'as')
          "override-replace-local-packages" (type 'ah')
          "custom-origin" (type '(ss)')
+         "treefile" (type 's')
 
          Available options:
          "apply-live" (type 'b')

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1439,6 +1439,9 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
         }
       changed = TRUE;
     }
+  auto treefile = (const char *)vardict_lookup_ptr (self->modifiers, "treefile", "&s");
+  if (treefile && !rpmostree_origin_merge_treefile (origin, treefile, &changed, error))
+    return FALSE;
 
   rpmostree_sysroot_upgrader_set_origin (upgrader, origin);
 

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -423,3 +423,13 @@ rpmostree_origin_remove_all_overrides (RpmOstreeOrigin *origin)
   auto changed = (*origin->treefile)->remove_all_overrides ();
   return changed;
 }
+
+/* Mutability: setter */
+gboolean
+rpmostree_origin_merge_treefile (RpmOstreeOrigin *origin, const char *treefile,
+                                 gboolean *out_changed, GError **error)
+{
+  CXX_TRY_VAR (changed, (*origin->treefile)->merge_treefile (treefile), error);
+  set_changed (out_changed, changed);
+  return TRUE;
+}

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -134,3 +134,6 @@ gboolean rpmostree_origin_remove_override_replace_local (RpmOstreeOrigin *origin
 gboolean rpmostree_origin_remove_override_replace (RpmOstreeOrigin *origin, const char *package);
 
 gboolean rpmostree_origin_remove_all_overrides (RpmOstreeOrigin *origin);
+
+gboolean rpmostree_origin_merge_treefile (RpmOstreeOrigin *origin, const char *treefile,
+                                          gboolean *out_changed, GError **error);


### PR DESCRIPTION
This new modifier will allow us to pass through future modifiers in
native treefile format rather than having to add separate modifiers each
time. Now that the origin is treefile-backed, it's a simple matter of
merging in the given treefile.