### PR TITLE
override: Honor `--install` in container case too

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -124,11 +124,15 @@ rpm-ostree override replace --experimental --from repo=fedora-coreos-pool \
 
 rpm -q afterburn-5.2.0-4.fc36.x86_64 afterburn-dracut-5.2.0-4.fc36.x86_64
 
-# test repo override by pkgname
-rpm-ostree override replace --experimental \
+# test repo override by pkgname, and also test --install
+if rpm -q strace; then
+  echo "strace should not be installed"; exit 1
+fi
+rpm-ostree override replace --install strace --experimental \
   --from repo=copr:copr.fedorainfracloud.org:group_CoreOS:continuous \
   afterburn \
   afterburn-dracut
+rpm -q strace
 
 # the continuous build's version has the git rev, prefixed with g
 rpm -q afterburn | grep g

--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -205,6 +205,7 @@ handle_override (RPMOSTreeSysroot *sysroot_proxy, RpmOstreeCommandInvocation *in
           CXX_TRY_VAR (pkgs, rpmostreecxx::stage_container_rpm_raw_fds (fds), error);
           treefile->add_packages_override_replace_local (pkgs);
         }
+      treefile->add_packages (util::rust_stringvec_from_strv (install_pkgs), true);
       treefile->add_packages_override_remove (util::rust_stringvec_from_strv (override_remove));
       return rpmostree_container_rebuild (*treefile, cancellable, error);
     }


### PR DESCRIPTION
Closes: https://github.com/coreos/rpm-ostree/issues/4192
