### PR TITLE
tests: Use `--bootable` when generating derived commits

### DIFF
--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -723,7 +723,7 @@ vm_ostree_repo_commit_layered_as_base() {
   ostree checkout --repo=$repo -H --fsync=no $from_rev $d
   # need to update the base rpmdb
   rsync -qIa --delete $d/usr/share/rpm/ $d/usr/lib/sysimage/rpm-ostree-base-db/
-  ostree commit --repo=$repo -b $to_ref --link-checkout-speedup --fsync=no --consume $d
+  ostree commit --repo=$repo -b $to_ref --link-checkout-speedup --fsync=no --bootable --consume $d
   # and inject pkglist metadata
   rpm-ostree testutils inject-pkglist $repo $to_ref >/dev/null
 EOF

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -86,7 +86,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     # Create a new ostree commit containing foo and export the commit as a container image
     with_foo_commit=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
     ostree refs ${with_foo_commit} --create vmcheck_tmp/new_update
-    new_commit=$(ostree commit -b vmcheck --tree=ref=vmcheck_tmp/new_update)
+    new_commit=$(ostree commit -b vmcheck --bootable --tree=ref=vmcheck_tmp/new_update)
     rm "${image_dir}" -rf
     ostree container encapsulate --compression-fast --repo=/ostree/repo ${new_commit} "$image"
 

--- a/tests/vmcheck/test-cached-rpm-diffs.sh
+++ b/tests/vmcheck/test-cached-rpm-diffs.sh
@@ -31,26 +31,26 @@ set -x
 # the usual update synthesis trickery
 noop_csum=$(vm_cmd ostree commit -b vmcheck --fsync=no \
                 --tree=ref=$(vm_get_booted_csum) \
-                --add-metadata-string=version=vDeployNoop)
+                --add-metadata-string=version=vDeployNoop --bootable)
 # put a pin on it so it doesn't get blown away
 vm_cmd ostree refs $noop_csum --create vmcheck_tmp/pinned
 vm_build_rpm pkg1
 vm_rpmostree install pkg1
 deploy_csum=$(vm_cmd ostree commit -b vmcheck --fsync=no \
                 --tree=ref=$(vm_get_pending_csum) \
-                --add-metadata-string=version=vDeploy)
+                --add-metadata-string=version=vDeploy --bootable)
 # put a pin on it so it doesn't get blown away
 vm_cmd ostree refs $deploy_csum --create vmcheck_tmp/pinned2
 vm_build_rpm pkg2
 vm_rpmostree install pkg2
 update_csum=$(vm_cmd ostree commit -b vmcheck --fsync=no \
                 --tree=ref=$(vm_get_pending_csum) \
-                --add-metadata-string=version=vUpdate)
+                --add-metadata-string=version=vUpdate --bootable)
 vm_build_rpm pkg3
 vm_rpmostree install pkg3
 rebase_csum=$(vm_cmd ostree commit -b vmcheck_tmp/other_branch --fsync=no \
                 --tree=ref=$(vm_get_pending_csum) \
-                --add-metadata-string=version=vRebase)
+                --add-metadata-string=version=vRebase --bootable)
 vm_rpmostree cleanup -p
 echo "ok setup"
 

--- a/tests/vmcheck/test-download-only.sh
+++ b/tests/vmcheck/test-download-only.sh
@@ -102,7 +102,7 @@ vm_rpmostree upgrade -C --unchanged-exit-77 || rc=$?
 assert_streq "$rc" "77"
 echo "ok check for change with --cache-only"
 
-$REMOTE_OSTREE commit -b vmcheck --tree=ref=vmcheck --timestamp '"Oct 21 1988"'
+$REMOTE_OSTREE commit -b vmcheck --tree=ref=vmcheck --bootable --timestamp '"Oct 21 1988"'
 vm_cmd ostree pull vmcheck_remote:vmcheck
 if vm_rpmostree upgrade -C |& tee out.txt; then
   assert_not_reached "upgraded to chronologically older commit"
@@ -141,7 +141,7 @@ vm_rpmostree cleanup -prmb
 vm_rpmostree rebase --remote vmcheck_remote
 vm_build_rpm_repo_mode skip foobar version 2.0
 vm_rpmostree override replace $YUMREPO/foobar-2.0-1.x86_64.rpm
