### PR TITLE
treefile: Add generic metadata

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -19,6 +19,10 @@ It supports the following parameters:
 
    Example: `ref: "cool-os/${releasever}/${stream}"`
 
+ * `metadata`: Mapping of strings to values, optional.  This can be used
+   for other tools to insert arbitrary metadata into the treefile which
+   they parse later, for example via `rpm-ostree compose tree --print-metadata-json`.
+
  * `gpg-key` (or `gpg_key`): string, optional: Key ID for GPG signing; the
    secret key must be in the home directory of the building user.  Defaults to
    none.


### PR DESCRIPTION
This has the same rationale as https://doc.rust-lang.org/cargo/reference/manifest.html#the-metadata-table

In FCOS we're using `rojig` solely for the `name` value; with this
we can add
```
metadata:
  name: fedora-coreos
```
into the FCOS manifest and stop (ab)using `rojig`.
