### PR TITLE
build-sys: Stop generating systemd units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,10 +75,6 @@
 /rpm-ostreed.conf.5
 /so_locations
 /src/daemon/org.projectatomic.rpmostree1.service
-/src/daemon/rpm-ostree-bootstatus.service
-/src/daemon/rpm-ostree-countme.service
-/src/daemon/rpm-ostreed-automatic.service
-/src/daemon/rpm-ostreed.service
 /src/lib/rpm-ostree-1.pc
 /src/lib/rpmostree-version.h
 /stamp-h1

--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -55,14 +55,14 @@ librpmostreed_sources = \
 dbusconf_DATA = $(srcdir)/src/daemon/org.projectatomic.rpmostree1.conf
 dbusconfdir = $(datadir)/dbus-1/system.d
 
-systemdunit_service_in_files = \
-	$(srcdir)/src/daemon/rpm-ostreed.service.in \
-	$(srcdir)/src/daemon/rpm-ostreed-automatic.service.in \
-	$(srcdir)/src/daemon/rpm-ostree-bootstatus.service.in \
-	$(srcdir)/src/daemon/rpm-ostree-countme.service.in \
+systemdunit_service_file_names = \
+	rpm-ostreed.service \
+	rpm-ostreed-automatic.service \
+	rpm-ostree-bootstatus.service \
+	rpm-ostree-countme.service \
 	$(NULL)
 
-systemdunit_service_files = $(systemdunit_service_in_files:.service.in=.service)
+systemdunit_service_files = $(addprefix $(srcdir)/src/daemon/,$(systemdunit_service_file_names))
 systemdunit_timer_files = \
 	$(srcdir)/src/daemon/rpm-ostreed-automatic.timer \
 	$(srcdir)/src/daemon/rpm-ostree-countme.timer \
@@ -74,13 +74,6 @@ systemdunit_DATA = \
 	$(NULL)
 
 systemdunitdir       = $(prefix)/lib/systemd/system/
-if BUILDOPT_ASAN
-daemon_asan_options = -e s,@SYSTEMD_ENVIRON\@,Environment=ASAN_OPTIONS=detect_leaks=false,
-else
-daemon_asan_options = -e /@SYSTEMD_ENVIRON\@/d
-endif
-$(systemdunit_service_files): Makefile
-	$(SED_SUBST) $(daemon_asan_options) $@.in > $@
 
 # We keep this stub script around to have SELinux labeling work,
 # plus some backwards compatibility.

--- a/src/daemon/rpm-ostree-bootstatus.service
+++ b/src/daemon/rpm-ostree-bootstatus.service
@@ -5,7 +5,7 @@ ConditionPathExists=/run/ostree-booted
 
 [Service]
 Type=oneshot
-ExecStart=@bindir@/rpm-ostree status -b
+ExecStart=rpm-ostree status -b
 RemainAfterExit=yes
 
 [Install]

--- a/src/daemon/rpm-ostree-countme.service
+++ b/src/daemon/rpm-ostree-countme.service
@@ -9,4 +9,4 @@ User=rpm-ostree
 DynamicUser=yes
 StateDirectory=rpm-ostree-countme
 StateDirectoryMode=750
-ExecStart=@bindir@/rpm-ostree countme
+ExecStart=rpm-ostree countme

--- a/src/daemon/rpm-ostreed-automatic.service
+++ b/src/daemon/rpm-ostreed-automatic.service
@@ -5,5 +5,5 @@ ConditionPathExists=/run/ostree-booted
 
 [Service]
 Type=simple
-ExecStart=@bindir@/rpm-ostree upgrade --trigger-automatic-update-policy
+ExecStart=rpm-ostree upgrade --trigger-automatic-update-policy
 StandardOutput=null

--- a/src/daemon/rpm-ostreed.service
+++ b/src/daemon/rpm-ostreed.service
@@ -28,8 +28,7 @@ NotifyAccess=main
 # Significantly bump this timeout from the default because
 # we do a lot of stuff on daemon startup.
 TimeoutStartSec=5m
-@SYSTEMD_ENVIRON@
 # We start this main process with full privileges; it may spawn unprivileged processes
 # with the rpm-ostree user.
-ExecStart=+@bindir@/rpm-ostree start-daemon
-ExecReload=@bindir@/rpm-ostree reload
+ExecStart=+rpm-ostree start-daemon
+ExecReload=rpm-ostree reload


### PR DESCRIPTION
First, there's no reason anymore to add `@bindir` to our systemd units.
systemd itself has had support for traversing default paths since
at least RHEL8.  I think the absolute path requirement dates
to RHEL7 era systemd.

(We were also subsituting some bits for ASAN, but that's been
 dead code for a while and in any case would have been better
 handled by injecting a drop-in into `/etc`)

Second, the build system has always been buggy in that we
were missing rules to regenerate when the source unit changed,
which caused me quite a bit of debugging confusion at one point.