-csum=$($REMOTE_OSTREE commit -b vmcheck --tree=ref=vmcheck)
+csum=$($REMOTE_OSTREE commit -b vmcheck --tree=ref=vmcheck --bootable)
 vm_rpmostree upgrade --download-only
 vm_assert_status_jq \
   ".deployments[0][\"base-checksum\"] != \"$csum\"" \

--- a/tests/vmcheck/test-layering-basic-2.sh
+++ b/tests/vmcheck/test-layering-basic-2.sh
@@ -32,7 +32,7 @@ assert_file_has_content output.txt '^Importing packages\.\.\.done'
 assert_file_has_content output.txt "Checking out tree "
 
 # upgrade with same foo in repos --> shouldn't re-import
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck --bootable
 vm_rpmostree upgrade | tee output.txt
 assert_not_file_has_content output.txt '^Importing packages\.\.\.'
 echo "ok reuse cached pkg"
@@ -77,7 +77,7 @@ ostree init --repo ${OLD_PKGCACHE_DIR} --mode=bare
 ostree pull-local --repo ${OLD_PKGCACHE_DIR} /ostree/repo \
   rpmostree/pkg/test-pkgcache-migrate-pkg{1,2}/1.0-1.x86__64
 EOF
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck --bootable
 cursor=$(vm_get_journal_cursor)
 vm_rpmostree upgrade | tee output.txt
 vm_wait_content_after_cursor $cursor 'migrated 2 cached packages'

--- a/tests/vmcheck/test-layering-relabel.sh
+++ b/tests/vmcheck/test-layering-relabel.sh
@@ -61,7 +61,7 @@ echo "ok layer selinux pkg"
 
 # now let's change the policy
 vm_build_selinux_rpm foobar-selinux /usr/bin/foobar shell_exec_t
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck --bootable
 vm_rpmostree upgrade
 root=$(vm_get_deployment_root 0)
 assert_actual_label $root/usr/bin/foobar shell_exec_t
@@ -77,7 +77,7 @@ root=$(vm_get_deployment_root 0)
 se_new_csum=$(vm_cmd ostree checksum $root/usr/etc/selinux/targeted/policy/policy.*)
 assert_not_streq "$se_csum" "$se_new_csum"
 csum=$(vm_get_deployment_info 0 checksum)
-vm_cmd ostree commit -b vmcheck --tree=ref=$csum
+vm_cmd ostree commit -b vmcheck --tree=ref=$csum --bootable
 vm_rpmostree cleanup -p
 echo "ok setup relabel"
 

--- a/tests/vmcheck/test-layering-relayer.sh
+++ b/tests/vmcheck/test-layering-relayer.sh
@@ -56,7 +56,7 @@ vm_assert_status_jq \
   '.deployments[0]["base-checksum"]' \
   '.deployments[0]["pending-base-checksum"]|not'
 # let's synthesize an upgrade
-commit=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck)
+commit=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck --bootable)
 vm_rpmostree upgrade
 vm_assert_status_jq \
   '.deployments[1]["base-checksum"]' \
@@ -75,7 +75,7 @@ echo "ok pkg foo relayered on upgrade"
 # DEPLOY
 
 commit=$(vm_cmd ostree commit -b vmcheck \
-           --tree=ref=vmcheck --add-metadata-string=version=my-commit)
+           --tree=ref=vmcheck --add-metadata-string=version=my-commit --bootable)
 vm_rpmostree deploy my-commit
 reboot_and_assert_base $commit
 echo "ok deploy"
@@ -85,7 +85,7 @@ echo "ok pkg foo relayered on deploy"
 
 # REBASE
 
-commit=$(vm_cmd ostree commit -b vmcheck_tmp/rebase_test --tree=ref=vmcheck)
+commit=$(vm_cmd ostree commit -b vmcheck_tmp/rebase_test --tree=ref=vmcheck --bootable)
 vm_rpmostree rebase --skip-purge vmcheck_tmp/rebase_test
 reboot_and_assert_base $commit
 echo "ok rebase"
