### PR TITLE
Only use single-threaded tokio reactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ systemd = "0.10.0"
 tempfile = "3.3.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tokio = { version = "1.16.1", features = ["full"] }
+tokio = { version = "1.16.1", features = ["time", "process", "rt", "net"] }
 xmlrpc = "0.15.1"
 termcolor = "1.1.3"
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -129,7 +129,7 @@ fn inner_main() -> Result<i32> {
     // Gather and pre-process command-line arguments.
     let (callname, args) = gather_cli_args(std::env::args_os())?;
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
+    let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .context("Failed to build tokio runtime")?;


### PR DESCRIPTION
Pairs with https://github.com/ostreedev/ostree-rs-ext/pull/321
and https://github.com/containers/containers-image-proxy-rs/pull/32

I saw https://www.reddit.com/r/rust/comments/v8e9fa/local_async_executors_and_why_they_should_be_the/
go by and I think it's a good argument why one should use single-threaded
tokio by default.

Specifically for rpm-ostree, this takes the daemon down from:

```
[root@cosa-devsh ~]# cat /proc/1759/task/*/comm
rpm-ostree
tokio-runtime-w
tokio-runtime-w
tokio-runtime-w
tokio-runtime-w
tokio-runtime-w
tokio-runtime-w
tokio-runtime-w
tokio-runtime-w
tokio-runtime-w
tokio-runtime-w
tokio-runtime-w
tokio-runtime-w
tokio-runtime-w
tokio-runtime-w
tokio-runtime-w
tokio-runtime-w
tokio-runtime-w
gmain
gdbus
pool-/usr/bin/r
[root@cosa-devsh ~]#
```

To:

```
[root@cosa-devsh ~]# cat /proc/1437/task/*/comm
rpm-ostree
tokio-runtime-w
gmain
gdbus
pool-/usr/bin/r
[root@cosa-devsh ~]#
```

Which seems way better.  A lot less thread stack spam in `t a a bt` in gdb
and in coredumps.
