### PR TITLE
composepost: A few more cap-std porting patches

### DIFF
--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -497,7 +497,7 @@ fn compose_postprocess_add_files(rootfs_dfd: &Dir, treefile: &mut Treefile) -> R
 }
 
 #[context("Symlinking {}", TRADITIONAL_RPMDB_LOCATION)]
-fn compose_postprocess_rpmdb(rootfs_dfd: &openat::Dir) -> Result<()> {
+fn compose_postprocess_rpmdb(rootfs_dfd: &Dir) -> Result<()> {
     /* This works around a potential issue with libsolv if we go down the
      * rpmostree_get_pkglist_for_root() path. Though rpm has been using the
      * /usr/share/rpm location (since the RpmOstreeContext set the _dbpath macro),
@@ -509,10 +509,10 @@ fn compose_postprocess_rpmdb(rootfs_dfd: &openat::Dir) -> Result<()> {
      * So we set the symlink now. This is also what we do on boot anyway for
      * compatibility reasons using tmpfiles.
      * */
-    rootfs_dfd.remove_all(TRADITIONAL_RPMDB_LOCATION)?;
+    rootfs_dfd.remove_all_optional(TRADITIONAL_RPMDB_LOCATION)?;
     rootfs_dfd.symlink(
-        TRADITIONAL_RPMDB_LOCATION,
         format!("../../{}", RPMOSTREE_RPMDB_LOCATION),
+        TRADITIONAL_RPMDB_LOCATION,
     )?;
     Ok(())
 }
@@ -533,7 +533,7 @@ pub fn compose_postprocess(
         rootfs_dfd.local_rename("etc", "usr/etc")?;
     }
 
-    compose_postprocess_rpmdb(rootfs_dfd)?;
+    compose_postprocess_rpmdb(rootfs_cap_std)?;
     compose_postprocess_units(rootfs_cap_std, treefile)?;
     if let Some(t) = treefile.parsed.base.default_target.as_deref() {
         compose_postprocess_default_target(rootfs_cap_std, t)?;

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -423,7 +423,7 @@ fn compose_postprocess_scripts(
 /// Logic for handling treefile `remove-files`.
 #[context("Handling `remove-files`")]
 pub fn compose_postprocess_remove_files(
-    rootfs_dfd: &openat::Dir,
+    rootfs_dfd: &Dir,
     treefile: &mut Treefile,
 ) -> CxxResult<()> {
     for name in treefile.parsed.base.remove_files.iter().flatten() {
@@ -435,7 +435,7 @@ pub fn compose_postprocess_remove_files(
             return Err(anyhow!("Invalid '..' in path: {}", name).into());
         }
         println!("Deleting: {}", name);
-        rootfs_dfd.remove_all(name)?;
+        rootfs_dfd.remove_all_optional(name)?;
     }
     Ok(())
 }
@@ -534,7 +534,7 @@ pub fn compose_postprocess(
     let etc_guard = crate::core::prepare_tempetc_guard(rootfs_dfd.as_raw_fd())?;
     // These ones depend on the /etc path
     compose_postprocess_mutate_os_release(rootfs_dfd, treefile, next_version)?;
-    compose_postprocess_remove_files(rootfs_dfd, treefile)?;
+    compose_postprocess_remove_files(rootfs_cap_std, treefile)?;
     compose_postprocess_add_files(rootfs_cap_std, treefile)?;
     etc_guard.undo()?;
 

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -356,17 +356,15 @@ fn compose_postprocess_units(rootfs_dfd: &Dir, treefile: &mut Treefile) -> Resul
 }
 
 #[context("Handling treefile 'default-target'")]
-fn compose_postprocess_default_target(rootfs_dfd: &openat::Dir, target: &str) -> Result<()> {
+fn compose_postprocess_default_target(rootfs: &Dir, target: &str) -> Result<()> {
     /* This used to be in /etc, but doing it in /usr makes more sense, as it's
      * part of the OS defaults. This was changed in particular to work with
      * ConditionFirstBoot= which runs `systemctl preset-all`:
      * https://github.com/projectatomic/rpm-ostree/pull/1425
      */
     let default_target_path = "usr/lib/systemd/system/default.target";
-    rootfs_dfd.remove_file_optional(default_target_path)?;
-    let dest = format!("/usr/lib/systemd/system/{target}");
-    rootfs_dfd.symlink(default_target_path, dest)?;
-
+    rootfs.remove_file_optional(default_target_path)?;
+    rootfs.symlink(target, default_target_path)?;
     Ok(())
 }
 
@@ -528,7 +526,7 @@ pub fn compose_postprocess(
     compose_postprocess_rpmdb(rootfs_dfd)?;
     compose_postprocess_units(rootfs_cap_std, treefile)?;
     if let Some(t) = treefile.parsed.base.default_target.as_deref() {
-        compose_postprocess_default_target(rootfs_dfd, t)?;
+        compose_postprocess_default_target(rootfs_cap_std, t)?;
     }
 
     treefile.write_compose_json(rootfs_cap_std)?;


### PR DESCRIPTION
composepost: Port default target bits to cap-std

Part of an ongoing effort to drop `openat`.

---

composepost: Port remove files handling to cap-std

Part of an ongoing effort to drop `openat`.

---

composepost: Port script function to cap-std

Part of an ongoing effort to drop `openat`.

---

composepost: Port rpmdb symlinking to cap-std

Part of an ongoing effort to drop `openat`.

---

composepost: Port os-release handling to cap-std

Part of an ongoing effort to drop `openat`.

---

composepost: Port outer wrapper function to cap-std

Part of an ongoing effort to drop `openat`.

---

