### PR TITLE
build: Compile with rpm 4.18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,13 @@ jobs:
   build-tests:
     name: "Build Integration Test Data"
     runs-on: ubuntu-latest
-    container: registry.ci.openshift.org/coreos/fcos-buildroot:testing-devel
+    container:
+      image: registry.ci.openshift.org/coreos/fcos-buildroot:testing-devel
+      # Run privileged to hack around createrepo_c hitting the classic seccomp
+      # broken behaviour of returning EPERM instead of ENOSYS. We should be able
+      # to drop this once `ubuntu-latest` is bumped to include the fix for
+      # https://github.com/opencontainers/runc/issues/2151.
+      options: "--user root --privileged"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -58,10 +58,8 @@ versionid=$(. /usr/lib/os-release && echo $VERSION_ID)
 # Let's start by trying to install a bona fide module.
 # NOTE: If changing this also change the layering-modules test
 case $versionid in
-  # yes, this is going backwards, see:
-  # https://github.com/coreos/fedora-coreos-tracker/issues/767#issuecomment-917191270
-  35) module=cri-o:1.19/default;;
   36) module=cri-o:1.23/default;;
+  37) module=cri-o:1.24/default;;
   *) assert_not_reached "Unsupported Fedora version: $versionid";;
 esac
 rpm-ostree ex module install "${module}"
@@ -78,14 +76,6 @@ fi
 versionid=$(grep -E '^VERSION_ID=' /etc/os-release)
 versionid=${versionid:11} # trim off VERSION_ID=
 case $versionid in
-  35)
-    url_suffix=2.13.0/5.fc35/x86_64/ignition-2.13.0-5.fc35.x86_64.rpm
-    # 2.14.0
-    koji_url=https://koji.fedoraproject.org/koji/buildinfo?buildID=1967838
-    koji_kernel_url=https://koji.fedoraproject.org/koji/buildinfo?buildID=1970751
-    kver=5.17.11
-    krev=200
-    ;;
   36)
     url_suffix=2.13.0/5.fc36/x86_64/ignition-2.13.0-5.fc36.x86_64.rpm
     # 2.14.0
@@ -93,6 +83,14 @@ case $versionid in
     koji_kernel_url=https://koji.fedoraproject.org/koji/buildinfo?buildID=1970749
     kver=5.17.11
     krev=300
