### PR TITLE
packaging: Drop `gnome-common`

### DIFF
--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -49,7 +49,6 @@ BuildRequires: autoconf automake libtool git
 # For docs
 BuildRequires: chrpath
 BuildRequires: gtk-doc
-BuildRequires: gnome-common
 BuildRequires: /usr/bin/g-ir-scanner
 # Core requirements
 # One way to check this: `objdump -p /path/to/rpm-ostree | grep LIBOSTREE` and pick the highest (though that might miss e.g. new struct members)


### PR DESCRIPTION
I think this got cargo-culted from somewhere else in the far
distant past; as best I can tell, we never used it.

Closes: https://github.com/coreos/rpm-ostree/issues/3870
