### PR TITLE
systemctl-wrapper: Pass through usage of --root directly && container ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,6 +103,25 @@ jobs:
         run: tar -C / -xzvf install.tar
       - name: Integration tests
         run: ./ci/test-container.sh
+  # Try to keep this in sync with https://github.com/ostreedev/ostree-rs-ext/blob/1fc115a760eeada22599e0f57026f58b22efded4/.github/workflows/rust.yml#L163
+  container-build:
+    name: "Container build"
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Checkout coreos-layering-examples
+        uses: actions/checkout@v3
+        with:
+          repository: coreos/coreos-layering-examples
+          path: coreos-layering-examples
+      - name: Download
+        uses: actions/download-artifact@v2
+        with:
+          name: install.tar
+      - name: Integration tests
+        run: ./ci/container-build-integration.sh
   cargo-deny:
     runs-on: ubuntu-latest
     steps:

--- a/ci/container-build-integration.sh
+++ b/ci/container-build-integration.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Verify container build flows
+set -euo pipefail
+
+examples=(tailscale replace-kernel)
+set -x
+
+workdir=${PWD}
+for example in "${examples[@]}"; do
+    cd coreos-layering-examples/${example}
+    # Inject our code
+    tar xvf ${workdir}/install.tar
+    sed -ie 's,^\(FROM .*\),\1\nADD usr/ /usr/,' Dockerfile
+    git diff
+
+    podman build -t localhost/fcos-$example .
+    cd ${workdir}
+done
+
+echo ok container image integration

--- a/src/libpriv/systemctl-wrapper.sh
+++ b/src/libpriv/systemctl-wrapper.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/bash
 # Used by rpmostree-core.c to intercept `systemctl` operations. We want to
 # handle `preset`, and ignore everything else such as `start`/`stop` etc.
+# However if --root is passed, we do want to support that.
 # See also https://github.com/projectatomic/rpm-ostree/issues/550
 
 for arg in "$@"; do
-    if [[ $arg == preset ]]; then
-        exec /usr/bin/systemctl.rpmostreesave "$@"
-    fi
+    case $arg in
+        preset | --root | --root=*) exec /usr/bin/systemctl.rpmostreesave "$@" ;;
+    esac
 done
 echo "rpm-ostree-systemctl: Ignored non-preset command:" "$@"


### PR DESCRIPTION


We need to honor the use of `systemctl` when executed by dracut.

This only ocurrs right now in the non-unified container path.

---

ci: Add a test case for container builds

This is derived from code added in
https://github.com/ostreedev/ostree-rs-ext/commit/972a1349d7643de7dd61d953d4b924b8e069bebd

Basically, let's test that two representative coreos-layering-examples
still build.

---

