### PR TITLE
packaging/spec: Upstream "Disable LTO on 32 bits"

### DIFF
--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -167,6 +167,9 @@ The %{name}-devel package includes the header files for %{name}-libs.
 
 %prep
 %autosetup -Sgit -n %{name}-%{version}
+%if 0%{?__isa_bits} == 32
+sed -ie 's,^lto = true,lto = false,' Cargo.toml
+%endif
 
 %build
 env NOCONFIGURE=1 ./autogen.sh


### PR DESCRIPTION
I.e. https://src.fedoraproject.org/rpms/rpm-ostree/c/f5f08e67231ae0e560b5cc1c844c48b3f7b33cb4

I'd like the spec in this repo to be canonical and the ones in dist-gits to just be direct imports.