### PR TITLE
Move `container-encapsulate` under `compose`

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -2037,6 +2037,9 @@ extern "C"
 
   void rpmostreecxx$cxxbridge1$cliwrap_destdir (::rust::String *return$) noexcept;
 
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$container_encapsulate (::rust::Vec< ::rust::String> *args) noexcept;
+
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$pull_container (
       const ::rpmostreecxx::OstreeRepo &repo, const ::rpmostreecxx::GCancellable &cancellable,
       ::rust::Str imgref, ::rust::Box< ::rpmostreecxx::ContainerImageState> *return$) noexcept;
@@ -3581,6 +3584,17 @@ cliwrap_destdir () noexcept
   ::rust::MaybeUninit< ::rust::String> return$;
   rpmostreecxx$cxxbridge1$cliwrap_destdir (&return$.value);
   return ::std::move (return$.value);
+}
+
+void
+container_encapsulate (::rust::Vec< ::rust::String> args)
+{
+  ::rust::ManuallyDrop< ::rust::Vec< ::rust::String> > args$ (::std::move (args));
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$container_encapsulate (&args$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
 }
 
 ::rust::Box< ::rpmostreecxx::ContainerImageState>

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1749,6 +1749,8 @@ void cliwrap_write_wrappers (::std::int32_t rootfs);
 
 ::rust::String cliwrap_destdir () noexcept;
 
+void container_encapsulate (::rust::Vec< ::rust::String> args);
+
 ::rust::Box< ::rpmostreecxx::ContainerImageState>
 pull_container (const ::rpmostreecxx::OstreeRepo &repo,
                 const ::rpmostreecxx::GCancellable &cancellable, ::rust::Str imgref);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -169,6 +169,11 @@ pub mod ffi {
         fn cliwrap_destdir() -> String;
     }
 
+    // container.rs
+    extern "Rust" {
+        fn container_encapsulate(args: Vec<String>) -> Result<()>;
+    }
+
     /// `ContainerImageState` is currently identical to ostree-rs-ext's `LayeredImageState` struct, because
     /// cxx.rs currently requires types used as extern Rust types to be defined by the same crate
     /// that contains the bridge using them, so we redefine an `ContainerImport` struct here.
@@ -883,6 +888,7 @@ pub(crate) use client::*;
 pub mod cliwrap;
 pub mod container;
 pub use cliwrap::*;
+pub(crate) use container::*;
 mod composepost;
 pub mod countme;
 pub(crate) use composepost::*;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -30,9 +30,12 @@ async fn inner_async_main(args: Vec<String>) -> Result<i32> {
             );
             return rpmostree_rust::container::entrypoint(&args_borrowed).await;
         }
-        // This is a custom wrapper for
+        // This is a deprecated entrypoint
         "container-encapsulate" => {
-            rpmostree_rust::container::container_encapsulate(&args_borrowed).await?;
+            rpmostree_rust::client::warn_future_incompatibility(
+                "This entrypoint is deprecated; use `rpm-ostree compose container-encapsulate` instead",
+            );
+            rpmostree_rust::container::container_encapsulate(args)?;
             return Ok(0);
         }
         _ => {}

--- a/src/app/rpmostree-builtin-compose.cxx
+++ b/src/app/rpmostree-builtin-compose.cxx
@@ -28,27 +28,30 @@
 
 #include <glib/gi18n.h>
 
