### PR TITLE
Prune container image layers during cleanup too

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -2057,6 +2057,10 @@ extern "C"
       const ::rpmostreecxx::OstreeRepo &repo, const ::rpmostreecxx::GCancellable &cancellable,
       ::rust::Str imgref, ::rust::Box< ::rpmostreecxx::ContainerImageState> *return$) noexcept;
 
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$container_prune (
+      const ::rpmostreecxx::OstreeRepo &repo,
+      const ::rpmostreecxx::GCancellable &cancellable) noexcept;
+
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$query_container_image_commit (
       const ::rpmostreecxx::OstreeRepo &repo, ::rust::Str c,
       ::rust::Box< ::rpmostreecxx::ContainerImageState> *return$) noexcept;
@@ -3613,6 +3617,17 @@ pull_container (const ::rpmostreecxx::OstreeRepo &repo,
       throw ::rust::impl< ::rust::Error>::error (error$);
     }
   return ::std::move (return$.value);
+}
+
+void
+container_prune (const ::rpmostreecxx::OstreeRepo &repo,
+                 const ::rpmostreecxx::GCancellable &cancellable)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$container_prune (repo, cancellable);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
 }
 
 ::rust::Box< ::rpmostreecxx::ContainerImageState>

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1762,6 +1762,9 @@ void deploy_from_self_entrypoint (::rust::Vec< ::rust::String> args);
 pull_container (const ::rpmostreecxx::OstreeRepo &repo,
                 const ::rpmostreecxx::GCancellable &cancellable, ::rust::Str imgref);
 
+void container_prune (const ::rpmostreecxx::OstreeRepo &repo,
+                      const ::rpmostreecxx::GCancellable &cancellable);
+
 ::rust::Box< ::rpmostreecxx::ContainerImageState>
 query_container_image_commit (const ::rpmostreecxx::OstreeRepo &repo, ::rust::Str c);
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -195,6 +195,7 @@ pub mod ffi {
             cancellable: &GCancellable,
             imgref: &str,
         ) -> Result<Box<ContainerImageState>>;
+        fn container_prune(repo: &OstreeRepo, cancellable: &GCancellable) -> Result<()>;
         fn query_container_image_commit(
             repo: &OstreeRepo,
             c: &str,

--- a/src/daemon/rpmostree-sysroot-core.cxx
+++ b/src/daemon/rpmostree-sysroot-core.cxx
@@ -214,6 +214,8 @@ rpmostree_syscore_cleanup (OstreeSysroot *sysroot, OstreeRepo *repo, GCancellabl
   /* Refs for the live state */
   ROSCXX_TRY (applylive_sync_ref (*sysroot), error);
 
+  CXX_TRY (rpmostreecxx::container_prune (*repo, *cancellable), error);
+
   /* And do a prune */
   guint64 freed_space;
   gint n_objects_total, n_objects_pruned;


### PR DESCRIPTION
This will handle cleaning up correctly after e.g. `rpm-ostree cleanup -p`.

Closes: https://github.com/coreos/rpm-ostree/issues/4179
