### PR TITLE
treefile: Retain directory path, not dfd

### DIFF
--- a/rust/src/extensions.rs
+++ b/rust/src/extensions.rs
@@ -197,7 +197,7 @@ impl Extensions {
             modules: self.modules.clone(),
             ..Default::default()
         };
-        Ok(Box::new(Treefile::new_from_config(ret, None)?))
+        Ok(Box::new(Treefile::new_from_config(ret)?))
     }
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -492,7 +492,7 @@ pub mod ffi {
         fn treefile_new_client_from_etc(basearch: &str) -> Result<Box<Treefile>>;
         fn treefile_delete_client_etc() -> Result<u32>;
 
-        fn get_workdir(&self) -> i32;
+        fn get_workdir(&self) -> &str;
         fn get_passwd_fd(&mut self) -> i32;
         fn get_group_fd(&mut self) -> i32;
         fn get_json_string(&self) -> String;

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -121,7 +121,7 @@ pub(crate) fn origin_to_treefile_inner(kf: &KeyFile) -> Result<Box<Treefile>> {
 
     cfg.derive.override_commit = keyfile_get_optional_string(kf, ORIGIN, "override-commit")?;
 
-    Ok(Box::new(Treefile::new_from_config(cfg, None)?))
+    Ok(Box::new(Treefile::new_from_config(cfg)?))
 }
 
 /// Convert an origin keyfile to a treefile config.

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -67,7 +67,6 @@ pub(crate) struct TreefileExternals {
 #[derive(Debug)]
 pub struct Treefile {
     primary_dfd: openat::Dir,
-    #[allow(dead_code)] // Not used in tests
     pub(crate) parsed: TreeComposeConfig,
     pub(crate) externals: TreefileExternals,
 }

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -294,9 +294,8 @@ install_packages (RpmOstreeTreeComposeContext *self, gboolean *out_unmodified,
   }
 
   {
-    int tf_dfd = (*self->treefile_rs)->get_workdir ();
-    g_autofree char *abs_tf_path = glnx_fdrel_abspath (tf_dfd, ".");
-    dnf_context_set_repo_dir (dnfctx, abs_tf_path);
+    auto treefile_dir = std::string ((*self->treefile_rs)->get_workdir ());
+    dnf_context_set_repo_dir (dnfctx, treefile_dir.c_str ());
   }
 
   /* By default, retain packages in addition to metadata with --cachedir, unless
@@ -1615,9 +1614,8 @@ rpmostree_compose_builtin_extensions (int argc, char **argv, RpmOstreeCommandInv
       = rpmostree_context_new_compose (cachedir_dfd, repo, *extension_tf);
 
   {
-    int tf_dfd = src_treefile->get_workdir ();
-    g_autofree char *abs_tf_path = glnx_fdrel_abspath (tf_dfd, ".");
-    dnf_context_set_repo_dir (rpmostree_context_get_dnf (ctx), abs_tf_path);
+    auto treefile_dir = std::string (src_treefile->get_workdir ());
+    dnf_context_set_repo_dir (rpmostree_context_get_dnf (ctx), treefile_dir.c_str ());
   }
 
 #define TMP_EXTENSIONS_ROOTFS "rpmostree-extensions.tmp"


### PR DESCRIPTION


This is part of https://github.com/coreos/rpm-ostree/issues/3832
but also just a general code cleanup - in general, using file descriptors
is great, but libdnf doesn't support them, so we are awkwardly holding
onto a dfd and using `/proc` to make it a path.

Since our treefile input is today always a filesystem path, we might
as well expose that back - we're just holding onto the parent directory
*path*.

If in the future we converted the treefile code to accept a cap-std
`Dir` as input, then in theory we'd likely want to push for libdnf
to have `dnf_context_set_repo_dfd` or so.

But, this simplifies the code today.