### PR TITLE
core: Allow lockfiles to reference missing package names

### DIFF
--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -1877,6 +1877,12 @@ rpmostree_context_prepare (RpmOstreeContext *self, GCancellable *cancellable, GE
         return FALSE;
     }
 
+  /* All modules are opt-in, so start off with everything disabled. We'll enable/install
+   * user-provided ones down below. We need to do this before `find_locked_packages` so that it can
+   * find non-modular versions of a package. */
+  if (!dnf_context_module_disable_all (dnfctx, error))
+    return FALSE;
+
   /* Now that we're done adding stuff to the sack, we can actually mark pkgs for install and
    * uninstall. We don't want to mix those two steps, otherwise we might confuse libdnf,
    * see: https://github.com/rpm-software-management/libdnf/issues/700 */
@@ -1975,11 +1981,6 @@ rpmostree_context_prepare (RpmOstreeContext *self, GCancellable *cancellable, GE
   /* Then, handle local packages to install */
   GLNX_HASH_TABLE_FOREACH_V (local_pkgs_to_install, DnfPackage *, pkg)
     hy_goal_install (goal, pkg);
-
-  /* All modules are opt-in, so start off with everything disabled. We'll
-   * enable/install user-provided ones down below. */
-  if (!dnf_context_module_disable_all (dnfctx, error))
-    return FALSE;
 
   /* Now repo-packages */
   g_autoptr (DnfPackageSet) pinned_pkgs = dnf_packageset_new (sack);

--- a/tests/compose/test-lockfile.sh
+++ b/tests/compose/test-lockfile.sh
@@ -173,6 +173,15 @@ fi
 assert_file_has_content err.txt "Couldn't find locked package 'unmatched-pkg-1.0-1.x86_64'"
 echo "ok strict mode locked pkg missing from rpmmd"
 
+# check that a locked pkg which isn't actually in the repos causes a warning in
+# non-strict mode
+runcompose \
+    --ex-lockfile="$PWD/versions.lock" \
+    --ex-lockfile="$PWD/override.lock" \
+    --dry-run "${treefile}" &>err.txt
+assert_file_has_content err.txt "warning: Couldn't find locked package 'unmatched-pkg'"
+echo "ok non-strict mode locked pkg missing from rpmmd"
+
 # test lockfile-repos, i.e. check that a pkg in a lockfile repo with higher
 # NEVRA isn't picked unless if it's not in the lockfile
 


### PR DESCRIPTION
I'm trying to reuse the x86_64 lockfile generated during a cosa build to
ensure that multi-arch builds for the same version will match (on
streams where we don't yet have in-git lockfiles). One issue with that
is that some packages are arch-specific (like `bootupd`), so composes on
s390x will fail. This relaxes the lockfile logic so that a locked
package can be ignored if we didn't find that package name at all in the
repos when in non-strict mode.

Lockfile semantics are to restrict the set of packages the depsolver
picks from, not to force the installation of some packages even if
unrequested (this is true even for strict mode). So if a locked package
name doesn't exist at all in the repos, there are no packages to
restrict.

We still warn so that a mistyped package name can more easily be
noticed. We also keep making it a hard error in strict mode since in
that workflow we expect lockfiles to be better managed.