### PR TITLE
cliwrap: Add -y option to yum/dnf

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -33,7 +33,7 @@ if ! test -x /usr/bin/yum; then
 fi
 
 # Test a critical path package
-yum install cowsay && yum clean all
+yum -y install cowsay && yum clean all
 cowsay "It worked"
 test '!' -d /var/cache/rpm-ostree
 

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -298,6 +298,14 @@ pub(crate) fn require_system_host_type(expected: SystemHostType) -> CxxResult<()
     Ok(())
 }
 
+/// Emit a warning about a potential future incompatible change we may make
+/// that would require adjustment from the user.
+pub(crate) fn warn_future_incompatibility(msg: impl AsRef<str>) {
+    let msg = msg.as_ref();
+    eprintln!("warning: {msg}");
+    std::thread::sleep(std::time::Duration::from_secs(1));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
We actually default to this...which is its own whole issue.  But
for now, just silently accept it for compatibility.

This required some juggling to separate out a new "global options"
struct from the subcommand.  (One can write both `yum -y install foo`
and `yum install -y foo`).  Luckily, clap supports this really well.
