### PR TITLE
Deduplicate code to compute state digest

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1669,8 +1669,9 @@ rpmostree_compose_builtin_extensions (int argc, char **argv, RpmOstreeCommandInv
   if (!glnx_opendirat (AT_FDCWD, opt_extensions_output_dir, TRUE, &output_dfd, error))
     return glnx_prefix_error (error, "Opening output dir");
 
-  g_autofree char *state_checksum;
-  if (!rpmostree_context_get_state_sha512 (ctx, &state_checksum, error))
+  g_autofree char *state_checksum
+      = rpmostree_context_get_state_digest (ctx, G_CHECKSUM_SHA512, error);
+  if (!state_checksum)
     return FALSE;
 
   CXX_TRY_VAR (changed,

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -395,9 +395,9 @@ install_packages (RpmOstreeTreeComposeContext *self, gboolean *out_unmodified,
     }
 
   /* FIXME - just do a depsolve here before we compute download requirements */
-  g_autofree char *ret_new_inputhash = NULL;
-  if (!rpmostree_composeutil_checksum (dnf_context_get_goal (dnfctx), self->repo,
-                                       **self->treefile_rs, &ret_new_inputhash, error))
+  g_autofree char *ret_new_inputhash
+      = rpmostree_context_get_state_digest (self->corectx, G_CHECKSUM_SHA256, error);
+  if (!ret_new_inputhash)
     return FALSE;
 
   g_assert (ret_new_inputhash != NULL);

--- a/src/app/rpmostree-composeutil.cxx
+++ b/src/app/rpmostree-composeutil.cxx
@@ -44,26 +44,6 @@
 #include "rpmostree-util.h"
 
 gboolean
-rpmostree_composeutil_checksum (HyGoal goal, OstreeRepo *repo, const rpmostreecxx::Treefile &tf,
-                                char **out_checksum, GError **error)
-{
-  GLNX_AUTO_PREFIX_ERROR ("Computing compose checksum", error);
-  g_autoptr (GChecksum) checksum = g_checksum_new (G_CHECKSUM_SHA256);
-
-  /* Hash in the treefile inputs (this includes all externals like postprocess, add-files,
-   * etc... and the final flattened treefile -- see treefile.rs for more details). */
-  CXX_TRY_VAR (tf_checksum, tf.get_checksum (*repo), error);
-  g_checksum_update (checksum, (const guint8 *)tf_checksum.data (), tf_checksum.size ());
-
-  /* Hash in each package */
-  if (!rpmostree_dnf_add_checksum_goal (checksum, goal, NULL, error))
-    return FALSE;
-
-  *out_checksum = g_strdup (g_checksum_get_string (checksum));
-  return TRUE;
-}
-
-gboolean
 rpmostree_composeutil_read_json_metadata (JsonNode *root, GHashTable *metadata, GError **error)
 {
   g_autoptr (GVariant) jsonmetav = json_gvariant_deserialize (root, "a{sv}", error);

--- a/src/app/rpmostree-composeutil.h
+++ b/src/app/rpmostree-composeutil.h
@@ -27,10 +27,6 @@
 
 G_BEGIN_DECLS
 
-gboolean rpmostree_composeutil_checksum (HyGoal goal, OstreeRepo *repo,
-                                         const rpmostreecxx::Treefile &tf, char **out_checksum,
-                                         GError **error);
-
 gboolean rpmostree_composeutil_read_json_metadata (JsonNode *root, GHashTable *metadata,
                                                    GError **error);
 gboolean rpmostree_composeutil_read_json_metadata_from_file (const char *path, GHashTable *metadata,

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -987,8 +987,9 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable, 
       if (!previous_sha512_v)
         return FALSE;
       const char *previous_state_sha512 = g_variant_get_string (previous_sha512_v, NULL);
-      g_autofree char *new_state_sha512 = NULL;
-      if (!rpmostree_context_get_state_sha512 (self->ctx, &new_state_sha512, error))
+      g_autofree char *new_state_sha512
+          = rpmostree_context_get_state_digest (self->ctx, G_CHECKSUM_SHA512, error);
+      if (!new_state_sha512)
         return FALSE;
 
       self->layering_changed = strcmp (previous_state_sha512, new_state_sha512) != 0;

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -2266,6 +2266,8 @@ char *
 rpmostree_context_get_state_digest (RpmOstreeContext *self, GChecksumType algo, GError **error)
 {
   g_autoptr (GChecksum) state_checksum = g_checksum_new (algo);
+  /* Hash in the treefile inputs (this includes all externals like postprocess, add-files,
+   * etc... and the final flattened treefile -- see treefile.rs for more details). */
   CXX_TRY_VAR (tf_checksum, self->treefile_rs->get_checksum (*self->ostreerepo), error);
   g_checksum_update (state_checksum, (const guint8 *)tf_checksum.data (), tf_checksum.size ());
 

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -122,8 +122,8 @@ void rpmostree_context_set_sepolicy (RpmOstreeContext *self, OstreeSePolicy *sep
 gboolean rpmostree_dnf_add_checksum_goal (GChecksum *checksum, HyGoal goal,
                                           OstreeRepo *pkgcache_repo, GError **error);
 
-gboolean rpmostree_context_get_state_sha512 (RpmOstreeContext *self, char **out_checksum,
-                                             GError **error);
+char *rpmostree_context_get_state_digest (RpmOstreeContext *self, GChecksumType algo,
+                                          GError **error);
 
 gboolean rpmostree_pkgcache_find_pkg_header (OstreeRepo *pkgcache, const char *nevra,
                                              const char *expected_sha256, GVariant **out_header,


### PR DESCRIPTION
core: Make checksum API support caller picking the algorithm

Prep for deduplicating with compose side which uses SHA-256.

---

Deduplicate code to compute state digest

Like most projects of nontrivial size, we're really good at
accumulating little bits of duplicated code.  Like barnacles on a
ship.

In this case, we have duplicate code to compute the "state checksum"
between the compose side and the core.  And for extra fun,
they used different checksum algorithms (SHA-256 vs SHA-512) for
probably no good reason.

Anyways, deduplicate them.  This is prep for properly pushing
more logic down into the core.

---

