### PR TITLE
build-sys: Disable LTO by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,8 +117,9 @@ opt-level = 1 # No optimizations are too slow for us.
 panic = "abort"
 # We assume we're being delivered via e.g. RPM which supports split debuginfo
 debug = true
-# We need this to avoid leaking symbols, see
-# https://internals.rust-lang.org/t/rust-staticlibs-and-optimizing-for-size/5746
+
+[profile.releaselto]
+inherits = "release"
 lto = "thin"
 
 [features]

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -166,9 +166,6 @@ The %{name}-devel package includes the header files for %{name}-libs.
 
 %prep
 %autosetup -Sgit -n %{name}-%{version}
-%if 0%{?__isa_bits} == 32
-sed -ie 's,^lto = true,lto = false,' Cargo.toml
-%endif
 
 %build
 env NOCONFIGURE=1 ./autogen.sh


### PR DESCRIPTION
Way back when, we landed a2bbc12812cb3a012cc4af50ff918dca21795c9e "rust: Enable lto by default".

However at the time, rpm-ostree was a C program with a Rust shared library.  Later we flipped it to being a Rust program with a C++ shared library.

And...that fixes the problem of leaking symbols that motivated having LTO on by default.

Let's defer the decision of using LTO to higher level build systems; operating systems/distros might set `RUSTFLAGS=-C lto` globally or per package as desired.

The immediate motivation here is that I don't always remember to do non-release builds locally and LTO is still a lot slower than non-LTO.
