### PR TITLE
[rhel8]: Switch to `BindReadOnlyPaths` for `/var/lib/containers`

### DIFF
--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -19,7 +19,7 @@ ProtectHome=true
 # Explicitly list paths here which we should never access.  The initial
 # entry here ensures that the skopeo process we fork won't interact with
 # application containers.
-InaccessiblePaths=-/var/lib/containers
+BindReadOnlyPaths=-/var/lib/containers
 NotifyAccess=main
 @SYSTEMD_ENVIRON@
 ExecStart=@bindir@/rpm-ostree start-daemon


### PR DESCRIPTION
This fixes https://bugzilla.redhat.com/show_bug.cgi?id=2111817

The way systemd implements `InaccessiblePaths` involves
recursively traversing all mounted paths in the target root, and
unmounting them; this takes about a tenth of a second in the kernel.
Further, after each unmount, it also re-parses
`/proc/self/mountinfo`.  The combination of these two things
makes handling mounts there `O(N²)` in userspace CPU time.

The implementation of `BindReadOnlyPaths` seems better; it just
effectively overmounts, which avoids any `O(N²)` behavior.

(cherry picked from commit 21c82ffe36dff61b2be8778634c571cb177a24e9)
