### PR TITLE
unit: Bump `TimeoutStartSec=5m`

### DIFF
--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -21,6 +21,9 @@ ProtectHome=true
 # application containers.
 InaccessiblePaths=-/var/lib/containers
 NotifyAccess=main
+# Significantly bump this timeout from the default because
+# we do a lot of stuff on daemon startup.
+TimeoutStartSec=5m
 @SYSTEMD_ENVIRON@
 ExecStart=@bindir@/rpm-ostree start-daemon
 ExecReload=@bindir@/rpm-ostree reload

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -38,6 +38,9 @@ echo "ok empty pkg arrays, and commit meta correct in status json"
 # All tests which require a booted system, but are nondestructive
 rpm-ostree testutils integration-read-only
 
+systemctl show -p TimeoutStartUSec rpm-ostreed.service > out.txt
+assert_file_has_content out.txt 'TimeoutStartUSec=5m'
+
 # Ensure we return an error when passing a wrong option.
 rpm-ostree --help | awk '/^$/ {in_commands=0} {if(in_commands==1){print $0}} /^Builtin Commands:/ {in_commands=1}' > commands.txt
 while read cmd; do


### PR DESCRIPTION
Significantly bump this timeout from the default because
we do a lot of stuff on daemon startup.

Immediate motivation is https://bugzilla.redhat.com/show_bug.cgi?id=2111817

But this is also related to the same problems that motivated
https://github.com/coreos/rpm-ostree/issues/3850
(cc https://github.com/coreos/rpm-ostree/pull/2932 )

We switched from the default DBus timeout of 25 seconds to the
systemd default of 90s; this bumps us all the way up to 5 minutes.

I think the right long term fix is the socket activation, but this
is an easy backportable fix that will hopefully paper over spurious
failures.

(That said, anyone who is hitting this regularly probably has
 a system too slow to really use, but...let's not stand in their
 way)
