### PR TITLE
Use `cargo vendor-filterer`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,15 @@ edition = "2021"
 #rust = "1.48"
 links = "rpmostreeinternals"
 
+# See https://github.com/cgwalters/cargo-vendor-filterer
+[package.metadata.vendor-filter]
+platforms = ["x86_64-unknown-linux-gnu"]
+all-features = true
+exclude-crate-paths = [ { name = "curl-sys", exclude = "curl" },
+                        { name = "libz-sys", exclude = "src/zlib" },
+                        { name = "libz-sys", exclude = "src/zlib-ng" },
+                      ]
+
 # This currently needs to duplicate the libraries in configure.ac
 # until we unify on Cargo as our build system
 [package.metadata.system-deps]

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -19,3 +19,4 @@ fi
 CXX_VER=$(cargo metadata --format-version 1 | jq -r '.packages[]|select(.name == "cxx").version')
 mkdir -p target
 time cargo install --root=target/cxxbridge cxxbridge-cmd --version "${CXX_VER}"
+time cargo install --root=target/cargo-vendor-filterer cargo-vendor-filterer --version ^0.5


### PR DESCRIPTION
I spent some time on https://github.com/cgwalters/cargo-vendor-filterer
intending to use it to drop out a lot of ugly stuff like `.a` files
in Windows crates.
