### PR TITLE
Two minor staticanalysis fixes

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -841,7 +841,7 @@ rpm_ostree_compose_context_new (const char *treefile_pathstr, const char *basear
     {
       g_auto (GVariantBuilder) builder;
       g_variant_builder_init (&builder, G_VARIANT_TYPE ("as"));
-      for (auto s : cmd)
+      for (auto &s : cmd)
         {
           g_variant_builder_add (&builder, "s", s.c_str ());
         }
@@ -861,7 +861,7 @@ rpm_ostree_compose_context_new (const char *treefile_pathstr, const char *basear
 
   if (layer_repo_src != nullptr)
     {
-      for (auto layer : layers)
+      for (auto &layer : layers)
         {
           if (!pull_local_into_target_repo (layer_repo_src, self->build_repo, layer.c_str (),
                                             cancellable, error))

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -439,7 +439,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader *self, const char
         CXX_TRY_VAR (import,
                      rpmostreecxx::pull_container (*self->repo, *cancellable, r.refspec.c_str ()),
                      error);
-        new_base_rev = strdup (import->merge_commit.c_str ());
+        new_base_rev = g_strdup (import->merge_commit.c_str ());
         break;
       }
     case rpmostreecxx::RefspecType::Checksum:

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -2929,7 +2929,7 @@ checkout_package_into_root (RpmOstreeContext *self, DnfPackage *pkg, int dfd, co
       = self->treefile_rs->get_files_remove_regex (dnf_package_get_name (pkg));
   files_remove_regex
       = g_ptr_array_new_full (files_remove_regex_patterns.size (), (GDestroyNotify)g_regex_unref);
-  for (auto pattern : files_remove_regex_patterns)
+  for (auto &pattern : files_remove_regex_patterns)
     {
       GRegex *regex = g_regex_new (pattern.c_str (), G_REGEX_JAVASCRIPT_COMPAT,
                                    static_cast<GRegexMatchFlags> (0), NULL);
@@ -3870,7 +3870,7 @@ process_ostree_layers (RpmOstreeContext *self, int rootfs_dfd, GCancellable *can
 
   auto progress = rpmostreecxx::progress_nitems_begin (n, "Checking out ostree layers");
   size_t i = 0;
-  for (auto ref : layers)
+  for (auto &ref : layers)
     {
       if (!process_one_ostree_layer (self, rootfs_dfd, ref.c_str (),
                                      OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_IDENTICAL, cancellable,
@@ -3879,7 +3879,7 @@ process_ostree_layers (RpmOstreeContext *self, int rootfs_dfd, GCancellable *can
       i++;
       progress->nitems_update (i);
     }
-  for (auto ref : override_layers)
+  for (auto &ref : override_layers)
     {
       if (!process_one_ostree_layer (self, rootfs_dfd, ref.c_str (),
                                      OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES, cancellable,


### PR DESCRIPTION
Use `auto&` where we should

Spotted by cppcheck.

---

upgrader: Use g_strdup() to match g_free()

In practice, these are always the same, but the analyzer
doesn't know that today.

---

