### PR TITLE
rust: Run `cargo clippy --fix`

### DIFF
--- a/rust/src/builtins/compose/commit.rs
+++ b/rust/src/builtins/compose/commit.rs
@@ -51,7 +51,7 @@ mod tests {
         let tmpdir = tempfile::tempdir().unwrap();
         let filepath = tmpdir.path().join("commit-id");
         let expected_id = "my-revision-id";
-        write_commit_id(&filepath.to_string_lossy(), &expected_id).unwrap();
+        write_commit_id(&filepath.to_string_lossy(), expected_id).unwrap();
         let read = std::fs::read_to_string(&filepath).unwrap();
         assert_eq!(read, expected_id);
     }

--- a/rust/src/cliwrap/yumdnf.rs
+++ b/rust/src/cliwrap/yumdnf.rs
@@ -122,12 +122,10 @@ impl RebaseCmd {
         use ostree_ext::container::SignatureSource;
         let sigverify = if self.no_signature_verification {
             SignatureSource::ContainerPolicyAllowInsecure
+        } else if let Some(remote) = self.ostree_remote.as_ref() {
+            SignatureSource::OstreeRemote(remote.to_string())
         } else {
-            if let Some(remote) = self.ostree_remote.as_ref() {
-                SignatureSource::OstreeRemote(remote.to_string())
-            } else {
-                SignatureSource::ContainerPolicy
-            }
+            SignatureSource::ContainerPolicy
         };
         Ok(ostree_ext::container::OstreeImageReference { sigverify, imgref })
     }
@@ -303,7 +301,7 @@ mod tests {
         ));
 
         fn strvec(s: impl IntoIterator<Item = &'static str>) -> Vec<String> {
-            s.into_iter().map(|s| String::from(s)).collect()
+            s.into_iter().map(String::from).collect()
         }
 
         // Tests for the ostree container case

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -422,7 +422,7 @@ mod test {
         // Replaced usermod.
         {
             let original_usermod = "original usermod";
-            d.atomic_write_with_perms(super::USERMOD_PATH, original_usermod, mode.clone())?;
+            d.atomic_write_with_perms(super::USERMOD_PATH, original_usermod, mode)?;
             let contents = d.read_to_string(super::USERMOD_PATH)?;
             assert_eq!(contents, original_usermod);
             let g = super::prepare_filesystem_script_prep(d.as_raw_fd())?;

--- a/rust/src/ffiutil.rs
+++ b/rust/src/ffiutil.rs
@@ -136,7 +136,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use glib;
+
     use std::{io, ptr};
 
     struct Foo {

--- a/rust/src/history.rs
+++ b/rust/src/history.rs
@@ -514,11 +514,11 @@ mod tests {
             assert!(
                 self.next_entry().unwrap()
                     == HistoryEntry {
-                        first_boot_timestamp: first_boot_timestamp,
-                        last_boot_timestamp: last_boot_timestamp,
-                        deploy_timestamp: deploy_timestamp,
+                        first_boot_timestamp,
+                        last_boot_timestamp,
+                        deploy_timestamp,
                         deploy_cmdline: "".to_string(),
-                        boot_count: boot_count,
+                        boot_count,
                         eof: false,
                     }
             );

--- a/rust/src/importer.rs
+++ b/rust/src/importer.rs
@@ -522,7 +522,7 @@ mod tests {
             let file_info = FileInfo::new();
             file_info.set_file_type(FileType::Directory);
             file_info.set_attribute_uint32("unix::mode", 0o721);
-            let out = translate_to_tmpfiles_d(&path, &file_info, &username, &groupname).unwrap();
+            let out = translate_to_tmpfiles_d(path, &file_info, username, groupname).unwrap();
             let expected = r#"d '/var/foo bar' 0721 testuser testgroup - -"#;
             assert_eq!(out, expected);
         }
@@ -531,7 +531,7 @@ mod tests {
             let file_info = FileInfo::new();
             file_info.set_file_type(FileType::SymbolicLink);
             file_info.set_symlink_target("/mytarget");
-            let out = translate_to_tmpfiles_d(&path, &file_info, &username, &groupname).unwrap();
+            let out = translate_to_tmpfiles_d(path, &file_info, username, groupname).unwrap();
             let expected = r#"L '/var/foo bar' - - - - /mytarget"#;
             assert_eq!(out, expected);
         }
@@ -540,7 +540,7 @@ mod tests {
             let file_info = FileInfo::new();
             file_info.set_file_type(FileType::Regular);
             file_info.set_attribute_uint32("unix::mode", 0o123);
-            let out = translate_to_tmpfiles_d(&path, &file_info, &username, &groupname).unwrap();
+            let out = translate_to_tmpfiles_d(path, &file_info, username, groupname).unwrap();
             let expected = r#"f '/var/foo bar' 0123 testuser testgroup - -"#;
             assert_eq!(out, expected);
         }
@@ -548,7 +548,7 @@ mod tests {
             // Other unsupported
             let file_info = FileInfo::new();
             file_info.set_file_type(FileType::Unknown);
-            translate_to_tmpfiles_d(&path, &file_info, &username, &groupname).unwrap_err();
+            translate_to_tmpfiles_d(path, &file_info, username, groupname).unwrap_err();
         }
     }
 

--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -524,7 +524,7 @@ mod test {
             ..Default::default()
         };
         let s = subpath(&d, Path::new("/foo"));
-        assert_eq!(s.as_ref().map(|s| s.as_path()), Some(Path::new("/usr/foo")));
+        assert_eq!(s.as_deref(), Some(Path::new("/usr/foo")));
     }
 }
 

--- a/rust/src/lockfile.rs
+++ b/rust/src/lockfile.rs
@@ -333,8 +333,8 @@ mod tests {
         let mut input = io::BufReader::new(INVALID_PRELUDE_JS.as_bytes());
         match utils::parse_stream::<LockfileConfig, _>(&utils::InputFormat::JSON, &mut input) {
             Err(ref e) => match e.downcast_ref::<io::Error>() {
-                Some(ref ioe) if ioe.kind() == io::ErrorKind::InvalidInput => {}
-                _ => panic!("Expected invalid lockfile, not {}", e.to_string()),
+                Some(ioe) if ioe.kind() == io::ErrorKind::InvalidInput => {}
+                _ => panic!("Expected invalid lockfile, not {}", e),
             },
             Ok(_) => panic!("Expected invalid lockfile"),
         }


### PR DESCRIPTION
We haven't yet enabled gating on clippy here, but I recently
discovered the `--fix` mode which is *so nice* for plowing through
things like the "extra &" lints.
