### PR TITLE
treefile: Make `container: true` opt-in to saner defaults

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -377,7 +377,8 @@ It supports the following parameters:
  * `container`: boolean, optional: Defaults to `false`.  If `true`, then
    rpm-ostree will not do any special handling of kernel, initrd or the
    /boot directory. This is useful if the target for the tree is some kind
-   of container which does not have its own kernel.
+   of container which does not have its own kernel.  This also implies
+   several other options, such as `tmp-is-dir: true` and `selinux: false`.
 
  * `add-files`: Array, optional: Copy external files to the rootfs.
 


### PR DESCRIPTION
As part of our expansion into a general "dnf image", it now makes total sense to use what's today `rpm-ostree compose image` to generate *non*-bootable container images.  For example, we could use this to generate coreos-assembler.

Then, we have the same compelling features that we use for the OS that apply there:

- sane change detection
- chunking

We could also use this to generate other containers, such as our buildroot image.
