### PR TITLE
Stabilize `rpm-ostree apply live`

### DIFF
--- a/docs/administrator-handbook.md
+++ b/docs/administrator-handbook.md
@@ -160,8 +160,6 @@ command that enables local initramfs generation.
 ### Experimental interface
 
 There is a generic `rpm-ostree ex` command that offers experimental features.
-One of those is `rpm-ostree ex apply-live`, which offers the ability to apply
-changes from the pending deployment to the booted deployment.
 
 See `man rpm-ostree` for more information.
 
@@ -206,11 +204,10 @@ Now, suppose that you want to test this change *live*.  There are two choices.
 The first choice is to run the `rpm-ostree override replace` command above to stage the deployment, and then run
 
 ```
-$ rpm-ostree ex apply-live --allow-replacement
+$ rpm-ostree apply-live --allow-replacement
 ```
 
-This is a currently experimental interface that will pull the pending
-changes and apply them live.  You can `rpm-ostree ex apply-live --reset`
+This will pull the pending changes and apply them live.  You can `rpm-ostree apply-live --reset`
 to revert back to the booted tree.
 
 ### Using `usroverlay`
@@ -222,7 +219,7 @@ server somewhere that may not be in an RPM even.
 The changes here will not persist across reboots, which makes this a great choice for
 testing.
 
-One downside though is there's no equivalent of `rpm-ostree ex apply-live --reset`
+One downside though is it does not currently work to `rpm-ostree apply-live --reset`
 today when `rpm-ostree usroverlay` is in place.  It's possible to find the original
 binaries in a previous deployment, or via `ostree checkout` of the base commit, etc.
 

--- a/docs/cliwrap.md
+++ b/docs/cliwrap.md
@@ -19,7 +19,7 @@ rpm-ostree today contains code to wrap/reimplement the latter, which includes `d
 $ rpm-ostree deploy --ex-cliwrap=true
 ```
 
-You may also want to follow this with an `rpm-ostree ex apply-live` to apply the change live.
+You may also want to follow this with an `rpm-ostree apply-live` to apply the change live.
 
 To disable: `rpm-ostree deploy --ex-cliwrap=false`
 

--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -710,33 +710,15 @@ Boston, MA 02111-1307, USA.
         </listitem>
       </varlistentry>
 
-      <varlistentry>
-        <term><command>ex</command></term>
-
-        <listitem>
-          <para>
-            This command offers access to experimental features; command line
-            stability is not guaranteed.  The available subcommands will be listed
-            by invoking <command>rpm-ostree ex</command>.  For example, there is
-            <command>rpm-ostree ex apply-live</command> which is an experimental
-            interface for applying changes to the booted deployment.
-          </para>
-        </listitem>
-      </varlistentry>
-
 
       <varlistentry>
-        <term><command>ex apply-live</command></term>
+        <term><command>apply-live</command></term>
 
         <listitem>
-          <para>
-            Experimental feature; subject to change.
-          </para>
-
           <para>
             Given a target OSTree commit (defaults to the pending deployment), create a transient
-            <literal>overlayfs</literal> filesystem for <literal>/usr</literal>, and synchronize
-            the changes to the booted filesystem tree.  By default, to ensure safety, only package additions
+            <literal>overlayfs</literal> filesystem for the booted <literal>/usr</literal>, and synchronize
+            the changes from the source to the booted filesystem tree.  By default, to ensure safety, only package additions
             are allowed.
           </para>
 
@@ -756,9 +738,15 @@ Boston, MA 02111-1307, USA.
             <title>Install postgresql live</title>
 
             <programlisting>$ rpm-ostree install postgresql-server
-$ rpm-ostree ex apply-live
+$ rpm-ostree apply-live
 $ systemctl start postgresql  # Some setup required
             </programlisting>
+
+            <para>
+              This is also the same as:
+            </para>
+
+            <programlisting>$ rpm-ostree install -A postgresql-server</programlisting>
           </example>
 
           <para>
@@ -774,6 +762,19 @@ $ systemctl start postgresql  # Some setup required
           </para>
         </listitem>
       </varlistentry>
+
+      <varlistentry>
+        <term><command>ex</command></term>
+
+        <listitem>
+          <para>
+            This command offers access to experimental features; command line
+            stability is not guaranteed.  The available subcommands will be listed
+            by invoking <command>rpm-ostree ex</command>.
+          </para>
+        </listitem>
+      </varlistentry>
+
 
       <varlistentry>
         <term><command>ex initramfs-etc</command></term>

