### PR TITLE
tests: Use `--offline` for second build

### DIFF
--- a/tests/compose-image.sh
+++ b/tests/compose-image.sh
@@ -54,7 +54,7 @@ rpm-ostree compose image --cachedir=cache --touch-if-changed=changed.stamp --ini
 skopeo inspect oci-archive:fedora-silverblue.ociarchive
 test -f changed.stamp
 rm -f changed.stamp
-rpm-ostree compose image --cachedir=cache --touch-if-changed=changed.stamp workstation-ostree-config/fedora-silverblue.yaml fedora-silverblue.ociarchive | tee out.txt
+rpm-ostree compose image --cachedir=cache --offline --touch-if-changed=changed.stamp workstation-ostree-config/fedora-silverblue.yaml fedora-silverblue.ociarchive | tee out.txt
 test '!' -f changed.stamp
 assert_file_has_content_literal out.txt 'No apparent changes since previous commit'
 


### PR DESCRIPTION
The test here flaked I think because the repository changed during the test, or we hit a different mirror.  Add `--offline` to ensure reproducibility.