@@ -104,7 +104,7 @@ vm_assert_status_jq ".deployments[0][\"base-checksum\"] == \"${commit}\"" \
                  '.deployments[0]["packages"]|index("foo") >= 0' \
                  '.deployments[0]["packages"]|index("bar") >= 0'
 commit=$(vm_cmd ostree commit -b vmcheck \
-                --tree=ref=vmcheck --add-metadata-string=version=my-commit2)
+                --tree=ref=vmcheck --add-metadata-string=version=my-commit2 --bootable)
 vm_rpmostree rebase ${commit}
 vm_assert_status_jq ".deployments[0][\"base-checksum\"] == \"${commit}\"" \
                  '.deployments[0]["packages"]|index("foo") >= 0' \

--- a/tests/vmcheck/test-layering-rpmdb.sh
+++ b/tests/vmcheck/test-layering-rpmdb.sh
@@ -56,7 +56,7 @@ echo "ok pkg foo added"
 
 # remember it for later
 vm_cmd ostree refs $(vm_get_booted_csum) --create vmcheck_tmp/with_foo
-csum_with_foo=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo)
+csum_with_foo=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo --bootable)
 
 # check that upgrading to it will make the package dormant
 
@@ -80,7 +80,7 @@ echo "ok can't layer conflicting pkg (dormant)"
 
 # now check that upgrading to a new base layer that drops foo relayers it
 
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/without_foo
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/without_foo --bootable
 vm_rpmostree upgrade
 vm_reboot
 
@@ -113,7 +113,7 @@ fi
 echo "ok can't layer conflicting pkg (base)"
 
 # ok, now go back to a base layer without foo and add bar
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/without_foo
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/without_foo --bootable
 vm_rpmostree upgrade
 vm_rpmostree pkg-add bar
 vm_reboot
@@ -122,7 +122,7 @@ vm_assert_layered_pkg bar present
 echo "ok pkg-add bar"
 
 # now let's try to do an upgrade to a base layer which *has* foo
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo --bootable
 if vm_rpmostree upgrade; then
   assert_not_reached "upgrade succeeded but new base has conflicting pkg foo"
 fi
@@ -150,7 +150,7 @@ echo "ok coloring layered"
 
 # now embed the x86_64 version into it
 vm_rpmostree install bloop.x86_64
-vm_cmd ostree commit -b vmcheck --tree=ref=$(vm_get_pending_csum) --fsync=no
+vm_cmd ostree commit -b vmcheck --tree=ref=$(vm_get_pending_csum) --fsync=no --bootable
 vm_rpmostree cleanup -p
 vm_rpmostree upgrade
 check_bloop_color 64-bit

--- a/tests/vmcheck/test-layering-unified.sh
+++ b/tests/vmcheck/test-layering-unified.sh
@@ -38,7 +38,7 @@ bar_rpm=/var/tmp/vmcheck/yumrepo/packages/x86_64/bar-1.0-1.x86_64.rpm
 
 # UPGRADE
 
-commit=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck)
+commit=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck --bootable)
 vm_status_watch_start
 vm_rpmostree upgrade --install bar --install $foo_rpm
 vm_status_watch_check "Transaction: upgrade --install bar --install $foo_rpm"
@@ -54,7 +54,7 @@ echo "ok upgrade with bar and local foo"
 
 # DEPLOY
 
-commit=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck \
+commit=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck --bootable \
            --add-metadata-string=version=SUPADUPAVERSION)
 vm_status_watch_start
 vm_rpmostree deploy SUPADUPAVERSION --install foo --install $bar_rpm
@@ -72,7 +72,7 @@ echo "ok deploy with foo and local bar"
 
 # REBASE
 
-commit=$(vm_cmd ostree commit -b vmcheck_tmp/rebase \
+commit=$(vm_cmd ostree commit -b vmcheck_tmp/rebase --bootable \
            --tree=ref=vmcheck --add-metadata-string=version=SUPADUPAVERSION)
 vm_status_watch_start
 vm_rpmostree rebase vmcheck_tmp/rebase SUPADUPAVERSION \

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -32,7 +32,7 @@ assert_file_has_content status.txt 'Commit:'
 
 # Locked finalization
 booted_csum=$(vm_get_booted_csum)
-commit=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck)
+commit=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck --bootable)
 vm_rpmostree deploy revision="${commit}" --lock-finalization
 vm_cmd test -f /run/ostree/staged-deployment-locked
 cursor=$(vm_get_journal_cursor)
