### PR TITLE
rebuild: Fix logic for container-only handling

### DIFF
--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -273,6 +273,8 @@ rpmostree_option_context_parse (GOptionContext *context, const GOptionEntry *mai
   bool container_capable = (flags & RPM_OSTREE_BUILTIN_FLAG_CONTAINER_CAPABLE) > 0;
   if (use_daemon && !(is_ostree_container && container_capable))
     {
+      if (out_sysroot_proxy == NULL)
+        return glnx_throw (error, "This command can only run in an OSTree container.");
       /* More gracefully handle the case where
        * no --sysroot option was specified and we're not booted via ostree
        * https://github.com/projectatomic/rpm-ostree/issues/1537

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -56,6 +56,11 @@ fi
 assert_file_has_content_literal err.txt 'error: Argument is invalid UTF-8'
 echo "ok error on non UTF-8"
 
+if rpm-ostree ex rebuild 2>err.txt; then
+    fatal "ex rebuild on host"
+fi
+assert_file_has_content_literal err.txt 'error: This command can only run in an OSTree container'
+
 rpm-ostree status --jsonpath '$.deployments[0].booted' > jsonpath.txt
 assert_file_has_content_literal jsonpath.txt 'true'
 echo "ok jsonpath"


### PR DESCRIPTION
Right now `ex rebuild` only works in an (ostree) container and trying to run it on an ostree host system, despite all the checking in that function just segfaults.

And the reason here is very illuminating: We were passing `NULL` for the out parameter for the DBus client.  Let's use that to instead be the signal that a command is current container *only*.

But, this is really a perfect example of where Rust would have entirely prevented this problem.
