### PR TITLE
composepost: Drop unnecessary injection of presets

### DIFF
--- a/tests/compose/test-basic.sh
+++ b/tests/compose/test-basic.sh
@@ -61,9 +61,6 @@ assert_file_has_content_literal autovar.txt 'd /var/tmp 1777 root root - -'
 assert_file_has_content_literal autovar.txt 'd /var/lib/polkit-1 0750 root polkitd - -'
 echo "ok autovar"
 
-# Validate this exists
-ostree --repo="${repo}" ls "${treeref}" /usr/lib/systemd/system/multi-user.target.wants/ostree-remount.service
-
 python3 <<EOF
 import json, yaml
 tf=yaml.safe_load(open("$treefile"))


### PR DESCRIPTION
First motivation: this logic is not idempotent as it should be, and someone hit this when trying to test out a local commit created via `compose commit`.

But bigger picture, quite a while ago we did
https://github.com/ostreedev/ostree/commit/73e3ccc401829025a9151fddff29d67a0ac2321d

I think we're at the point where we can hard require that updated ostree.
