### PR TITLE
workflows: update actions to current major versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,10 +89,9 @@ jobs:
   #     - name: Remove system Rust toolchain
   #       run: dnf remove -y rust cargo
   #     - name: Install toolchain
-  #       uses: actions-rs/toolchain@v1
+  #       uses: dtolnay/rust-toolchain@v1
   #       with:
   #         toolchain: ${{ env['ACTION_LINTS_TOOLCHAIN']  }}
-  #         default: true
   #         components: rustfmt, clippy
   #     - name: cargo fmt (check)
   #       run: cargo fmt -- --check -l

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
   #   container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
   #   steps:
   #     - name: Checkout repository
-  #       uses: actions/checkout@v2
+  #       uses: actions/checkout@v3
   #     - name: Install dependencies
   #       run: ./ci/installdeps.sh
   #     - name: Remove system Rust toolchain
@@ -119,13 +119,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Download build
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: install.tar
       - name: Install
         run: tar -C / -xzvf install.tar && rm -f install.tar
       - name: Download tests
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: tests.tar
       - name: Install Tests
@@ -146,7 +146,7 @@ jobs:
           repository: coreos/coreos-layering-examples
           path: coreos-layering-examples
       - name: Download
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: install.tar
       - name: Integration tests
@@ -172,7 +172,7 @@ jobs:
       - name: Install test dependencies
         run: ./ci/install-test-deps.sh
       - name: Download build
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: install.tar
       - name: Install
@@ -192,7 +192,7 @@ jobs:
       - name: Install test dependencies
         run: ./ci/install-test-deps.sh
       - name: Download build
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: install.tar
       - name: Install
@@ -210,7 +210,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Download build
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: install.tar
       - name: Install


### PR DESCRIPTION
Fixes [deprecation warnings](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) for Node.js 12.