### PR TITLE
tests: Add a helper to go more fully offline

### DIFF
--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -513,3 +513,13 @@ libtest_prepare_offline() {
     rpm-ostree cleanup -pr
     rm -vrf /etc/yum.repos.d/*
 }
+
+# Like libtest_prepare_offline but also rebases to a vmcheck ref
+libtest_prepare_fully_offline() {
+    libtest_prepare_offline
+    # Also disable zincati since we're rebasing
+    systemctl mask --now zincati
+    booted_commit=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
+    ostree refs ${booted_commit} --create vmcheck
+    rpm-ostree rebase :vmcheck
+}

--- a/tests/kolainst/destructive/apply-live
+++ b/tests/kolainst/destructive/apply-live
@@ -23,19 +23,20 @@ set -euo pipefail
 
 set -x
 
-libtest_prepare_offline
+libtest_prepare_fully_offline
 libtest_enable_repover 0
 cd $(mktemp -d)
 
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
 "")
 
+# Verify we're offline
+rpm-ostree upgrade --unchanged-exit-77 || rc=$?
+assert_streq "${rc}" 77
+
 if rpm -q foo 2>/dev/null; then
   fatal "found foo"
 fi
-
-# Turn off zincati since we're rebasing
-systemctl mask --now zincati
 
 rpm -qa | sort > original-rpmdb.txt
 


### PR DESCRIPTION
In our other offline tests we do a rebase to a `vmcheck` ref; let's add a helper that does that so that things that want to test *package* upgrades using the offline repo don't try to access the real FCOS ostree repo.
