### PR TITLE
Finish porting to cap-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,27 +1607,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
-name = "openat"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95aa7c05907b3ebde2610d602f4ddd992145cc6a84493647c30396f30ba83abe"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "openat-ext"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf3e4baa7f516441f58373f58aaf6e91a5dfa2e2b50e68a0d313b082014c61d"
-dependencies = [
- "libc",
- "nix 0.23.1",
- "openat",
- "rand",
-]
-
-[[package]]
 name = "openssl"
 version = "0.10.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,8 +2120,6 @@ dependencies = [
  "nix 0.25.0",
  "oci-spec",
  "once_cell",
- "openat",
- "openat-ext",
  "openssl",
  "os-release",
  "ostree-ext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,6 @@ libdnf-sys = { path = "rust/libdnf-sys", version = "0.1.0" }
 maplit = "1.0"
 memfd = "0.6.0"
 nix = "0.25.0"
-openat = "0.1.21"
-openat-ext = "^0.2.3"
 openssl = "0.10.44"
 once_cell = "1.16.0"
 oci-spec = "0.5"

--- a/rust/src/capstdext.rs
+++ b/rust/src/capstdext.rs
@@ -4,13 +4,11 @@
 //  SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use cap_std::fs::DirBuilder;
-use cap_std::io_lifetimes::BorrowedFd;
 use cap_std_ext::cap_std;
 use cap_std_ext::cap_std::fs::Dir;
 use std::ffi::OsStr;
 use std::io::Result;
 use std::os::unix::fs::DirBuilderExt;
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::path::Path;
 
 pub(crate) fn dirbuilder_from_mode(m: u32) -> DirBuilder {
@@ -18,23 +16,6 @@ pub(crate) fn dirbuilder_from_mode(m: u32) -> DirBuilder {
     r.mode(m);
     r
 }
-
-#[allow(dead_code)]
-/// Create a new cap-std Dir instance from an openat Dir instance.
-pub(crate) fn from_openat(o: &openat::Dir) -> std::io::Result<Dir> {
-    let o = unsafe { BorrowedFd::borrow_raw(o.as_raw_fd()) };
-    Dir::reopen_dir(&o)
-}
-
-#[allow(dead_code)]
-/// Create a new openat Dir instance from a cap-std Dir instance.
-pub(crate) fn to_openat(o: &Dir) -> std::io::Result<openat::Dir> {
-    let src = unsafe { openat::Dir::from_raw_fd(o.as_raw_fd()) };
-    let r = src.sub_dir(".");
-    let _ = src.into_raw_fd();
-    r
-}
-
 /// Given a (possibly absolute) filename, return its parent directory and filename.
 pub(crate) fn open_dir_of(
     path: &Path,

--- a/rust/src/ffiutil.rs
+++ b/rust/src/ffiutil.rs
@@ -36,17 +36,7 @@ use cap_std_ext::{cap_std, rustix};
 use ostree_ext::{gio, glib};
 use std::ffi::CString;
 use std::fmt::Display;
-use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::ptr;
-
-// View `fd` as an `openat::Dir` instance.  Lifetime of return value
-// must be less than or equal to that of parameter.
-pub(crate) fn ffi_view_openat_dir(fd: libc::c_int) -> openat::Dir {
-    let src = unsafe { openat::Dir::from_raw_fd(fd) };
-    let r = src.sub_dir(".").expect("ffi_view_openat_dir");
-    let _ = src.into_raw_fd();
-    r
-}
 
 /// Create a new cap_std directory for an openat version.
 /// This creates a new file descriptor, because we can't guarantee they are
@@ -54,16 +44,6 @@ pub(crate) fn ffi_view_openat_dir(fd: libc::c_int) -> openat::Dir {
 pub(crate) unsafe fn ffi_dirfd(fd: libc::c_int) -> std::io::Result<cap_std::fs::Dir> {
     let fd = unsafe { rustix::fd::BorrowedFd::borrow_raw(fd) };
     cap_std::fs::Dir::reopen_dir(&fd)
-}
-
-// View `fd` as an `Option<openat::Dir>` instance.  Lifetime of return value
-// must be less than or equal to that of parameter.
-#[allow(dead_code)]
-pub(crate) fn ffi_view_openat_dir_option(fd: libc::c_int) -> Option<openat::Dir> {
-    match fd {
-        -1 => None,
-        _ => Some(ffi_view_openat_dir(fd)),
-    }
 }
 
 // Functions to map Rust's Error into the "GError convention":

--- a/rust/src/passwd.rs
+++ b/rust/src/passwd.rs
@@ -655,9 +655,9 @@ impl PasswdDB {
     /// Add content from a `passwd` file.
     #[context("Parsing users from /{}", passwd_path)]
     fn add_passwd_content(&mut self, rootfs_dfd: i32, passwd_path: &str) -> Result<()> {
-        let rootfs = ffiutil::ffi_view_openat_dir(rootfs_dfd);
-        let db = rootfs.open_file(passwd_path)?;
-        let entries = nameservice::passwd::parse_passwd_content(BufReader::new(db))?;
+        let rootfs = unsafe { &crate::ffiutil::ffi_dirfd(rootfs_dfd)? };
+        let db = rootfs.open(passwd_path).map(BufReader::new)?;
+        let entries = nameservice::passwd::parse_passwd_content(db)?;
 
         for user in entries {
             let id = Uid::from_raw(user.uid);
@@ -682,9 +682,9 @@ pub fn new_passwd_entries() -> Box<PasswdEntries> {
 impl PasswdEntries {
     /// Add all groups from a given `group` file.
     pub fn add_group_content(&mut self, rootfs_dfd: i32, group_path: &str) -> CxxResult<()> {
-        let rootfs = ffiutil::ffi_view_openat_dir(rootfs_dfd);
-        let db = rootfs.open_file(group_path)?;
-        let entries = nameservice::group::parse_group_content(BufReader::new(db))?;
+        let rootfs = unsafe { crate::ffiutil::ffi_dirfd(rootfs_dfd)? };
+        let db = rootfs.open(group_path).map(BufReader::new)?;
+        let entries = nameservice::group::parse_group_content(db)?;
 
         for group in entries {
             let id = Gid::from_raw(group.gid);
@@ -695,9 +695,9 @@ impl PasswdEntries {
 
     /// Add all users from a given `passwd` file.
     pub fn add_passwd_content(&mut self, rootfs_dfd: i32, passwd_path: &str) -> CxxResult<()> {
-        let rootfs = ffiutil::ffi_view_openat_dir(rootfs_dfd);
-        let db = rootfs.open_file(passwd_path)?;
-        let entries = nameservice::passwd::parse_passwd_content(BufReader::new(db))?;
+        let rootfs = unsafe { crate::ffiutil::ffi_dirfd(rootfs_dfd)? };
+        let db = rootfs.open(passwd_path).map(BufReader::new)?;
+        let entries = nameservice::passwd::parse_passwd_content(db)?;
 
         for user in entries {
             let uid = Uid::from_raw(user.uid);

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -10,7 +10,6 @@
 use crate::cxxrsutil::*;
 use crate::variant_utils;
 use anyhow::{bail, Context, Result};
-use cap_std_ext::cap_std;
 use glib::Variant;
 use once_cell::sync::Lazy;
 use ostree_ext::prelude::*;
@@ -19,7 +18,7 @@ use regex::Regex;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::io::prelude::*;
-use std::os::unix::io::{AsRawFd, IntoRawFd};
+use std::os::unix::io::IntoRawFd;
 use std::path::Path;
 use std::{fs, io};
 
@@ -243,16 +242,6 @@ pub(crate) fn shellsafe_quote(input: Cow<str>) -> Cow<str> {
         // SAFETY: if input is UTF-8, so is the quoted string.
         Cow::Owned(quoted.into_string().expect("non UTF-8 quoted output"))
     }
-}
-
-/// Create a new cap_std directory for an openat version.
-/// This creates a new file descriptor, because we can't guarantee they are
-/// interchangable; for example right now openat uses `O_PATH`
-#[allow(dead_code)]
-pub(crate) fn openat_to_dirfd(f: &openat::Dir) -> Result<cap_std::fs::Dir> {
-    // For now we just delegate to the FFI code
-    let r = unsafe { crate::ffiutil::ffi_dirfd(f.as_raw_fd())? };
-    Ok(r)
 }
 
 /// Translate a relative unprefixed path according to ostree rules, if needed.


### PR DESCRIPTION
This changes the last few bits to cap-std, and finally drops `openat`!
