### PR TITLE
Always use merge commit for container deployments

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -436,12 +436,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader *self, const char
         CXX_TRY_VAR (import,
                      rpmostreecxx::pull_container (*self->repo, *cancellable, r.refspec.c_str ()),
                      error);
-        // Note this duplicates
-        // https://github.com/ostreedev/ostree-rs-ext/blob/22a663f64e733e7ba8382f11f853ce4202652254/lib/src/container/store.rs#L64
-        if (import->is_layered)
-          new_base_rev = strdup (import->merge_commit.c_str ());
-        else
-          new_base_rev = strdup (import->base_commit.c_str ());
+        new_base_rev = strdup (import->merge_commit.c_str ());
         break;
       }
     case rpmostreecxx::RefspecType::Checksum:

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -51,7 +51,8 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     rpm-ostree rebase --experimental "$image_pull" | tee out.txt
     assert_file_has_content out.txt 'Importing.*'"$image_pull"
     rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"ostree-unverified-image:$image\""
-    rpmostree_assert_status ".deployments[0][\"checksum\"] == \"${checksum}\""
+    # Verify we use the merge commit now
+    rpmostree_assert_status ".deployments[0][\"checksum\"] != \"${checksum}\""
     echo "ok rebase to container image reference"
 
     rpm-ostree status | tee out.txt
@@ -67,8 +68,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     /tmp/autopkgtest-reboot 1
     ;;
   1)
-    # Add a new RPM via local layering, then export the new locally-generated commit as
-    # a base image, then test upgrading to that.
+    # Some tests of other things
 
     if rpm-ostree deploy 42 2>err.txt; then
         fatal "unexpectedly deployed version from container image reference"
@@ -83,35 +83,13 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     rpm-ostree install ${KOLA_EXT_DATA}/rpm-repos/0/packages/x86_64/foo-1.2-3.x86_64.rpm
     echo "ok layering package"
 
-    # Test upgrade
+    # Test no-op upgrade
     rpm-ostree upgrade | tee out.txt
     assert_file_has_content_literal out.txt "Pulling manifest: ${image_pull}"
     assert_file_has_content out.txt "No upgrade available."
     echo "ok no upgrade available"
 
-    # Create a new ostree commit containing foo and export the commit as a container image
-    with_foo_commit=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
-    ostree refs ${with_foo_commit} --create vmcheck_tmp/new_update
-    new_commit=$(ostree commit -b vmcheck --bootable --tree=ref=vmcheck_tmp/new_update)
-    rm "${image_dir}" -rf
-    ostree container encapsulate --compression-fast --repo=/ostree/repo ${new_commit} "$image"
-
-    rpm-ostree uninstall foo
-    rpm-ostree upgrade
-    rpmostree_assert_status ".deployments[0][\"checksum\"] == \"${new_commit}\""
-
-    /tmp/autopkgtest-reboot 2
-    ;;
-  2)
-    # Export the booted image again, but this time test layered containers via a `podman build`.
-
-    rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"${image_pull}\""
-    assert_streq $(rpm -q foo) foo-1.2-3.x86_64
-
-    checksum=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
-    rm "${image_dir}" -rf
-    ostree container encapsulate --compression-fast --repo=/ostree/repo ${checksum} "${image}"
-    # https://github.com/ostreedev/ostree-rs-ext/issues/153
+    # Now, copy the OCI dir to containers-storage for a local build
     skopeo copy $image containers-storage:localhost/fcos
     rm "${image_dir}" -rf
     td=$(mktemp -d)


### PR DESCRIPTION
In this whole project of "ostree native containers", there's been some fuzziness as far as whether the container stuff is just a "transport" or whether it more *replaces* the ostree data.

We definitely have support for the former, which we need.

But there's this confusing leftover logic on the client side which uses the base ostree commit if we can - which we can *only* do if there's exactly one container image layer.  Which...is really a dead approach now that we have "chunked" container images.

Switch to always deploying the merge commit, since that's what we'll use in all real production scenarios.

This is prep for image layer GC handling - we want to be able to *always* fetch the container image merge commit.

Currently trying to do that trips up in our integration tests which use a bare `ostree container encapsulate` and rebase to it.
