### PR TITLE
daemon: Implement ListRepos method

### DIFF
--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -331,6 +331,19 @@
       <arg type="s" name="transaction_address" direction="out"/>
     </method>
 
+    <!-- List configured repositories.
+	Available properties:
+	"id" (type 's')
+	"description" (type 's')
+	"is-devel" (type 'b')
+	"is-source" (type 'b')
+	"is-enabled" (type 'b')
+    -->
+    <method name="ListRepos">
+      <arg type="aa{sv}" name="repos" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantList"/>
+    </method>
+
     <!-- Available modifiers:
          "set-refspec" (type 's')
          "set-revision" (type 's')

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -523,3 +523,11 @@ libtest_prepare_fully_offline() {
     ostree refs ${booted_commit} --create vmcheck
     rpm-ostree rebase :vmcheck
 }
+
+# Invoke a method on the OS interface of the booted OS
+rpmostree_busctl_call_os() {
+  stateroot=$(rpm-ostree status --booted --json | jq -r '.deployments[0].osname')
+  ospath=/org/projectatomic/rpmostree1/${stateroot//-/_}
+  busctl call org.projectatomic.rpmostree1 $ospath \
+    org.projectatomic.rpmostree1.OS "$@"
+}

--- a/tests/kolainst/Makefile
+++ b/tests/kolainst/Makefile
@@ -15,6 +15,7 @@ install: all
 	rsync -prlv ./destructive $(KOLA_TESTDIR)/
 	rsync -prlv ../common/*.sh $(KOLA_TESTDIR)/nondestructive/data/
 	rsync -prlv ../common/*.sh $(KOLA_TESTDIR)/destructive/data/
+	rsync -prlv rpm-repos/ $(KOLA_TESTDIR)/nondestructive/data/rpm-repos/
 	rsync -prlv ../gpghome $(KOLA_TESTDIR)/destructive/data/
 	rsync -prlv rpm-repos/ $(KOLA_TESTDIR)/destructive/data/rpm-repos/
 


### PR DESCRIPTION
This is to implement one of missing methods required for gnome-software to stop calling libdnf directly in it.

See https://gitlab.gnome.org/GNOME/gnome-software/-/issues/1793 for more information.