### PR TITLE
docs/HACKING: Mention cpio as test dependency

### DIFF
--- a/ci/testdeps.txt
+++ b/ci/testdeps.txt
@@ -4,4 +4,4 @@ createrepo_c rpm-sign
 python3-pyyaml
 libubsan libasan libtsan elfutils fuse sudo python3-gobject-base
 selinux-policy-devel selinux-policy-targeted python3-createrepo_c
-rsync python3-rpm parallel distribution-gpg-keys
+rsync python3-rpm parallel distribution-gpg-keys cpio


### PR DESCRIPTION
The dependencies installed by running `./ci/installdeps.sh` do not
include `cpio`, which is required to pass the `initramfs` test in `make
check`.

Adds a new section to `HACKING.md` that explicitly mentions this.