### PR TITLE
upgrade: Warn and sleep if we find a deprecated v0 format container

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -2,8 +2,8 @@
 
 stage("Build") {
 parallel rpms: {
-  def n = 5
-  buildPod(memory: "2Gi", cpu: "${n}") {
+  def n = 4
+  buildPod(memory: "4Gi", cpu: "${n}") {
       checkout scm
       // 2:1 job to CPU at most should keep us from getting kicked out
       shwrap("""RPM_BUILD_NCPUS=${n} CARGO_BUILD_JOBS=${n} ./ci/coreosci-rpmbuild.sh""")

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -24,8 +24,8 @@ codestyle: {
 }
 }
 
-def nhosts = 5
-def mem = (nhosts * 1024) + 512
+def nhosts = 4
+def mem = (nhosts * 1536) + 512
 cosaPod(runAsUser: 0, memory: "${mem}Mi", cpu: "${nhosts}") {
   stage("Unit Tests") {
     checkout scm
@@ -60,7 +60,7 @@ cosaPod(runAsUser: 0, memory: "${mem}Mi", cpu: "${nhosts}") {
   }
   stage("vmcheck") {
     try {
-      timeout(time: 30, unit: 'MINUTES') {
+      timeout(time: 45, unit: 'MINUTES') {
         shwrap("COSA_DIR=${env.WORKSPACE} JOBS=${nhosts} tests/vmcheck.sh")
       }
     } finally {

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -84,6 +84,10 @@ async fn pull_container_async(
         PrepareResult::AlreadyPresent(r) => return Ok(r.into()),
         PrepareResult::Ready(r) => r,
     };
+    if prep.export_layout == ostree_container::ExportLayout::V0 {
+        output_message(&format!("warning: pulled image is using deprecated v0 format; support will be dropped in a future release"));
+        std::thread::sleep(std::time::Duration::from_secs(5));
+    }
     let progress_printer =
         tokio::task::spawn(async move { layer_progress_print(layer_progress).await });
     let digest = prep.manifest_digest.clone();

--- a/tests/kolainst/destructive/layering-fedorainfra
+++ b/tests/kolainst/destructive/layering-fedorainfra
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: { "tags": "needs-internet" }
+# kola: { "tags": "needs-internet", "minMemory": 1536 }
 # Test https://github.com/coreos/rpm-ostree/pull/2420
 # i.e. using overrides from Fedora Infrastructure tools (koji/bodhi)
 set -euo pipefail

--- a/tests/kolainst/destructive/layering-modules
+++ b/tests/kolainst/destructive/layering-modules
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kola: { "tags": "needs-internet" }
+# kola: { "tags": "needs-internet", "minMemory": 1536 }
 set -euo pipefail
 
 . ${KOLA_EXT_DATA}/libtest.sh


### PR DESCRIPTION
This is prep for https://github.com/ostreedev/ostree-rs-ext/issues/332
