### PR TITLE
sysroot: Fix conflicting authentication options && build: Release 2022.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,18 +268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cjson"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b601fb350e2fdbbd2ffb19aef2141fa90864d8fdca83d64466cb9bdb5694a7"
-dependencies = [
- "itoa 0.4.7",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
 name = "clap"
 version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,6 +1589,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "olpc-cjson"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87dc75cf72208cd853671c1abccc5d5d1e43b1e378dde67340ef933219a8c13c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "ostree-ext"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a42fe3d8c03891e75cca54d34850996c3dadcdd3f275f8baa5e8d2150bad93"
+checksum = "ef836913a9f14fb36da644f977c82fa59a72097d6185ff0281618aa0419ad6d7"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1708,7 +1707,6 @@ dependencies = [
  "cap-std-ext",
  "cap-tempfile",
  "chrono",
- "cjson",
  "clap",
  "containers-image-proxy",
  "flate2",
@@ -1721,6 +1719,7 @@ dependencies = [
  "libc",
  "libsystemd",
  "oci-spec",
+ "olpc-cjson",
  "once_cell",
  "openssl",
  "ostree",

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2022])
-m4_define([release_version], [18])
+m4_define([release_version], [19])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/rust/src/isolation.rs
+++ b/rust/src/isolation.rs
@@ -60,6 +60,7 @@ pub(crate) fn run_systemd_worker_sync(cfg: &UnitConfig) -> Result<()> {
 /// Return a prepared subprocess configuration that will run as an unprivileged user if possible.
 ///
 /// This currently only drops privileges when run under systemd with DynamicUser.
+#[allow(dead_code)]
 pub(crate) fn unprivileged_subprocess(binary: &str) -> Command {
     // TODO: if we detect we're running in a container as uid 0, perhaps at least switch to the
     // "bin" user if we can?


### PR DESCRIPTION
sysroot: Use ostree-ext isolation and auth paths

When the authfile code was drained into ostree-ext, we want
to start using it instead of having a duplicate copy.

xref https://github.com/containers/containers-image-proxy-rs/issues/44

---

Update to ostree-ext 0.10.3

This fixes pulls from authenticated registries.

Closes: https://github.com/containers/containers-image-proxy-rs/issues/44

---

build: Release 2022.19

This fixes pulls from authenticated registries.

---

