### PR TITLE
app: Improve error-prefixing in local RPM file handling

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -8,6 +8,7 @@ use crate::ffi::SystemHostType;
 use crate::utils;
 use anyhow::{anyhow, Result};
 use cap_std_ext::rustix;
+use fn_error_context::context;
 use gio::prelude::*;
 use ostree_ext::{gio, glib};
 use std::io::{BufRead, Write};
@@ -127,6 +128,7 @@ pub(crate) fn is_src_rpm_arg(arg: &str) -> bool {
 /// RPM URLs we need to fetch, and if so download those URLs and return file
 /// descriptors for the content.
 /// TODO(cxx-rs): This would be slightly more elegant as Result<Option<Vec<i32>>>
+#[context("Handling argument {}", arg)]
 pub(crate) fn client_handle_fd_argument(
     arg: &str,
     arch: &str,

--- a/src/app/rpmostree-clientlib.cxx
+++ b/src/app/rpmostree-clientlib.cxx
@@ -873,7 +873,7 @@ rpmostree_sort_pkgs_strv (const char *const *pkgs, GUnixFDList *fd_list, gboolea
             {
               auto idx = g_unix_fd_list_append (fd_list, fd, error);
               if (idx < 0)
-                return FALSE;
+                return glnx_prefix_error (error, "dup(%s)", pkg);
               g_variant_builder_add (&builder, "h", idx);
             }
         }


### PR DESCRIPTION
Before:

```
$ sudo rpm-ostree install foobar.rpm
error: Preparing D-Bus arguments: No such file or directory (os error 2)
```

After:

```
$ sudo rpm-ostree install foobar.rpm
error: Preparing D-Bus arguments: Handling argument foobar.rpm: No such file or directory (os error 2)
```

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2134215#c10