### PR TITLE
cliwrap/rpm: Don't drop privileges in a container image

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -37,6 +37,9 @@ yum -y install cowsay && yum clean all
 cowsay "It worked"
 test '!' -d /var/cache/rpm-ostree
 
+rpm -e cowsay
+if rpm -q cowsay; then fatal "failed to remove cowsay"; fi
+
 versionid=$(. /usr/lib/os-release && echo $VERSION_ID)
 # Let's start by trying to install a bona fide module.
 # NOTE: If changing this also change the layering-modules test

--- a/rust/src/cliwrap/rpm.rs
+++ b/rust/src/cliwrap/rpm.rs
@@ -86,9 +86,10 @@ fn disposition(host: SystemHostType, argv: &[&str]) -> Result<RunDisposition> {
 
 /// Primary entrypoint to running our wrapped `rpm` handling.
 pub(crate) fn main(host: SystemHostType, argv: &[&str]) -> Result<()> {
-    if host == SystemHostType::OstreeHost && cliutil::is_unlocked()? {
-        // For now if we're unlocked, just directly exec rpm. In the future we
-        // may choose to take over installing a package live.
+    let is_unlocked_ostree = host == SystemHostType::OstreeHost && cliutil::is_unlocked()?;
+    // For now if we're in a container or unlocked, just directly exec rpm. In the future we
+    // may choose to actually redirect commands like `rpm -e foo` to `rpm-ostree uninstall foo`.
+    if host == SystemHostType::OstreeContainer || is_unlocked_ostree {
         cliutil::exec_real_binary("rpm", argv)
     } else {
         match disposition(host, argv)? {


### PR DESCRIPTION
This was breaking `rpm -e ansible` in https://github.com/coreos/coreos-layering-examples/blob/2da697387875f2f24cc697cf2871c4b212f9ff43/ansible-firewalld/Dockerfile#L12 when cliwrap is enabled.
