### PR TITLE
rustix: use libc backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,6 +2095,7 @@ dependencies = [
  "regex",
  "rpmostree-client",
  "rust-ini",
+ "rustix",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ c_utf8 = "0.1.0"
 camino = "1.0.9"
 cap-std-ext = "0.26"
 cap-std = { version = "0.25", features = ["fs_utf8"] }
+# Explicitly force on libc
+rustix = { version = "0.35", features = ["use-libc"] }
 cap-primitives = "0.25.2"
 cap-tempfile = "0.25.2"
 chrono = { version = "0.4.19", features = ["serde"] }


### PR DESCRIPTION
See rationale in https://github.com/bytecodealliance/rustix/issues/215
I wrote it so that we can use it here.

And specifically this will fix a currently s390x-specific build failure
because `rustix` only depends on the `errno` crate if it's using the
libc backend, and this creates currently `s390x` specific build failures
for us.

(This overlaps with https://github.com/coreos/rpm-ostree/pull/3840 and is an alternative, complementary fix)