### PR TITLE
container: Ensure unprivileged fetch can read `/run/ostree/auth.json`

### DIFF
--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -550,7 +550,7 @@ pub(crate) fn get_features() -> Vec<String> {
         .collect()
 }
 
-fn impl_sealed_memfd(description: &str, content: &[u8]) -> Result<std::fs::File> {
+pub(crate) fn impl_sealed_memfd(description: &str, content: &[u8]) -> Result<std::fs::File> {
     let mfd = memfd::MemfdOptions::default()
         .allow_sealing(true)
         .close_on_exec(true)


### PR DESCRIPTION
In OCP we link this to the kube pull secret, which is mode 0600.

Default to reading it as root and passing it via a memfd.

Closes: https://github.com/coreos/rpm-ostree/issues/4032
