### PR TITLE
container: Encapsulate at format version 1 by default

### DIFF
--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -68,7 +68,7 @@ struct ContainerEncapsulateOpts {
     max_layers: Option<NonZeroU32>,
 
     /// The encapsulated container format version; must be 0 or 1.
-    #[clap(long, default_value = "0")]
+    #[clap(long, default_value = "1")]
     format_version: u32,
 
     #[clap(long)]


### PR DESCRIPTION
This really must be the new default since we want to drop the old format very soon.
