### PR TITLE
rust/src/cliwrap: Add `RPMOSTREE_CLIWRAP_SKIP` to skip cliwraps

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -98,4 +98,14 @@ rpm-ostree override replace $koji_kernel_url
 # test that the new initramfs was generated
 test -f /usr/lib/modules/${kver}-${krev}.fc${versionid}.x86_64/initramfs.img
 
+# test skipping cliwraps
+export RPMOSTREE_CLIWRAP_SKIP=1
+if yum swap foo 2>err.txt; then
+    fatal "skipping cliwrap"
+fi
+if ! grep -qe "error: No such file or directory" err.txt; then
+    cat err.txt
+    fatal "did not find expected error when skipping CLI wraps."
+fi
+
 echo ok

--- a/docs/cliwrap.md
+++ b/docs/cliwrap.md
@@ -27,6 +27,10 @@ To disable: `rpm-ostree deploy --ex-cliwrap=false`
 
 This is just `cliwrap: true` in the treefile.
 
+## Globally Skipping cliwrap via environment variable
+
+To skip cliwrap set the `RPMOSTREE_CLIWRAP_SKIP` enviroment variable with any value.
+
 ## Wrapped commands
 
 ### rpm

--- a/rust/src/cliwrap.rs
+++ b/rust/src/cliwrap.rs
@@ -60,6 +60,11 @@ pub fn entrypoint(args: &[&str]) -> Result<()> {
     // And now these are the args for the command
     let args = &args[1..];
 
+    // Call original binary if environment variable is set
+    if std::env::var_os("RPMOSTREE_CLIWRAP_SKIP").is_some() {
+        return cliutil::exec_real_binary(name, args);
+    }
+
     let host_type = crate::get_system_host_type()?;
     if matches!(
         host_type,


### PR DESCRIPTION
Add environment variable to globally skip cli wraps. This is a follow up of #3689 