### PR TITLE
dirdiff: Port to cap-std

### DIFF
--- a/rust/src/dirdiff.rs
+++ b/rust/src/dirdiff.rs
@@ -6,15 +6,22 @@
 
 //! Compute difference between two filesystem trees.
 
+use anyhow::Context;
 use anyhow::Result;
+use cap_std::fs::{Dir, Metadata};
+use cap_std::io_lifetimes;
+use cap_std_ext::cap_std;
+use cap_std_ext::dirext::CapStdExtDirExt;
 use fn_error_context::context;
-use openat_ext::OpenatDirExt;
+use io_lifetimes::AsFilelike;
 use serde_derive::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::fmt;
+use std::io::BufReader;
 
 use std::io::Read;
+use std::path::Path;
 
 pub(crate) type FileSet = BTreeSet<String>;
 
@@ -71,15 +78,10 @@ impl fmt::Display for Diff {
     }
 }
 
-fn file_content_changed(
-    src: &openat::Dir,
-    dest: &openat::Dir,
-    path: &str,
-    expected_len: u64,
-) -> Result<bool> {
+fn file_content_changed(src: &Dir, dest: &Dir, path: &str, expected_len: u64) -> Result<bool> {
     let mut remaining = expected_len;
-    let mut srcf = std::io::BufReader::new(src.open_file(path)?);
-    let mut destf = std::io::BufReader::new(dest.open_file(path)?);
+    let mut srcf = src.open(path).map(BufReader::new)?;
+    let mut destf = dest.open(path).map(BufReader::new)?;
     let mut srcbuf = [0; 4096];
     let mut destbuf = [0; 4096];
     let bufsize = srcbuf.len();
@@ -100,27 +102,32 @@ fn file_content_changed(
 }
 
 fn is_changed(
-    src: &openat::Dir,
-    dest: &openat::Dir,
+    src: &Dir,
+    dest: &Dir,
     path: &str,
-    srcmeta: &openat::Metadata,
-    destmeta: &openat::Metadata,
+    srcmeta: &Metadata,
+    destmeta: &Metadata,
 ) -> Result<bool> {
+    use cap_primitives::fs::read_link_contents;
     if srcmeta.permissions() != destmeta.permissions() {
         return Ok(true);
     }
-    Ok(match srcmeta.simple_type() {
-        openat::SimpleType::File => {
-            if srcmeta.len() != destmeta.len() {
-                true
-            } else {
-                file_content_changed(src, dest, path, srcmeta.len())?
-            }
+    let t = srcmeta.file_type();
+    let r = if t.is_file() {
+        if srcmeta.len() != destmeta.len() {
+            true
+        } else {
+            file_content_changed(src, dest, path, srcmeta.len())
+                .context("Comparing file content")?
         }
-        openat::SimpleType::Symlink => src.read_link(path)? != dest.read_link(path)?,
-        openat::SimpleType::Other => false,
-        openat::SimpleType::Dir => false,
-    })
+    } else if t.is_symlink() {
+        let src_target = read_link_contents(&src.as_filelike_view(), Path::new(path))?;
+        let dest_target = read_link_contents(&dest.as_filelike_view(), Path::new(path))?;
+        src_target != dest_target
+    } else {
+        false
+    };
+    Ok(r)
 }
 
 fn canonicalize_name<'a>(prefix: Option<&str>, name: &'a str) -> Cow<'a, str> {
@@ -131,16 +138,12 @@ fn canonicalize_name<'a>(prefix: Option<&str>, name: &'a str) -> Cow<'a, str> {
     }
 }
 
