### PR TITLE
A few prep patches for unprivileged compose/build

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1014,10 +1014,7 @@ impl_install_tree (RpmOstreeTreeComposeContext *self, gboolean *out_changed,
   if (!inject_advisories (self, cancellable, error))
     return FALSE;
 
-  /* Destroy this now so the libdnf stack won't have any references
-   * into the filesystem before we manipulate it.
-   */
-  g_clear_object (&self->corectx);
+  rpmostree_context_prepare_commit (self->corectx);
 
   if (g_strcmp0 (g_getenv ("RPM_OSTREE_BREAK"), "post-yum") == 0)
     return FALSE;

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -4704,8 +4704,11 @@ rpmostree_context_commit (RpmOstreeContext *self, const char *parent,
         = g_variant_ref_sink (g_variant_builder_end (&metadata_builder));
     // Unfortunately this API takes GVariantDict, not GVariantBuilder, so convert
     g_autoptr (GVariantDict) metadata_dict = g_variant_dict_new (metadata_so_far);
-    if (!ostree_commit_metadata_for_bootable (root, metadata_dict, cancellable, error))
-      return FALSE;
+    if (!self->treefile_rs->get_container ())
+      {
+        if (!ostree_commit_metadata_for_bootable (root, metadata_dict, cancellable, error))
+          return FALSE;
+      }
     g_autoptr (GVariant) metadata = g_variant_dict_end (metadata_dict);
 
     {

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -4495,6 +4495,15 @@ rpmostree_context_assemble_end (RpmOstreeContext *self, GCancellable *cancellabl
   return TRUE;
 }
 
+// De-initialize any references to open files in the target root, preparing
+// it for commit.
+void
+rpmostree_context_prepare_commit (RpmOstreeContext *self)
+{
+  /* Clear this out to ensure it's not holding open any files */
+  g_clear_object (&self->dnfctx);
+}
+
 gboolean
 rpmostree_context_commit (RpmOstreeContext *self, const char *parent,
                           RpmOstreeAssembleType assemble_type, char **out_commit,
@@ -4641,6 +4650,8 @@ rpmostree_context_commit (RpmOstreeContext *self, const char *parent,
 
     g_variant_builder_add (&metadata_builder, "{sv}", "rpmostree.state-sha512",
                            g_variant_new_string (state_checksum));
+
+    rpmostree_context_prepare_commit (self);
 
     CXX_TRY (rpmostreecxx::postprocess_cleanup_rpmdb (self->tmprootfs_dfd), error);
 

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -119,6 +119,7 @@ rpmostree_context_init (RpmOstreeContext *self)
   self->tmprootfs_dfd = -1;
   self->dnf_cache_policy = RPMOSTREE_CONTEXT_DNF_CACHE_DEFAULT;
   self->enable_rofiles = TRUE;
+  self->unprivileged = getuid () != 0;
 }
 
 static void

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -177,6 +177,7 @@ int rpmostree_context_get_tmprootfs_dfd (RpmOstreeContext *self);
 
 gboolean rpmostree_context_get_kernel_changed (RpmOstreeContext *self);
 
+void rpmostree_context_prepare_commit (RpmOstreeContext *self);
 /* NB: tmprootfs_dfd is allowed to have pre-existing data */
 /* devino_cache can be NULL if no previous cache established */
 gboolean rpmostree_context_assemble (RpmOstreeContext *self, GCancellable *cancellable,


### PR DESCRIPTION
core: Initialize unprivileged member variable

This was added a while ago but apparently never used; prep for
future work around unprivileged builds.

---

core: Add an API to deinitialize libdnf

The compose side currently deallocates the whole core object.  Today
the commit logic is duplicated in compose/build and core.  This will
help move us fully to using the core for commit.

---

core: Also only set bootable metadata if `!container`

The commit logic is duplicated between core/compose; this currently
doesn't matter, but it will in the future when we unify these.

---

