### PR TITLE
core: Filter for latest when downloading packages

### DIFF
--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -2372,6 +2372,7 @@ rpmostree_find_and_download_packages (const char *const *packages, const char *s
             hy_autoquery HyQuery query = hy_subject_get_best_solution (
                 subject, sack, NULL, &nevra, FALSE, TRUE, FALSE, FALSE, FALSE);
             hy_query_filter (query, HY_PKG_REPONAME, HY_EQ, repo);
+            hy_query_filter_num (query, HY_PKG_LATEST_PER_ARCH_BY_PRIORITY, HY_EQ, 1);
             g_autoptr (GPtrArray) results = hy_query_run (query);
             if (!results || results->len == 0)
               return glnx_throw (error, "No matches for \"%s\" in repo '%s'", subject, repo);

--- a/tests/kolainst/destructive/override-pinning
+++ b/tests/kolainst/destructive/override-pinning
@@ -53,7 +53,7 @@ if rpm-ostree override replace enoent --experimental --freeze --from repo=test-r
 fi
 assert_file_has_content_literal err.txt 'No matches'
 
-# query and fetch for the lastest version of a package from enabled repos
+# query and fetch for the latest version of a package from enabled repos
 rpmostree_assert_status \
   '.deployments[0]["base-local-replacements"]|length == 0' \
   '.deployments[0]["requested-base-local-replacements"]|length == 0'

--- a/tests/kolainst/kolainst-build.sh
+++ b/tests/kolainst/kolainst-build.sh
@@ -81,6 +81,7 @@ build_module_defaults foomodular \
   defprofile with-default-profile:default
 
 # To test remote override replace
+build_rpm zincati version 99.99 release 2
 build_rpm zincati version 99.99 release 3
 
 mv ${test_tmpdir}/yumrepo/* ${test_tmpdir}/rpm-repos/${repover}


### PR DESCRIPTION
The tightly-scoped function `rpmostree_find_and_download_packages` function just takes a query and returns fds to downloaded packages. It does not do any depsolving, so it's up to us to select the exact package we want to download. This means explicitly telling libdnf we want the latest version. This matches e.g. `dnf download`.

Closes: #4037