### PR TITLE
yumdnf: Make `yum install cowsay` just do it and not lecture

### DIFF
--- a/tests/kolainst/destructive/cliwrap
+++ b/tests/kolainst/destructive/cliwrap
@@ -52,10 +52,8 @@ assert_file_has_content out.txt 'This system is rpm-ostree based'
 rm -f out.txt
 echo "ok cliwrap rpm + dracut"
 
-if yum install tmux 2>err.txt; then
-    fatal "yum install worked"
-fi
-assert_file_has_content err.txt "operating system extensions"
+yum -y install foo
+rpm -q foo
 echo "ok cliwrap yum install"
 
 rpm-ostree deploy --ex-cliwrap=false


### PR DESCRIPTION
Previously the design logic around `yum install` here was to
try to encourage people to containerize and do things like
install debug tools in a `toolbox`.

But, this lecture model lacks empathy. And more importantly,
not every rpm-ostree based OS will want this.  For now I commented
out the code for this, I'm thinking we add an opt-in config
file flag that allows enabling this mode.

(But, an issue right now is we only have a daemon config, not
 a client config file...and if you follow this, perhaps the
 config flag should actually be in `/etc/dnf.conf`...which
 we should really start reading...and that's a whole other
 ball of wax.)

So for now let's just make `yum install cowsay` do what the user
asked for.

(Also, this makes more sense now that we correctly handle `-y`,
 which we didn't before)
