### PR TITLE
cxxrsutil: Drop use of `&mut` in `gobj_wrap()`

### DIFF
--- a/rust/src/builtins/compose/commit.rs
+++ b/rust/src/builtins/compose/commit.rs
@@ -8,7 +8,7 @@ use indoc::printdoc;
 use std::pin::Pin;
 
 /// Print statistics related to an ostree transaction.
-pub fn print_ostree_txn_stats(mut stats: Pin<&mut crate::FFIOstreeRepoTransactionStats>) {
+pub fn print_ostree_txn_stats(stats: Pin<&mut crate::FFIOstreeRepoTransactionStats>) {
     let stats = &stats.gobj_wrap();
     printdoc!(
         "Metadata Total: {meta_total}

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -956,7 +956,7 @@ fn ensure_symlink(rootfs: &Dir, target: &str, linkpath: &str) -> Result<bool> {
 
 pub fn workaround_selinux_cross_labeling(
     rootfs_dfd: i32,
-    mut cancellable: Pin<&mut crate::FFIGCancellable>,
+    cancellable: Pin<&mut crate::FFIGCancellable>,
 ) -> CxxResult<()> {
     let rootfs = crate::ffiutil::ffi_view_openat_dir(rootfs_dfd);
     let cancellable = &cancellable.gobj_wrap();
@@ -1037,7 +1037,7 @@ fn workaround_selinux_cross_labeling_recurse(
 
 pub fn prepare_rpmdb_base_location(
     rootfs_dfd: i32,
-    mut cancellable: Pin<&mut crate::FFIGCancellable>,
+    cancellable: Pin<&mut crate::FFIGCancellable>,
 ) -> CxxResult<()> {
     let rootfs = crate::ffiutil::ffi_view_openat_dir(rootfs_dfd);
     let cancellable = &cancellable.gobj_wrap();

--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -28,7 +28,7 @@ pub trait FFIGObjectWrapper {
     /// Use this function in Rust code that accepts glib-rs
     /// objects passed via cxx-rs to synthesize the expected glib-rs
     /// wrapper type.
-    fn gobj_wrap(&mut self) -> Self::Wrapper;
+    fn gobj_wrap(&self) -> Self::Wrapper;
 
     /// Convert a borrowed cxx-rs type back into a borrowed version
     /// of the glib-rs type.
@@ -48,8 +48,8 @@ macro_rules! impl_wrap {
     ($w:ident, $bound:path, $sys:path) => {
         impl FFIGObjectWrapper for $w {
             type Wrapper = $bound;
-            fn gobj_wrap(&mut self) -> Self::Wrapper {
-                unsafe { glib::translate::from_glib_none(&mut self.0 as *mut _) }
+            fn gobj_wrap(&self) -> Self::Wrapper {
+                unsafe { glib::translate::from_glib_none(&self.0 as *const _) }
             }
 
             fn glib_reborrow(&self) -> glib::translate::Borrowed<Self::Wrapper> {

--- a/rust/src/deployment_utils.rs
+++ b/rust/src/deployment_utils.rs
@@ -27,7 +27,7 @@ pub(crate) fn deployment_generate_id_impl(deployment: &ostree::Deployment) -> St
 }
 
 pub fn deployment_for_id(
-    mut ffi_sysroot: Pin<&mut crate::ffi::OstreeSysroot>,
+    ffi_sysroot: Pin<&mut crate::ffi::OstreeSysroot>,
     deploy_id: &str,
 ) -> CxxResult<*mut crate::FFIOstreeDeployment> {
     let sysroot = &ffi_sysroot.gobj_wrap();
@@ -57,7 +57,7 @@ fn deployment_for_id_impl(
 }
 
 pub fn deployment_checksum_for_id(
-    mut ffi_sysroot: Pin<&mut crate::ffi::OstreeSysroot>,
+    ffi_sysroot: Pin<&mut crate::ffi::OstreeSysroot>,
     deploy_id: &str,
 ) -> CxxResult<String> {
     let sysroot = &ffi_sysroot.gobj_wrap();
@@ -69,7 +69,7 @@ pub fn deployment_checksum_for_id(
 }
 
 pub fn deployment_get_base(
-    mut ffi_sysroot: Pin<&mut crate::ffi::OstreeSysroot>,
+    ffi_sysroot: Pin<&mut crate::ffi::OstreeSysroot>,
     opt_deploy_id: &str,
     opt_os_name: &str,
 ) -> CxxResult<*mut crate::FFIOstreeDeployment> {

--- a/rust/src/initramfs.rs
+++ b/rust/src/initramfs.rs
@@ -143,7 +143,7 @@ pub(crate) fn get_dracut_random_cpio() -> &'static [u8] {
 #[context("Generating initramfs overlay")]
 pub(crate) fn initramfs_overlay_generate(
     files: &Vec<String>,
-    mut cancellable: Pin<&mut crate::FFIGCancellable>,
+    cancellable: Pin<&mut crate::FFIGCancellable>,
 ) -> CxxResult<i32> {
     let cancellable = &cancellable.gobj_wrap();
     let files: HashSet<String> = files.iter().cloned().collect();


### PR DESCRIPTION
Prep for updating to the newer glib, which seems to change something related to how Deref works here.

We never needed to cast to a `&mut` reference here - the semantics of glib-rs all use "interior mutability" (which contrasts with how cxx.rs tries to propagate C++ `const` with Rust borrows).
