### PR TITLE
install: Add `-y/--assumeyes` option, prompt on tty by default

### DIFF
--- a/docs/administrator-handbook.md
+++ b/docs/administrator-handbook.md
@@ -92,7 +92,7 @@ As a special case, it is supported to live-apply just package additions, assumin
 that there are not other pending changes:
 
 ```
-# rpm-ostree install -A <pkg>
+# rpm-ostree install -yA <pkg>
 ```
 
 ### Modularity

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1951,6 +1951,10 @@ extern "C"
                                                            ::rust::String *return$) noexcept;
 
   bool rpmostreecxx$cxxbridge1$running_in_container () noexcept;
+
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$confirm (bool *return$) noexcept;
+
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$confirm_or_abort () noexcept;
   ::std::size_t rpmostreecxx$cxxbridge1$Bubblewrap$operator$sizeof () noexcept;
   ::std::size_t rpmostreecxx$cxxbridge1$Bubblewrap$operator$alignof () noexcept;
 
@@ -3336,6 +3340,28 @@ bool
 running_in_container () noexcept
 {
   return rpmostreecxx$cxxbridge1$running_in_container ();
+}
+
+bool
+confirm ()
+{
+  ::rust::MaybeUninit<bool> return$;
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$confirm (&return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
+}
+
+void
+confirm_or_abort ()
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$confirm_or_abort ();
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
 }
 
 ::std::size_t

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1719,6 +1719,10 @@ void client_start_daemon ();
 
 bool running_in_container () noexcept;
 
+bool confirm ();
+
+void confirm_or_abort ();
+
 void bubblewrap_selftest ();
 
 ::rust::Vec< ::std::uint8_t> bubblewrap_run_sync (::std::int32_t rootfs_dfd,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -103,6 +103,8 @@ pub mod ffi {
         fn client_handle_fd_argument(arg: &str, arch: &str, is_replace: bool) -> Result<Vec<i32>>;
         fn client_render_download_progress(progress: &GVariant) -> String;
         fn running_in_container() -> bool;
+        fn confirm() -> Result<bool>;
+        fn confirm_or_abort() -> Result<()>;
     }
 
     #[derive(Debug)]

--- a/src/app/rpmostree-clientlib.cxx
+++ b/src/app/rpmostree-clientlib.cxx
@@ -657,10 +657,16 @@ rpmostree_transaction_client_run (RpmOstreeCommandInvocation *invocation,
   g_variant_dict_lookup (&optdict, "reboot", "b", &opt_reboot);
   gboolean opt_dry_run = FALSE;
   g_variant_dict_lookup (&optdict, "dry-run", "b", &opt_dry_run);
+  gboolean opt_print_interactive = FALSE;
+  g_variant_dict_lookup (&optdict, "print-interactive", "b", &opt_print_interactive);
   gboolean opt_apply_live = FALSE;
   g_variant_dict_lookup (&optdict, "apply-live", "b", &opt_apply_live);
 
-  if (opt_dry_run)
+  if (opt_print_interactive)
+    {
+      /* Nothing; we print the transaction by default */
+    }
+  else if (opt_dry_run)
     {
       g_print ("Exiting because of '--dry-run' option\n");
     }

--- a/tests/kolainst/destructive/apply-live
+++ b/tests/kolainst/destructive/apply-live
@@ -101,7 +101,7 @@ rm -rf /etc/testpkg-etc \
 echo myconfig > /etc/testpkg-etc-other.conf
 grep myconfig /etc/testpkg-etc-other.conf
 
-rpm-ostree install -A testpkg-etc testdaemon | tee out.txt
+rpm-ostree install -yA testpkg-etc testdaemon | tee out.txt
 assert_file_has_content_literal out.txt 'Successfully updated running filesystem tree.'
 rpm -q bar test{pkg-etc,daemon} > rpmq.txt
 assert_file_has_content rpmq.txt bar-1.0-1 test{pkg-etc,daemon}-1.0-1


### PR DESCRIPTION
This is the dual/inverse of
https://github.com/coreos/rpm-ostree/pull/3884/commits/87a1da1fb36a9b23ac9215317ce7580d61aecd7f

A big difference between rpm-ostree and yum/dnf today is
rpm-ostree does *not* prompt when you type `rpm-ostree install foo`;
it just does the operation by default.  One rationale for this is because
it doesn't apply live, it really can't break anything before
the admin has a chance to take action.

Valid cases here include:

 - Discovering that you typo'd the package name
 - Adding the package drags in a lot more dependencies than expected

However, when we added `-A/--apply-live` we broke that guarantee.
Now of course unlike traditional yum we have rollbacks.   But still,
I think in the future we should switch the default to prompting for
confirmation *only* when `-A/--apply-live` is passed.

Add `-y/--assumeyes` matching yum so that users who want that
no prompt behavior can start adding it now.

We avoid breaking backwards compatibility here for *scripts* by
adding `-y` if we detect that `-A` is passed and stdin is not a tty.
