### PR TITLE
ridiculous-rhel-devel-workaround: Try to replace all packages

### DIFF
--- a/ci/ridiculous-rhel-devel-workaround.sh
+++ b/ci/ridiculous-rhel-devel-workaround.sh
@@ -27,10 +27,13 @@ if test -f /usr/lib/os-release; then
         cd util-linux
         yum -y install centpkg
         yum -y builddep *.spec
-        if test '!' -d "$(arch)"; then
+        builddir=$(arch)
+        if test '!' -d "$builddir"; then
             centpkg local
         fi
-        yum -y install $(arch)/libsmartcols-devel*.rpm
+        rm -vf $builddir/*debuginfo*.rpm
+        rm -vf $builddir/*python*.rpm
+        rpm -Uvh --oldpackage $builddir/*.rpm
     fi
 else
     echo "Unhandled OS" 1>&2


### PR DESCRIPTION
And now it happened; the version of util-linux in the container
versus the source we're trying to clone got out of sync.

Replace both packages to hopefully fix CI.
