### PR TITLE
core: Ignore subdirectories of `/usr/lib/modules` without a kernel

### DIFF
--- a/tests/compose/test-misc-tweaks.sh
+++ b/tests/compose/test-misc-tweaks.sh
@@ -13,6 +13,12 @@ build_rpm foobar-rec
 build_rpm quuz
 build_rpm corge version 1.0
 build_rpm corge version 2.0
+build_rpm thirdpartymodules version 2.3 \
+  files "/usr/lib/modules/4.7.8-10.x86_64/foo.ko
+         /usr/lib/modules/4.9.3-2.x86_64/foo.ko
+         /usr/lib/modules/5.8.1-11.x86_64/foo.ko
+         " \
+  install "for v in 4.7.8-10.x86_64 4.9.3-2.x86_64 5.8.1-11.x86_64; do d=%{buildroot}/usr/lib/modules/\$v; mkdir -p \$d && echo kmod\$v > \$d/foo.ko; done"
 # test `remove-from-packages` (files shared with other pkgs should not be removed)
 build_rpm barbar \
           files "/etc/sharedfile
@@ -26,7 +32,7 @@ build_rpm barbaz \
 echo gpgcheck=0 >> yumrepo.repo
 ln "$PWD/yumrepo.repo" config/yumrepo.repo
 # the top-level manifest doesn't have any packages, so just set it
-treefile_append "packages" $'["\'foobar >= 0.5\' quuz \'corge < 2.0\' barbar barbaz"]'
+treefile_append "packages" $'["\'foobar >= 0.5\' quuz \'corge < 2.0\' barbar barbaz thirdpartymodules"]'
 
 # With docs and recommends, also test multi includes
 cat > config/documentation.yaml <<'EOF'

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -159,6 +159,9 @@ ADD baz-2.0-1.x86_64.rpm /run/rpm-ostree/staged-rpms/${baz_chksum}.rpm
 RUN rpm-ostree ex rebuild
 RUN echo some config file > /etc/someconfig.conf
 RUN echo somedata > /usr/share/somenewdata
+# Verify we're ignoring subdirectories that don't contain vmlinuz https://github.com/coreos/rpm-ostree/issues/3965
+RUN mkdir -p /usr/lib/modules/blah && touch /usr/lib/modules/blah/foo
+RUN rpm-ostree cleanup -m
 EOF
     # Older podman found in RHEL8 blows up without /etc/resolv.conf
     # which happens in our qemu path.


### PR DESCRIPTION
There's a valid use case of installing a 3rd party RPM which has
pre-built kmods for *multiple* kernel versions.  What we care about
here is that there aren't actually multiple kernel binaries aka
`vmlinuz`.

Closes: https://github.com/coreos/rpm-ostree/issues/3965
