### PR TITLE
Final prep patches for remote overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,4 +111,5 @@
 /tests/check/test-lib-introspection.sh.log
 /tests/check/test-lib-introspection.sh.test
 /tests/check/test-lib-introspection.sh.trs
+/tests/kola
 _libs

--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -131,14 +131,7 @@ handle_override (RPMOSTreeSysroot *sysroot_proxy, RpmOstreeCommandInvocation *in
       if (queries->len > 0)
         {
           g_ptr_array_add (queries, NULL);
-          g_autofree char *refresh_transaction_address = NULL;
 
-          if (!rpmostree_os_call_refresh_md_sync (os_proxy, options, &refresh_transaction_address,
-                                                  cancellable, error))
-            return FALSE;
-          if (!rpmostree_transaction_get_response_sync (
-                  sysroot_proxy, (const char *)refresh_transaction_address, cancellable, error))
-            return FALSE;
           if (!rpmostree_osexperimental_call_download_packages_sync (
                   osexperimental_proxy, (const char *const *)queries->pdata, opt_from, NULL,
                   &fetched_rpms_fds, cancellable, error))

--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -76,8 +76,7 @@ handle_override (RPMOSTreeSysroot *sysroot_proxy, RpmOstreeCommandInvocation *in
                  const char *const *override_reset, GCancellable *cancellable, GError **error)
 {
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
-  RPMOSTreeOSExperimental *osexperimental_proxy = NULL;
-
+  glnx_unref_object RPMOSTreeOSExperimental *osexperimental_proxy = NULL;
   if (!rpmostree_load_os_proxies (sysroot_proxy, opt_osname, cancellable, &os_proxy,
                                   &osexperimental_proxy, error))
     return FALSE;

--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -21,6 +21,7 @@
 #include "config.h"
 
 #include "rpmostree-container.h"
+#include "rpmostree-core.h"
 #include "rpmostree-libbuiltin.h"
 #include "rpmostree-override-builtins.h"
 
@@ -71,6 +72,60 @@ static GOptionEntry remove_option_entries[] = { { "replace", 0, 0, G_OPTION_ARG_
                                                 { NULL } };
 
 static gboolean
+sort_replacements (RPMOSTreeOSExperimental *osexperimental_proxy,
+                   const char *const *replacement_args, char ***out_local,
+                   GUnixFDList **out_fd_list, GCancellable *cancellable, GError **error)
+{
+  g_autoptr (GPtrArray) local = g_ptr_array_new_with_free_func (g_free);
+  g_autoptr (GPtrArray) freeze = g_ptr_array_new_with_free_func (g_free);
+  for (const char *const *it = replacement_args; it && *it; it++)
+    {
+      auto arg = *it;
+      if (rpmostreecxx::is_http_arg (arg) || rpmostreecxx::is_rpm_arg (arg))
+        {
+          g_ptr_array_add (local, (gpointer)g_strdup (arg));
+        }
+      // if the pkg is a valid nevra, then treat it as frozen
+      else if (opt_freeze || rpmostree_is_valid_nevra (arg))
+        {
+          g_ptr_array_add (freeze, (gpointer)g_strdup (arg));
+        }
+      else
+        {
+          glnx_throw (error, "Remote overrides are not supported yet on the CLI");
+        }
+    }
+
+  g_autoptr (GUnixFDList) fd_list = NULL;
+  if (freeze->len > 0)
+    {
+      g_ptr_array_add (freeze, NULL);
+
+      /* this is really just a D-Bus wrapper around `rpmostree_find_and_download_packages` */
+      if (!rpmostree_osexperimental_call_download_packages_sync (
+              osexperimental_proxy, (const char *const *)freeze->pdata, opt_from, NULL, &fd_list,
+              cancellable, error))
+        return FALSE;
+
+      int nfds;
+      const int *fds = g_unix_fd_list_peek_fds (fd_list, &nfds);
+      for (guint i = 0; i < nfds; i++)
+        g_ptr_array_add (local, g_strdup_printf ("file:///proc/self/fd/%d", fds[i]));
+    }
+
+  if (local->len > 0)
+    {
+      g_ptr_array_add (local, NULL);
+      *out_local = (char **)g_ptr_array_free (util::move_nullify (local), FALSE);
+    }
+  else
+    *out_local = NULL;
+
+  *out_fd_list = util::move_nullify (fd_list);
+  return TRUE;
+}
+
+static gboolean
 handle_override (RPMOSTreeSysroot *sysroot_proxy, RpmOstreeCommandInvocation *invocation,
                  const char *const *override_remove, const char *const *override_replace,
                  const char *const *override_reset, GCancellable *cancellable, GError **error)
@@ -81,58 +136,21 @@ handle_override (RPMOSTreeSysroot *sysroot_proxy, RpmOstreeCommandInvocation *in
                                   &osexperimental_proxy, error))
     return FALSE;
 
-  g_autoptr (GUnixFDList) fetched_rpms_fds = NULL;
-  g_autoptr (GPtrArray) override_replace_final = NULL;
-
   if (!opt_experimental && (opt_freeze || opt_from))
     return glnx_throw (error, "Must specify --experimental to use --freeze or --from");
 
+  g_autoptr (GUnixFDList) fd_list = NULL; /* this is just used to own the fds */
+
+  /* By default, we assume all the args are local overrides. If --from is used, we have to sort them
+   * first to handle --freeze and (eventually) remote overrides. */
+  g_auto (GStrv) override_replace_local = NULL;
   if (override_replace && opt_from)
     {
-      override_replace_final = g_ptr_array_new_with_free_func (free);
-      g_autoptr (GPtrArray) queries = g_ptr_array_new ();
+      if (!sort_replacements (osexperimental_proxy, override_replace, &override_replace_local,
+                              &fd_list, cancellable, error))
+        return FALSE;
 
-      for (const char *const *it = override_replace; it && *it; it++)
-        {
-          auto pkg = *it;
-
-          if (rpmostreecxx::is_http_arg (pkg) || rpmostreecxx::is_rpm_arg (pkg))
-            {
-              g_ptr_array_add (override_replace_final, (gpointer)g_strdup (pkg));
-            }
-          // if the pkg is a valid nevra, then treat it as frozen
-          else if (opt_freeze || rpmostree_is_valid_nevra (pkg))
-            {
-              g_ptr_array_add (queries, (gpointer)pkg);
-            }
-          else
-            {
-              return glnx_throw (error, "CLI remote overrides not supported yet");
-            }
-        }
-      if (queries->len > 0)
-        {
-          g_ptr_array_add (queries, NULL);
-
-          if (!rpmostree_osexperimental_call_download_packages_sync (
-                  osexperimental_proxy, (const char *const *)queries->pdata, opt_from, NULL,
-                  &fetched_rpms_fds, cancellable, error))
-            return FALSE;
-
-          const int nfds = fetched_rpms_fds ? g_unix_fd_list_get_length (fetched_rpms_fds) : 0;
-          g_assert_cmpuint (nfds, >, 0);
-
-          for (guint i = 0; i < nfds; i++)
-            {
-              gint fd = g_unix_fd_list_get (fetched_rpms_fds, i, error);
-              if (fd < 0)
-                return FALSE;
-              g_ptr_array_add (override_replace_final,
-                               g_strdup_printf ("file:///proc/self/fd/%d", fd));
-            }
-          g_ptr_array_add (override_replace_final, NULL);
-          override_replace = (const char *const *)override_replace_final->pdata;
-        }
+      override_replace = override_replace_local;
     }
 
   /* Perform uninstalls offline; users don't expect the "auto-update" behaviour here. But

--- a/src/daemon/rpmostreed-os-experimental.cxx
+++ b/src/daemon/rpmostreed-os-experimental.cxx
@@ -171,16 +171,12 @@ static gboolean
 prepare_download_pkgs_txn (const gchar *const *queries, const char *source,
                            GUnixFDList **out_fd_list, GError **error)
 {
-  GUnixFDList *fd_list = NULL;
-  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
-
   if (!queries || !*queries)
     return glnx_throw (error, "No queries passed");
 
   OstreeSysroot *sysroot = rpmostreed_sysroot_get_root (rpmostreed_sysroot_get ());
   OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment (sysroot);
   const char *osname = ostree_deployment_get_osname (booted_deployment);
-  g_autoptr (GPtrArray) dnf_pkgs = g_ptr_array_new_with_free_func (g_object_unref);
 
   g_autoptr (OstreeDeployment) cfg_merge_deployment
       = ostree_sysroot_get_merge_deployment (sysroot, osname);
@@ -191,73 +187,14 @@ prepare_download_pkgs_txn (const gchar *const *queries, const char *source,
   g_autofree char *origin_deployment_root
       = rpmostree_get_deployment_root (sysroot, origin_merge_deployment);
 
-  OstreeRepo *repo = ostree_sysroot_repo (sysroot);
-  g_autoptr (RpmOstreeContext) ctx = rpmostree_context_new_client (repo);
-  rpmostree_context_set_dnf_caching (ctx, RPMOSTREE_CONTEXT_DNF_CACHE_FOREVER);
-  /* We could bypass rpmostree_context_setup() here and call dnf_context_setup() ourselves
-   * since we're not actually going to perform any installation. Though it does provide us
-   * with the right semantics for install/source_root. */
+  g_autofree char *cfg_deployment_root
+      = rpmostree_get_deployment_root (sysroot, cfg_merge_deployment);
 
-  if (!rpmostree_context_setup (ctx, NULL, origin_deployment_root, cancellable, error))
-    return glnx_prefix_error (error, "Setting up dnf context");
-
-  /* point libdnf to our repos dir */
-  rpmostree_context_configure_from_deployment (ctx, sysroot, cfg_merge_deployment);
-
-  if (!rpmostree_context_download_metadata (ctx, DNF_CONTEXT_SETUP_SACK_FLAG_SKIP_RPMDB,
-                                            cancellable, error))
-    return glnx_prefix_error (error, "Downloading metadata");
-
-  DnfSack *sack = dnf_context_get_sack (rpmostree_context_get_dnf (ctx));
-  CXX_TRY_VAR (parsed_source, rpmostreecxx::parse_override_source (source), error);
-
-  if (parsed_source.kind == rpmostreecxx::OverrideReplacementType::Repo)
-    {
-      const char *source_name = parsed_source.name.c_str ();
-      for (const char *const *it = queries; it && *it; it++)
-        {
-          auto pkg_name = static_cast<const char *> (*it);
-          g_autoptr (GPtrArray) pkglist = NULL;
-          HyNevra nevra = NULL;
-          g_auto (HySubject) subject = hy_subject_create (pkg_name);
-          hy_autoquery HyQuery query = hy_subject_get_best_solution (
-              subject, sack, NULL, &nevra, FALSE, TRUE, TRUE, TRUE, FALSE);
-          hy_query_filter (query, HY_PKG_REPONAME, HY_EQ, source_name);
-          pkglist = hy_query_run (query);
-          if (!pkglist || pkglist->len == 0)
-            return glnx_throw (error, "No matches for \"%s\" in repo '%s'", pkg_name, source_name);
-
-          g_ptr_array_add (dnf_pkgs, g_object_ref (pkglist->pdata[0]));
-        }
-    }
-  /* Future source kinds go here */
-  else
-    return glnx_throw (error, "Unsupported source type");
-
-  rpmostree_set_repos_on_packages (rpmostree_context_get_dnf (ctx), dnf_pkgs);
-
-  if (!rpmostree_download_packages (dnf_pkgs, cancellable, error))
-    return glnx_prefix_error (error, "Downloading packages");
-
-  fd_list = g_unix_fd_list_new ();
-  for (unsigned int i = 0; i < dnf_pkgs->len; i++)
-    {
-      DnfPackage *pkg = static_cast<DnfPackage *> (dnf_pkgs->pdata[i]);
-      const gchar *path = dnf_package_get_filename (pkg);
-      gint fd = -1;
-
-      if (!glnx_openat_rdonly (AT_FDCWD, path, TRUE, &fd, error))
-        return FALSE;
-
-      if (g_unix_fd_list_append (fd_list, fd, error) < 0)
-        return FALSE;
-
-      if (!rpmostree_pkg_is_local (pkg))
-        {
-          if (!glnx_unlinkat (AT_FDCWD, path, 0, error))
-            return FALSE;
-        }
-    }
+  g_autoptr (GUnixFDList) fd_list = NULL;
+  g_autoptr (GCancellable) cancellable = g_cancellable_new ();
+  if (!rpmostree_find_and_download_packages (queries, source, origin_deployment_root,
+                                             cfg_deployment_root, &fd_list, cancellable, error))
+    return FALSE;
 
   *out_fd_list = util::move_nullify (fd_list);
   return TRUE;

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -144,6 +144,11 @@ GPtrArray *rpmostree_context_get_packages_to_import (RpmOstreeContext *self);
 gboolean rpmostree_context_set_lockfile (RpmOstreeContext *self, char **lockfiles, gboolean strict,
                                          GError **error);
 
+gboolean rpmostree_find_and_download_packages (const char *const *packages, const char *source,
+                                               const char *source_root, const char *repo_root,
+                                               GUnixFDList **out_fd_list, GCancellable *cancellable,
+                                               GError **error);
+
 gboolean rpmostree_download_packages (GPtrArray *packages, GCancellable *cancellable,
                                       GError **error);
 

--- a/src/libpriv/rpmostree-origin.cxx
+++ b/src/libpriv/rpmostree-origin.cxx
@@ -160,6 +160,13 @@ rpmostree_origin_has_overrides_remove_name (RpmOstreeOrigin *origin, const char 
 }
 
 /* Mutability: getter */
+rust::Vec<rpmostreecxx::OverrideReplacement>
+rpmostree_origin_get_overrides_replace (RpmOstreeOrigin *origin)
+{
+  return (*origin->treefile)->get_packages_override_replace ();
+}
+
+/* Mutability: getter */
 rust::Vec<rust::String>
 rpmostree_origin_get_overrides_local_replace (RpmOstreeOrigin *origin)
 {

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -54,6 +54,9 @@ rust::Vec<rust::String> rpmostree_origin_get_overrides_remove (RpmOstreeOrigin *
 
 bool rpmostree_origin_has_overrides_remove_name (RpmOstreeOrigin *origin, const char *name);
 
+rust::Vec<rpmostreecxx::OverrideReplacement>
+rpmostree_origin_get_overrides_replace (RpmOstreeOrigin *origin);
+
 rust::Vec<rust::String> rpmostree_origin_get_overrides_local_replace (RpmOstreeOrigin *origin);
 
 rust::String rpmostree_origin_get_override_commit (RpmOstreeOrigin *origin);

--- a/src/libpriv/rpmostree-rpm-util.cxx
+++ b/src/libpriv/rpmostree-rpm-util.cxx
@@ -1207,6 +1207,15 @@ rpmostree_sack_get_by_pkgname (DnfSack *sack, const char *pkgname, DnfPackage **
   return TRUE;
 }
 
+gboolean
+rpmostree_sack_has_pkgname (DnfSack *sack, const char *pkgname)
+{
+  g_autoptr (DnfPackage) pkg = NULL;
+  if (rpmostree_sack_get_by_pkgname (sack, pkgname, &pkg, NULL) && pkg)
+    return TRUE;
+  return FALSE;
+}
+
 GPtrArray *
 rpmostree_sack_get_packages (DnfSack *sack)
 {

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -146,6 +146,8 @@ gboolean rpmostree_sack_has_subject (DnfSack *sack, const char *pattern);
 gboolean rpmostree_sack_get_by_pkgname (DnfSack *sack, const char *pkgname, DnfPackage **out_pkg,
                                         GError **error);
 
+gboolean rpmostree_sack_has_pkgname (DnfSack *sack, const char *pkgname);
+
 GPtrArray *rpmostree_sack_get_packages (DnfSack *sack);
 
 GPtrArray *rpmostree_sack_get_sorted_packages (DnfSack *sack);

--- a/tests/kolainst/destructive/override-pinning
+++ b/tests/kolainst/destructive/override-pinning
@@ -35,6 +35,24 @@ EOF
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
 "")
 
+# try an invalid source
+if rpm-ostree override replace zincati --experimental --freeze --from foo=bar 2>err.txt; then
+  assert_not_reached "Successfully replaced from source foo=bar?"
+fi
+assert_file_has_content_literal err.txt 'Parsing override source'
+
+# try an invalid repo
+if rpm-ostree override replace zincati --experimental --freeze --from repo=enoent 2>err.txt; then
+  assert_not_reached "Successfully replaced from source repo=enoent?"
+fi
+assert_file_has_content_literal err.txt 'No matches'
+
+# try a non-existent package
+if rpm-ostree override replace enoent --experimental --freeze --from repo=test-repo 2>err.txt; then
+  assert_not_reached "Successfully replaced non-existent package?"
+fi
+assert_file_has_content_literal err.txt 'No matches'
+
 # query and fetch for the lastest version of a package from enabled repos
 rpmostree_assert_status \
   '.deployments[0]["base-local-replacements"]|length == 0' \


### PR DESCRIPTION
Split out of https://github.com/coreos/rpm-ostree/pull/3636. That should be the last of them!

See individual commit messages.