### PR TITLE
tests/encapsulate.sh: Explicitly test chunked encapsulation here

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,6 +86,24 @@ jobs:
         run: tar -C / -xzvf install.tar
       - name: Integration tests
         run: env TMPDIR=/var/tmp JOBS=3 ./tests/compose.sh
+  container-encapsulate:
+    name: "Encapsulate tests"
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: registry.ci.openshift.org/coreos/coreos-assembler:latest
+      options: "--user root --privileged -v /var/tmp:/var/tmp"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Download build
+        uses: actions/download-artifact@v2
+        with:
+          name: install.tar
+      - name: Install
+        run: tar -C / -xzvf install.tar
+      - name: Integration tests
+        run: env TMPDIR=/var/tmp ./tests/encapsulate.sh
   build-c9s:
     name: "Build (c9s)"
     runs-on: ubuntu-latest

--- a/tests/encapsulate.sh
+++ b/tests/encapsulate.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -xeuo pipefail
+# Pull the latest FCOS build, unpack its container image, and verify
+# that we can re-encapsulate it as chunked.
+
+container=quay.io/coreos-assembler/fcos:testing-devel
+
+tmpdir=$(mktemp -d)
+cd ${tmpdir}
+ostree --repo=repo init --mode=bare-user
+cat /etc/ostree/remotes.d/fedora.conf >> repo/config
+# Pull and unpack the ostree content, discarding the container wrapping
+ostree container unencapsulate --write-ref=testref --repo=repo ostree-remote-registry:fedora:$container
+# Re-pack it as a (chunked) container
+rpm-ostree container-encapsulate --repo=repo \
+    --label=foo=bar --label baz=blah \
+    testref oci:test.oci
+skopeo inspect oci:test.oci | jq -r .Labels.foo > labels.txt
+grep -qFe bar labels.txt
+echo ok


### PR DESCRIPTION
This will hopefully soon be the default, but we were missing CI for
it.  As a bonus, this *also* tests the `ostree-remote-registry`
flow that does the ostree GPG verification when pulling a container.
