### PR TITLE
treefile: Support `repovars` key

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -471,3 +471,7 @@ version of `rpm-ostree`.
      `packages`.
    * `install`: Array of strings, required: Set of RPM module specs to install
      (the same formats as dnf are supported, e.g. `NAME[:STREAM][/PROFILE]`).
+ * `repovars`: object (`Map<String, String>`), optional: yum repository variable
+   names to use when substituting variables in yum repo files. The `releasever`
+   variable name is invalid. Use the `releasever` key instead. The `basearch`
+   name is invalid; it is filled in automatically.

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1744,6 +1744,7 @@ struct Treefile final : public ::rust::Opaque
   void sanitycheck_externals () const;
   ::rust::Box< ::rpmostreecxx::RpmImporterFlags>
   importer_flags (::rust::Str pkg_name) const noexcept;
+  ::rust::String write_repovars (::std::int32_t workdir_dfd_raw) const;
   void validate_for_container () const;
   ::rpmostreecxx::Refspec get_base_refspec () const noexcept;
   void rebase (::rust::Str new_refspec, ::rust::Str custom_origin_url,
@@ -2602,6 +2603,11 @@ extern "C"
   ::rpmostreecxx::RpmImporterFlags *
   rpmostreecxx$cxxbridge1$Treefile$importer_flags (const ::rpmostreecxx::Treefile &self,
                                                    ::rust::Str pkg_name) noexcept;
+
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$Treefile$write_repovars (const ::rpmostreecxx::Treefile &self,
+                                                   ::std::int32_t workdir_dfd_raw,
+                                                   ::rust::String *return$) noexcept;
 
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$Treefile$validate_for_container (
       const ::rpmostreecxx::Treefile &self) noexcept;
@@ -5151,6 +5157,19 @@ Treefile::importer_flags (::rust::Str pkg_name) const noexcept
 {
   return ::rust::Box< ::rpmostreecxx::RpmImporterFlags>::from_raw (
       rpmostreecxx$cxxbridge1$Treefile$importer_flags (*this, pkg_name));
+}
+
+::rust::String
+Treefile::write_repovars (::std::int32_t workdir_dfd_raw) const
+{
+  ::rust::MaybeUninit< ::rust::String> return$;
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$Treefile$write_repovars (*this, workdir_dfd_raw, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
 void

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1526,6 +1526,7 @@ struct Treefile final : public ::rust::Opaque
   void sanitycheck_externals () const;
   ::rust::Box< ::rpmostreecxx::RpmImporterFlags>
   importer_flags (::rust::Str pkg_name) const noexcept;
+  ::rust::String write_repovars (::std::int32_t workdir_dfd_raw) const;
   void validate_for_container () const;
   ::rpmostreecxx::Refspec get_base_refspec () const noexcept;
   void rebase (::rust::Str new_refspec, ::rust::Str custom_origin_url,

--- a/rust/src/extensions.rs
+++ b/rust/src/extensions.rs
@@ -183,11 +183,12 @@ impl Extensions {
             .context("while serializing")?)
     }
 
-    /// Create a treefile representing just what needs to be installed for extensions.
+    /// Create a treefile representing just what needs to be installed for extensions. This
+    /// includes all information related to packages, modules, and repos.
     pub(crate) fn generate_treefile(&self, src: &Treefile) -> CxxResult<Box<Treefile>> {
         let mut repos = src.parsed.base.repos.clone().unwrap_or_default();
         repos.extend(self.repos.iter().flatten().cloned());
-        let ret = TreeComposeConfig {
+        let parsed = TreeComposeConfig {
             base: BaseComposeConfigFields {
                 repos: Some(repos),
                 releasever: src.parsed.base.releasever.clone(),
@@ -197,7 +198,11 @@ impl Extensions {
             modules: self.modules.clone(),
             ..Default::default()
         };
-        Ok(Box::new(Treefile::new_from_config(ret)?))
+        Ok(Box::new(Treefile {
+            directory: src.directory.clone(),
+            parsed,
+            externals: Default::default(),
+        }))
     }
 }
 

--- a/rust/src/extensions.rs
+++ b/rust/src/extensions.rs
@@ -191,6 +191,7 @@ impl Extensions {
         let parsed = TreeComposeConfig {
             base: BaseComposeConfigFields {
                 repos: Some(repos),
+                repovars: src.parsed.base.repovars.clone(),
                 releasever: src.parsed.base.releasever.clone(),
                 ..Default::default()
             },

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -599,6 +599,7 @@ pub mod ffi {
         fn print_experimental_notices(&self);
         fn sanitycheck_externals(&self) -> Result<()>;
         fn importer_flags(&self, pkg_name: &str) -> Box<RpmImporterFlags>;
+        fn write_repovars(&self, workdir_dfd_raw: i32) -> Result<String>;
 
         // these functions are more related to derivation
         fn validate_for_container(&self) -> Result<()>;

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -287,6 +287,8 @@ set_repos_dir (DnfContext *dnfctx, rpmostreecxx::Treefile &treefile, GCancellabl
 {
   auto treefile_dir = std::string (treefile.get_workdir ());
   dnf_context_set_repo_dir (dnfctx, treefile_dir.c_str ());
+  const char *no_dirs[] = { NULL };
+  dnf_context_set_vars_dir (dnfctx, no_dirs);
   return TRUE;
 }
 

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -586,7 +586,7 @@ rpmostree_dnfcontext_fix_vars_dir (DnfContext *context, GError **error)
       g_string_append (slashdotdot_prefix, "/..");
 
   // Tweak each directory, prepending the relevant amount of `..`.
-  g_autoptr (GPtrArray) tweaked_dirs = g_ptr_array_new ();
+  g_autoptr (GPtrArray) tweaked_dirs = g_ptr_array_new_with_free_func (g_free);
   for (int dir_index = 0; orig_dirs[dir_index] != NULL; dir_index++)
     {
       const gchar *dir = orig_dirs[dir_index];

--- a/tests/compose/test-basic-unified.sh
+++ b/tests/compose/test-basic-unified.sh
@@ -38,6 +38,14 @@ treefile_pyedit "tf['modules'] = {
   'install': [],
 }"
 
+# also test repovar substitution
+treefile_pyedit "tf['repovars'] = {
+  'foobar': 'yumrepo',
+  'unused': 'bazboo',
+}"
+sed -i -e 's,baseurl=\(.*\)/yumrepo,baseurl=\1/$foobar,' yumrepo.repo
+assert_file_has_content_literal yumrepo.repo '$foobar'
+
 build_rpm foomodular requires foomodular-ext
 build_rpm foomodular-ext
 build_rpm foomodular-optional

--- a/tests/compose/test-basic.sh
+++ b/tests/compose/test-basic.sh
@@ -22,6 +22,14 @@ tf['repo-packages'] = [{
 }]
 "
 
+# also test repovar substitution
+treefile_pyedit "tf['repovars'] = {
+  'foobar': 'yumrepo',
+  'unused': 'bazboo',
+}"
+sed -i -e 's,baseurl=\(.*\)/yumrepo,baseurl=\1/$foobar,' yumrepo.repo
+assert_file_has_content_literal yumrepo.repo '$foobar'
+
 treefile_pyedit "tf['add-commit-metadata']['foobar'] = 'bazboo'"
 treefile_pyedit "tf['add-commit-metadata']['overrideme'] = 'old var'"
 


### PR DESCRIPTION
As part of improving our treefile composition capabilities, add a new
`repovars` field to the spec to support driving yum repo variables from
the treefile.

This will be used for example to parameterize the `rhel-8-server-ose`
yum repo definition based on the RHCOS stream.

There's more improvements possible here, like supporting treefile
variable substitution.