### PR TITLE
rust: Minor misc clippy fixes

### DIFF
--- a/rust/libdnf-sys/lib.rs
+++ b/rust/libdnf-sys/lib.rs
@@ -53,6 +53,7 @@ pub mod ffi {
         fn get_name(self: Pin<&mut DnfPackage>) -> String;
         fn get_evr(self: Pin<&mut DnfPackage>) -> String;
         fn get_arch(self: Pin<&mut DnfPackage>) -> String;
+        /// SAFETY: This can only be called on a valid pointer
         unsafe fn dnf_package_from_ptr(pkg: *mut FFIDnfPackage) -> UniquePtr<DnfPackage>;
 
         type DnfRepo;
@@ -60,6 +61,7 @@ pub mod ffi {
         fn get_ref<'a>(self: Pin<&'a mut DnfRepo>) -> Pin<&'a mut FFIDnfRepo>;
         fn get_id(self: Pin<&mut DnfRepo>) -> String;
         fn get_timestamp_generated(self: Pin<&mut DnfRepo>) -> u64;
+        /// SAFETY: This can only be called on a valid pointer
         unsafe fn dnf_repo_from_ptr(pkg: *mut FFIDnfRepo) -> UniquePtr<DnfRepo>;
 
         type DnfSack;

--- a/rust/rpmostree-client/src/lib.rs
+++ b/rust/rpmostree-client/src/lib.rs
@@ -76,7 +76,7 @@ impl Deployment {
     pub fn get_base_commit(&self) -> &str {
         self.base_checksum
             .as_deref()
-            .unwrap_or_else(|| self.checksum.as_str())
+            .unwrap_or(self.checksum.as_str())
     }
 
     /// Find a given metadata key in the base commit, which must hold a non-empty string.

--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -488,7 +488,7 @@ pub(crate) fn bubblewrap_run_sync(
     if capture_stdout {
         let buf = bwrap.run_captured(cancellable)?;
         tempetc.undo()?;
-        Ok(buf.as_ref().iter().copied().collect())
+        Ok(buf.as_ref().to_vec())
     } else {
         bwrap.run_inner(cancellable)?;
         tempetc.undo()?;

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -280,9 +280,9 @@ pub(crate) fn get_system_host_type() -> CxxResult<SystemHostType> {
 }
 
 pub(crate) fn system_host_type_str(t: &SystemHostType) -> &'static str {
-    match t {
-        &SystemHostType::OstreeContainer => "ostree container",
-        &SystemHostType::OstreeHost => "ostree host",
+    match *t {
+        SystemHostType::OstreeContainer => "ostree container",
+        SystemHostType::OstreeHost => "ostree host",
         _ => "unknown",
     }
 }

--- a/rust/src/cliwrap.rs
+++ b/rust/src/cliwrap.rs
@@ -47,7 +47,7 @@ pub fn entrypoint(args: &[&str]) -> Result<()> {
     // The outer code should always pass us at least one arg.
     let name = args
         .get(0)
-        .map(|&x| x)
+        .copied()
         .ok_or_else(|| anyhow!("Missing required argument"))?;
     // Handle this case early, it's not like the other cliwrap bits.
     if name == "install-to-root" {

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -749,6 +749,7 @@ fn var_to_tmpfiles(rootfs: &Dir, cancellable: Option<&gio::Cancellable>) -> Resu
 /// This proceeds depth-first and progressively deletes translated subpaths as it goes.
 /// `prefix` is updated at each recursive step, so that in case of errors it can be
 /// used to pinpoint the faulty path.
+#[allow(clippy::nonminimal_bool)]
 fn convert_path_to_tmpfiles_d_recurse(
     out_entries: &mut BTreeSet<String>,
     pwdb: &PasswdDB,

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -1106,7 +1106,7 @@ fn rewrite_rpmdb_for_target_inner(rootfs_dfd: &openat::Dir, normalize: bool) -> 
     // Sometimes we can end up with build-to-build variance in the underlying rpmdb
     // files. Attempt to sort that out, if requested.
     if normalize {
-        let rootfs_dfd = crate::capstdext::from_openat(&rootfs_dfd)?;
+        let rootfs_dfd = crate::capstdext::from_openat(rootfs_dfd)?;
         normalization::normalize_rpmdb(&rootfs_dfd, RPMOSTREE_RPMDB_LOCATION)?;
     }
 

--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -283,8 +283,8 @@ pub async fn container_encapsulate(args: &[&str]) -> Result<()> {
         // of minutes or seconds.
         let change_time_offset = change_time_offset_secs / (60 * 60);
         state.packagemeta.insert(ObjectSourceMeta {
-            identifier: Rc::clone(&nevra),
-            name: Rc::clone(&nevra),
+            identifier: Rc::clone(nevra),
+            name: Rc::clone(nevra),
             srcid: Rc::from(pkgmeta.src_pkg().to_str().unwrap()),
             change_time_offset,
         });

--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -380,7 +380,7 @@ pub async fn container_encapsulate(args: &[&str]) -> Result<()> {
         n => anyhow::bail!("Invalid format version {n}"),
     };
     let opts = ExportOpts {
-        copy_meta_keys: copy_meta_keys,
+        copy_meta_keys,
         max_layers: opt.max_layers,
         format,
         ..Default::default()

--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -205,7 +205,7 @@ mod err {
         where
             C: Display + Send + Sync + 'static,
         {
-            Self(format!("{}: {}", context.to_string(), self))
+            Self(format!("{context}: {self}"))
         }
     }
 

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -518,7 +518,7 @@ fn generate_object_path_impl(
     }
 
     let segment = next_segment.as_ref();
-    if segment.len() == 0 {
+    if segment.is_empty() {
         return Err(anyhow::anyhow!("Cannot append empty segment: {base}"));
     }
     base.push('/');

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -260,7 +260,7 @@ pub(crate) fn deployment_layeredmeta_load_commit(
     // SAFETY: return value is "not nullable".
     let checksum = deployment.csum().unwrap();
     let commit = &repo.load_variant(ostree::ObjectType::Commit, &checksum)?;
-    deployment_layeredmeta_from_commit_impl(&deployment, &commit)
+    deployment_layeredmeta_from_commit_impl(deployment, commit)
 }
 
 #[context("Loading origin status")]

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -47,19 +47,19 @@ fn vdict_insert_strv<'a>(dict: &glib::VariantDict, k: &str, v: impl IntoIterator
 
 /// Insert values from `v` into the target `dict` with key `k`.
 fn vdict_insert_optvec(dict: &glib::VariantDict, k: &str, v: Option<&Vec<String>>) {
-    let v = v.iter().map(|s| s.iter()).flatten().map(|s| s.as_str());
+    let v = v.iter().flat_map(|s| s.iter()).map(|s| s.as_str());
     vdict_insert_strv(dict, k, v);
 }
 
 /// Insert keys from the provided map into the target `dict` with key `k`.
 fn vdict_insert_optmap(dict: &glib::VariantDict, k: &str, v: Option<&BTreeMap<String, String>>) {
-    let v = v.iter().map(|s| s.keys()).flatten().map(|s| s.as_str());
+    let v = v.iter().flat_map(|s| s.keys()).map(|s| s.as_str());
     vdict_insert_strv(dict, k, v);
 }
 
 /// Insert keys from the provided map into the target `dict` with key `k`.
 fn vdict_insert_optset(dict: &glib::VariantDict, k: &str, v: Option<&BTreeSet<String>>) {
-    let v = v.iter().map(|s| s.iter()).flatten().map(|s| s.as_str());
+    let v = v.iter().flat_map(|s| s.iter()).map(|s| s.as_str());
     vdict_insert_strv(dict, k, v);
 }
 

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -524,7 +524,7 @@ fn generate_object_path_impl(
     base.push('/');
     append_to_object_path(&mut base, segment);
 
-    return Ok(base);
+    Ok(base)
 }
 
 pub(crate) fn generate_object_path(base: &str, next_segment: &str) -> CxxResult<String> {

--- a/rust/src/deployment_utils.rs
+++ b/rust/src/deployment_utils.rs
@@ -62,7 +62,7 @@ pub fn deployment_checksum_for_id(
 ) -> CxxResult<String> {
     let sysroot = &ffi_sysroot.gobj_wrap();
 
-    let deployment = deployment_for_id_impl(&sysroot, deploy_id)?;
+    let deployment = deployment_for_id_impl(sysroot, deploy_id)?;
     // SAFETY: result is not-nullable in the C API.
     let csum = deployment.csum().unwrap();
     Ok(csum.to_string())
@@ -77,7 +77,7 @@ pub fn deployment_get_base(
     let deploy_id = opt_string(opt_deploy_id);
     let os_name = opt_string(opt_os_name);
 
-    let deployment = deployment_get_base_impl(&sysroot, deploy_id, os_name)?;
+    let deployment = deployment_get_base_impl(sysroot, deploy_id, os_name)?;
 
     let depl_ptr: *mut ostree::ffi::OstreeDeployment = deployment.to_glib_full();
     Ok(depl_ptr as *mut _)

--- a/rust/src/importer.rs
+++ b/rust/src/importer.rs
@@ -109,7 +109,7 @@ impl RpmImporter {
     }
 
     fn get_first_path_element(rel_path: &str) -> String {
-        match rel_path.split_once("/") {
+        match rel_path.split_once('/') {
             Some((dirname, _rest)) => dirname.to_string(),
             None => rel_path.to_string(),
         }

--- a/rust/src/importer.rs
+++ b/rust/src/importer.rs
@@ -276,7 +276,7 @@ impl RpmImporter {
         let symlink_entries = self.tmpfiles_symlink_entries();
         let all_entries = symlink_entries.iter().chain(self.tmpfiles_entries.iter());
         all_entries.fold(String::new(), |mut buf, entry| {
-            buf.push_str(&entry);
+            buf.push_str(entry);
             buf.push('\n');
             buf
         })

--- a/rust/src/initramfs.rs
+++ b/rust/src/initramfs.rs
@@ -25,7 +25,7 @@ fn list_files_recurse<P: glib::IsA<gio::Cancellable>>(
     // Maybe add a glib feature for openat-ext to support cancellability?  Or
     // perhaps we should just use futures and ensure GCancellable bridges to that.
     if let Some(c) = cancellable {
-        let _ = c.set_error_if_cancelled()?;
+        c.set_error_if_cancelled()?;
     }
     let meta = d.symlink_metadata(path).context("stat")?;
     if meta.is_dir() {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -11,6 +11,8 @@
 #![deny(missing_debug_implementations)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![forbid(unused_must_use)]
+#![deny(clippy::dbg_macro)]
+#![deny(clippy::todo)]
 #![allow(clippy::ptr_arg)]
 
 // pub(crate) utilities

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -41,10 +41,8 @@ pub(crate) fn origin_to_treefile_inner(kf: &KeyFile) -> Result<Box<Treefile>> {
     let mut cfg: crate::treefile::TreeComposeConfig = Default::default();
     let base_refspec = if let Some(r) = keyfile_get_optional_string(kf, ORIGIN, "refspec")? {
         Some(r)
-    } else if let Some(r) = keyfile_get_optional_string(kf, ORIGIN, "baserefspec")? {
-        Some(r)
     } else {
-        None
+        keyfile_get_optional_string(kf, ORIGIN, "baserefspec")?
     };
 
     let container_image_reference = keyfile_get_optional_string(kf, ORIGIN, ORIGIN_CONTAINER)?;

--- a/rust/src/passwd.rs
+++ b/rust/src/passwd.rs
@@ -311,7 +311,7 @@ fn passwd_compose_prep_impl(
     let mut db = cap_std::fs::DirBuilder::new();
     db.recursive(true);
     db.mode(0o755);
-    rootfs.create_dir_with(dest, &mut db)?;
+    rootfs.create_dir_with(dest, &db)?;
 
     // TODO(lucab): consider reworking these to avoid boolean results.
     let found_passwd_data = data_from_json(rootfs, treefile, dest, "passwd")?;

--- a/rust/src/testutils.rs
+++ b/rust/src/testutils.rs
@@ -194,10 +194,7 @@ fn update_os_tree(opts: &SyntheticUpgradeOpts) -> Result<()> {
     }
     assert!(mutated > 0);
     println!("Mutated ELF files: {}", mutated);
-    let src_ref = opts
-        .src_ref
-        .as_deref()
-        .unwrap_or_else(|| opts.ostref.as_str());
+    let src_ref = opts.src_ref.as_deref().unwrap_or(opts.ostref.as_str());
     let mut cmd = Command::new("ostree");
     cmd.arg(format!("--repo={}", repo_path.to_str().unwrap()))
         .args(&["commit", "--consume", "-b"])

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1952,7 +1952,7 @@ impl TreefileExternals {
 
 /// For increased readability in YAML/JSON, we support whitespace in individual
 /// array elements.
-fn whitespace_split_packages<'a>(pkgs: &BTreeSet<String>) -> Result<BTreeSet<String>> {
+fn whitespace_split_packages(pkgs: &BTreeSet<String>) -> Result<BTreeSet<String>> {
     let mut ret = BTreeSet::new();
     for element in pkgs {
         ret.extend(split_whitespace_unless_quoted(element)?.map(String::from));

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -275,7 +275,7 @@ fn treefile_parse<P: AsRef<Path>>(
     let tf = treefile_parse_stream(fmt, &mut f, basearch).map_err(|e| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("Parsing {}: {}", filename.to_string_lossy(), e.to_string()),
+            format!("Parsing {}: {e}", filename.to_string_lossy()),
         )
     })?;
     let postprocess_script = if let Some(ref postprocess) = tf.base.postprocess_script.as_ref() {
@@ -1864,7 +1864,7 @@ fn build_name_to_nevra_map(
     nevras
         .iter()
         .flatten()
-        .map(|(nevra, _)| Ok((libdnf_sys::hy_split_nevra(&nevra)?.name, nevra.clone())))
+        .map(|(nevra, _)| Ok((libdnf_sys::hy_split_nevra(nevra)?.name, nevra.clone())))
         .collect()
 }
 

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1024,10 +1024,7 @@ impl Treefile {
                 .derive
                 .override_replace
                 .as_ref()
-                .map(|v| {
-                    v.iter()
-                        .fold(false, |prev, o| prev || o.packages.contains(name_or_nevra))
-                })
+                .map(|v| v.iter().any(|o| o.packages.contains(name_or_nevra)))
                 .unwrap_or_default()
     }
 
@@ -1067,7 +1064,7 @@ impl Treefile {
             .derive
             .override_replace_local
             .as_mut()
-            .and_then(|map| Some(map.remove(package).is_some()))
+            .map(|map| map.remove(package).is_some())
             .unwrap_or_default()
     }
 
@@ -1136,7 +1133,7 @@ impl Treefile {
             .derive
             .override_remove
             .as_mut()
-            .and_then(|set| Some(set.remove(package)))
+            .map(|set| set.remove(package))
             .unwrap_or_default()
     }
 

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -309,7 +309,7 @@ pub(crate) fn translate_path_for_ostree_impl(path: &str) -> Option<String> {
     }
 
     // All remaining cases do not need translation.
-    return None;
+    None
 }
 
 #[cfg(test)]

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -54,19 +54,13 @@ where
     let parsed: T = match fmt {
         InputFormat::JSON => {
             let pf: T = serde_json::from_reader(input).map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!("serde-json: {}", e.to_string()),
-                )
+                io::Error::new(io::ErrorKind::InvalidInput, format!("serde-json: {e}"))
             })?;
             pf
         }
         InputFormat::YAML => {
             let pf: T = serde_yaml::from_reader(input).map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!("serde-yaml: {}", e.to_string()),
-                )
+                io::Error::new(io::ErrorKind::InvalidInput, format!("serde-yaml: {e}"))
             })?;
             pf
         }

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -272,7 +272,7 @@ pub fn translate_path_for_ostree(path: &str) -> String {
 
 /// Translate a relative unprefixed path according to ostree rules, if needed.
 pub(crate) fn translate_path_for_ostree_impl(path: &str) -> Option<String> {
-    assert!(!path.starts_with("/"));
+    assert!(!path.starts_with('/'));
     assert!(!path.starts_with("./"));
 
     // etc/foo -> usr/etc/foo


### PR DESCRIPTION
lib: Add `deny(clippy::dbg_macro & todo)`

We don't want these in production code in git.

---

rust: Fix single-character clippy lint

I think this can be slightly more efficient.

---

rust: Fix clippy unnecessary ref lints

---

rust: A few more misc clippy fixes

---

rust: A few more misc clippy fixes

---

rust: A few more misc clippy fixes

---

rust: A few more misc clippy fixes

---

rust: A few more misc clippy fixes

---

