### PR TITLE
upgrader: Can't currently check-only in container flow

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -413,6 +413,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader *self, const char
 {
   g_assert (cancellable);
 
+  const gboolean check = (flags & OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY) > 0;
   const gboolean allow_older = (self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_ALLOW_OLDER) > 0;
   const gboolean synthetic = (self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_SYNTHETIC_PULL) > 0;
 
@@ -432,6 +433,8 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader *self, const char
         if (override_commit)
           return glnx_throw (error, "Specifying commit overrides for container-image-reference "
                                     "type refspecs is not supported");
+        if (check)
+          return glnx_throw (error, "Cannot currently check for updates without downloading");
 
         CXX_TRY_VAR (import,
                      rpmostreecxx::pull_container (*self->repo, *cancellable, r.refspec.c_str ()),

--- a/tests/kolainst/destructive/container-rebase-upgrade
+++ b/tests/kolainst/destructive/container-rebase-upgrade
@@ -39,6 +39,11 @@ rpm-ostree upgrade
 # https://github.com/coreos/rpm-ostree/issues/4107
 podman image rm -f shouldnotexist || true
 test -d /run/containers
+# https://github.com/coreos/rpm-ostree/issues/4176
+if rpm-ostree upgrade --check 2>err.txt; then
+    fatal "expected upgrade --check not to work yet"
+fi
+assert_file_has_content_literal err.txt "Cannot currently check for updates without downloading"
 rpm-ostree upgrade
 
 echo "ok upgrade after podman"


### PR DESCRIPTION
For https://github.com/coreos/rpm-ostree/issues/4176 We'll fix this at some point soon, but for now let's clearly error out.
