### PR TITLE
ci: Fix check for LVM omission

### DIFF
--- a/tests/vmcheck/test-override-kernel.sh
+++ b/tests/vmcheck/test-override-kernel.sh
@@ -74,6 +74,7 @@ assert_file_has_content_literal lsinitrd.txt etc/foobar.conf
 
 echo "ok override kernel with custom initramfs args"
 
+vm_cmd lsinitrd -m ${newroot}/usr/lib/modules/${kernel_release}/initramfs.img > lsinitrd-modules.txt
 # FCOS omits lvm; check that we still omit lvm here too
-assert_file_has_content_literal lsinitrd.txt "--omit 'lvm'"
+assert_not_file_has_content_literal lsinitrd-modules.txt lvm
 echo "ok override kernel uses base initramfs args"


### PR DESCRIPTION
This needs adjustment for
https://github.com/coreos/fedora-coreos-config/pull/1828/commits/1a29ef849f1fba0ae64d48e143a71d3f94bd91ac
since we are no longer omitting via command line arguments.
