### PR TITLE
compose: stop passing JSON treefile to function computing checksum

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -397,8 +397,7 @@ install_packages (RpmOstreeTreeComposeContext *self, gboolean *out_unmodified,
   /* FIXME - just do a depsolve here before we compute download requirements */
   g_autofree char *ret_new_inputhash = NULL;
   if (!rpmostree_composeutil_checksum (dnf_context_get_goal (dnfctx), self->repo,
-                                       **self->treefile_rs, self->treefile, &ret_new_inputhash,
-                                       error))
+                                       **self->treefile_rs, &ret_new_inputhash, error))
     return FALSE;
 
   g_assert (ret_new_inputhash != NULL);

--- a/src/app/rpmostree-composeutil.cxx
+++ b/src/app/rpmostree-composeutil.cxx
@@ -45,7 +45,7 @@
 
 gboolean
 rpmostree_composeutil_checksum (HyGoal goal, OstreeRepo *repo, const rpmostreecxx::Treefile &tf,
-                                JsonObject *treefile, char **out_checksum, GError **error)
+                                char **out_checksum, GError **error)
 {
   GLNX_AUTO_PREFIX_ERROR ("Computing compose checksum", error);
   g_autoptr (GChecksum) checksum = g_checksum_new (G_CHECKSUM_SHA256);

--- a/src/app/rpmostree-composeutil.h
+++ b/src/app/rpmostree-composeutil.h
@@ -28,8 +28,8 @@
 G_BEGIN_DECLS
 
 gboolean rpmostree_composeutil_checksum (HyGoal goal, OstreeRepo *repo,
-                                         const rpmostreecxx::Treefile &tf, JsonObject *treefile,
-                                         char **out_checksum, GError **error);
+                                         const rpmostreecxx::Treefile &tf, char **out_checksum,
+                                         GError **error);
 
 gboolean rpmostree_composeutil_read_json_metadata (JsonNode *root, GHashTable *metadata,
                                                    GError **error);


### PR DESCRIPTION
It's been an unused parameter since we moved the checksum logic into the treefile.

Prep for future work in pushing the checksum computation into core.
