### PR TITLE
encapsulate: Add `--copymeta-opt`

### DIFF
--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -59,6 +59,10 @@ struct ContainerEncapsulateOpts {
     #[clap(name = "copymeta", long)]
     copy_meta_keys: Vec<String>,
 
+    /// Propagate an optionally-present OSTree commit metadata key to container label
+    #[clap(name = "copymeta-opt", long)]
+    copy_meta_opt_keys: Vec<String>,
+
     /// Corresponds to the Dockerfile `CMD` instruction.
     #[clap(long)]
     cmd: Option<Vec<String>>,
@@ -382,6 +386,7 @@ pub fn container_encapsulate(args: Vec<String>) -> CxxResult<()> {
     let mut copy_meta_keys = opt.copy_meta_keys;
     // Default to copying the input hash to support cheap change detection
     copy_meta_keys.push("rpmostree.inputhash".to_string());
+    let copy_meta_opt_keys = opt.copy_meta_opt_keys;
 
     let config = Config {
         labels: Some(labels),
@@ -394,6 +399,7 @@ pub fn container_encapsulate(args: Vec<String>) -> CxxResult<()> {
     };
     let opts = ExportOpts {
         copy_meta_keys,
+        copy_meta_opt_keys,
         max_layers: opt.max_layers,
         format,
         ..Default::default()

--- a/tests/encapsulate.sh
+++ b/tests/encapsulate.sh
@@ -17,8 +17,10 @@ ostree container unencapsulate --write-ref=testref --repo=repo ostree-remote-reg
 # Re-pack it as a (chunked) container
 
 rpm-ostree compose container-encapsulate --repo=repo \
-    --label=foo=bar --label baz=blah \
+    --label=foo=bar --label baz=blah --copymeta-opt fedora-coreos.stream --copymeta-opt nonexistent.key \
     testref oci:test.oci
-skopeo inspect oci:test.oci | jq -r .Labels.foo > labels.txt
-grep -qFe bar labels.txt
+skopeo inspect oci:test.oci | jq -r .Labels > labels.json
+for label in foo baz 'fedora-coreos.stream'; do 
+    jq -re ".\"${label}\"" < labels.json
+done
 echo ok


### PR DESCRIPTION
I meant to do this after landing the ostree-ext updates in order to push forward https://github.com/coreos/coreos-assembler/pull/3214
