### PR TITLE
A few minor patches just to feel alive

### DIFF
--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -530,7 +530,7 @@ fn compose_postprocess_mutate_os_release(
         rootfs_dfd,
         crate::ffi::BubblewrapMutability::Immutable,
     )?;
-    bwrap.append_child_argv(&["realpath", "/etc/os-release"]);
+    bwrap.append_child_argv(["realpath", "/etc/os-release"]);
     let cancellable = &gio::Cancellable::new();
     let cancellable = Some(cancellable);
     let path = bwrap.run_captured(cancellable)?;
@@ -1095,7 +1095,7 @@ fn rewrite_rpmdb_for_target_inner(rootfs_dfd: &openat::Dir, normalize: bool) -> 
 
     // Fork the target rpmdb to write the content from memory to disk
     let mut bwrap = Bubblewrap::new_with_mutability(rootfs_dfd, BubblewrapMutability::RoFiles)?;
-    bwrap.append_child_argv(&["rpmdb", dbpath_arg.as_str(), "--importdb"]);
+    bwrap.append_child_argv(["rpmdb", dbpath_arg.as_str(), "--importdb"]);
     bwrap.take_stdin_fd(dbfd.into_raw_fd());
     let cancellable = gio::Cancellable::new();
     bwrap

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -768,11 +768,7 @@ fn convert_path_to_tmpfiles_d_recurse(
 
         // Workaround for nfs-utils in RHEL7:
         // https://bugzilla.redhat.com/show_bug.cgi?id=1427537
-        let mut retain_entry = false;
-        if meta.is_file() && full_path.starts_with("var/lib/nfs") {
-            retain_entry = true;
-        }
-
+        let retain_entry = meta.is_file() && full_path.starts_with("var/lib/nfs");
         if !retain_entry && !(meta.is_dir() || meta.is_symlink()) {
             rootfs
                 .remove_file_optional(&full_path)

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -191,8 +191,7 @@ fn verify_kernel_hmac_impl(moddir: &Dir) -> Result<()> {
 
     let hmac_path = ".vmlinuz.hmac";
 
-    let hmac_contents = if let Some(f) = moddir.open_optional(hmac_path)? {
-        let mut f = BufReader::new(f);
+    let hmac_contents = if let Some(mut f) = moddir.open_optional(hmac_path)?.map(BufReader::new) {
         let mut s = String::new();
         f.read_to_string(&mut s)?;
         s

--- a/rust/src/extensions.rs
+++ b/rust/src/extensions.rs
@@ -204,6 +204,7 @@ impl Extensions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
 
     fn base_rpmdb() -> Vec<StringMapping> {
         vec![
@@ -228,7 +229,7 @@ extensions:
         packages:
             - bazboo
 "###;
-        let mut input = std::io::BufReader::new(buf.as_bytes());
+        let mut input = Cursor::new(buf);
         let extensions = extensions_load_stream(&mut input, "x86_64", &base_rpmdb()).unwrap();
         assert!(extensions.get_repos() == vec!["my-repo"]);
         assert!(extensions.get_os_extension_packages() == vec!["bazboo"]);
@@ -273,7 +274,7 @@ extensions:
         packages:
             - foobar
 "###;
-        let mut input = std::io::BufReader::new(buf.as_bytes());
+        let mut input = Cursor::new(buf);
         match extensions_load_stream(&mut input, "x86_64", &base_rpmdb()) {
             Ok(_) => panic!("expected failure from extension in base"),
             Err(ref e) => assert!(e.to_string() == "package foobar already present in base"),

--- a/rust/src/nameservice/group.rs
+++ b/rust/src/nameservice/group.rs
@@ -75,7 +75,7 @@ pub(crate) fn parse_group_content(content: impl BufRead) -> Result<Vec<GroupEntr
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{BufReader, Cursor};
+    use std::io::Cursor;
 
     fn mock_group_entry() -> GroupEntry {
         GroupEntry {
@@ -107,7 +107,7 @@ staff:x:50:operator
 +
 "#;
 
-        let input = BufReader::new(Cursor::new(content));
+        let input = Cursor::new(content);
         let groups = parse_group_content(input).unwrap();
         assert_eq!(groups.len(), 9);
         assert_eq!(groups[8], mock_group_entry());

--- a/rust/src/nameservice/passwd.rs
+++ b/rust/src/nameservice/passwd.rs
@@ -80,7 +80,7 @@ pub(crate) fn parse_passwd_content(content: impl BufRead) -> Result<Vec<PasswdEn
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{BufReader, Cursor};
+    use std::io::Cursor;
 
     fn mock_passwd_entry() -> PasswdEntry {
         PasswdEntry {
@@ -114,7 +114,7 @@ someuser:x:1000:1000:Foo BAR,,,:/home/foobar:/bin/bash
 +
 "#;
 
-        let input = BufReader::new(Cursor::new(content));
+        let input = Cursor::new(content);
         let groups = parse_passwd_content(input).unwrap();
         assert_eq!(groups.len(), 4);
         assert_eq!(groups[3], mock_passwd_entry());

--- a/rust/src/nameservice/shadow.rs
+++ b/rust/src/nameservice/shadow.rs
@@ -110,7 +110,7 @@ pub(crate) fn parse_shadow_content(content: impl BufRead) -> Result<Vec<ShadowEn
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{BufReader, Cursor};
+    use std::io::Cursor;
 
     fn mock_shadow_entry() -> ShadowEntry {
         ShadowEntry {
@@ -140,7 +140,7 @@ systemd-resolve:!!:::::::
 rngd:!!:::::::
 "#;
 
-        let input = BufReader::new(Cursor::new(content));
+        let input = Cursor::new(content);
         let entries = parse_shadow_content(input).unwrap();
         assert_eq!(entries.len(), 6);
         assert_eq!(entries[2], mock_shadow_entry());

--- a/rust/src/normalization.rs
+++ b/rust/src/normalization.rs
@@ -141,7 +141,7 @@ pub(crate) fn normalize_rpmdb(rootfs: &Dir, rpmdb_path: impl AsRef<Path>) -> Res
         &bwrap_rootfs,
         crate::ffi::BubblewrapMutability::Immutable,
     )?;
-    bwrap.append_child_argv(&["rpm", "--eval", "%{_db_backend}"]);
+    bwrap.append_child_argv(["rpm", "--eval", "%{_db_backend}"]);
     let cancellable = gio::Cancellable::new();
     let db_backend = bwrap.run_captured(Some(&cancellable))?;
 
@@ -466,7 +466,7 @@ mod bdb_normalize {
             &bwrap_rootfs,
             crate::ffi::BubblewrapMutability::Immutable,
         )?;
-        verify.append_child_argv(&["db_verify", "-q", path]);
+        verify.append_child_argv(["db_verify", "-q", path]);
         let cancellable = gio::Cancellable::new();
         verify.run_captured(Some(&cancellable))?;
 
@@ -478,7 +478,7 @@ mod bdb_normalize {
             &bwrap_rootfs,
             crate::ffi::BubblewrapMutability::Immutable,
         )?;
-        dump.append_child_argv(&["db_dump", path]);
+        dump.append_child_argv(["db_dump", path]);
         let cancellable = gio::Cancellable::new();
         let digest = sha256(&dump.run_captured(Some(&cancellable))?);
 

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -3670,7 +3670,9 @@ conditional-include:
             let tf = new_test_treefile(workdir.path(), VALID_PRELUDE, None).unwrap();
             tf.write_compose_json(rootdir)?;
         }
-        let mut src = std::io::BufReader::new(rootdir.open_file(COMPOSE_JSON_PATH)?);
+        let mut src = rootdir
+            .open_file(COMPOSE_JSON_PATH)
+            .map(std::io::BufReader::new)?;
         let cfg = treefile_parse_stream(utils::InputFormat::JSON, &mut src, None)?;
         assert_eq!(cfg.base.treeref.unwrap(), "exampleos/x86_64/blah");
         Ok(())


### PR DESCRIPTION
composepost: Drop unnecessary `mut`

We can just directly use the return value of the condition instead
of `if condition { var = true }`.

---

bwrap: Change append API to take an iterator

Just noticed this when I had the code open for something else.
It's more generic/flexible to take an iterator here; that way at least
one caller doesn't need a temporary `Vec`.

---

rust: Use `.map(BufReader::new)` in two places

I find this more readable; either it drops an extra variable,
or lessens the indentation.

---

rust: Just use `Cursor` for reading byte arrays

Wrapping a byte array in a `BufReader` is pointless; as a bonus
also, one can create a `Cursor` directly from a `&str` instead
of needing to invoke `as_bytes()`.

---

