### PR TITLE
status: Make `--booted --json` do the expected thing together

### DIFF
--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -73,7 +73,7 @@ static GOptionEntry option_entries[]
           "EXPRESSION" },
         { "booted", 'b', 0, G_OPTION_ARG_NONE, &opt_only_booted, "Only print the booted deployment",
           NULL },
-        { "pending-exit-77", 'b', 0, G_OPTION_ARG_NONE, &opt_pending_exit_77,
+        { "pending-exit-77", 0, 0, G_OPTION_ARG_NONE, &opt_pending_exit_77,
           "If pending deployment available, exit 77", NULL },
         { NULL } };
 

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -38,6 +38,10 @@ assert_jq status.json \
 rm status.json
 echo "ok empty pkg arrays, and commit meta correct in status json"
 
+rpm-ostree status -b --json > status.json
+assert_jq status.json '.deployments|length == 1'
+echo "ok --booted --json"
+
 # All tests which require a booted system, but are nondestructive
 rpm-ostree testutils integration-read-only
 


### PR DESCRIPTION
Unfortunately the implement involves some ugly grubbing through GVariant...really need to port this stuff to Rust.

Closes: https://github.com/coreos/rpm-ostree/issues/2829
