### PR TITLE
Update to ostree-ext 0.10, glib 0.16, cap-std 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ checksum = "88ad0e1e3e88dd237a156ab9f571021b8a158caa0ae44b1968a241efb5144c1e"
 
 [[package]]
 name = "cap-primitives"
-version = "0.25.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba063daa90ed40882bb288ac4ecaa942d655d15cf74393d41d2267b5d7daf120"
+checksum = "e58ae40664c77c3dd4c0df2e5bc97743ede4b814f9970d81228e69d101702e03"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -174,16 +174,15 @@ dependencies = [
  "ipnet",
  "maybe-owned",
  "rustix",
- "winapi-util",
  "windows-sys",
  "winx",
 ]
 
 [[package]]
 name = "cap-std"
-version = "0.25.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3a603c9f3bd2181ed128ab3cd32fbde7cff76afc64a3576662701c4aee7e2b"
+checksum = "2b515b8f641ddea066fc2ce25f2c27b60c1f7c2f50f7b8c8c4acfe70a1a51646"
 dependencies = [
  "camino",
  "cap-primitives",
@@ -195,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std-ext"
-version = "0.26.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2efd8f69529838e5adf942ed8f0fc36f7ae9dfdcbb4cf6b8509a6c299396529"
+checksum = "a0badf359e8c413450053dc1334baf0c9db77ac9313d0b96f46acd276445377d"
 dependencies = [
  "cap-tempfile",
  "rustix",
@@ -205,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "cap-tempfile"
-version = "0.25.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d435f791da84cb800b98a1de48d145a08e70d8172d335e87446c79b17bfbf3"
+checksum = "ad935d619cca685eb3a93e31f27c5217e0d2fd90ae47977ff178039084e19c34"
 dependencies = [
  "cap-std",
  "rand",
@@ -230,15 +229,6 @@ name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
-
-[[package]]
-name = "cfg-expr"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a1d12766bbdd5d44caab5df04a9bffec9cd855a1b44b15de5665d70c085f94"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "cfg-expr"
@@ -312,7 +302,7 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -363,11 +353,13 @@ dependencies = [
 
 [[package]]
 name = "containers-image-proxy"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a191524738c08441cf7841c77e8d6bc7fbdc73caa083f07772b6588b830b9"
+checksum = "9be0dd8c7b65d32573bf87971654947921013cb1c690d68b737aaa653826fae3"
 dependencies = [
  "anyhow",
+ "cap-std-ext",
+ "cap-tempfile",
  "capctl",
  "fn-error-context",
  "futures-util",
@@ -787,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "fs-set-times"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a267b6a9304912e018610d53fe07115d8b530b160e85db4d2d3a59f3ddde1aec"
+checksum = "e25ca26b0001154679ce0901527330e6153b670d17ccd1f86bab4e45dfba1a74"
 dependencies = [
  "io-lifetimes",
  "rustix",
@@ -920,61 +912,67 @@ dependencies = [
 
 [[package]]
 name = "gio"
-version = "0.14.3"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a7057cd21d64bfa7ac027b344a7f50f677fb3308693df0e8c70fb55d29f0d"
+checksum = "1d4a17d999e6e4e05d87c2bb05b7140d47769bc53211711a33e2f91536458714"
 dependencies = [
  "bitflags",
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-util",
  "gio-sys",
  "glib",
  "libc",
  "once_cell",
+ "pin-project-lite",
+ "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "gio-sys"
-version = "0.14.0"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a41df66e57fcc287c4bcf74fc26b884f31901ea9792ec75607289b456f48fa"
+checksum = "e9b693b8e39d042a95547fc258a7b07349b1f0b48f4b2fa3108ba3c51c0b5229"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps 3.2.0",
+ "system-deps",
  "winapi",
 ]
 
 [[package]]
 name = "glib"
-version = "0.14.4"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fb802e3798d75b415bea8f016eed88d50106ce82f1274e80f31d80cfd4b056"
+checksum = "d5204a4217749b385cefbfb7bf3a2fcde83e4ce6d0945f64440a1f5bd4010305"
 dependencies = [
  "bitflags",
  "futures-channel",
  "futures-core",
  "futures-executor",
  "futures-task",
+ "futures-util",
+ "gio-sys",
  "glib-macros",
  "glib-sys",
  "gobject-sys",
  "libc",
  "once_cell",
  "smallvec",
+ "thiserror",
 ]
 
 [[package]]
 name = "glib-macros"
-version = "0.14.1"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aad66361f66796bfc73f530c51ef123970eb895ffba991a234fcf7bea89e518"
+checksum = "e084807350b01348b6d9dbabb724d1a0bb987f47a2c85de200e98e12e30733bf"
 dependencies = [
  "anyhow",
- "heck 0.3.3",
+ "heck",
  "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
@@ -984,23 +982,23 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
-version = "0.14.0"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1d60554a212445e2a858e42a0e48cece1bd57b311a19a9468f70376cf554ae"
+checksum = "c61a4f46316d06bfa33a7ac22df6f0524c8be58e3db2d9ca99ccb1f357b62a65"
 dependencies = [
  "libc",
- "system-deps 3.2.0",
+ "system-deps",
 ]
 
 [[package]]
 name = "gobject-sys"
-version = "0.14.0"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa92cae29759dae34ab5921d73fff5ad54b3d794ab842c117e36cafc7994c3f5"
+checksum = "3520bb9c07ae2a12c7f2fbb24d4efc11231c8146a86956413fb1a79bb760a0f1"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps 3.2.0",
+ "system-deps",
 ]
 
 [[package]]
@@ -1056,15 +1054,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -1242,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "io-extras"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5d8c2ab5becd8720e30fd25f8fa5500d8dc3fceadd8378f05859bd7b46fc49"
+checksum = "4ad797ac2cd70ff82f6d9246d36762b41c1db15b439fd48bcb70914269642354"
 dependencies = [
  "io-lifetimes",
  "windows-sys",
@@ -1252,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c3f4eff5495aee4c0399d7b6a0dc2b6e81be84242ffbfcf253ebacccc1d0cb"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1273,15 +1262,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cee08a007a59a8adfc96f69738ddf59e374888dfd84b49c4b916543067644d58"
 dependencies = [
  "nom 5.1.2",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1325,7 +1305,7 @@ dependencies = [
  "cmake",
  "cxx",
  "cxx-build",
- "system-deps 6.0.3",
+ "system-deps",
 ]
 
 [[package]]
@@ -1379,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.46"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
+checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
 
 [[package]]
 name = "log"
@@ -1427,9 +1407,9 @@ checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memfd"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480b5a5de855d11ff13195950bdc8b98b5e942ef47afc447f6615cdcc4e15d80"
+checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
 dependencies = [
  "rustix",
 ]
@@ -1718,9 +1698,9 @@ checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "ostree"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3106805eb979ca1a46dd10a126384849f683a583f9ecb1c1fba4af293ee129ff"
+checksum = "075e224494c835757887025f344b06ab940e21c6bfaf41b7c629cee0328c8e7f"
 dependencies = [
  "bitflags",
  "cap-std",
@@ -1737,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "ostree-ext"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e14d02ceb2624f839a034266e2ebe148e17d66e82520e449a58fb0701cf77f3"
+checksum = "ae3ba185ef658253d6ee73551377598f31a429cb7e3b8a69ee4d54c4f6c4a0c0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1778,15 +1758,15 @@ dependencies = [
 
 [[package]]
 name = "ostree-sys"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2171f373b9592c4e8fa31a4ccd63f310a57da0e04513aab9b616447681e5dc92"
+checksum = "fe57dcbabc3b1ef80f97eb614453d90dc81a39c8f26eb540bd8e68bcae4d0e2f"
 dependencies = [
  "gio-sys",
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps 3.2.0",
+ "system-deps",
 ]
 
 [[package]]
@@ -2171,7 +2151,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "system-deps 6.0.3",
+ "system-deps",
  "systemd",
  "tempfile",
  "termcolor",
@@ -2193,9 +2173,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.35.11"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb2fda4666def1433b1b05431ab402e42a1084285477222b72d6c564c417cef"
+checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
 dependencies = [
  "bitflags",
  "errno",
@@ -2390,24 +2370,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "strum"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
-
-[[package]]
-name = "strum_macros"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,33 +2388,15 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480c269f870722b3b08d2f13053ce0c2ab722839f472863c3e2d61ff3a1c2fa6"
-dependencies = [
- "anyhow",
- "cfg-expr 0.8.0",
- "heck 0.3.3",
- "itertools",
- "pkg-config",
- "strum",
- "strum_macros",
- "thiserror",
- "toml",
- "version-compare 0.0.11",
-]
-
-[[package]]
-name = "system-deps"
 version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2955b1fe31e1fa2fbd1976b71cc69a606d7d4da16f6de3333d0c92d51419aeff"
 dependencies = [
- "cfg-expr 0.11.0",
- "heck 0.4.0",
+ "cfg-expr",
+ "heck",
  "pkg-config",
  "toml",
- "version-compare 0.1.0",
+ "version-compare",
 ]
 
 [[package]]
@@ -2778,12 +2722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,12 +2780,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version-compare"
-version = "0.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c18c859eead79d8b95d09e4678566e8d70105c4e7b251f707a03df32442661b"
 
 [[package]]
 name = "version-compare"
@@ -2992,46 +2924,60 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
+ "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
 ]
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.36.1"
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"
@@ -3044,9 +2990,9 @@ dependencies = [
 
 [[package]]
 name = "winx"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b01e010390eb263a4518c8cebf86cb67469d1511c00b749a47b64c39e8054d"
+checksum = "9baf690e238840de84bbfad6ad72d6628c41d34c1a5e276dab7fb2c9167ca1ac"
 dependencies = [
  "bitflags",
  "io-lifetimes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,13 +46,13 @@ binread = "2.2.0"
 bitflags = "1.3"
 c_utf8 = "0.1.0"
 camino = "1.1.1"
-cap-std-ext = "0.26"
-cap-std = { version = "0.25", features = ["fs_utf8"] }
+cap-std-ext = "1.0"
+cap-std = { version = "1.0.1", features = ["fs_utf8"] }
 containers-image-proxy = "0.5.1"
 # Explicitly force on libc
-rustix = { version = "0.35", features = ["use-libc"] }
-cap-primitives = "0.25.3"
-cap-tempfile = "0.25.3"
+rustix = { version = "0.36", features = ["use-libc"] }
+cap-primitives = "1.0.1"
+cap-tempfile = "1.0.1"
 chrono = { version = "0.4.22", features = ["serde"] }
 clap = { version = "3.2.23", features = ["derive"] }
 cxx = "1.0.82"
@@ -75,7 +75,7 @@ openssl = "0.10.42"
 once_cell = "1.16.0"
 oci-spec = "0.5"
 os-release = "0.1.0"
-ostree-ext = "0.9.0"
+ostree-ext = "0.10.0"
 paste = "1.0"
 phf = { version = "0.11", features = ["macros"] }
 rand = "0.8.5"

--- a/rust/src/builtins/apply_live.rs
+++ b/rust/src/builtins/apply_live.rs
@@ -51,17 +51,17 @@ pub(crate) fn applylive_entrypoint(args: &Vec<String>) -> CxxResult<()> {
     let opts = &Opts::parse_from(args.iter());
     let client = &mut crate::client::ClientConnection::new()?;
     let sysroot = &ostree::Sysroot::new_default();
-    sysroot.load(gio::NONE_CANCELLABLE)?;
+    sysroot.load(gio::Cancellable::NONE)?;
 
     let args = get_args_variant(sysroot, opts)?;
 
-    let params = Variant::from_tuple(&[args]);
+    let params = Variant::tuple_from_iter([args]);
     let reply = &client.get_os_ex_proxy().call_sync(
         "LiveFs",
         Some(&params),
         gio::DBusCallFlags::NONE,
         -1,
-        gio::NONE_CANCELLABLE,
+        gio::Cancellable::NONE,
     )?;
     let txn_address = reply
         .get::<(String,)>()
@@ -74,7 +74,7 @@ pub(crate) fn applylive_entrypoint(args: &Vec<String>) -> CxxResult<()> {
 // Postprocessing after the daemon has reported completion; print an rpmdb diff.
 pub(crate) fn applylive_finish(sysroot: &crate::ffi::OstreeSysroot) -> CxxResult<()> {
     let sysroot = sysroot.glib_reborrow();
-    let cancellable = gio::NONE_CANCELLABLE;
+    let cancellable = gio::Cancellable::NONE;
     sysroot.load_if_changed(cancellable)?;
     let repo = &sysroot.repo().unwrap();
     let booted = &sysroot.require_booted_deployment()?;

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -49,7 +49,7 @@ impl ClientConnection {
             Some(BUS_NAME),
             SYSROOT_PATH,
             "org.projectatomic.rpmostree1.Sysroot",
-            gio::NONE_CANCELLABLE,
+            gio::Cancellable::NONE,
         )?;
         // Today the daemon mode requires running inside a booted deployment.
         let booted = sysroot_proxy
@@ -65,7 +65,7 @@ impl ClientConnection {
             Some(BUS_NAME),
             booted,
             OS_INTERFACE,
-            gio::NONE_CANCELLABLE,
+            gio::Cancellable::NONE,
         )?;
         let booted_ex_proxy = gio::DBusProxy::new_sync(
             &bus_conn,
@@ -74,7 +74,7 @@ impl ClientConnection {
             Some(BUS_NAME),
             booted,
             OS_EX_INTERFACE,
-            gio::NONE_CANCELLABLE,
+            gio::Cancellable::NONE,
         )?;
         Ok(Self {
             conn,

--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -165,7 +165,7 @@ fn manifest_diff(src: &ImageManifest, dest: &ImageManifest) -> ManifestDiff {
 
 pub(crate) fn compose_image(args: Vec<String>) -> CxxResult<()> {
     use crate::isolation::self_command;
-    let cancellable = gio::NONE_CANCELLABLE;
+    let cancellable = gio::Cancellable::NONE;
 
     let opt = Opt::parse_from(args.iter().skip(1));
 

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -1422,7 +1422,7 @@ OSTREE_VERSION='33.4'
             expected_disk_size
         );
 
-        var_to_tmpfiles(&rootfs, gio::NONE_CANCELLABLE).unwrap();
+        var_to_tmpfiles(&rootfs, gio::Cancellable::NONE).unwrap();
 
         let autovar_path = "usr/lib/tmpfiles.d/rpm-ostree-1-autovar.conf";
         assert!(!rootfs.try_exists("var/lib").unwrap());
@@ -1500,7 +1500,7 @@ OSTREE_VERSION='33.4'
         // File timestamps may not increment faster than e.g. 10ms.  Really
         // what we should be doing is using inode versions.
         std::thread::sleep(std::time::Duration::from_millis(100));
-        tweak_selinux_timestamps(&rootfs, gio::NONE_CANCELLABLE).unwrap();
+        tweak_selinux_timestamps(&rootfs, gio::Cancellable::NONE).unwrap();
 
         for (fname, before_meta) in files.iter().zip(metas.iter()) {
             let fpath = format!("{}/{}", PREFIX, fname);
@@ -1517,7 +1517,7 @@ OSTREE_VERSION='33.4'
         let rootfs = openat::Dir::open(temp_rootfs.path()).unwrap();
 
         {
-            let done = hardlink_rpmdb_base_location(&rootfs, gio::NONE_CANCELLABLE).unwrap();
+            let done = hardlink_rpmdb_base_location(&rootfs, gio::Cancellable::NONE).unwrap();
             assert_eq!(done, false);
         }
 
@@ -1533,7 +1533,7 @@ OSTREE_VERSION='33.4'
             rootfs.write_file(*entry, 0o755).unwrap();
         }
 
-        let done = hardlink_rpmdb_base_location(&rootfs, gio::NONE_CANCELLABLE).unwrap();
+        let done = hardlink_rpmdb_base_location(&rootfs, gio::Cancellable::NONE).unwrap();
         assert_eq!(done, true);
 
         assert_eq!(rootfs.exists(RPMOSTREE_BASE_RPMDB).unwrap(), true);

--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -124,7 +124,7 @@ fn build_mapping_recurse(
     state: &mut MappingBuilder,
 ) -> Result<()> {
     use std::collections::btree_map::Entry;
-    let cancellable = gio::NONE_CANCELLABLE;
+    let cancellable = gio::Cancellable::NONE;
     let e = dir.enumerate_children(
         "standard::name,standard::type",
         gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
@@ -214,7 +214,7 @@ pub fn container_encapsulate(args: Vec<String>) -> CxxResult<()> {
     let args = args.iter().skip(1).map(|s| s.as_str());
     let opt = ContainerEncapsulateOpts::parse_from(args);
     let repo = &ostree_ext::cli::parse_repo(&opt.repo)?;
-    let (root, rev) = repo.read_commit(opt.ostree_ref.as_str(), gio::NONE_CANCELLABLE)?;
+    let (root, rev) = repo.read_commit(opt.ostree_ref.as_str(), gio::Cancellable::NONE)?;
     let pkglist = progress_task("Reading packages", || -> Result<_> {
         let cancellable = gio::Cancellable::new();
         let r = crate::ffi::package_variant_list_for_commit(
@@ -292,7 +292,7 @@ pub fn container_encapsulate(args: Vec<String>) -> CxxResult<()> {
         });
     }
 
-    let kernel_dir = ostree_ext::bootabletree::find_kernel_dir(&root, gio::NONE_CANCELLABLE)?;
+    let kernel_dir = ostree_ext::bootabletree::find_kernel_dir(&root, gio::Cancellable::NONE)?;
     if let Some(kernel_dir) = kernel_dir {
         let kernel_ver: Utf8PathBuf = kernel_dir
             .basename()
@@ -300,7 +300,7 @@ pub fn container_encapsulate(args: Vec<String>) -> CxxResult<()> {
             .try_into()
             .map_err(anyhow::Error::msg)?;
         let initramfs = kernel_dir.child("initramfs.img");
-        if initramfs.query_exists(gio::NONE_CANCELLABLE) {
+        if initramfs.query_exists(gio::Cancellable::NONE) {
             let path: Utf8PathBuf = initramfs
                 .path()
                 .unwrap()
@@ -322,7 +322,7 @@ pub fn container_encapsulate(args: Vec<String>) -> CxxResult<()> {
     }
 
     let rpmdb = root.resolve_relative_path(crate::composepost::RPMOSTREE_RPMDB_LOCATION);
-    if rpmdb.query_exists(gio::NONE_CANCELLABLE) {
+    if rpmdb.query_exists(gio::Cancellable::NONE) {
         // TODO add mapping for rpmdb
     }
 
@@ -470,7 +470,7 @@ fn find_encapsulated_commits(repo: &Utf8Path) -> Result<Vec<String>> {
 /// the container ostree commit to the host and deploys it, optionally rebooting.
 pub(crate) fn deploy_from_self_entrypoint(args: Vec<String>) -> CxxResult<()> {
     use nix::sys::statvfs;
-    let cancellable = gio::NONE_CANCELLABLE;
+    let cancellable = gio::Cancellable::NONE;
     let opts = UpdateFromRunningOpts::parse_from(args);
 
     let sysroot = opts.target_root.join("sysroot");

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -15,7 +15,6 @@ use cap_std_ext::prelude::CapStdExtDirExt;
 use ffiutil::*;
 use fn_error_context::context;
 use glib::prelude::StaticVariantType;
-use glib::translate::ToGlibPtr;
 use libdnf_sys::*;
 use ostree_ext::container::OstreeImageReference;
 use ostree_ext::glib;
@@ -299,7 +298,9 @@ pub(crate) fn get_header_variant(
             let nevra = crate::rpmutils::cache_branch_to_nevra(cachebranch);
             format!("In commit {cached_rev} for {nevra}")
         })?;
-    Ok(r.to_glib_full() as *mut _)
+    let p = r.as_ptr();
+    std::mem::forget(r);
+    Ok(p as *mut _)
 }
 
 pub(crate) fn stage_container_rpms(rpms: Vec<String>) -> CxxResult<Vec<String>> {

--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -220,7 +220,7 @@ mod test {
 
     #[test]
     fn passthrough() -> Result<()> {
-        let cancellable = gio::NONE_CANCELLABLE;
+        let cancellable = gio::Cancellable::NONE;
         let td = tempfile::tempdir()?;
         let p = td.path().join("repo");
         let r = ostree::Repo::new_for_path(&p);

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -349,14 +349,14 @@ fn get_cached_signatures_variant(
 
     cachedir.create_dir_all(remote_dir)?;
     cachedir.remove_file_optional(&cached_relpath)?;
-    let verify_result = repo.verify_commit_for_remote(checksum, remote, gio::NONE_CANCELLABLE)?;
+    let verify_result = repo.verify_commit_for_remote(checksum, remote, gio::Cancellable::NONE)?;
     let n = verify_result.count_all();
     let mut sigs: Vec<glib::Variant> = Vec::with_capacity(n as usize);
     for i in 0..n {
         sigs.push(glib::Variant::from_variant(&verify_result.all(i).unwrap())); // we know index is in range
     }
 
-    let v = glib::Variant::from_array::<glib::Variant>(&sigs);
+    let v = glib::Variant::array_from_iter_with_type(&*glib::Variant::static_variant_type(), sigs);
     let perms = cap_std::fs::Permissions::from_mode(0o600);
     cachedir.atomic_write_with_perms(&cached_relpath, &v.data_as_bytes(), perms)?;
     Ok(v)

--- a/rust/src/fedora_integration.rs
+++ b/rust/src/fedora_integration.rs
@@ -227,7 +227,7 @@ fn get_base_package_list() -> Result<HashSet<String>> {
         )
     } else {
         let sysroot = &ostree::Sysroot::new_default();
-        sysroot.load(gio::NONE_CANCELLABLE)?;
+        sysroot.load(gio::Cancellable::NONE)?;
         let deployments = sysroot.deployments();
         let default = deployments
             .get(0)

--- a/rust/src/initramfs.rs
+++ b/rust/src/initramfs.rs
@@ -157,7 +157,7 @@ mod test {
 
     #[test]
     fn test_initramfs_overlay() -> Result<()> {
-        let cancellable = gio::NONE_CANCELLABLE;
+        let cancellable = gio::Cancellable::NONE;
         let tmpd = cap_tempfile::tempdir(cap_std::ambient_authority())?;
         tmpd.create_dir_all("etc/foo")?;
         tmpd.write("etc/foo/somefile", "somecontents")?;

--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -88,13 +88,13 @@ fn write_live_state(
     let found_live_stamp = rundir.exists(LIVE_STATE_NAME);
 
     let commit = Some(state.commit.as_str()).filter(|s| !s.is_empty());
-    repo.set_ref_immediate(None, LIVE_REF, commit, gio::NONE_CANCELLABLE)?;
+    repo.set_ref_immediate(None, LIVE_REF, commit, gio::Cancellable::NONE)?;
     let inprogress_commit = Some(state.inprogress.as_str()).filter(|s| !s.is_empty());
     repo.set_ref_immediate(
         None,
         LIVE_REF_INPROGRESS,
         inprogress_commit,
-        gio::NONE_CANCELLABLE,
+        gio::Cancellable::NONE,
     )?;
 
     // Ensure the stamp file exists
@@ -125,7 +125,7 @@ fn apply_diff(repo: &ostree::Repo, diff: &FileTreeDiff, commit: &str, destdir: &
     if !diff.changed_dirs.is_empty() {
         anyhow::bail!("Changed directories are not supported yet");
     }
-    let cancellable = gio::NONE_CANCELLABLE;
+    let cancellable = gio::Cancellable::NONE;
     // This applies to all added/changed content, we just
     // overwrite `subpath` in each run.
     let mut opts = ostree::RepoCheckoutAtOptions {
@@ -222,7 +222,7 @@ fn update_etc(
         anyhow::bail!("Changed directories are not supported yet");
     }
 
-    let cancellable = gio::NONE_CANCELLABLE;
+    let cancellable = gio::Cancellable::NONE;
     // This applies to all added/changed content, we just
     // overwrite `subpath` in each run.
     let mut opts = ostree::RepoCheckoutAtOptions {
@@ -456,7 +456,7 @@ pub(crate) fn transaction_apply_live(
     let mut state = state.unwrap_or_default();
 
     let rootfs_dfd = Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
-    let sepolicy = ostree::SePolicy::new_at(rootfs_dfd.as_raw_fd(), gio::NONE_CANCELLABLE)?;
+    let sepolicy = ostree::SePolicy::new_at(rootfs_dfd.as_raw_fd(), gio::Cancellable::NONE)?;
 
     // Record that we're targeting this commit
     state.inprogress = target_commit.to_string();

--- a/rust/src/modularity.rs
+++ b/rust/src/modularity.rs
@@ -111,13 +111,13 @@ fn modules_impl_host(key: &str, opts: &InstallOpts) -> Result<()> {
         .ok_or_else(|| anyhow!("Failed to find default-deployment property"))?;
     let modifiers = get_modifiers_variant(key, &opts.modules)?;
     let options = get_options_variant(opts)?;
-    let params = Variant::from_tuple(&[modifiers, options]);
+    let params = Variant::tuple_from_iter([modifiers, options]);
     let reply = &client.get_os_proxy().call_sync(
         "UpdateDeployment",
         Some(&params),
         gio::DBusCallFlags::NONE,
         -1,
-        gio::NONE_CANCELLABLE,
+        gio::Cancellable::NONE,
     )?;
     let reply = reply
         .get::<(String,)>()

--- a/rust/src/origin.rs
+++ b/rust/src/origin.rs
@@ -10,7 +10,6 @@ use crate::cxxrsutil::*;
 use crate::treefile::Treefile;
 use anyhow::{anyhow, bail, Result};
 use fn_error_context::context;
-use glib::translate::ToGlibPtr;
 use glib::KeyFile;
 use ostree_ext::glib;
 use std::collections::BTreeMap;
@@ -134,7 +133,9 @@ pub(crate) fn origin_to_treefile(kf: &crate::ffi::GKeyFile) -> CxxResult<Box<Tre
 /// Convert a treefile config to an origin keyfile.
 pub(crate) fn treefile_to_origin(tf: &Treefile) -> Result<*mut crate::FFIGKeyFile> {
     let kf = treefile_to_origin_inner(tf)?;
-    Ok(kf.to_glib_full() as *mut _)
+    let p = kf.as_ptr();
+    std::mem::forget(kf);
+    Ok(p as *mut _)
 }
 
 /// Set a keyfile value to a string list.

--- a/rust/src/testutils.rs
+++ b/rust/src/testutils.rs
@@ -242,7 +242,7 @@ fn test_moo() -> Result<()> {
     let bus_conn = client_conn.pin_mut().get_connection();
     let bus_conn = bus_conn.glib_reborrow();
 
-    let params = Variant::from_tuple(&[true.to_variant()]);
+    let params = Variant::tuple_from_iter([true.to_variant()]);
     let reply = &bus_conn.call_sync(
         Some("org.projectatomic.rpmostree1"),
         "/org/projectatomic/rpmostree1/fedora_coreos",
@@ -252,7 +252,7 @@ fn test_moo() -> Result<()> {
         Some(glib::VariantTy::new("(s)").unwrap()),
         gio::DBusCallFlags::NONE,
         -1,
-        gio::NONE_CANCELLABLE,
+        gio::Cancellable::NONE,
     )?;
     let reply = reply.child_value(0);
     // Unwrap safety: We validated the (s) above.
@@ -295,7 +295,7 @@ fn test_pkg_variants(repo: &ostree::Repo, booted_commit: &str) -> Result<()> {
 }
 
 fn integration_read_only() -> Result<()> {
-    let cancellable = gio::NONE_CANCELLABLE;
+    let cancellable = gio::Cancellable::NONE;
     let sysroot = &ostree::Sysroot::new_default();
     sysroot.load(cancellable)?;
     let repo = &sysroot.repo().unwrap();


### PR DESCRIPTION
Depends:

- [x] https://github.com/coreos/rpm-ostree/pull/4174
- [x] ostree-ext 0.10 official release

---

Fortunately, having cap-std at 1.0 lets us avoid level
of semver bumps going forward.