### PR TITLE
compose/image: Add `--label`

### DIFF
--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -76,6 +76,10 @@ struct Opt {
     /// JSON-formatted lockfile; can be specified multiple times.
     lockfiles: Vec<Utf8PathBuf>,
 
+    /// Additional labels for the container image, in KEY=VALUE format
+    #[clap(name = "label", long, short)]
+    labels: Vec<String>,
+
     #[clap(long, value_parser)]
     /// Update the timestamp or create this file on changes
     touch_if_changed: Option<Utf8PathBuf>,
@@ -273,10 +277,12 @@ pub(crate) fn compose_image(args: Vec<String>) -> CxxResult<()> {
     };
     let target_imgref = target_imgref.to_string();
 
+    let label_args = opt.labels.into_iter().map(|v| format!("--label={v}"));
+
     let s = self_command()
+        .args(&["compose", "container-encapsulate"])
+        .args(label_args)
         .args(&[
-            "compose",
-            "container-encapsulate",
             "--repo",
             repo.as_str(),
             commitid.as_str(),

--- a/tests/compose-image.sh
+++ b/tests/compose-image.sh
@@ -44,7 +44,10 @@ repos:
   - fedora  # Intentially using frozen GA repo
 EOF
 cp /etc/yum.repos.d/*.repo .
-rpm-ostree compose image --cachedir=../cache-container --initialize minimal.yaml minimal.ociarchive
+rpm-ostree compose image --cachedir=../cache-container --label=foo=bar --label=baz=blah --initialize minimal.yaml minimal.ociarchive
+skopeo inspect oci-archive:minimal.ociarchive > inspect.json
+test $(jq -r '.Labels["foo"]' < inspect.json) = bar
+test $(jq -r '.Labels["baz"]' < inspect.json) = blah
 # Also verify change detection
 rpm-ostree compose image --cachedir=../cache-container --touch-if-changed changed.stamp minimal.yaml minimal.ociarchive
 test '!' -f changed.stamp


### PR DESCRIPTION
I think we should also support this in the treefile, but adding it to the CLI is straightforward and useful in cases where one wouldn't want to invalidate the cache.

Closes: https://github.com/coreos/rpm-ostree/issues/4133
