### PR TITLE
Add `ex deploy-from-self`

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -2040,6 +2040,9 @@ extern "C"
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$container_encapsulate (::rust::Vec< ::rust::String> *args) noexcept;
 
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$deploy_from_self_entrypoint (::rust::Vec< ::rust::String> *args) noexcept;
+
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$pull_container (
       const ::rpmostreecxx::OstreeRepo &repo, const ::rpmostreecxx::GCancellable &cancellable,
       ::rust::Str imgref, ::rust::Box< ::rpmostreecxx::ContainerImageState> *return$) noexcept;
@@ -3591,6 +3594,17 @@ container_encapsulate (::rust::Vec< ::rust::String> args)
 {
   ::rust::ManuallyDrop< ::rust::Vec< ::rust::String> > args$ (::std::move (args));
   ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$container_encapsulate (&args$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
+}
+
+void
+deploy_from_self_entrypoint (::rust::Vec< ::rust::String> args)
+{
+  ::rust::ManuallyDrop< ::rust::Vec< ::rust::String> > args$ (::std::move (args));
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$deploy_from_self_entrypoint (&args$.value);
   if (error$.ptr)
     {
       throw ::rust::impl< ::rust::Error>::error (error$);

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1751,6 +1751,8 @@ void cliwrap_write_wrappers (::std::int32_t rootfs);
 
 void container_encapsulate (::rust::Vec< ::rust::String> args);
 
+void deploy_from_self_entrypoint (::rust::Vec< ::rust::String> args);
+
 ::rust::Box< ::rpmostreecxx::ContainerImageState>
 pull_container (const ::rpmostreecxx::OstreeRepo &repo,
                 const ::rpmostreecxx::GCancellable &cancellable, ::rust::Str imgref);

--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -4,6 +4,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::num::NonZeroU32;
+use std::process::Command;
 use std::rc::Rc;
 
 use anyhow::Result;
@@ -23,6 +24,7 @@ use ostree_ext::prelude::*;
 use ostree_ext::{gio, ostree};
 
 use crate::cxxrsutil::FFIGObjectReWrap;
+use crate::CxxResult;
 
 /// Main entrypoint for container
 pub async fn entrypoint(args: &[&str]) -> Result<i32> {
@@ -397,5 +399,119 @@ pub fn container_encapsulate(args: Vec<String>) -> Result<()> {
         .await
     })?;
     println!("Pushed digest: {}", digest);
+    Ok(())
+}
+
+#[derive(clap::Parser)]
+struct UpdateFromRunningOpts {
+    /// Path to target system root
+    #[clap(value_parser)]
+    target_root: Utf8PathBuf,
+
+    #[clap(long)]
+    /// Reboot after performing operation
+    reboot: bool,
+}
+
+// This reimplements https://github.com/ostreedev/ostree/pull/2691 basically
+fn find_encapsulated_commits(repo: &Utf8Path) -> Result<Vec<String>> {
+    let objects = Dir::open_ambient_dir(&repo.join("objects"), cap_std::ambient_authority())?;
+    let mut r = Vec::new();
+    for entry in objects.entries()? {
+        let entry = entry?;
+        let etype = entry.file_type()?;
+        if !etype.is_dir() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = if let Some(n) = name.to_str() {
+            n
+        } else {
+            continue;
+        };
+
+        let subd = entry.open_dir()?;
+        for entry in subd.entries()? {
+            let entry = entry?;
+            let etype = entry.file_type()?;
+            if !etype.is_file() {
+                continue;
+            }
+            let subname = entry.file_name();
+            let subname = if let Some(n) = subname.to_str() {
+                Utf8Path::new(n)
+            } else {
+                continue;
+            };
+            if let (Some(stem), Some("commit")) = (subname.file_stem(), subname.extension()) {
+                r.push(format!("{name}{stem}"));
+            }
+        }
+    }
+
+    Ok(r)
+}
+
+/// The implementation of `rpm-ostree ex deploy-from-self`, which writes
+/// the container ostree commit to the host and deploys it, optionally rebooting.
+pub(crate) fn deploy_from_self_entrypoint(args: Vec<String>) -> CxxResult<()> {
+    use nix::sys::statvfs;
+    let cancellable = gio::NONE_CANCELLABLE;
+    let opts = UpdateFromRunningOpts::parse_from(args);
+
+    let sysroot = opts.target_root.join("sysroot");
+
+    if statvfs::statvfs(sysroot.as_std_path())?
+        .flags()
+        .contains(statvfs::FsFlags::ST_RDONLY)
+    {
+        let status = Command::new("mount")
+            .args(["-o", "remount,rw", sysroot.as_str()])
+            .status()?;
+        if !status.success() {
+            return Err(format!("Failed to remount /sysroot writable: {:?}", status).into());
+        }
+    }
+
+    let src_repo_path = Utf8Path::new("/ostree/repo");
+    // Just verify it can be opened for now...in the future ideally we'll use https://github.com/ostreedev/ostree/pull/2701
+    let src_repo = ostree::Repo::open_at(libc::AT_FDCWD, src_repo_path.as_str(), cancellable)?;
+    drop(src_repo);
+
+    let encapsulated_commits = find_encapsulated_commits(src_repo_path)?;
+    let commit = match encapsulated_commits.as_slice() {
+        [] => return Err(format!("No encapsulated commit found in container").into()),
+        [c] => c.as_str(),
+        o => return Err(format!("Found {} commit objects, expected just one", o.len()).into()),
+    };
+
+    let target_repo = sysroot.join("ostree/repo");
+    let target_repo = ostree::Repo::open_at(libc::AT_FDCWD, target_repo.as_str(), cancellable)?;
+
+    {
+        let flags = ostree::RepoPullFlags::MIRROR;
+        let opts = glib::VariantDict::new(None);
+        let refs = [commit];
+        opts.insert("refs", &&refs[..]);
+        opts.insert("flags", &(flags.bits() as i32));
+        let options = opts.to_variant();
+        target_repo.pull_with_options(
+            &format!("file://{src_repo_path}"),
+            &options,
+            None,
+            cancellable,
+        )?;
+    }
+
+    println!("Imported: {commit}");
+
+    let status = Command::new("chroot")
+        .args(&[opts.target_root.as_str(), "rpm-ostree", "rebase", commit])
+        .args(opts.reboot.then(|| "--reboot"))
+        .status()?;
+    if !status.success() {
+        return Err(format!("Failed to deploy commit: {:?}", status).into());
+    }
+
     Ok(())
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -172,6 +172,7 @@ pub mod ffi {
     // container.rs
     extern "Rust" {
         fn container_encapsulate(args: Vec<String>) -> Result<()>;
+        fn deploy_from_self_entrypoint(args: Vec<String>) -> Result<()>;
     }
 
     /// `ContainerImageState` is currently identical to ostree-rs-ext's `LayeredImageState` struct, because

--- a/src/app/rpmostree-builtin-ex.cxx
+++ b/src/app/rpmostree-builtin-ex.cxx
@@ -31,6 +31,9 @@ static RpmOstreeCommand ex_subcommands[]
           "Inspect rpm-ostree history of the system", rpmostree_ex_builtin_history },
         { "initramfs-etc", (RpmOstreeBuiltinFlags)0, "Track initramfs configuration files",
           rpmostree_ex_builtin_initramfs_etc },
+        { "deploy-from-self", (RpmOstreeBuiltinFlags)(RPM_OSTREE_BUILTIN_FLAG_CONTAINER_CAPABLE),
+          "Deploy OSTree commit in container repository to target system",
+          rpmostree_ex_builtin_deploy_from_self },
         /* This is currently only for CoreOS layering; so hide it to not confuse
          * users. */
         { "rebuild",
@@ -67,5 +70,17 @@ rpmostree_ex_builtin_module (int argc, char **argv, RpmOstreeCommandInvocation *
   for (int i = 0; i < argc; i++)
     rustargv.push_back (std::string (argv[i]));
   ROSCXX_TRY (modularity_entrypoint (rustargv), error);
+  return TRUE;
+}
+
+gboolean
+rpmostree_ex_builtin_deploy_from_self (int argc, char **argv,
+                                       RpmOstreeCommandInvocation *invocation,
+                                       GCancellable *cancellable, GError **error)
+{
+  rust::Vec<rust::String> rustargv;
+  for (int i = 0; i < argc; i++)
+    rustargv.push_back (std::string (argv[i]));
+  CXX_TRY (rpmostreecxx::deploy_from_self_entrypoint (rustargv), error);
   return TRUE;
 }

--- a/src/app/rpmostree-ex-builtins.h
+++ b/src/app/rpmostree-ex-builtins.h
@@ -36,6 +36,7 @@ BUILTINPROTO (history);
 BUILTINPROTO (initramfs_etc);
 BUILTINPROTO (module);
 BUILTINPROTO (rebuild);
+BUILTINPROTO (deploy_from_self);
 
 #undef BUILTINPROTO
 

--- a/tests/kolainst/destructive/container-update-inplace
+++ b/tests/kolainst/destructive/container-update-inplace
@@ -1,0 +1,43 @@
+#!/bin/bash
+# kola: { "timeoutMin": 20 }
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. ${KOLA_EXT_DATA}/libtest.sh
+
+set -x
+
+libtest_prepare_offline
+cd $(mktemp -d)
+image_dir=/var/tmp/fcos
+image=oci:$image_dir
+image_pull=ostree-unverified-image:$image
+tmp_imagedir=/var/tmp/fcos-tmp
+arch=$(arch)
+
+systemctl mask --now zincati
+
+# Take the existing ostree commit, and export it to a container image, then rebase to it.
+checksum=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
+
+ostree container encapsulate --repo=/ostree/repo ${checksum} containers-storage:localhost/fcos
+podman run --privileged --pid=host --net=host --rm -v /:/run/host --rm localhost/fcos rpm-ostree ex deploy-from-self /run/host
+
+echo ok container-update-inplace


### PR DESCRIPTION
This experimental command is intended to be mainly used in OCP
where we're trying to do a cutover to the new format container images.
However, we have the problem of old disk images where the rpm-ostree
there is too old to understand the container bits.  (Not to mention
skopeo is too old)

This code (+ integration test) demonstrates running the new OS
update *as a privileged container* which mounts the host filesystem
and performs the update that way.

A downside of this is that we only write the raw ostree commit;
we don't write the container-ostree refs; in other words, the
next update will need to re-pull the container.  That's...fixable,
it just requires a bit more nontrivial work that we can do later
as an optimization.
