### PR TITLE
treefile: Deprecate `initramfs-args` key

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -113,6 +113,8 @@ It supports the following parameters:
     case for this with Dracut is `--filesystems xfs,ext4` to ensure
     specific filesystem drivers are included.  If not specified,
     `--no-hostonly` will be used.
+    Deprecated; you should place files in `/etc/dracut.conf.d` instead. This
+    option is ignored when regenerating the initramfs in the container flow.
 
  * `rpmdb`: String, optional: The RPM database backend.  Can be one of
     `target` (the default) or `host`.  Legacy values 

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1448,6 +1448,15 @@ impl Treefile {
                 )
             }
         }
+        if self
+            .parsed
+            .initramfs_args
+            .as_ref()
+            .map_or(false, |v| !v.is_empty())
+        {
+            deprecated = true;
+            eprintln!("warning: initramfs-args is deprecated, use /etc/dracut.conf.d")
+        }
         if deprecated {
             std::thread::sleep(std::time::Duration::from_secs(3));
         }

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -1098,6 +1098,8 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self, GCancellable *cancellabl
       /* append the extra args */
       rust::Vec<rust::String> add_dracut_argv;
       if (rpmostree_origin_get_regenerate_initramfs (self->computed_origin))
+        /* Note this option is deprecated, but we still read it for now. See
+         * https://github.com/coreos/rpm-ostree/issues/3799. */
         add_dracut_argv = rpmostree_origin_get_initramfs_args (self->computed_origin);
       for (auto &arg : add_dracut_argv)
         g_ptr_array_add (initramfs_args, g_strdup (arg.c_str ()));


### PR DESCRIPTION
Users should use `/etc/dracut.conf.d` instead. This option does not work
when regenerating the initramfs in the container flow.

We'll want to keep supporting it internally for a while in the upgrade
code, until all known composers have moved away from it, and reasonably
enough time for client systems to get the resulting updated trees.

See discussions in https://github.com/coreos/rpm-ostree/issues/3799.