### PR TITLE
Enable `ex module` in a container

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -252,6 +252,12 @@ pub mod ffi {
         fn directory_size(dfd: i32, mut cancellable: Pin<&mut GCancellable>) -> Result<u64>;
     }
 
+    // container.cxx
+    unsafe extern "C++" {
+        include!("rpmostree-container.hpp");
+        fn container_rebuild(treefile: &str) -> Result<()>;
+    }
+
     // deployment_utils.rs
     extern "Rust" {
         fn deployment_for_id(

--- a/src/libpriv/rpmostree-container.cxx
+++ b/src/libpriv/rpmostree-container.cxx
@@ -68,3 +68,15 @@ rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile, GCancellable *can
 
   return TRUE;
 }
+
+namespace rpmostreecxx
+{
+void
+container_rebuild (rust::Str treefile)
+{
+  auto tf = rpmostreecxx::treefile_new_from_string (treefile, true);
+  g_autoptr (GError) local_error = NULL;
+  if (!rpmostree_container_rebuild (*tf, NULL, &local_error))
+    util::throw_gerror (local_error);
+}
+}

--- a/src/libpriv/rpmostree-container.hpp
+++ b/src/libpriv/rpmostree-container.hpp
@@ -1,7 +1,4 @@
-/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
- *
- * Copyright (C) 2022 Red Hat, Inc.
- *
+/*
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
  * by the Free Software Foundation; either version 2 of the licence or (at
@@ -18,20 +15,11 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#include <glib.h>
-
-#include "rpmostree-cxxrs.h"
-
 #pragma once
+
+#include "rust/cxx.h"
 
 namespace rpmostreecxx
 {
 void container_rebuild (rust::Str treefile);
 }
-
-G_BEGIN_DECLS
-
-gboolean rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile, GCancellable *cancellable,
-                                      GError **error);
-
-G_END_DECLS

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -1777,8 +1777,6 @@ rpmostree_context_prepare (RpmOstreeContext *self, GCancellable *cancellable, GE
       /* There are things we don't support in the container flow. */
       g_assert_cmpint (packages_local_fileoverride.size (), ==, 0);
       g_assert_cmpint (exclude_packages.size (), ==, 0);
-      g_assert_cmpint (modules_enable.size (), ==, 0);
-      g_assert_cmpint (modules_install.size (), ==, 0);
     }
 
   /* setup sack if not yet set up */

--- a/tests/kolainst/destructive/layering-modules
+++ b/tests/kolainst/destructive/layering-modules
@@ -7,10 +7,9 @@ cd $(mktemp -d)
 
 set -x
 
-versionid=$(grep -E '^VERSION_ID=' /etc/os-release)
-versionid=${versionid:11} # trim off VERSION_ID=
-
+versionid=$(. /usr/lib/os-release && echo $VERSION_ID)
 # Let's start by trying to install a bona fide module.
+# NOTE: If changing this also change test-container.sh
 case $versionid in
   # yes, this is going backwards, see:
   # https://github.com/coreos/fedora-coreos-tracker/issues/767#issuecomment-917191270


### PR DESCRIPTION
This just plumbs through the bits into the treefile/rebuild flow,
although we also now need an API that exposes the `rebuild` flow to
C++.

Unfortunately due to circular dependencies we can't reference
the Rust-defined `Treefile` type in a C++ API that is then exposed
back to Rust, so we serialize the treefile as a string.

Closes: https://github.com/coreos/rpm-ostree/issues/3736