@@ -107,7 +107,7 @@ echo "ok rebase from local repo remote"
 # Add metadata string containing EnfOfLife attribtue
 META_ENDOFLIFE_MESSAGE="this is a test for metadata message"
 commit=$(vm_cmd ostree commit -b vmcheck \
-            --tree=ref=vmcheck --add-metadata-string=ostree.endoflife="'${META_ENDOFLIFE_MESSAGE}'")
+            --tree=ref=vmcheck --add-metadata-string=ostree.endoflife="'${META_ENDOFLIFE_MESSAGE}'" --bootable)
 vm_rpmostree upgrade
 vm_assert_status_jq ".deployments[0][\"endoflife\"] == \"${META_ENDOFLIFE_MESSAGE}\""
 echo "ok endoflife metadata gets parsed correctly"
@@ -183,7 +183,7 @@ vm_assert_status_jq ".deployments|length == 1"
 echo "ok unpin"
 
 # https://github.com/ostreedev/ostree/pull/1055
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck --timestamp=\"October 25 1985\"
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck --timestamp=\"October 25 1985\" --bootable
 if vm_rpmostree upgrade 2>err.txt; then
     fatal "upgraded to older commit?"
 fi
@@ -223,7 +223,7 @@ echo "ok detecting file name conflicts before writing rpmdb"
 vm_rpmostree cleanup -rp
 vm_rpmostree status
 echo "before redeploy"
-csum=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck)
+csum=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck --bootable)
 # restart to make daemon see the pending checksum
 vm_cmd systemctl restart rpm-ostreed
 vm_assert_status_jq '.deployments[0]["pending-base-checksum"]'
@@ -303,7 +303,7 @@ assert_file_has_content status.txt "error: opendir"
 echo "ok previous staged failure in status"
 
 # check that --skip-branch-check indeeds skips branch checking
-csum=$(vm_cmd ostree commit -b otherbranch --tree=ref=vmcheck)
+csum=$(vm_cmd ostree commit -b otherbranch --tree=ref=vmcheck --bootable)
 if vm_rpmostree deploy $csum 2>err.txt; then
     assert_not_reached "Deployed to commit on different branch"
 fi
@@ -331,7 +331,7 @@ vm_assert_status_jq ".\"update-driver\"[\"driver-name\"] == \"TestDriver\"" \
 echo "ok deploy --register-driver with empty string revision"
 
 # Ensure that we are prevented from rebasing when an updates driver is registered
-commit=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck)
+commit=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck --bootable)
 if vm_rpmostree rebase :"${commit}" --skip-purge 2>err.txt;then
   assert_not_reached "Rebase with updates driver registered unexpectedly succeeded"
 fi

--- a/tests/vmcheck/test-override-local-replace.sh
+++ b/tests/vmcheck/test-override-local-replace.sh
@@ -123,7 +123,7 @@ vm_cmd rpm-ostree status > status.txt
 assert_file_has_content_literal status.txt 'bar 1.0-1 -> 0.9-1'
 echo "ok override replace resets previous override"
 
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck --bootable
 vm_rpmostree upgrade
 vm_assert_status_jq \
   '.deployments[0]["base-local-replacements"]|length == 3' \

--- a/tests/vmcheck/test-override-remove.sh
+++ b/tests/vmcheck/test-override-remove.sh
@@ -113,7 +113,7 @@ vm_cmd rpm-ostree status > status.txt
 assert_file_has_content status.txt '\(foo bar\|bar foo\) 1\.0-1'
 echo "ok override remove foo and bar"
 
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck --bootable
 vm_rpmostree upgrade --cache-only
 vm_assert_status_jq \
   '.deployments[0]["base-removals"]|length == 2' \


### PR DESCRIPTION
To ensure we consistently have the `ostree.bootable` key which
we'd like to make mandatory in the future.

cc https://github.com/ostreedev/ostree-rs-ext/commit/9c4a75b3778a3f2fdece095f8f5f7a6289ab512d
