### PR TITLE
Add an always-on `container` feature

### DIFF
--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -536,7 +536,7 @@ pub(crate) fn varsubstitute(s: &str, subs: &Vec<crate::ffi::StringMapping>) -> C
 pub(crate) fn get_features() -> Vec<String> {
     // These constant features were originally set in configure.ac, but have migrated to
     // Rust in the interest in having less logic in autoconf.
-    let defaults = ["rust", "compose"].into_iter().map(Some);
+    let defaults = ["rust", "compose", "container"].into_iter().map(Some);
     let conditionals = [
         cfg!(feature = "fedora-integration").then(|| "fedora-integration"),
         cfg!(feature = "bin-unit-tests").then(|| "bin-unit-tests"),


### PR DESCRIPTION
I want to be able to detect in OCP when we have a new enough
rpm-ostree to use the container path.

I started doing some version-number parsing, but then realized
what we really want is a feature.

(That said, now that I think about it a bit more this feature
 in theory should be dynamic, e.g. the daemon could detect on
 startup whether `/usr/bin/skopeo` exists and is new enough, etc.
 But, no need to block on that right now)
