### PR TITLE
container-encapsulate: Format errors correctly

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -53,6 +53,7 @@ async fn inner_async_main(args: Vec<String>) -> Result<i32> {
                     "This entrypoint is deprecated; use `rpm-ostree compose container-encapsulate` instead",
                     );
                     rpmostree_rust::container::container_encapsulate(args_orig).map(|_| 0)
+                    .map_err(anyhow::Error::msg)
                 },
                 // C++ main
                 _ => Ok(rpmostree_rust::ffi::rpmostree_main(args)?),


### PR DESCRIPTION
We need to use `CxxResult` across the cxx (Rust <-> C++) bridge to ensure that we format errors correctly.  I noticed this when looking at an error from `rpm-ostree compose container-encapsulate`.
