### PR TITLE
compose: Fix `container` to work again, add a test

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1186,9 +1186,10 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self, GCancellable *cancellable, 
   const char *gpgkey_c = NULL;
   if (!gpgkey.empty ())
     gpgkey_c = gpgkey.c_str ();
+  auto container = (*self->treefile_rs)->get_container ();
   if (!rpmostree_compose_commit (self->rootfs_dfd, self->build_repo, parent_revision, metadata,
-                                 detached_metadata, gpgkey_c, selinux, self->devino_cache,
-                                 &new_revision, cancellable, error))
+                                 detached_metadata, gpgkey_c, container, selinux,
+                                 self->devino_cache, &new_revision, cancellable, error))
     return glnx_prefix_error (error, "Writing commit");
   g_assert (new_revision != NULL);
 

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -1174,8 +1174,9 @@ find_pkg_in_ostree (RpmOstreeContext *self, DnfPackage *pkg, OstreeSePolicy *sep
   OstreeRepo *repo = get_pkgcache_repo (self);
   /* Init output here, since we have several early returns */
   *out_in_ostree = FALSE;
+  auto selinux_enabled = self->treefile_rs->get_selinux ();
   /* If there's no sepolicy, then we always match */
-  *out_selinux_match = (sepolicy == NULL);
+  *out_selinux_match = (sepolicy == NULL || !selinux_enabled);
 
   /* NB: we're not using a pkgcache yet in the compose path */
   if (repo == NULL)
@@ -1244,7 +1245,7 @@ find_pkg_in_ostree (RpmOstreeContext *self, DnfPackage *pkg, OstreeSePolicy *sep
 
   /* We found an import, let's load the sepolicy state */
   *out_in_ostree = TRUE;
-  if (sepolicy)
+  if (sepolicy && selinux_enabled)
     {
       CXX_TRY_VAR (selinux_match, rpmostreecxx::commit_has_matching_sepolicy (*commit, *sepolicy),
                    error);

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -751,7 +751,7 @@ on_progress_timeout (gpointer datap)
 gboolean
 rpmostree_compose_commit (int rootfs_fd, OstreeRepo *repo, const char *parent_revision,
                           GVariant *src_metadata, GVariant *detached_metadata,
-                          const char *gpg_keyid, gboolean enable_selinux,
+                          const char *gpg_keyid, gboolean container, gboolean enable_selinux,
                           OstreeRepoDevInoCache *devino_cache, char **out_new_revision,
                           GCancellable *cancellable, GError **error)
 {
@@ -827,8 +827,11 @@ rpmostree_compose_commit (int rootfs_fd, OstreeRepo *repo, const char *parent_re
 
   // Unfortunately this API takes GVariantDict, not GVariantBuilder, so convert
   g_autoptr (GVariantDict) metadata_dict = g_variant_dict_new (src_metadata);
-  if (!ostree_commit_metadata_for_bootable (root_tree, metadata_dict, cancellable, error))
-    return glnx_prefix_error (error, "Looking for bootable kernel");
+  if (!container)
+    {
+      if (!ostree_commit_metadata_for_bootable (root_tree, metadata_dict, cancellable, error))
+        return glnx_prefix_error (error, "Looking for bootable kernel");
+    }
   g_autoptr (GVariant) metadata = g_variant_dict_end (metadata_dict);
 
   g_autofree char *new_revision = NULL;

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -36,9 +36,10 @@ gboolean rpmostree_rootfs_fixup_selinux_store_root (int rootfs_dfd, GCancellable
 
 gboolean rpmostree_compose_commit (int rootfs_dfd, OstreeRepo *repo, const char *parent,
                                    GVariant *metadata, GVariant *detached_metadata,
-                                   const char *gpg_keyid, gboolean enable_selinux,
-                                   OstreeRepoDevInoCache *devino_cache, char **out_new_revision,
-                                   GCancellable *cancellable, GError **error);
+                                   const char *gpg_keyid, gboolean container,
+                                   gboolean enable_selinux, OstreeRepoDevInoCache *devino_cache,
+                                   char **out_new_revision, GCancellable *cancellable,
+                                   GError **error);
 
 G_END_DECLS
 

--- a/tests/compose/test-container.sh
+++ b/tests/compose/test-container.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -xeuo pipefail
+
+dn=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=libcomposetest.sh
+. "${dn}/libcomposetest.sh"
+
+jq . "$treefile"
+jq '{"repos", "releasever"}' < "$treefile" > manifest.json.new
+cat >container.json << 'EOF'
+{
+  "packages": ["coreutils", "rpm"],
+  "container": true,
+  "selinux": false
+}
+EOF
+cat manifest.json.new container.json | jq -s add > "$treefile"
+jq . $treefile
+runcompose
+echo "ok compose container"


### PR DESCRIPTION
Now that we have `rpm-ostree container-encapsulate` which generates
chunked reproducible images, it makes sense to generalize this again
(particularly as part of "yum image") to also build non-bootable
base images (i.e. that don't have a kernel or SELinux labeling).
