### PR TITLE
Deprecate `ex-container` entrypoint (use `ostree container`)

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -301,7 +301,7 @@ pub(crate) fn require_system_host_type(expected: SystemHostType) -> CxxResult<()
 
 /// Emit a warning about a potential future incompatible change we may make
 /// that would require adjustment from the user.
-pub(crate) fn warn_future_incompatibility(msg: impl AsRef<str>) {
+pub fn warn_future_incompatibility(msg: impl AsRef<str>) {
     let msg = msg.as_ref();
     eprintln!("warning: {msg}");
     std::thread::sleep(std::time::Duration::from_secs(1));

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -878,7 +878,7 @@ pub(crate) use crate::builtins::compose::commit::*;
 pub(crate) use crate::builtins::compose::*;
 mod bwrap;
 pub(crate) use bwrap::*;
-mod client;
+pub mod client;
 pub(crate) use client::*;
 pub mod cliwrap;
 pub mod container;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -25,6 +25,9 @@ async fn inner_async_main(args: Vec<String>) -> Result<i32> {
     match arg {
         // TODO(lucab): move consumers to the multicall entrypoint, then drop this.
         "ex-container" => {
+            rpmostree_rust::client::warn_future_incompatibility(
+                "This entrypoint is deprecated; use `ostree container` instead",
+            );
             return rpmostree_rust::container::entrypoint(&args_borrowed).await;
         }
         // This is a custom wrapper for

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -44,7 +44,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     # Since we're switching OS update stream, turn off zincati
     systemctl mask --now zincati
 
-    rpm-ostree ex-container 'export' --repo=/ostree/repo ${checksum} "${image}"
+    ostree container encapsulate --repo=/ostree/repo ${checksum} "${image}"
     rpm-ostree rebase "$image_pull" --experimental | tee out.txt
     assert_file_has_content out.txt 'Importing.*'"$image_pull"
     rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"ostree-unverified-image:$image\""
@@ -88,7 +88,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     ostree refs ${with_foo_commit} --create vmcheck_tmp/new_update
     new_commit=$(ostree commit -b vmcheck --tree=ref=vmcheck_tmp/new_update)
     rm "${image_dir}" -rf
-    rpm-ostree ex-container export --repo=/ostree/repo ${new_commit} "$image"
+    ostree container encapsulate --repo=/ostree/repo ${new_commit} "$image"
 
     rpm-ostree uninstall foo
     rpm-ostree upgrade
@@ -104,7 +104,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
 
     checksum=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
     rm "${image_dir}" -rf
-    rpm-ostree ex-container 'export' --repo=/ostree/repo ${checksum} "${image}"
+    ostree container encapsulate --repo=/ostree/repo ${checksum} "${image}"
     # https://github.com/ostreedev/ostree-rs-ext/issues/153
     skopeo copy $image containers-storage:localhost/fcos
     rm "${image_dir}" -rf


### PR DESCRIPTION
This is how we want to expose it to users, so use the deprecation
warning infrastructure (which is also a way to remind ourselves
about things we can remove in the future).  Change the test
code to use the new CLI.
