### PR TITLE
libpriv/core: overlay ostree content before running scriptlets

### DIFF
--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -4298,6 +4298,10 @@ rpmostree_context_assemble (RpmOstreeContext *self, GCancellable *cancellable, G
    * replacements */
   if (overlays->len > 0 || overrides_replace->len > 0)
     {
+      /* Any ostree refs to overlay */
+      if (!process_ostree_layers (self, tmprootfs_dfd, cancellable, error))
+        return FALSE;
+
       CXX_TRY_VAR (fs_prep, rpmostreecxx::prepare_filesystem_script_prep (tmprootfs_dfd), error);
 
       auto passwd_entries = rpmostreecxx::new_passwd_entries ();
@@ -4408,10 +4412,6 @@ rpmostree_context_assemble (RpmOstreeContext *self, GCancellable *cancellable, G
               return FALSE;
           }
       }
-
-      /* Any ostree refs to overlay */
-      if (!process_ostree_layers (self, tmprootfs_dfd, cancellable, error))
-        return FALSE;
 
       {
         auto task = rpmostreecxx::progress_begin_task ("Running posttrans scripts");


### PR DESCRIPTION
This moves the overlaying of ostree layers earlier in the composing
process, so that their content is present on disk before any
scriptlet is run.
Before this, layered files were added only after `%pre` and `%post`
logic already ran. However, that resulted in troubles when trying
to add configuration fragments which would influence scriptlets behavior
(e.g. `sysusers.d` entries), as the files were not present in the target
envinroment at the time the scripts are executed.
This friction was notably observed with systemd `%post` script, which runs
`systemd-sysusers` and would miss any customization/fragments from ostree
layers.