### PR TITLE
ci: Tweaks for stopping infra container

### DIFF
--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -558,7 +558,7 @@ vm_start_httpd() {
   local port=$1; shift
 
   vm_cmd podman rm -f $name || true
-  vm_run_container --net=host -d --name $name --privileged \
+  vm_run_container --net=host --stop-signal 'SIGKILL' -d --name $name --privileged \
     -v $dir:/srv --workdir /srv -- \
     python3 -m http.server $port
 
@@ -573,7 +573,7 @@ vm_start_httpd() {
 # $1 - service name
 vm_stop_httpd() {
   local name=$1; shift
-  vm_cmd podman rm -f $name
+  vm_cmd podman rm --time 60 -f $name
   set +E
   trap - ERR
 }


### PR DESCRIPTION
For some reason in CI this seems to flake sometimes; probably because the test VM is being slow, and podman's timeout here manifests as an error.

```
[2022-09-12T07:50:36.497Z] FAIL: autoupdate-check
...
[2022-09-12T07:50:36.497Z]    autoupdate-check: ++ vm_cmd podman rm -f ostree_server
[2022-09-12T07:50:36.497Z]    autoupdate-check: ++ ssh -o User=root -o ControlMaster=auto -o ControlPath=/dev/shm/ssh-vmcheck-1662968784022193459.sock -o ControlPersist=yes -F /tmp/test.5GM9dO/ssh-config vmcheck podman rm -f ostree_server
[2022-09-12T07:50:36.497Z]    autoupdate-check: time="2022-09-12T07:50:30Z" level=warning msg="StopSignal SIGTERM failed to stop container ostree_server in 10 seconds, resorting to SIGKILL"
[2022-09-12T07:50:36.497Z]    autoupdate-check: 724d3f3809207344bff562263b80810348927d9547a6e54d9e48704e926cf7b6
[2022-09-12T07:50:36.497Z]    autoupdate-check: ++ set +E
[2022-09-12T07:50:36.497Z]    autoupdate-check: ++ trap - ERR
```

Let's use SIGKILL from the start to avoid having to context switch in the process, and while we're here bump the timeout.
