### PR TITLE
build-sys: Don't delete systemd units in `make clean`

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -108,5 +108,4 @@ EXTRA_DIST += \
 
 CLEANFILES += \
 	$(service_DATA) \
-	$(systemdunit_service_files) \
 	$(NULL)


### PR DESCRIPTION
This is a fixup for the previous change to not generate the systemd units.
