### PR TITLE
tests/override-pinning: Adapt to latest expected output

### DIFF
--- a/tests/kolainst/destructive/override-pinning
+++ b/tests/kolainst/destructive/override-pinning
@@ -50,7 +50,7 @@ rpmostree_assert_status \
 rpm-ostree cleanup -p
 rpm-ostree override replace zincati-99.99-3.x86_64 --experimental --from repo=test-repo
 rpm-ostree status > status.txt
-assert_file_has_content status.txt 'ReplacedBasePackages: zincati .* -> 99.99-3'
+assert_file_has_content status.txt 'LocalOverrides: zincati .* -> 99.99-3'
 rpmostree_assert_status \
   '.deployments[0]["base-local-replacements"]|length == 1' \
   '.deployments[0]["requested-base-local-replacements"]|length == 1'


### PR DESCRIPTION
PR #3757 renamed `ReplacedBasePackages` to `LocalOverrides` and PR #3758
independently added a new test which expects the old output. Fix it.

Classic semantic merge conflict[1].

[1] https://bors.tech/essay/2017/02/02/pitch/