### PR TITLE
Rework useradd(etc) sysusers integration to work in container flow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,23 @@ jobs:
         with:
           name: install.tar
           path: install.tar
+  build-tests:
+    name: "Build Integration Test Data"
+    runs-on: ubuntu-latest
+    container: registry.ci.openshift.org/coreos/fcos-buildroot:testing-devel
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      # https://github.com/actions/checkout/issues/760
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Build
+        run: make -C tests/kolainst && make -C tests/kolainst install DESTDIR=$(pwd)/install && tar -C install -czf tests.tar .
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: tests.tar
+          path: tests.tar
   cxx-verify:
     name: "Verify CXX generation"
     runs-on: ubuntu-latest
@@ -89,7 +106,7 @@ jobs:
         run: ./ci/clang-build-check.sh
   integration:
     name: "Container Integration"
-    needs: build
+    needs: [build, build-tests]
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos:testing-devel
     steps:
@@ -100,7 +117,13 @@ jobs:
         with:
           name: install.tar
       - name: Install
-        run: tar -C / -xzvf install.tar
+        run: tar -C / -xzvf install.tar && rm -f install.tar
+      - name: Download tests
+        uses: actions/download-artifact@v2
+        with:
+          name: tests.tar
+      - name: Install Tests
+        run: tar -C / -xzvf tests.tar && rm -f tests.tar
       - name: Integration tests
         run: ./ci/test-container.sh
   # Try to keep this in sync with https://github.com/ostreedev/ostree-rs-ext/blob/1fc115a760eeada22599e0f57026f58b22efded4/.github/workflows/rust.yml#L163

--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -6,6 +6,16 @@ fatal() {
     exit 1
 }
 
+repodir=/usr/lib/coreos-assembler/tests/kola/rpm-ostree/destructive/data/rpm-repos/
+
+cat >/etc/yum.repos.d/libtest.repo <<EOF
+[libtest]
+name=libtest repo
+baseurl=file://${repodir}/0
+gpgcheck=0
+enabled=1
+EOF
+
 # Verify container flow
 if rpm-ostree status 2>err.txt; then
     fatal "status in container"
@@ -14,6 +24,10 @@ if ! grep -qe "error.*This system was not booted via libostree" err.txt; then
     cat err.txt
     fatal "did not find expected error"
 fi
+
+rpm-ostree install testdaemon
+grep -qF 'u testdaemon-user' /usr/lib/sysusers.d/35-rpmostree-pkg-user-testdaemon-user.conf
+grep -qF 'g testdaemon-group' /usr/lib/sysusers.d/30-rpmostree-pkg-group-testdaemon-group.conf
 
 origindir=/etc/rpm-ostree/origin.d
 mkdir -p "${origindir}"

--- a/src/libpriv/rpmostree-container.cxx
+++ b/src/libpriv/rpmostree-container.cxx
@@ -45,6 +45,14 @@ rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile, GCancellable *can
   if (!glnx_opendirat (AT_FDCWD, "/", TRUE, &rootfs_fd, error))
     return FALSE;
 
+  // Forcibly turn this on for the container flow because it's the only sane
+  // way for installing RPM packages that invoke useradd/groupadd to work.
+  g_setenv ("RPMOSTREE_EXP_BRIDGE_SYSUSERS", "1", TRUE);
+
+  // This is a duplicate of the bits in rpmostree-scripts.cxx which we need
+  // for now because we aren't going through that code path today.
+  g_setenv ("SYSTEMD_OFFLINE", "1", TRUE);
+
   // Ensure we have our wrappers for groupadd/systemctl set up
   CXX_TRY_VAR (fs_prep, rpmostreecxx::prepare_filesystem_script_prep (rootfs_fd), error);
 

--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -373,8 +373,6 @@ rpmostree_run_script_in_bwrap_container (int rootfs_fd, GLnxTmpDir *var_lib_rpm_
   if (bridge_sysusers != NULL)
     bwrap->setenv ("RPMOSTREE_EXP_BRIDGE_SYSUSERS", rust::String (bridge_sysusers));
 
-  bwrap->setenv ("RPMOSTREE_SCRIPT_PKG_NAME", name);
-
   /* https://github.com/systemd/systemd/pull/7631 AKA
    * "systemctl,verbs: Introduce SYSTEMD_OFFLINE environment variable"
    * https://github.com/systemd/systemd/commit/f38951a62837a00a0b1ff42d007e9396b347742d

--- a/tests/kolainst/kolainst-build.sh
+++ b/tests/kolainst/kolainst-build.sh
@@ -53,8 +53,8 @@ build_rpm testdaemon \
              build "echo testdaemon-binary > %{name}" \
              install "mkdir -p %{buildroot}/{usr/bin,var/lib/%{name}}
                       install %{name} %{buildroot}/usr/bin" \
-             pre "groupadd -r testdaemon-group
-                  useradd -r testdaemon-user -g testdaemon-group -s /sbin/nologin" \
+             pre "getent group testdaemon-group &>/dev/null || groupadd -r testdaemon-group
+                  getent passwd testdaemon-user &>/dev/null || useradd -r testdaemon-user -g testdaemon-group -s /sbin/nologin" \
              files "/usr/bin/%{name}
                     /var/lib/%{name}"
 # Will be useful for testing cancellation


### PR DESCRIPTION
First, right now our container flow doesn't use the "unified core" mode which means we aren't intercepting scripts.  We hence can't set the environment variable which gives us the package name.

Rework the sysusers file generation to not include the package name - in the end, while it is useful for debugging, in practice I don't think it's necessary.

Next, if we're in a container build, turn on the sysusers.d interception by default.  I think this is the default stance we should be taking now, and the container flow is a fresh new API.

Finally, add support for `useradd -G` which is used by libvirt, e.g. https://src.fedoraproject.org/rpms/libvirt/blob/rawhide/f/libvirt.spec#_1621

`useradd -r -u 107 -g qemu -G kvm -d / -s /sbin/nologin -c "qemu user" qemu`
