### PR TITLE
rust: Also vendor for `s390x-unknown-linux-gnu`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ publish = false
 
 # See https://github.com/cgwalters/cargo-vendor-filterer
 [package.metadata.vendor-filter]
-platforms = ["x86_64-unknown-linux-gnu"]
+platforms = ["x86_64-unknown-linux-gnu", "s390x-unknown-linux-gnu"]
 all-features = true
 exclude-crate-paths = [ { name = "curl-sys", exclude = "curl" },
                         { name = "libz-sys", exclude = "src/zlib" },


### PR DESCRIPTION
This will fix a currently s390x-specific build failure
because `rustix` only depends on the `errno` crate if it's using the
libc backend, and this creates currently `s390x` specific build failures
for us.

Closes: https://github.com/coreos/rpm-ostree/issues/3839
