### PR TITLE
lib/rust: Drop two more `Pin<&mut T>`

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -35,8 +35,8 @@ impl ClientConnection {
     /// Create a new connection object.
     pub(crate) fn new() -> Result<Self> {
         let mut conn = crate::ffi::new_client_connection()?;
-        let mut bus_conn = conn.pin_mut().get_connection();
-        let bus_conn = bus_conn.gobj_wrap();
+        let bus_conn = conn.pin_mut().get_connection();
+        let bus_conn = bus_conn.glib_reborrow();
         // This proxy will synchronously load the properties, including Booted that
         // we depend on for the next proxy.
         let sysroot_proxy = gio::DBusProxy::new_sync(

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -144,7 +144,7 @@ pub mod ffi {
     // builtins/apply_live.rs
     extern "Rust" {
         fn applylive_entrypoint(args: &Vec<String>) -> Result<()>;
-        fn applylive_finish(sysroot: Pin<&mut OstreeSysroot>) -> Result<()>;
+        fn applylive_finish(sysroot: &OstreeSysroot) -> Result<()>;
     }
 
     // builtins/compose/
@@ -768,7 +768,7 @@ pub mod ffi {
         #[allow(missing_debug_implementations)]
         type ClientConnection;
         fn new_client_connection() -> Result<UniquePtr<ClientConnection>>;
-        fn get_connection<'a>(self: Pin<&'a mut ClientConnection>) -> Pin<&'a mut GDBusConnection>;
+        fn get_connection<'a>(self: Pin<&'a mut ClientConnection>) -> &'a GDBusConnection;
         fn transaction_connect_progress_sync(&self, address: &str) -> Result<()>;
     }
 

--- a/rust/src/testutils.rs
+++ b/rust/src/testutils.rs
@@ -242,8 +242,8 @@ fn test_moo() -> Result<()> {
     crate::ffi::client_require_root()?;
 
     let mut client_conn = crate::ffi::new_client_connection()?;
-    let mut bus_conn = client_conn.pin_mut().get_connection();
-    let bus_conn = bus_conn.gobj_wrap();
+    let bus_conn = client_conn.pin_mut().get_connection();
+    let bus_conn = bus_conn.glib_reborrow();
 
     let params = Variant::from_tuple(&[true.to_variant()]);
     let reply = &bus_conn.call_sync(

--- a/src/app/rpmostree-clientlib.h
+++ b/src/app/rpmostree-clientlib.h
@@ -44,7 +44,7 @@ public:
   ClientConnection (GDBusConnection *connp) : conn (connp) {}
   ~ClientConnection () { g_clear_object (&conn); }
 
-  GDBusConnection &
+  const GDBusConnection &
   get_connection ()
   {
     return *conn;


### PR DESCRIPTION
Minor ongoing cleanup.
