### PR TITLE
container: Make `--format-version` properly optional

### DIFF
--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -65,7 +65,7 @@ struct ContainerEncapsulateOpts {
     max_layers: Option<NonZeroU32>,
 
     /// The encapsulated container format version; must be 0 or 1.
-    #[clap(long)]
+    #[clap(long, default_value = "0")]
     format_version: u32,
 
     #[clap(long)]


### PR DESCRIPTION
It was intended to be so.  This is the "dual" of
https://github.com/coreos/coreos-assembler/pull/3000

(There's no CI for this here yet - working on it but this
 is hopefully an obviously-correct patch)
