### PR TITLE
kargs: Simplify idempotent append and delete operations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,7 +81,7 @@ PKG_PROG_PKG_CONFIG
 dnl Remember to update AM_CPPFLAGS in Makefile.am when bumping GIO req.
 PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 dnl These are the dependencies of the public librpmostree-1.0.0 shared library
-PKG_CHECK_MODULES(PKGDEP_LIBRPMOSTREE, [gio-unix-2.0 >= 2.50.0 json-glib-1.0 ostree-1 >= 2021.2 rpm >= 4.16])
+PKG_CHECK_MODULES(PKGDEP_LIBRPMOSTREE, [gio-unix-2.0 >= 2.50.0 json-glib-1.0 ostree-1 >= 2022.7 rpm >= 4.16])
 dnl And these additional ones are used by for the rpmostreeinternals C/C++ library
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [polkit-gobject-1 libarchive])
 

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -2679,7 +2679,6 @@ kernel_arg_apply_patching (KernelArgTransaction *self, RpmOstreeSysrootUpgrader 
       = static_cast<char **> (vardict_lookup_strv_canonical (self->options, "append-if-missing"));
   g_autofree char **delete_if_present
       = static_cast<char **> (vardict_lookup_strv_canonical (self->options, "delete-if-present"));
-  g_auto (GStrv) existing_kargs = g_strsplit (self->existing_kernel_args, " ", -1);
   gboolean changed = FALSE;
 
   /* Delete all the entries included in the kernel args */
@@ -2708,9 +2707,9 @@ kernel_arg_apply_patching (KernelArgTransaction *self, RpmOstreeSysrootUpgrader 
   for (char **iter = append_if_missing; iter && *iter; iter++)
     {
       const char *arg = *iter;
-      if (!g_strv_contains (existing_kargs, arg))
+      if (!ostree_kernel_args_contains (kargs, arg))
         {
-          ostree_kernel_args_append (kargs, arg);
+          ostree_kernel_args_append_if_missing (kargs, arg);
           changed = TRUE;
         }
     }
@@ -2718,9 +2717,9 @@ kernel_arg_apply_patching (KernelArgTransaction *self, RpmOstreeSysrootUpgrader 
   for (char **iter = delete_if_present; iter && *iter; iter++)
     {
       const char *arg = *iter;
-      if (g_strv_contains (existing_kargs, arg))
+      if (ostree_kernel_args_contains (kargs, arg))
         {
-          if (!ostree_kernel_args_delete (kargs, arg, error))
+          if (!ostree_kernel_args_delete_if_present (kargs, arg, error))
             return FALSE;
           changed = TRUE;
         }


### PR DESCRIPTION
Simplify idempotent operations.
Allows us to drop `existing_kargs` variable.
Fixes the corner case where `--append foo --append-if-missing foo` would append `foo` twice.

Uses new libostree OstreeKernelArgs API symbols:
    ostree_kernel_args_contains
    ostree_kernel_args_append_if_missing
    ostree_kernel_args_delete_if_present

Signed-off-by: Rafael Garcia Ruiz <rafael.garcia@collabora.com>
