### PR TITLE
ridiculous-rhel-devel-workaround: use yum localinstall instead of rpm -U

### DIFF
--- a/ci/ridiculous-rhel-devel-workaround.sh
+++ b/ci/ridiculous-rhel-devel-workaround.sh
@@ -33,7 +33,7 @@ if test -f /usr/lib/os-release; then
         fi
         rm -vf $builddir/*debuginfo*.rpm
         rm -vf $builddir/*python*.rpm
-        rpm -Uvh --oldpackage $builddir/*.rpm
+        yum -y localinstall $builddir/*.rpm
     fi
 else
     echo "Unhandled OS" 1>&2

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -10,6 +10,7 @@ use anyhow::{anyhow, Result};
 use cap_std_ext::rustix;
 use gio::prelude::*;
 use ostree_ext::{gio, glib};
+use std::env;
 use std::io::{BufRead, Write};
 use std::os::unix::io::IntoRawFd;
 use std::process::Command;
@@ -356,9 +357,6 @@ mod tests {
 
     #[test]
     fn test_running_in_container() {
-        assert_eq!(
-            Path::new("/run/.containerenv").exists(),
-            running_in_container()
-        );
+        assert_eq!(env::var("container").is_ok(), running_in_container());
     }
 }


### PR DESCRIPTION
It looks like util-linux in the container is in sync again with the one
we clone, so we can just install what we need. However using yum
instead of rpm avoids the exit code 24 and might future proof this
in case the dependencies get out of sync again.