### PR TITLE
[rhel8] libpriv/postprocess: work around semanage bug

### DIFF
--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -4,6 +4,11 @@ set -xeuo pipefail
 . ${KOLA_EXT_DATA}/libtest.sh
 cd $(mktemp -d)
 
+# Sanity-check the policy isn't marked as modified
+if ostree admin config-diff | grep 'selinux/targeted/policy'; then
+    assert_not_reached "selinux policy is marked as modified"
+fi
+
 # Ensure multicall is correctly set up and working.
 R_O_DIGEST=$(sha512sum $(which rpm-ostree) | cut -d' ' -f1)
 O_C_DIGEST=$(sha512sum $(which /usr/libexec/libostree/ext/ostree-container) | cut -d' ' -f1)


### PR DESCRIPTION
There is a bug in the latest semanage code which causes an invocation of `semodule --rebuild-if-modules-changed` to still write a policy even though nothing changed since a full policy build. On FCOS and RHCOS, this bug is triggered as early as `ostree admin deploy` in cosa when creating the disk images. This results in shipping images with a policy diff baked in.

Hack around this by immediately rerunning
`semodule --rebuild-if-modules-changed` after building the policy.

Fixes: https://github.com/openshift/os/issues/1036
(cherry picked from commit 479050e7540dc90de9ec6f49960b98e095537224)