### PR TITLE
A few more patches to drop unnecessary `Pin<&mut T>`

### DIFF
--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -251,7 +251,7 @@ mod test {
         let fd = r.dfd();
         assert_eq!(
             fd,
-            crate::ffi::testutil_validate_cxxrs_passthrough(r.gobj_rewrap())
+            crate::ffi::testutil_validate_cxxrs_passthrough(r.reborrow_cxx())
         );
         Ok(())
     }

--- a/rust/src/deployment_utils.rs
+++ b/rust/src/deployment_utils.rs
@@ -11,8 +11,8 @@ use std::pin::Pin;
 /// Get a currently unique (for this host) identifier for the deployment.
 // TODO - adding the deployment timestamp would make it
 // persistently unique, needs API in libostree.
-pub fn deployment_generate_id(mut deployment: Pin<&mut crate::FFIOstreeDeployment>) -> String {
-    let deployment = deployment.gobj_wrap();
+pub fn deployment_generate_id(deployment: &crate::FFIOstreeDeployment) -> String {
+    let deployment = deployment.glib_reborrow();
     deployment_generate_id_impl(&deployment)
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -299,31 +299,31 @@ pub mod ffi {
 
     // daemon.rs
     extern "Rust" {
-        fn daemon_sanitycheck_environment(sysroot: Pin<&mut OstreeSysroot>) -> Result<()>;
-        fn deployment_generate_id(deployment: Pin<&mut OstreeDeployment>) -> String;
+        fn daemon_sanitycheck_environment(sysroot: &OstreeSysroot) -> Result<()>;
+        fn deployment_generate_id(deployment: &OstreeDeployment) -> String;
         fn deployment_populate_variant(
-            mut sysroot: Pin<&mut OstreeSysroot>,
-            mut deployment: Pin<&mut OstreeDeployment>,
-            mut dict: Pin<&mut GVariantDict>,
+            sysroot: &OstreeSysroot,
+            deployment: &OstreeDeployment,
+            dict: &GVariantDict,
         ) -> Result<()>;
         fn generate_baselayer_refs(
-            mut sysroot: Pin<&mut OstreeSysroot>,
-            mut repo: Pin<&mut OstreeRepo>,
-            cancellable: Pin<&mut GCancellable>,
+            sysroot: &OstreeSysroot,
+            repo: &OstreeRepo,
+            cancellable: &GCancellable,
         ) -> Result<()>;
         fn variant_add_remote_status(
-            mut repo: Pin<&mut OstreeRepo>,
+            repo: &OstreeRepo,
             refspec: &str,
             base_checksum: &str,
-            mut dict: Pin<&mut GVariantDict>,
+            dict: &GVariantDict,
         ) -> Result<()>;
         fn deployment_layeredmeta_from_commit(
-            mut deployment: Pin<&mut OstreeDeployment>,
-            mut commit: Pin<&mut GVariant>,
+            deployment: &OstreeDeployment,
+            commit: &GVariant,
         ) -> Result<DeploymentLayeredMeta>;
         fn deployment_layeredmeta_load(
-            mut repo: Pin<&mut OstreeRepo>,
-            mut deployment: Pin<&mut OstreeDeployment>,
+            repo: &OstreeRepo,
+            deployment: &OstreeDeployment,
         ) -> Result<DeploymentLayeredMeta>;
         fn parse_override_source(source: &str) -> Result<OverrideReplacementSource>;
         fn parse_revision(source: &str) -> Result<ParsedRevision>;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -174,12 +174,12 @@ pub mod ffi {
     // sysroot_upgrade.rs
     extern "Rust" {
         fn pull_container(
-            repo: Pin<&mut OstreeRepo>,
-            cancellable: Pin<&mut GCancellable>,
+            repo: &OstreeRepo,
+            cancellable: &GCancellable,
             imgref: &str,
         ) -> Result<Box<ContainerImageState>>;
         fn query_container_image(
-            repo: Pin<&mut OstreeRepo>,
+            repo: &OstreeRepo,
             imgref: &str,
         ) -> Result<Box<ContainerImageState>>;
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -751,7 +751,7 @@ pub mod ffi {
             version_suffix: &str,
             last_version: &str,
         ) -> Result<String>;
-        fn testutil_validate_cxxrs_passthrough(repo: Pin<&mut OstreeRepo>) -> i32;
+        fn testutil_validate_cxxrs_passthrough(repo: &OstreeRepo) -> i32;
     }
 
     unsafe extern "C++" {

--- a/src/libpriv/rpmostree-util.cxx
+++ b/src/libpriv/rpmostree-util.cxx
@@ -256,9 +256,9 @@ util_next_version (rust::Str auto_version_prefix, rust::Str version_suffix_rs, /
 // A test function to validate that we can pass glib-rs types
 // from Rust back through cxx-rs to C++.
 int
-testutil_validate_cxxrs_passthrough (OstreeRepo &repo) noexcept
+testutil_validate_cxxrs_passthrough (const OstreeRepo &repo) noexcept
 {
-  return ostree_repo_get_dfd (&repo);
+  return ostree_repo_get_dfd (&const_cast<OstreeRepo &> (repo));
 }
 
 } /* namespace */

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -183,7 +183,7 @@ namespace rpmostreecxx
 rust::String util_next_version (rust::Str auto_version_prefix, rust::Str version_suffix,
                                 rust::Str last_version);
 
-int testutil_validate_cxxrs_passthrough (OstreeRepo &repo) noexcept;
+int testutil_validate_cxxrs_passthrough (const OstreeRepo &repo) noexcept;
 
 }
 


### PR DESCRIPTION
lib/daemon: Drop unnecessary Pin<&mut T>

Part of an ongoing effort.

---

lib: Drop one unnecessary Pin<&mut T>

Part of an ongoing effort.

---

lib: Drop a few more unnecessary Pin<&mut T>

Part of an ongoing effort.

---

