### PR TITLE
Fix remaining clippy lints + add CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,13 @@ on:
 permissions:
   contents: read
 
+env:
+  CARGO_TERM_COLOR: always
+  # Minimum supported Rust version (MSRV)
+  ACTION_MSRV_TOOLCHAIN: 1.60.0
+  # Pinned toolchain for linting
+  ACTION_LINTS_TOOLCHAIN: 1.60.0
+
 jobs:
   build:
     name: "Build"
@@ -42,6 +49,32 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Codestyle
         run: ./ci/verify-cxx.sh
+  # TODO: Enable this once we've switched closer to having `cargo build`
+  # be the primary buildsystem entrypoint.  Right now the problem is
+  # in order to build the libdnf-sys dependency it relies on us having
+  # run through autoconf, but that flow wants to a "real" Rust build
+  # and not clippy.
+  # linting:
+  #   name: "Lints, pinned toolchain"
+  #   runs-on: ubuntu-latest
+  #   container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v2
+  #     - name: Install dependencies
+  #       run: ./ci/installdeps.sh
+  #     - name: Remove system Rust toolchain
+  #       run: dnf remove -y rust cargo
+  #     - name: Install toolchain
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: ${{ env['ACTION_LINTS_TOOLCHAIN']  }}
+  #         default: true
+  #         components: rustfmt, clippy
+  #     - name: cargo fmt (check)
+  #       run: cargo fmt -- --check -l
+  #     - name: cargo clippy (warnings)
+  #       run: cargo clippy -- -D warnings
   build-clang:
     name: "Build (clang)"
     runs-on: ubuntu-latest

--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -61,7 +61,8 @@ macro_rules! impl_wrap {
 
             fn reborrow_cxx(&'a self) -> &Self::ReWrapped {
                 let p: *const $sys = self.to_glib_none().0;
-                unsafe { std::mem::transmute(p) }
+                let p = p as *const Self::ReWrapped;
+                unsafe { &*p }
             }
         }
     };

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -850,6 +850,7 @@ impl Treefile {
         add_sha256_nevra_to_map(map, packages)
     }
 
+    #[allow(clippy::if_same_then_else)]
     pub(crate) fn remove_packages(
         &mut self,
         packages: Vec<String>,


### PR DESCRIPTION
rust/cxx: Fix clippy lint around use of `transmute`

Casting the pointer and then synthesizing a reference from it
is apparently better:

https://rust-lang.github.io/rust-clippy/stable/index.html#transmute_ptr_to_ref

---

rust/treefile: Allow a clippy lint

I think the way this code is now is fine.

---

ci: Add a clippy check

This uses a pinned toolchain, like our other CI flows.

---

