### PR TITLE
daemon: Add logging of sysroot load and locking times

### DIFF
--- a/src/daemon/rpmostreed-transaction.cxx
+++ b/src/daemon/rpmostreed-transaction.cxx
@@ -603,6 +603,7 @@ transaction_initable_init (GInitable *initable, GCancellable *cancellable, GErro
 
       if (!ostree_sysroot_load (priv->sysroot, cancellable, error))
         return FALSE;
+      sd_journal_print (LOG_INFO, "Loaded sysroot");
 
       if (!ostree_sysroot_try_lock (priv->sysroot, &lock_acquired, error))
         return FALSE;


### PR DESCRIPTION
In https://issues.redhat.com/browse/OCPBUGS-2866 we're seeing a timeout, this will in the future help us potentially understand a root cause (is it sysroot loading being slow or the locking or something else)?