### PR TITLE
ci: Add infrastructure for use with Prow upgrade testing

### DIFF
--- a/ci/prow/Dockerfile.ci-updates
+++ b/ci/prow/Dockerfile.ci-updates
@@ -1,0 +1,14 @@
+# This container will be executed in Prow (but could also be run elsewhere)
+# and spawns a VM which will verify updates work
+# This really just depends on `cosa run`, which we could
+# in theory split out separately at some point later.
+FROM quay.io/coreos-assembler/coreos-assembler:latest
+WORKDIR /srv
+USER root
+# Grab all of our ci scripts
+COPY /ci/ /ci/
+# Install the script in /usr/bin, and put the kola test in place
+RUN ln -sr /ci/prow/e2e-upgrades.sh /usr/bin/e2e-upgrades && cp -a /ci/prow/kola /usr/lib/coreos-assembler/tests/kola/rpm-ostree
+USER builder
+ENTRYPOINT []
+CMD ["/usr/bin/e2e-upgrades"]

--- a/ci/prow/Dockerfile.fcos
+++ b/ci/prow/Dockerfile.fcos
@@ -1,0 +1,10 @@
+# This Dockerfile generates a container image that installs a build from git into
+# a Fedora CoreOS image.
+FROM quay.io/coreos-assembler/fcos-buildroot:testing-devel as builder
+WORKDIR /src
+COPY . .
+RUN ./ci/build.sh && make install DESTDIR=$(pwd)/install && tar -C install -czf /srv/install.tar .
+
+FROM quay.io/fedora/fedora-coreos:testing-devel
+COPY --from=builder /srv/install.tar /tmp
+RUN tar -xvf /tmp/install.tar && ostree container commit 

--- a/ci/prow/Dockerfile.fcos2
+++ b/ci/prow/Dockerfile.fcos2
@@ -1,0 +1,4 @@
+# This Dockerfile should actually derive from the first build,
+# and verifies a subsequent update
+FROM quay.io/fedora/fedora-coreos:testing-devel
+RUN touch /etc/somenewfile && rpm -e moby-engine && ostree container commit 

--- a/ci/prow/e2e-upgrades.sh
+++ b/ci/prow/e2e-upgrades.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# Attempt to keep this script in sync with https://github.com/containers/bootc/blob/main/ci/run-kola.sh
+
+# We require the an image containing our binaries-under-test to have been injected
+# by an external system, e.g. Prow 
+# https://docs.ci.openshift.org/docs/architecture/ci-operator/#referring-to-images-in-tests
+
+tmpdir="$(mktemp -d -p /var/tmp)"
+cd "${tmpdir}"
+
+echo "ostree-unverified-registry:$TARGET_IMAGE" > target-image
+echo "ostree-unverified-registry:$UPGRADE_IMAGE" > upgrade-image
+# Detect Prow; if we find it, assume the image requires a pull secret
+if test -n "${JOB_NAME_HASH:-}"; then
+    oc registry login --to auth.json
+else
+    # Default to an empty secret to exercise that path
+    echo '{}' > auth.json
+fi
+cat > config.bu << 'EOF'
+variant: fcos
+version: 1.1.0
+storage:
+  files:
+    - path: /etc/target-image
+      contents:
+        local: target-image
+    - path: /etc/upgrade-image
+      contents:
+        local: upgrade-image
+    - path: /etc/ostree/auth.json
+      contents:
+        local: auth.json
+EOF
+butane -d . < config.bu > config.ign
+
+if test -z "${BASE_QEMU_IMAGE:-}"; then
+    coreos-installer download -p qemu -f qcow2.xz --decompress
+    BASE_QEMU_IMAGE=./"$(echo *.qcow2)"
+fi
+kola run  --append-ignition config.ign --oscontainer ostree-unverified-registry:${TARGET_IMAGE} --qemu-image "${BASE_QEMU_IMAGE}" ext.rpm-ostree.upgrades
+
+echo "ok kola upgrades"

--- a/ci/prow/kola/upgrades
+++ b/ci/prow/kola/upgrades
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Verify upgrades pulling from remote (authenticated) registries.
+## kola:
+##   timeoutMin: 30
+##   tags: "needs-internet"
+#
+# Copyright (C) 2022 Red Hat, Inc.
+
+set -xeuo pipefail
+
+cd $(mktemp -d)
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+    expected_image=$(cat /etc/target-image)
+    booted_image=$(rpm-ostree status --json | jq -r '.deployments[0]["container-image-reference"]')
+    
+    test "$expected_image" = "$booted_image"
+
+    rpm-ostree upgrade >out.txt
+    grep -qF 'No upgrade available' out.txt
+
+    rpm -q moby-engine
+    test '!' -f /etc/somenewfile
+
+    upgrade_image=$(cat /etc/upgrade-image)
+    rpm-ostree rebase ${upgrade_image}
+    /tmp/autopkgtest-reboot 1
+    ;;
+  "1")
+    expected_image=$(cat /etc/upgrade-image)
+    booted_image=$(rpm-ostree status --json | jq -r '.deployments[0]["container-image-reference"]')
+    test "$expected_image" = "$booted_image"
+
+    rpm-ostree upgrade >out.txt
+    grep -qF 'No upgrade available' out.txt
+
+    if rpm -q moby-engine 2>/dev/null; then
+      echo "found package expected to be removed"
+      exit 1
+    fi
+    test -f /etc/somenewfile
+
+    echo "ok e2e upgrade"
+    ;;
+  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac


### PR DESCRIPTION
This will help cover the gap in pulling from remote authenticated registries.

The logic here mirrors that in
https://github.com/containers/bootc/blob/main/ci/run-kola.sh
