### PR TITLE
Use default `all` rule for bindings

### DIFF
--- a/Makefile.bindings
+++ b/Makefile.bindings
@@ -2,6 +2,9 @@
 # Makefile needs to be independent
 binding_rust_sources = $(shell find rust/src/ -name '*.rs') Cargo.toml Cargo.lock
 
+all: rpmostree-cxxrs.h rpmostree-cxxrs.cxx rust/cxx.h
+.PHONY: all
+
 rust/cxx.h: Makefile.bindings
 	./target/cxxbridge/bin/cxxbridge --header | clang-format --assume-filename=$@ >$@.tmp && mv $@.tmp $@
 
@@ -21,7 +24,3 @@ rpmostree-cxxrs.cxx: $(binding_rust_sources) rpmostree-cxxrs.h
 	else \
 	  echo cxxbridge failed; exit 1; \
 	fi
-
-# Invoked in CI
-bindings: rpmostree-cxxrs.h rpmostree-cxxrs.cxx rust/cxx.h
-.PHONY: bindings

--- a/ci/verify-cxx.sh
+++ b/ci/verify-cxx.sh
@@ -3,9 +3,9 @@
 set -xeuo pipefail
 dn=$(dirname $0)
 $dn/install-cxx.sh
-make -f Makefile.bindings bindings
+make -f Makefile.bindings
 if ! git diff; then
-    echo "Found diff in cxx-generated code; please run: make -f Makefile.bindings bindings" 1>&2
+    echo "Found diff in cxx-generated code; please run: make -f Makefile.bindings" 1>&2
     exit 1
 fi
 echo "ok: cxx generated code matches"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -25,7 +25,7 @@ pub(crate) use cxxrsutil::*;
 ///
 /// # Regenerating
 ///
-/// After you change APIs in here, you must run `make -f Makefile.bindings bindings`
+/// After you change APIs in here, you must run `make -f Makefile.bindings`
 /// to regenerate the C++ bridge side.
 ///
 /// # File layout


### PR DESCRIPTION
This makes rebuilding the bindings more obvious.
