### PR TITLE
libpriv/kernel: fix kver parsing from vmlinuz in /boot and /usr/lib/ostree-boot

### DIFF
--- a/src/libpriv/rpmostree-kernel.cxx
+++ b/src/libpriv/rpmostree-kernel.cxx
@@ -261,6 +261,14 @@ rpmostree_find_kernel (int rootfs_dfd, GCancellable *cancellable, GError **error
         return NULL;
     }
 
+  /* Strip off the digest if we got it from /boot or /usr/lib/ostree-boot */
+  if (kernel_path != NULL)
+    {
+      const size_t n = strlen (kver);
+      if (n > 65 && kver[n - 65] == '-' && ostree_validate_checksum_string (kver + n - 64, NULL))
+        kver[n - 65] = '\0';
+    }
+
   /* Finally, the newer model of having the kernel with the modules */
   if (kernel_path == NULL)
     {


### PR DESCRIPTION
When deriving the kver from the `vmlinuz` file found in `/boot` and `/usr/lib/ostree-boot`, we need to strip the trailing bootcsum digest if we added it. This is an issue for Fedora IoT, which still uses `boot-location: new` (we should probably move to deprecate that option in favour of just `modules`).

Closes: #4241