--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -329,7 +329,7 @@ fn rerun_tmpfiles() -> Result<()> {
     })
 }
 
-/// Implementation of `rpm-ostree ex apply-live`.
+/// Implementation of `rpm-ostree apply-live`.
 pub(crate) fn transaction_apply_live(
     sysroot: &crate::ffi::OstreeSysroot,
     options: &crate::ffi::GVariant,

--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -43,6 +43,8 @@ static RpmOstreeCommand commands[] = {
     static_cast<RpmOstreeBuiltinFlags> (RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD
                                         | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT),
     "Commands to compose a tree", rpmostree_builtin_compose },
+  { "apply-live", (RpmOstreeBuiltinFlags)0, "Apply pending deployment changes to booted deployment",
+    rpmostree_builtin_apply_live },
   { "cleanup", static_cast<RpmOstreeBuiltinFlags> (RPM_OSTREE_BUILTIN_FLAG_CONTAINER_CAPABLE),
     "Clear cached/pending data", rpmostree_builtin_cleanup },
   { "db", static_cast<RpmOstreeBuiltinFlags> (RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD),

--- a/src/app/rpmostree-builtin-applylive.cxx
+++ b/src/app/rpmostree-builtin-applylive.cxx
@@ -31,8 +31,8 @@
 #include <libglnx.h>
 
 gboolean
-rpmostree_ex_builtin_apply_live (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
-                                 GCancellable *cancellable, GError **error)
+rpmostree_builtin_apply_live (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+                              GCancellable *cancellable, GError **error)
 {
   rust::Vec<rust::String> rustargv;
   for (int i = 0; i < argc; i++)

--- a/src/app/rpmostree-builtin-ex.cxx
+++ b/src/app/rpmostree-builtin-ex.cxx
@@ -22,27 +22,26 @@
 
 #include "rpmostree-ex-builtins.h"
 
-static RpmOstreeCommand ex_subcommands[] = {
-  { "livefs", (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_HIDDEN),
-    "Apply pending deployment changes to booted deployment", rpmostree_ex_builtin_apply_live },
-  { "apply-live", (RpmOstreeBuiltinFlags)0, "Apply pending deployment changes to booted deployment",
-    rpmostree_ex_builtin_apply_live },
-  { "history", (RpmOstreeBuiltinFlags)RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    "Inspect rpm-ostree history of the system", rpmostree_ex_builtin_history },
-  { "initramfs-etc", (RpmOstreeBuiltinFlags)0, "Track initramfs configuration files",
-    rpmostree_ex_builtin_initramfs_etc },
-  /* This is currently only for CoreOS layering; so hide it to not confuse
-   * users. */
-  { "rebuild",
-    (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_HIDDEN
-                            | RPM_OSTREE_BUILTIN_FLAG_CONTAINER_CAPABLE),
-    "Rebuild system based on configuration", rpmostree_ex_builtin_rebuild },
-  /* To graduate out of experimental, simply revert:
-   * https://github.com/coreos/rpm-ostree/pull/3078 */
-  { "module", static_cast<RpmOstreeBuiltinFlags> (0), "Commands to install/uninstall modules",
-    rpmostree_ex_builtin_module },
-  { NULL, (RpmOstreeBuiltinFlags)0, NULL, NULL }
-};
+static RpmOstreeCommand ex_subcommands[]
+    = { { "livefs", (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_HIDDEN),
+          "Apply pending deployment changes to booted deployment", rpmostree_builtin_apply_live },
+        { "apply-live", (RpmOstreeBuiltinFlags)0,
+          "Apply pending deployment changes to booted deployment", rpmostree_builtin_apply_live },
+        { "history", (RpmOstreeBuiltinFlags)RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+          "Inspect rpm-ostree history of the system", rpmostree_ex_builtin_history },
+        { "initramfs-etc", (RpmOstreeBuiltinFlags)0, "Track initramfs configuration files",
+          rpmostree_ex_builtin_initramfs_etc },
+        /* This is currently only for CoreOS layering; so hide it to not confuse
+         * users. */
+        { "rebuild",
+          (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_HIDDEN
+                                  | RPM_OSTREE_BUILTIN_FLAG_CONTAINER_CAPABLE),
+          "Rebuild system based on configuration", rpmostree_ex_builtin_rebuild },
+        /* To graduate out of experimental, simply revert:
+         * https://github.com/coreos/rpm-ostree/pull/3078 */
+        { "module", static_cast<RpmOstreeBuiltinFlags> (0), "Commands to install/uninstall modules",
+          rpmostree_ex_builtin_module },
+        { NULL, (RpmOstreeBuiltinFlags)0, NULL, NULL } };
 
 /*
 static GOptionEntry global_entries[] = {

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -32,6 +32,7 @@ G_BEGIN_DECLS
                                      RpmOstreeCommandInvocation *invocation,                       \
                                      GCancellable *cancellable, GError **error)
 
+BUILTINPROTO (apply_live);
 BUILTINPROTO (compose);
 BUILTINPROTO (countme);
 BUILTINPROTO (upgrade);

--- a/src/app/rpmostree-ex-builtins.h
+++ b/src/app/rpmostree-ex-builtins.h
@@ -32,7 +32,6 @@ G_BEGIN_DECLS
                                         GCancellable *cancellable, GError **error)
 
 BUILTINPROTO (unpack);
-BUILTINPROTO (apply_live);
 BUILTINPROTO (history);
 BUILTINPROTO (initramfs_etc);
 BUILTINPROTO (module);

--- a/tests/kolainst/destructive/apply-live
+++ b/tests/kolainst/destructive/apply-live
@@ -72,7 +72,7 @@ rpm-ostree install bar
 rpmostree_assert_status '.deployments|length == 2' \
                     '.deployments[0]["live-replaced"]|not' \
                     '.deployments[1]["live-replaced"]'
-if rpm-ostree ex apply-live 2>err.txt; then
+if rpm-ostree apply-live 2>err.txt; then
     fatal "live-removed foo"
 fi
 assert_file_has_content_literal err.txt 'packages would be removed: 1, enable replacement to override'
@@ -129,7 +129,7 @@ assert_file_has_content_literal status.txt 'LiveDiff: 3 added'
 echo "ok apply-live stage2"
 
 # Now undo it all
-rpm-ostree ex apply-live --reset --allow-replacement
+rpm-ostree apply-live --reset --allow-replacement
 rpm -qa | sort > current-rpmdb.txt
 diff -u original-rpmdb.txt current-rpmdb.txt
 if test -f /usr/bin/bar; then
@@ -151,7 +151,7 @@ mkdir -p ${td}/usr/share/localdata
 echo mytestdata > ${td}/usr/share/localdata/mytestfile
 ostree commit --base=localref --selinux-policy-from-base -b localref --tree=dir=${td} --consume
 rpm-ostree rebase :localref
-rpm-ostree ex apply-live
+rpm-ostree apply-live
 cat /usr/share/localdata/mytestfile > out.txt
 assert_file_has_content out.txt mytestdata
 echo "ok local ref without package changes"

--- a/tests/kolainst/destructive/cliwrap
+++ b/tests/kolainst/destructive/cliwrap
@@ -28,7 +28,7 @@ libtest_enable_repover 0
 cd $(mktemp -d)
 
 rpm-ostree deploy --ex-cliwrap=true
-rpm-ostree ex apply-live  # yep it works!
+rpm-ostree apply-live  # yep it works!
 
 wrapdir="/usr/libexec/rpm-ostree/wrapped"
 if ! test -d "${wrapdir}"; then
@@ -59,7 +59,7 @@ assert_file_has_content err.txt "operating system extensions"
 echo "ok cliwrap yum install"
 
 rpm-ostree deploy --ex-cliwrap=false
-rpm-ostree ex apply-live --allow-replacement
+rpm-ostree apply-live --allow-replacement
 rpm --version
 rpm -qa >/dev/null
 rpm --verify bash >out.txt || true


### PR DESCRIPTION
I think it's time; this has been basically working for a long
time now.  We implicitly stabilized most of this anyways
when we added `rpm-ostree install -A`.

There are a ton more things we can do, but I think
the status quo is useful.  Let's ensure people don't fear to use it.

One specific motivation I have here is to have `yum install foo`
default to `rpm-ostree install -A` and it's all just clearer
if the `apply-live` as a whole is stable.