-fn diff_recurse(
-    prefix: Option<&str>,
-    src: &openat::Dir,
-    dest: &openat::Dir,
-    diff: &mut Diff,
-) -> Result<()> {
+fn diff_recurse(prefix: Option<&str>, src: &Dir, dest: &Dir, diff: &mut Diff) -> Result<()> {
     let list_prefix = prefix.unwrap_or(".");
-    for entry in src.list_dir(list_prefix)? {
+    for entry in src.read_dir(list_prefix)? {
         let entry = entry?;
-        let name = if let Some(name) = entry.file_name().to_str() {
+        let name = entry.file_name();
+        let name = if let Some(name) = name.to_str() {
             name
         } else {
             // For now ignore invalid UTF-8 names
@@ -148,17 +151,18 @@ fn diff_recurse(
         };
         let path = canonicalize_name(prefix, name);
         let pathp = &*path;
-        let srctype = src.get_file_type(&entry)?;
-        let is_dir = srctype == openat::SimpleType::Dir;
+        let srctype = entry.file_type()?;
+        let is_dir = srctype.is_dir();
 
-        match dest.metadata_optional(pathp)? {
+        match dest.symlink_metadata_optional(pathp)? {
             Some(destmeta) => {
-                let desttype = destmeta.simple_type();
+                let desttype = destmeta.file_type();
                 let changed = if srctype != desttype {
                     true
                 } else {
-                    let srcmeta = src.metadata(pathp)?;
-                    is_changed(src, dest, pathp, &srcmeta, &destmeta)?
+                    let srcmeta = src.symlink_metadata(pathp)?;
+                    is_changed(src, dest, pathp, &srcmeta, &destmeta)
+                        .context("Comparing for changes")?
                 };
                 if is_dir {
                     diff_recurse(Some(pathp), src, dest, diff)?;
@@ -181,20 +185,21 @@ fn diff_recurse(
 
     // Iterate over the target (to) directory, and find any
     // files/directories which were not present in the source.
-    for entry in dest.list_dir(list_prefix)? {
+    for entry in dest.read_dir(list_prefix)? {
         let entry = entry?;
-        let name = if let Some(name) = entry.file_name().to_str() {
+        let name = entry.file_name();
+        let name = if let Some(name) = name.to_str() {
             name
         } else {
             // For now ignore invalid UTF-8 names
             continue;
         };
         let path = canonicalize_name(prefix, name);
-        if src.metadata_optional(&*path)?.is_some() {
+        if src.symlink_metadata_optional(&*path)?.is_some() {
             continue;
         }
-        let desttype = dest.get_file_type(&entry)?;
-        if desttype == openat::SimpleType::Dir {
+        let desttype = entry.file_type()?;
+        if desttype.is_dir() {
             diff.added_dirs.insert(path.into_owned());
         } else {
             diff.added_files.insert(path.into_owned());
@@ -205,7 +210,7 @@ fn diff_recurse(
 
 /// Given two directories, compute the diff between them.
 #[context("Computing filesystem diff")]
-pub(crate) fn diff(src: &openat::Dir, dest: &openat::Dir) -> Result<Diff> {
+pub(crate) fn diff(src: &Dir, dest: &Dir) -> Result<Diff> {
     let mut diff = Diff {
         ..Default::default()
     };
@@ -216,54 +221,53 @@ pub(crate) fn diff(src: &openat::Dir, dest: &openat::Dir) -> Result<Diff> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::fs::Permissions;
+    use cap_std::fs::Permissions;
     use std::os::unix::fs::PermissionsExt;
 
     #[test]
     fn test_diff() -> Result<()> {
-        let td = tempfile::tempdir()?;
-        let td = openat::Dir::open(td.path())?;
-        td.create_dir("a", 0o755)?;
-        td.create_dir("b", 0o755)?;
-        let a = td.sub_dir("a")?;
-        let b = td.sub_dir("b")?;
+        let td = cap_tempfile::tempdir(cap_std::ambient_authority())?;
+        td.create_dir("a")?;
+        td.create_dir("b")?;
+        let a = td.open_dir("a")?;
+        let b = td.open_dir("b")?;
         for d in [&a, &b].iter() {
-            d.ensure_dir_all("sub1/sub2", 0o755)?;
-            d.write_file_contents("sub1/subfile", 0o644, "subfile")?;
-            d.ensure_dir_all("sub1/sub3", 0o755)?;
-            d.ensure_dir_all("sub2/sub4", 0o755)?;
-            d.write_file_contents("sub2/subfile2", 0o644, "subfile2")?;
-            d.write_file_contents("somefile", 0o644, "somefile")?;
-            d.symlink("link2root", "/")?;
-            d.symlink("brokenlink", "enoent")?;
-            d.symlink("somelink", "otherlink")?;
-            d.symlink("otherlink", "sub1/sub2")?;
+            d.create_dir_all("sub1/sub2")?;
+            d.write("sub1/subfile", "subfile")?;
+            d.create_dir_all("sub1/sub3")?;
+            d.create_dir_all("sub2/sub4")?;
+            d.write("sub2/subfile2", "subfile2")?;
+            d.write("somefile", "somefile")?;
+            cap_primitives::fs::symlink_contents("/", &d.as_filelike_view(), "link2root")?;
+            d.symlink("enoent", "brokenlink")?;
+            d.symlink("otherlink", "somelink")?;
+            d.symlink("sub1/sub2", "otherlink")?;
         }
         // Initial setup with identical dirs
-        let d = diff(&a, &b)?;
+        let d = diff(&a, &b).unwrap();
         assert_eq!(d.count(), 0);
 
         // Remove a file
         b.remove_file("somefile")?;
-        let d = diff(&a, &b)?;
+        let d = diff(&a, &b).unwrap();
         assert_eq!(d.count(), 1);
         assert_eq!(d.removed_files.len(), 1);
 
         // Change a file
-        b.write_file_contents("somefile", 0o644, "somefile2")?;
+        b.write("somefile", "somefile2")?;
         let d = diff(&a, &b)?;
         assert_eq!(d.count(), 1);
         assert_eq!(d.changed_files.len(), 1);
         assert!(d.changed_files.contains("somefile"));
 
         // Many changes
-        a.write_file_contents("sub1/sub2/subfile1", 0o644, "subfile1")?;
-        a.write_file_contents("sub1/sub2/subfile2", 0o644, "subfile2")?;
-        b.write_file_contents("sub1/someotherfile", 0o644, "somefile3")?;
+        a.write("sub1/sub2/subfile1", "subfile1")?;
+        a.write("sub1/sub2/subfile2", "subfile2")?;
+        b.write("sub1/someotherfile", "somefile3")?;
         b.remove_file("link2root")?;
-        b.symlink("link2root", "/notroot")?;
-        b.remove_all("sub2")?;
-        a.open_file("sub1/subfile")?
+        cap_primitives::fs::symlink_contents("/notroot", &b.as_filelike_view(), "link2root")?;
+        b.remove_dir_all("sub2")?;
+        a.open("sub1/subfile")?
             .set_permissions(Permissions::from_mode(0o600))?;
         let d = diff(&a, &b)?;
         assert_eq!(d.count(), 7);

--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -455,7 +455,7 @@ pub(crate) fn transaction_apply_live(
 
     let mut state = state.unwrap_or_default();
 
-    let rootfs_dfd = openat::Dir::open("/")?;
+    let rootfs_dfd = Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
     let sepolicy = ostree::SePolicy::new_at(rootfs_dfd.as_raw_fd(), gio::NONE_CANCELLABLE)?;
 
     // Record that we're targeting this commit
@@ -465,8 +465,8 @@ pub(crate) fn transaction_apply_live(
     // Gather the current diff of /etc - we need to avoid changing
     // any files which are locally modified.
     let config_diff = progress_task("Computing /etc diff to preserve", || -> Result<_> {
-        let usretc = &rootfs_dfd.sub_dir("usr/etc")?;
-        let etc = &rootfs_dfd.sub_dir("etc")?;
+        let usretc = &rootfs_dfd.open_dir("usr/etc")?;
+        let etc = &rootfs_dfd.open_dir("etc")?;
         crate::dirdiff::diff(usretc, etc)
     })?;
     println!("Computed /etc diff: {}", &config_diff);


### PR DESCRIPTION
Part of https://github.com/coreos/rpm-ostree/issues/3832

This one had all the subtleties, *all* of which involve symlinks:

- Need to remember to swap the order of arguments to `symlink`
- Drop to cap-primitives to read/write absolute links instead of just calling `read_link`
- Use `symlink_metadata` and not `metadata`
