### PR TITLE
Give a better error for `ex module` in a container

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -15,6 +15,14 @@ if ! grep -qe "error.*This system was not booted via libostree" err.txt; then
     fatal "did not find expected error"
 fi
 
+if rpm-ostree ex module install foo 2>err.txt; then
+  fatal "module in container"
+fi
+if ! grep -qe 'error.*requires an ostree host system' err.txt; then
+    cat err.txt
+    fatal "did not find expected error"
+fi
+
 origindir=/etc/rpm-ostree/origin.d
 mkdir -p "${origindir}"
 cat > "${origindir}/clienterror.yaml" << 'EOF'

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -34,6 +34,7 @@ pub(crate) struct ClientConnection {
 impl ClientConnection {
     /// Create a new connection object.
     pub(crate) fn new() -> Result<Self> {
+        require_system_host_type(SystemHostType::OstreeHost)?;
         let mut conn = crate::ffi::new_client_connection()?;
         let bus_conn = conn.pin_mut().get_connection();
         let bus_conn = bus_conn.glib_reborrow();
@@ -292,7 +293,7 @@ pub(crate) fn require_system_host_type(expected: SystemHostType) -> CxxResult<()
     if current != expected {
         let expected = system_host_type_str(&expected);
         let current = system_host_type_str(&current);
-        return Err(format!("Current system type: {current} Expected: {expected}").into());
+        return Err(format!("This command requires an {expected} system; found: {current}").into());
     }
     Ok(())
 }


### PR DESCRIPTION
The modularity code is native Rust, which is great, but means it
currently bypasses the infrastructure we added mostly on the C++
side (where most CLI entrypoint logic is) to detect the case of
ostree host/DBus versus container etc.

The Rust side already has a nice `ClientConnection` object that
basically expresses the need for an ostree host.  And we already
had a Rust API that's useful to error out here; combine those
two and tweak the error message.

(A future patch will change `ex module` to actually work, but
 this is a correct starting point)
