### PR TITLE
Documentation tweaks for the `initramfs` and `initramfs-etc` commands

### DIFF
--- a/docs/administrator-handbook.md
+++ b/docs/administrator-handbook.md
@@ -155,7 +155,7 @@ layered packages and local state will be carried across.
 ### Other local state changes
 
 See `man rpm-ostree` for more.  For example, there is an `rpm-ostree initramfs`
-command that enables local initramfs generation.
+command that enables local initramfs generation by rerunning dracut.
 
 ### Experimental interface
 

--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -711,6 +711,32 @@ Boston, MA 02111-1307, USA.
         </listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><command>initramfs-etc</command></term>
+
+        <listitem>
+          <para>
+            Add configuration (<literal>/etc</literal>) files into the initramfs without
+            regenerating the entire initramfs. This is useful to be able to configure
+            services backing the root block device as well as early-boot services like
+            systemd and journald.
+          </para>
+
+          <para>
+            Use <command>--track</command> to start tracking a specific file. Can be
+            specified multiple times. A new deployment will be generated. Use
+            <command>--untrack</command> or <command>--untrack-all</command> to stop
+            tracking files.
+          </para>
+
+          <para>
+            When there are tracked files, any future created deployment (e.g. when doing an
+            upgrade) will ensure that they are synced. You can additionally use
+            <command>--force-sync</command> to simply generate a new deployment with the
+            latest versions of tracked files without upgrading.
+          </para>
+        </listitem>
+      </varlistentry>
 
       <varlistentry>
         <term><command>apply-live</command></term>
@@ -772,34 +798,6 @@ $ systemctl start postgresql  # Some setup required
             This command offers access to experimental features; command line
             stability is not guaranteed.  The available subcommands will be listed
             by invoking <command>rpm-ostree ex</command>.
-          </para>
-        </listitem>
-      </varlistentry>
-
-
-      <varlistentry>
-        <term><command>initramfs-etc</command></term>
-
-        <listitem>
-          <para>
-            Add configuration (<literal>/etc</literal>) files into the initramfs without
-            regenerating the entire initramfs. This is useful to be able to configure
-            services backing the root block device as well as early-boot services like
-            systemd and journald.
-          </para>
-
-          <para>
-            Use <command>--track</command> to start tracking a specific file. Can be
-            specified multiple times. A new deployment will be generated. Use
-            <command>--untrack</command> or <command>--untrack-all</command> to stop
-            tracking files.
-          </para>
-
-          <para>
-            When there are tracked files, any future created deployment (e.g. when doing an
-            upgrade) will ensure that they are synced. You can additionally use
-            <command>--force-sync</command> to simply generate a new deployment with the
-            latest versions of tracked files without upgrading.
           </para>
         </listitem>
       </varlistentry>

--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -692,9 +692,10 @@ Boston, MA 02111-1307, USA.
 
           <para>
             Use <command>--enable</command> to turn on client side initramfs
-            regeneration. A new deployment will be generated, and after reboot,
-            further upgrades will continue regenerating. You must reboot for the
-            new initramfs to take effect.
+            regeneration. This runs dracut to create the new initramfs. A new
+            deployment will be generated with this new initramfs, and after
+            reboot, further upgrades will continue regenerating. You must reboot
+            for the new initramfs to take effect.
           </para>
 
           <para>

--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -708,6 +708,12 @@ Boston, MA 02111-1307, USA.
             The <command>--disable</command> option will disable
             regeneration.  You must reboot for the change to take effect.
           </para>
+
+          <para>
+            Note that for the simpler use case of adding a few files to the
+            initramfs, you can use <command>rpm-ostree initramfs-etc</command>
+            instead. It is more lightweight and does not involve running dracut.
+          </para>
         </listitem>
       </varlistentry>
 

--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -778,13 +778,9 @@ $ systemctl start postgresql  # Some setup required
 
 
       <varlistentry>
-        <term><command>ex initramfs-etc</command></term>
+        <term><command>initramfs-etc</command></term>
 
         <listitem>
-          <para>
-            Experimental feature; subject to change.
-          </para>
-
           <para>
             Add configuration (<literal>/etc</literal>) files into the initramfs without
             regenerating the entire initramfs. This is useful to be able to configure

--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -81,7 +81,7 @@ static RpmOstreeCommand commands[] = {
     rpmostree_builtin_refresh_md },
   { "kargs", static_cast<RpmOstreeBuiltinFlags> (0), "Query or modify kernel arguments",
     rpmostree_builtin_kargs },
-  { "initramfs-etc", (RpmOstreeBuiltinFlags)0, "Track initramfs configuration files",
+  { "initramfs-etc", (RpmOstreeBuiltinFlags)0, "Add files to the initramfs",
     rpmostree_builtin_initramfs_etc },
   /* Rust-implemented commands; they're here so that they show up in `rpm-ostree
    * --help` alongside the other commands, but the command itself is fully

--- a/src/app/rpmostree-builtin-initramfs.cxx
+++ b/src/app/rpmostree-builtin-initramfs.cxx
@@ -38,8 +38,8 @@ static gboolean opt_lock_finalization;
 
 static GOptionEntry option_entries[]
     = { { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
-        { "enable", 0, 0, G_OPTION_ARG_NONE, &opt_enable, "Enable regenerating initramfs locally",
-          NULL },
+        { "enable", 0, 0, G_OPTION_ARG_NONE, &opt_enable,
+          "Enable regenerating initramfs locally using dracut", NULL },
         { "arg", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_add_arg,
           "Append ARG to the dracut arguments", "ARG" },
         { "disable", 0, 0, G_OPTION_ARG_NONE, &opt_disable,


### PR DESCRIPTION
This came up recently. It can be confusing to understand the difference between the two. Add some more details around that.