-static RpmOstreeCommand compose_subcommands[]
-    = { { "tree", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-          "Process a \"treefile\"; install packages and commit the result to an OSTree repository",
-          rpmostree_compose_builtin_tree },
-        { "install",
-          (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD
-                                  | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT),
-          "Install packages into a target path", rpmostree_compose_builtin_install },
-        { "postprocess",
-          (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD
-                                  | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT),
-          "Perform final postprocessing on an installation root",
-          rpmostree_compose_builtin_postprocess },
-        { "commit",
-          (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD
-                                  | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT),
-          "Commit a target path to an OSTree repository", rpmostree_compose_builtin_commit },
-        { "extensions", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-          "Download RPM packages guaranteed to depsolve with a base OSTree",
-          rpmostree_compose_builtin_extensions },
-        { NULL, (RpmOstreeBuiltinFlags)0, NULL, NULL } };
+static RpmOstreeCommand compose_subcommands[] = {
+  { "tree", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+    "Process a \"treefile\"; install packages and commit the result to an OSTree repository",
+    rpmostree_compose_builtin_tree },
+  { "install",
+    (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD
+                            | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT),
+    "Install packages into a target path", rpmostree_compose_builtin_install },
+  { "postprocess",
+    (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD
+                            | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT),
+    "Perform final postprocessing on an installation root", rpmostree_compose_builtin_postprocess },
+  { "commit",
+    (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD
+                            | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT),
+    "Commit a target path to an OSTree repository", rpmostree_compose_builtin_commit },
+  { "extensions", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+    "Download RPM packages guaranteed to depsolve with a base OSTree",
+    rpmostree_compose_builtin_extensions },
+  { "container-encapsulate", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+    "Generate a reproducible \"chunked\" container image (using RPM data) from an OSTree commit",
+    rpmostree_compose_builtin_container_encapsulate },
+  { NULL, (RpmOstreeBuiltinFlags)0, NULL, NULL }
+};
 
 gboolean
 rpmostree_builtin_compose (int argc, char **argv, RpmOstreeCommandInvocation *invocation,

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1731,3 +1731,19 @@ rpmostree_compose_builtin_extensions (int argc, char **argv, RpmOstreeCommandInv
 
   return TRUE;
 }
+
+gboolean
+rpmostree_compose_builtin_container_encapsulate (int argc, char **argv,
+                                                 RpmOstreeCommandInvocation *invocation,
+                                                 GCancellable *cancellable, GError **error)
+{
+  rust::Vec<rust::String> rustargv;
+  g_assert_cmpint (argc, >, 0);
+  rustargv.push_back (std::string (argv[0]));
+  // Re-inject argument required by the Rust side
+  rustargv.push_back (std::string ("container-encapsulate"));
+  for (int i = 1; i < argc; i++)
+    rustargv.push_back (std::string (argv[i]));
+  CXX_TRY (rpmostreecxx::container_encapsulate (rustargv), error);
+  return TRUE;
+}

--- a/src/app/rpmostree-compose-builtins.h
+++ b/src/app/rpmostree-compose-builtins.h
@@ -41,5 +41,9 @@ gboolean rpmostree_compose_builtin_commit (int argc, char **argv,
 gboolean rpmostree_compose_builtin_extensions (int argc, char **argv,
                                                RpmOstreeCommandInvocation *invocation,
                                                GCancellable *cancellable, GError **error);
+gboolean rpmostree_compose_builtin_container_encapsulate (int argc, char **argv,
+                                                          RpmOstreeCommandInvocation *invocation,
+                                                          GCancellable *cancellable,
+                                                          GError **error);
 
 G_END_DECLS

--- a/tests/encapsulate.sh
+++ b/tests/encapsulate.sh
@@ -5,6 +5,9 @@ set -xeuo pipefail
 
 container=quay.io/coreos-assembler/fcos:testing-devel
 
+# First, verify the legacy entrypoint still works for now
+rpm-ostree container-encapsulate --help >/dev/null
+
 tmpdir=$(mktemp -d)
 cd ${tmpdir}
 ostree --repo=repo init --mode=bare-user
@@ -12,7 +15,8 @@ cat /etc/ostree/remotes.d/fedora.conf >> repo/config
 # Pull and unpack the ostree content, discarding the container wrapping
 ostree container unencapsulate --write-ref=testref --repo=repo ostree-remote-registry:fedora:$container
 # Re-pack it as a (chunked) container
-rpm-ostree container-encapsulate --repo=repo \
+
+rpm-ostree compose container-encapsulate --repo=repo \
     --label=foo=bar --label baz=blah \
     testref oci:test.oci
 skopeo inspect oci:test.oci | jq -r .Labels.foo > labels.txt


### PR DESCRIPTION
One really awkward thing right now is that anything on the Rust
side isn't emitted when one runs `rpm-ostree --help`.  Long
term we need to hard port all the CLI to Rust.

In the short term, I wanted to promote/document `container-encapsulate`.
Let's fix the "not in --help" problem by moving it where it probably
should have been to start - under the `compose` verb which is
our "build stuff".
