### PR TITLE
rust: Bump to ostree-ext 0.8.2 &&  tests/container-image: Use `--compression-fast`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,19 +354,6 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "terminal_size",
- "winapi",
-]
-
-[[package]]
-name = "console"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
@@ -1171,23 +1158,11 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
-dependencies = [
- "console 0.14.1",
- "lazy_static",
- "number_prefix",
- "regex",
-]
-
-[[package]]
-name = "indicatif"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc42b206e70d86ec03285b123e65a5458c92027d1fb2ae3555878b8113b3ddf"
 dependencies = [
- "console 0.15.1",
+ "console",
  "number_prefix",
  "unicode-width",
 ]
@@ -1658,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "ostree-ext"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48d13c84ccafa8e23b1c08094593de0a25e5b7c3e14786b5590fd9d766cf753"
+checksum = "b7d284276e1d9c7a8651d03f967064734c9e038b725a78412dcf9a31ba16f0a8"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1676,8 +1651,7 @@ dependencies = [
  "futures-util",
  "gvariant",
  "hex",
- "indicatif 0.16.2",
- "io-lifetimes",
+ "indicatif",
  "libc",
  "oci-spec",
  "once_cell",
@@ -2059,7 +2033,7 @@ dependencies = [
  "fail",
  "fn-error-context",
  "futures",
- "indicatif 0.17.0",
+ "indicatif",
  "indoc",
  "libc",
  "libdnf-sys",

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -88,7 +88,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     ostree refs ${with_foo_commit} --create vmcheck_tmp/new_update
     new_commit=$(ostree commit -b vmcheck --tree=ref=vmcheck_tmp/new_update)
     rm "${image_dir}" -rf
-    ostree container encapsulate --repo=/ostree/repo ${new_commit} "$image"
+    ostree container encapsulate --compression-fast --repo=/ostree/repo ${new_commit} "$image"
 
     rpm-ostree uninstall foo
     rpm-ostree upgrade
@@ -104,7 +104,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
 
     checksum=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
     rm "${image_dir}" -rf
-    ostree container encapsulate --repo=/ostree/repo ${checksum} "${image}"
+    ostree container encapsulate --compression-fast --repo=/ostree/repo ${checksum} "${image}"
     # https://github.com/ostreedev/ostree-rs-ext/issues/153
     skopeo copy $image containers-storage:localhost/fcos
     rm "${image_dir}" -rf


### PR DESCRIPTION
rust: Bump to ostree-ext 0.8.2

---

tests/container-image: Use `--compression-fast`

What we really want is https://github.com/ostreedev/ostree-rs-ext/issues/153
to support pushing/pulling directly from `containers-storage`, but
in the short term this should improve CI times.

---

