### PR TITLE
composepost: Use `cap-std`'s `fs_utf8`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d684df5773e4af5c343c466f47151db7e7a4366daab609b4a6bb7a75aecf732"
 dependencies = [
+ "camino",
  "cap-primitives",
  "io-extras",
  "io-lifetimes 0.5.1",
@@ -2108,6 +2109,7 @@ dependencies = [
  "bitflags",
  "c_utf8",
  "camino",
+ "cap-std",
  "cap-std-ext",
  "cap-tempfile",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ bitflags = "1.3"
 c_utf8 = "0.1.0"
 camino = "1.0.9"
 cap-std-ext = "0.25"
+cap-std = { version = "0.24", features = ["fs_utf8"] }
 cap-tempfile = "0.24.4"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = { version = "3.2.4", features = ["derive"] }


### PR DESCRIPTION
This cleans up and centralizes pathname conversions and error
handling; we don't care about handling non-UTF-8 paths in any way,
we should just (gracefully) error out.
