### PR TITLE
Use symlink API from cap-primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,6 +2061,7 @@ dependencies = [
  "bitflags",
  "c_utf8",
  "camino",
+ "cap-primitives",
  "cap-std",
  "cap-std-ext",
  "cap-tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ c_utf8 = "0.1.0"
 camino = "1.0.9"
 cap-std-ext = "0.26"
 cap-std = { version = "0.25", features = ["fs_utf8"] }
+cap-primitives = "0.25.1"
 cap-tempfile = "0.25.1"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = { version = "3.2.6", features = ["derive"] }

--- a/rust/src/capstdext.rs
+++ b/rust/src/capstdext.rs
@@ -6,11 +6,9 @@
 use cap_std::fs::DirBuilder;
 use cap_std_ext::cap_std;
 use cap_std_ext::cap_std::fs::Dir;
-use cap_std_ext::rustix;
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsStr;
 use std::io::Result;
 use std::os::unix::fs::DirBuilderExt;
-use std::os::unix::prelude::OsStringExt;
 use std::path::Path;
 
 pub(crate) fn dirbuilder_from_mode(m: u32) -> DirBuilder {
@@ -36,55 +34,4 @@ pub(crate) fn open_dir_of(
         )
     })?;
     Ok((parent, filename))
-}
-
-pub(crate) fn read_link_contents_impl(dir: &Dir, path: &Path) -> Result<OsString> {
-    let parent = path
-        .parent()
-        .filter(|v| !v.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    let dir = dir.open_dir(parent)?;
-    let filename = path.file_name().ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "the source path does not name a file",
-        )
-    })?;
-    let l = rustix::fs::readlinkat(&dir, filename, Vec::new())?;
-    Ok(OsString::from_vec(l.into_bytes()))
-}
-
-// Today cap-std's read_link *also* verifies that the link target doesn't lead outside
-// the filesystem.  I think this is arguably incorrect behavior, but for now let's
-// add an API that does this.
-pub(crate) fn read_link_contents(dir: &Dir, path: impl AsRef<Path>) -> Result<OsString> {
-    read_link_contents_impl(dir, path.as_ref())
-}
-
-#[cfg(test)]
-pub(crate) fn write_link_contents_impl(dir: &Dir, contents: &OsStr, path: &Path) -> Result<()> {
-    let parent = path
-        .parent()
-        .filter(|v| !v.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    let dir = dir.open_dir(parent)?;
-    let filename = path.file_name().ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "the source path does not name a file",
-        )
-    })?;
-    rustix::fs::symlinkat(contents, &dir, filename).map_err(Into::into)
-}
-
-// Today cap-std's read_link *also* verifies that the link target doesn't lead outside
-// the filesystem.  I think this is arguably incorrect behavior, but for now let's
-// add an API that does this.
-#[cfg(test)]
-pub(crate) fn write_read_link_contents(
-    dir: &Dir,
-    original: impl AsRef<OsStr>,
-    path: impl AsRef<Path>,
-) -> Result<()> {
-    write_link_contents_impl(dir, original.as_ref(), path.as_ref())
 }


### PR DESCRIPTION
This drops the copy of the code we have here.  At some point in
the future I may to add the API to cap-std's high level.
