### PR TITLE
rust: Bump to ostree-ext 0.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "ostree-ext"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d284276e1d9c7a8651d03f967064734c9e038b725a78412dcf9a31ba16f0a8"
+checksum = "df4deae91dbcd44fec84a7a6050b19e1952c35ddcab956d283dea86c9f7d6c37"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -86,7 +86,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     # Create a new ostree commit containing foo and export the commit as a container image
     with_foo_commit=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
     ostree refs ${with_foo_commit} --create vmcheck_tmp/new_update
-    new_commit=$(ostree commit -b vmcheck --tree=ref=vmcheck_tmp/new_update)
+    new_commit=$(ostree commit -b vmcheck --bootable --tree=ref=vmcheck_tmp/new_update)
     rm "${image_dir}" -rf
     ostree container encapsulate --compression-fast --repo=/ostree/repo ${new_commit} "$image"
 


### PR DESCRIPTION
Mainly for the whiteout support, which is going to be
really important for handling package overrides.
