### PR TITLE
ci: Don't try to install -devel packages on FCOS

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -9,7 +9,7 @@ parallel rpms: {
       shwrap("""RPM_BUILD_NCPUS=${n} CARGO_BUILD_JOBS=${n} ./ci/coreosci-rpmbuild.sh""")
       // make it easy for anyone to download the RPMs
       archiveArtifacts '*.rpm'
-      stash excludes: '*.src.rpm', includes: '*.rpm', name: 'rpms'
+      stash excludes: '*-devel*.rpm,*.src.rpm', includes: '*.rpm', name: 'rpms'
   }
 },
 codestyle: {


### PR DESCRIPTION
The recent changes to coreos-assembler in
https://github.com/coreos/coreos-assembler/pull/2954
broke this, and I think what we were trying to do here should
be fixed.
