### PR TITLE
Ask for a larger open file descriptor limit in case we need to compile things

### DIFF
--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -20,6 +20,11 @@ ProtectHome=true
 # entry here ensures that the skopeo process we fork won't interact with
 # application containers.
 InaccessiblePaths=-/var/lib/containers
+# Some popular akmods, when invoked through akmods-ostree-post, will want to
+# open more files than we would normally have access to. This is sometimes a
+# function of the number of logical CPU cores, and so we are generous in our
+# request of systemd.
+LimitNOFILE=65535
 NotifyAccess=main
 @SYSTEMD_ENVIRON@
 ExecStart=@bindir@/rpm-ostree start-daemon


### PR DESCRIPTION
Some popular akmods — notably akmod-nvidia in RPMFusion — will open a number of
files as a function of their compilation concurrency, which is generally set by
inspecting the number of logical CPU cores. On systems with a large number of
logical CPU cores, we can run afoul of Systemd default limits as part of the
compilation that can happen in `akmods-ostree-post`. In lieu of reducing akmod
compilation efficiency by pretending to be a less-powerful system, we instead
ask to be allowed to open more files at once.

By test at time of authoring, a limit of 2048 open file descriptors is
sufficient for a system with 36 logical cores. 8192 open file descriptors is
sufficient for a system with 128 logical cores. It is unknown if this
is a linear relationship or otherwise.

Closes #3706