### PR TITLE
Use `DynamicUser=yes` for main service, isolate container fetch

### DIFF
--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -5,6 +5,10 @@ ConditionPathExists=/ostree
 RequiresMountsFor=/boot
 
 [Service]
+# See similar code in rpm-ostree-countme.service
+User=rpm-ostree
+DynamicUser=yes
+# As of right now, our primary API is DBus.  But see also https://github.com/coreos/rpm-ostree/issues/3850
 Type=dbus
 BusName=org.projectatomic.rpmostree1
 # To use the read-only sysroot bits
@@ -25,5 +29,7 @@ NotifyAccess=main
 # we do a lot of stuff on daemon startup.
 TimeoutStartSec=5m
 @SYSTEMD_ENVIRON@
-ExecStart=@bindir@/rpm-ostree start-daemon
+# We start this main process with full privileges; it may spawn unprivileged processes
+# with the rpm-ostree user.
+ExecStart=+@bindir@/rpm-ostree start-daemon
 ExecReload=@bindir@/rpm-ostree reload


### PR DESCRIPTION
This is a different approach to
https://github.com/coreos/rpm-ostree/pull/3239

A core principle I want to maintain going forward is that the host
updates is isolated from containerized applications.

Today for example the containers/storage stack will do things like
access `~/.docker` and worse things like `/var/lib/containers` for
caching purposes.

Quite a while ago when we added the `rpm-ostree-countme.service`
we also added a use of `DynamicUser=yes` there, but only for that
service.

I was thinking about this and realized that systemd for quite some
time has given us the ability to have our own code opt-in to
the user ID switch; this is the `+` prefix to the `ExecStart`.
(One side effect is this *also* disables the existing `ProtectHome`
 etc. but as we move to isolate more that will be needed less)

Add a little bit of code which supports forking a child process using
`setpriv` to dynamically switch to the `rpm-ostree` user allocated
by systemd.

We already added all the infrastructure necessary to wrap `skopeo`
using this in
https://github.com/containers/containers-image-proxy-rs/pull/15/commits/caee79329caaddf5b5afc8caeb0bb18657041599

Now, we are guaranteed that the fetcher process runs with very low
privileges (no access to application containers) and has no persistent
state.

No more HTTP as root in the container path!
