### PR TITLE
Remove last uses of `Pin<&mut someglibtype>`

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1379,7 +1379,7 @@ struct Bubblewrap final : public ::rust::Opaque
   void bind_read (::rust::Str src, ::rust::Str dest) noexcept;
   void bind_readwrite (::rust::Str src, ::rust::Str dest) noexcept;
   void setup_compat_var ();
-  void run (::rpmostreecxx::GCancellable &cancellable);
+  void run (const ::rpmostreecxx::GCancellable &cancellable);
   ~Bubblewrap () = delete;
 
 private:
@@ -2011,7 +2011,7 @@ extern "C"
 
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$Bubblewrap$run (::rpmostreecxx::Bubblewrap &self,
-                                          ::rpmostreecxx::GCancellable &cancellable) noexcept;
+                                          const ::rpmostreecxx::GCancellable &cancellable) noexcept;
 
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$applylive_entrypoint (const ::rust::Vec< ::rust::String> &args) noexcept;
@@ -2125,7 +2125,7 @@ extern "C"
 
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$directory_size (::std::int32_t dfd,
-                                          ::rpmostreecxx::GCancellable &cancellable,
+                                          const ::rpmostreecxx::GCancellable &cancellable,
                                           ::std::uint64_t *return$) noexcept;
 
   ::rust::repr::PtrLen
@@ -3483,7 +3483,7 @@ Bubblewrap::setup_compat_var ()
 }
 
 void
-Bubblewrap::run (::rpmostreecxx::GCancellable &cancellable)
+Bubblewrap::run (const ::rpmostreecxx::GCancellable &cancellable)
 {
   ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Bubblewrap$run (*this, cancellable);
   if (error$.ptr)
@@ -3868,7 +3868,7 @@ rewrite_rpmdb_for_target (::std::int32_t rootfs_dfd, bool normalize)
 }
 
 ::std::uint64_t
-directory_size (::std::int32_t dfd, ::rpmostreecxx::GCancellable &cancellable)
+directory_size (::std::int32_t dfd, const ::rpmostreecxx::GCancellable &cancellable)
 {
   ::rust::MaybeUninit< ::std::uint64_t> return$;
   ::rust::repr::PtrLen error$

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1165,7 +1165,7 @@ struct Bubblewrap final : public ::rust::Opaque
   void bind_read (::rust::Str src, ::rust::Str dest) noexcept;
   void bind_readwrite (::rust::Str src, ::rust::Str dest) noexcept;
   void setup_compat_var ();
-  void run (::rpmostreecxx::GCancellable &cancellable);
+  void run (const ::rpmostreecxx::GCancellable &cancellable);
   ~Bubblewrap () = delete;
 
 private:
@@ -1804,7 +1804,8 @@ void postprocess_cleanup_rpmdb (::std::int32_t rootfs_dfd);
 
 void rewrite_rpmdb_for_target (::std::int32_t rootfs_dfd, bool normalize);
 
-::std::uint64_t directory_size (::std::int32_t dfd, ::rpmostreecxx::GCancellable &cancellable);
+::std::uint64_t directory_size (::std::int32_t dfd,
+                                const ::rpmostreecxx::GCancellable &cancellable);
 
 ::rpmostreecxx::OstreeDeployment *deployment_for_id (::rpmostreecxx::OstreeSysroot &sysroot,
                                                      ::rust::Str deploy_id);

--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -13,7 +13,6 @@ use ostree_ext::{gio, glib};
 use std::num::NonZeroUsize;
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
-use std::pin::Pin;
 use std::process::Command;
 
 // Links in the rootfs to /usr
@@ -430,11 +429,8 @@ impl Bubblewrap {
     }
 
     /// Execute the instance; requires a cancellable for C++.
-    pub(crate) fn run(
-        &mut self,
-        mut cancellable: Pin<&mut crate::FFIGCancellable>,
-    ) -> CxxResult<()> {
-        let cancellable = &cancellable.gobj_wrap();
+    pub(crate) fn run(&mut self, cancellable: &crate::FFIGCancellable) -> CxxResult<()> {
+        let cancellable = &cancellable.glib_reborrow();
         self.run_inner(Some(cancellable))?;
         Ok(())
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -143,7 +143,7 @@ pub mod ffi {
         fn bind_readwrite(&mut self, src: &str, dest: &str);
         fn setup_compat_var(&mut self) -> Result<()>;
 
-        fn run(&mut self, cancellable: Pin<&mut GCancellable>) -> Result<()>;
+        fn run(&mut self, cancellable: &GCancellable) -> Result<()>;
     }
 
     // builtins/apply_live.rs
@@ -254,7 +254,7 @@ pub mod ffi {
         fn compose_postprocess_rpm_macro(rootfs_dfd: i32) -> Result<()>;
         fn postprocess_cleanup_rpmdb(rootfs_dfd: i32) -> Result<()>;
         fn rewrite_rpmdb_for_target(rootfs_dfd: i32, normalize: bool) -> Result<()>;
-        fn directory_size(dfd: i32, mut cancellable: Pin<&mut GCancellable>) -> Result<u64>;
+        fn directory_size(dfd: i32, cancellable: &GCancellable) -> Result<u64>;
     }
 
     // container.cxx


### PR DESCRIPTION
The end of an ongoing cleanup.  I also noticed that clippy
was warning about the `transmute` in this code, so it's nice
to be able to fix that by just deleting it!
