### PR TITLE
apply-live: Invoke systemctl daemon-reload after unit files change

### DIFF
--- a/tests/kolainst/destructive/apply-live
+++ b/tests/kolainst/destructive/apply-live
@@ -23,16 +23,23 @@ set -euo pipefail
 
 set -x
 
-libtest_prepare_fully_offline
-libtest_enable_repover 0
 cd $(mktemp -d)
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
 "")
 
+libtest_prepare_fully_offline
+libtest_enable_repover 0
+
 # Verify we're offline
 rpm-ostree upgrade --unchanged-exit-77 || rc=$?
 assert_streq "${rc}" 77
+
+/tmp/autopkgtest-reboot "1"
+;;
+"1")
+
+rpm-ostree cleanup -pr
 
 if rpm -q foo 2>/dev/null; then
   fatal "found foo"
@@ -141,6 +148,24 @@ assert_not_file_has_content_literal status.txt 'LiveDiff:'
 
 echo "ok livefs reset"
 
+# testing apply-live when changes made to systemd unit while upgrade
+rpm-ostree cleanup -pr
+rpm-ostree install pkgsystemd
+/tmp/autopkgtest-reboot "2"
+;;
+"2")
+pkgsystemd > pkg_version.txt
+assert_file_has_content_literal pkg_version.txt '1.0-1'
+rm -f pkg_version.txt
+sed -i -e 's,rpm-repos/0,rpm-repos/1,' /etc/yum.repos.d/libtest.repo
+rpm-ostree upgrade
+rpm-ostree apply-live --allow-replacement | tee out_ap.txt
+pkgsystemd > pkg_version.txt
+assert_file_has_content_literal pkg_version.txt '2.0-1'
+rm -f pkg_version.txt
+assert_file_has_content out_ap.txt 'Successfully updated running filesystem tree; Following services may need to be restarted:'
+assert_file_has_content out_ap.txt 'pkgsystemd.service'
+
 # Validate that we can generate a local ostree commit
 # that adds content, but doesn't change any packages -
 # i.e. there's no package diff.  This is a bit of a corner
@@ -158,4 +183,5 @@ assert_file_has_content out.txt mytestdata
 echo "ok local ref without package changes"
 ;;
 *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+
 esac

--- a/tests/kolainst/kolainst-build.sh
+++ b/tests/kolainst/kolainst-build.sh
@@ -62,6 +62,16 @@ build_rpm testpkg-post-infinite-loop \
              post "echo entering testpkg-post-infinite-loop 1>&2; while true; do sleep 1h; done"
 build_rpm testpkg-touch-run \
              post "touch /{run,tmp,var/tmp}/should-not-persist"
+
+# Will be useful in checking difference in package version while doing apply-live 
+build_rpm pkgsystemd \
+  version 1.0 \
+  release 1 \
+  build 'echo -e "[Unit]\nDescription=Testinglive apply\n\n[Service]\nExecStart=/bin/bash echo done\n\n[Install]\nWantedBy=multi-user.target" > %{name}.service' \
+  install "mkdir -p %{buildroot}/usr/lib/systemd/system
+           install %{name}.service %{buildroot}/usr/lib/systemd/system" \
+  files "/usr/lib/systemd/system/%{name}.service"
+
 # Test module
 build_rpm foomodular
 build_module foomodular \
@@ -90,6 +100,15 @@ mv ${test_tmpdir}/yumrepo/* ${test_tmpdir}/rpm-repos/${repover}
 repover=1
 mkdir ${test_tmpdir}/rpm-repos/${repover}
 build_rpm zincati version 99.99 release 4
+
+#different package version to test apply-live
+build_rpm pkgsystemd \
+  version 2.0 \
+  release 1 \
+  build 'echo -e "[Unit]\nDescription=Testinglive apply\n\n[Service]\nExecStart=/bin/bash echo upgradeDone\n\n[Install]\nWantedBy=multi-user.target" > %{name}.service' \
+  install "mkdir -p %{buildroot}/usr/lib/systemd/system 
+           install %{name}.service %{buildroot}/usr/lib/systemd/system" \
+  files "/usr/lib/systemd/system/%{name}.service"
 mv ${test_tmpdir}/yumrepo/* ${test_tmpdir}/rpm-repos/${repover}
 
 # Create an empty repo when we want to test inability to find a package


### PR DESCRIPTION
Reolves #3992 

apply-live.rs: Does a daemon-reload after configuration changes made to /usr/lib/systemd/system

This is done to avoid prompting the user for restarting "some" services, which creates confusion.
