### PR TITLE
normalization: Port to cap-std

### DIFF
--- a/rust/src/capstdext.rs
+++ b/rust/src/capstdext.rs
@@ -4,16 +4,34 @@
 //  SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use cap_std::fs::DirBuilder;
+use cap_std::io_lifetimes::BorrowedFd;
 use cap_std_ext::cap_std;
 use cap_std_ext::cap_std::fs::Dir;
 use std::ffi::OsStr;
 use std::io::Result;
 use std::os::unix::fs::DirBuilderExt;
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::path::Path;
 
 pub(crate) fn dirbuilder_from_mode(m: u32) -> DirBuilder {
     let mut r = DirBuilder::new();
     r.mode(m);
+    r
+}
+
+#[allow(dead_code)]
+/// Create a new cap-std Dir instance from an openat Dir instance.
+pub(crate) fn from_openat(o: &openat::Dir) -> std::io::Result<Dir> {
+    let o = unsafe { BorrowedFd::borrow_raw(o.as_raw_fd()) };
+    Dir::reopen_dir(&o)
+}
+
+#[allow(dead_code)]
+/// Create a new openat Dir instance from a cap-std Dir instance.
+pub(crate) fn to_openat(o: &Dir) -> std::io::Result<openat::Dir> {
+    let src = unsafe { openat::Dir::from_raw_fd(o.as_raw_fd()) };
+    let r = src.sub_dir(".");
+    let _ = src.into_raw_fd();
     r
 }
 

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -1109,7 +1109,8 @@ fn rewrite_rpmdb_for_target_inner(rootfs_dfd: &openat::Dir, normalize: bool) -> 
     // Sometimes we can end up with build-to-build variance in the underlying rpmdb
     // files. Attempt to sort that out, if requested.
     if normalize {
-        normalization::normalize_rpmdb(rootfs_dfd, RPMOSTREE_RPMDB_LOCATION)?;
+        let rootfs_dfd = crate::capstdext::from_openat(&rootfs_dfd)?;
+        normalization::normalize_rpmdb(&rootfs_dfd, RPMOSTREE_RPMDB_LOCATION)?;
     }
 
     tempetc.undo()?;


### PR DESCRIPTION
Add some helper conversions from `openat` temporarily.

Part of an ongoing effort.
