### PR TITLE
rhel8: Two cherry picks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,9 +1670,9 @@ dependencies = [
 
 [[package]]
 name = "ostree-ext"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31a3981faab95c06279c0c6d02c7948983ca5783904f10164881569b7f467c14"
+checksum = "d48d13c84ccafa8e23b1c08094593de0a25e5b7c3e14786b5590fd9d766cf753"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1705,7 +1705,7 @@ dependencies = [
  "term_size",
  "tokio",
  "tokio-stream",
- "tokio-util 0.6.9",
+ "tokio-util 0.7.2",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ links = "rpmostreeinternals"
 
 # See https://github.com/cgwalters/cargo-vendor-filterer
 [package.metadata.vendor-filter]
-platforms = ["x86_64-unknown-linux-gnu"]
+platforms = ["x86_64-unknown-linux-gnu", "s390x-unknown-linux-gnu"]
 all-features = true
 exclude-crate-paths = [ { name = "curl-sys", exclude = "curl" },
                         { name = "libz-sys", exclude = "src/zlib" },


### PR DESCRIPTION
rust: Also vendor for `s390x-unknown-linux-gnu`

This will fix a currently s390x-specific build failure
because `rustix` only depends on the `errno` crate if it's using the
libc backend, and this creates currently `s390x` specific build failures
for us.

Closes: https://github.com/coreos/rpm-ostree/issues/3839

---

Bump to ostree-ext 0.8.1

Pull in the fix for https://github.com/ostreedev/ostree-rs-ext/issues/339

---

