### PR TITLE
Fix build on c9s and add CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,3 +86,28 @@ jobs:
         run: tar -C / -xzvf install.tar
       - name: Integration tests
         run: env TMPDIR=/var/tmp JOBS=3 ./tests/compose.sh
+  build-c9s:
+    name: "Build (c9s)"
+    runs-on: ubuntu-latest
+    container: quay.io/centos/centos:stream9
+    steps:
+      - name: Install git
+        run: yum -y install git
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      # https://github.com/actions/checkout/issues/760
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Run ridiculous RHEL -devel package workaround
+        run: ./ci/ridiculous-rhel-devel-workaround.sh
+      - name: Install dependencies
+        run: ./ci/installdeps.sh
+      - name: Build
+        run: ./ci/build.sh && make install DESTDIR=$(pwd)/install && tar -C install -czf install.tar .
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: install-c9s.tar
+          path: install.tar

--- a/ci/ridiculous-rhel-devel-workaround.sh
+++ b/ci/ridiculous-rhel-devel-workaround.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/bash
+#
+# Builds libsmartcols-devel which libdnf depends on
+#
+# RHEL and -devel packages are just broken.  Today RHEL9 doesn't ship libsmartcols-devel,
+# and it's not even in CRB so we need to rebuild it ourself.  Which, should actually be
+# a normal and natural thing to do, except our RPM build process is totally
+# not designed to handle chained builds sanely.  See also https://github.com/projectatomic/rpmdistro-gitoverlay/
+#
+# If we had a more NixOS like model where the binaries are just a *cache of the source*,
+# then here we'd just add the centos "CRB" binary cache.
+
+set -xeuo pipefail
+
+dn=$(dirname $0)
+. ${dn}/libbuild.sh
+
+if test -f /usr/lib/os-release; then
+    . /usr/lib/os-release
+    if [[ "${ID_LIKE}" =~ rhel ]] && [[ ${VERSION_ID} -gt 8 ]]; then
+        yum -y install yum-utils
+        # https://docs.fedoraproject.org/en-US/epel/#_el9
+        yum config-manager --set-enabled crb
+        yum -y install epel-release
+        yum -y install git
+        test -d util-linux || git clone https://gitlab.com/redhat/centos-stream/rpms/util-linux
+        cd util-linux
+        yum -y install centpkg
+        yum -y builddep *.spec
+        if test '!' -d "$(arch)"; then
+            centpkg local
+        fi
+        yum -y install $(arch)/libsmartcols-devel*.rpm
+    fi
+else
+    echo "Unhandled OS" 1>&2
+    exit 1
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -81,7 +81,7 @@ PKG_PROG_PKG_CONFIG
 dnl Remember to update AM_CPPFLAGS in Makefile.am when bumping GIO req.
 PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 dnl These are the dependencies of the public librpmostree-1.0.0 shared library
-PKG_CHECK_MODULES(PKGDEP_LIBRPMOSTREE, [gio-unix-2.0 >= 2.50.0 json-glib-1.0 ostree-1 >= 2021.2 rpm >= 4.17])
+PKG_CHECK_MODULES(PKGDEP_LIBRPMOSTREE, [gio-unix-2.0 >= 2.50.0 json-glib-1.0 ostree-1 >= 2021.2 rpm >= 4.16])
 dnl And these additional ones are used by for the rpmostreeinternals C/C++ library
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [polkit-gobject-1 libarchive])
 


### PR DESCRIPTION
build: Drop dependency on rpm to 4.16

This is what's in RHEL9 right now.

---

ci: Add c9s build

We need to cover c9s to keep making upstream releases there.

---