+    ;;
+  37)
+    url_suffix=2.14.0/3.fc37/x86_64/ignition-2.14.0-3.fc37.x86_64.rpm
+    # 2.14.0-4
+    koji_url=https://koji.fedoraproject.org/koji/buildinfo?buildID=2013062
+    koji_kernel_url=https://koji.fedoraproject.org/koji/buildinfo?buildID=2084352
+    kver=6.0.7
+    krev=301
     ;;
   *) fatal "Unsupported Fedora version: $versionid";;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,9 @@ PKG_CHECK_MODULES(PKGDEP_LIBRPMOSTREE, [gio-unix-2.0 >= 2.50.0 json-glib-1.0 ost
 dnl And these additional ones are used by for the rpmostreeinternals C/C++ library
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [polkit-gobject-1 libarchive])
 
+AS_IF([pkg-config --atleast-version=4.18.0 rpm],
+  AC_DEFINE([BUILDOPT_RPM_INTERRUPT_SAFETY_DEFAULT], 1, [Set if we do not need to turn on interrupt safety in librpm]))
+
 dnl RHEL8.1 has old libarchive
 AS_IF([pkg-config --atleast-version=3.3.3 libarchive],
   [AC_DEFINE([HAVE_LIBARCHIVE_ZSTD], 1, [Define if we have libarchive with zstd])])

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -241,3 +241,7 @@ $PYTHON autofiles.py > files.devel \
 %files libs -f files.lib
 
 %files devel -f files.devel
+
+%changelog
+* Thu Nov 17 2022 Colin Walters <walters@verbum.org> - 2022.15-3
+- Dummy change to satisfy rpm timestamp clamping

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -198,7 +198,9 @@ rpmostree_context_new_base (OstreeRepo *repo)
    * otherwise we keep calling _rpmostree_reset_rpm_sighandlers() in
    * various places.
    */
+#ifndef BUILDOPT_RPM_INTERRUPT_SAFETY_DEFAULT
   rpmsqSetInterruptSafety (FALSE);
+#endif
 
   self->dnfctx = dnf_context_new ();
   dnf_context_set_http_proxy (self->dnfctx, g_getenv ("http_proxy"));

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -238,6 +238,10 @@ rm -rf %{buildroot}
 %files
 /usr/bin/$name
 $files
+
+%changelog
+* Thu Nov 17 2022 Colin Walters <walters@verbum.org>
+- Dummy change to satisfy rpm timestamp clamping
 EOF
 
     # because it'd be overkill to set up mock for this, let's just fool

--- a/tests/compose-image.sh
+++ b/tests/compose-image.sh
@@ -32,7 +32,7 @@ cd minimal-test
 cat > minimal.yaml << 'EOF'
 container: true
 recommends: false
-releasever: 36
+releasever: 37
 packages:
   - rootfiles
   - fedora-repos-modular
@@ -60,7 +60,7 @@ mkdir minimal-test
 cd minimal-test
 cat > minimal.yaml << 'EOF'
 boot-location: modules
-releasever: 36
+releasever: 37
 packages:
   - bash
   - rpm

--- a/tests/compose.sh
+++ b/tests/compose.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # freeze on a specific commit for tests for reproducibility and since it should
 # always work to target older treefiles
-FEDORA_COREOS_CONFIG_COMMIT=c452af04d86af6bed58fa9bd0543025d5fe3a3f6
+FEDORA_COREOS_CONFIG_COMMIT=ce65013fcb9f10bfee1c7c1c27477c6c6ce676b3
 
 dn=$(cd "$(dirname "$0")" && pwd)
 topsrcdir=$(cd "$dn/.." && pwd)
@@ -49,7 +49,7 @@ if [ ! -d compose-cache ]; then
   # default; we'll want it to test `install-langs`. This also means that we have
   # to add updates-archive to the repo list.
   # Also neuter OSTree layers; we don't re-implement cosa's auto-layering sugar
-  curl -LO https://src.fedoraproject.org/rpms/fedora-repos/raw/f36/f/fedora-updates-archive.repo
+  curl -LO https://src.fedoraproject.org/rpms/fedora-repos/raw/f37/f/fedora-updates-archive.repo
   python3 -c '
 import sys, json
 y = json.load(sys.stdin)

--- a/tests/kolainst/destructive/layering-modules
+++ b/tests/kolainst/destructive/layering-modules
@@ -11,10 +11,8 @@ versionid=$(. /usr/lib/os-release && echo $VERSION_ID)
 # Let's start by trying to install a bona fide module.
 # NOTE: If changing this also change test-container.sh
 case $versionid in
-  # yes, this is going backwards, see:
-  # https://github.com/coreos/fedora-coreos-tracker/issues/767#issuecomment-917191270
-  35) module=cri-o:1.19/default;;
   36) module=cri-o:1.23/default;;
+  37) module=cri-o:1.24/default;;
   *) assert_not_reached "Unsupported Fedora version: $versionid";;
 esac
 rpm-ostree ex module install "${module}"

--- a/tests/vmcheck/test-override-kernel.sh
+++ b/tests/vmcheck/test-override-kernel.sh
@@ -41,8 +41,8 @@ versionid=${versionid:11} # trim off VERSION_ID=
 current=$(vm_get_booted_csum)
 vm_cmd rpm-ostree db list "${current}" > current-dblist.txt
 case $versionid in
-  35) kernel_release=5.14.10-300.fc35.x86_64;;
   36) kernel_release=5.17.5-300.fc36.x86_64;;
+  37) kernel_release=6.0.7-301.fc37.x86_64;;
   *) assert_not_reached "Unsupported Fedora version: $versionid";;
 esac
 assert_not_file_has_content current-dblist.txt $kernel_release


### PR DESCRIPTION
(FCOS was bumped to Fedora 37, which of course we hadn't been testing here until now, so time to make the necessary adjustments)

The interrupt safety API was dropped as being unnecessary.
