### PR TITLE
Add .git-blame-ignore-revs and seed with `clang-format` commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# Run through `clang-format`:
+# https://github.com/coreos/rpm-ostree/pull/3475
+be45a74d0802c764d04cdfc6f3bcc12872b3bb33


### PR DESCRIPTION
We can include in this file commits which do mechanical changes like
linting that are rarely of value when tracing through history. You can
then tell `git blame` to ignore those commits using:

```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

The GitHub blame UI automatically does this.

Closes: #3963