### PR TITLE
override: Don't crash if argument produces no file descriptors

### DIFF
--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -200,7 +200,8 @@ handle_override (RPMOSTreeSysroot *sysroot_proxy, RpmOstreeCommandInvocation *in
           g_autoptr (DnfContext) ctx = dnf_context_new ();
           auto basearch = dnf_context_get_base_arch (ctx);
           CXX_TRY_VAR (fds, rpmostreecxx::client_handle_fd_argument (arg, basearch, true), error);
-          g_assert_cmpint (fds.size (), >, 0);
+          if (fds.size () == 0)
+            return glnx_throw (error, "Non-local replacement overrides not implemented yet");
           CXX_TRY_VAR (pkgs, rpmostreecxx::stage_container_rpm_raw_fds (fds), error);
           treefile->add_packages_override_replace_local (pkgs);
         }


### PR DESCRIPTION
Previously,

```
 # podman run --rm -ti quay.io/fedora/fedora-coreos:stable
 $ podman run --rm -ti quay.io/fedora/fedora-coreos:stable
 $ rpm-ostree override replace foo
 **
 rpm-ostreed:ERROR:src/app/rpmostree-override-builtins.cxx:203:gboolean handle_override(RPMOSTreeSysroot*, RpmOstreeCommandInvocation*, const char* const*, const char* const*, const char* const*, GCancellable*, GError**): assertion failed (fds.size () > 0): (0 > 0)
 Bail out! rpm-ostreed:ERROR:src/app/rpmostree-override-builtins.cxx:203:gboolean handle_override(RPMOSTreeSysroot*, RpmOstreeCommandInvocation*, const char* const*, const char* const*, const char* const*, GCancellable*, GError**): assertion failed (fds.size () > 0): (0 > 0)
 Aborted (core dumped)
```

Now:

```
 # podman run --rm -ti quay.io/fedora/fedora-coreos:stable
 $ rpm-ostree override replace foo
 error: Non-local replacement overrides not implemented yet
```
