### PR TITLE
OCPBUGS-4858: Backport image GC fixes to rhel8 branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "build-env"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,7 +213,7 @@ dependencies = [
  "cap-std",
  "rand",
  "rustix",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -281,21 +290,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1fe12880bae935d142c8702d500c63a4e8634b6c3c57ad72bf978fc7b6249a"
@@ -306,9 +300,9 @@ dependencies = [
  "clap_lex",
  "indexmap",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -350,19 +344,6 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
-]
-
-[[package]]
-name = "console"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "terminal_size",
- "winapi",
 ]
 
 [[package]]
@@ -417,6 +398,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +457,16 @@ checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -573,7 +573,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -617,6 +617,17 @@ checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
 dependencies = [
  "derive_builder_core",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -904,6 +915,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check 0.9.3",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,7 +1235,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
 dependencies = [
- "console 0.14.1",
+ "console",
  "lazy_static",
  "number_prefix",
  "regex",
@@ -1217,7 +1247,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc42b206e70d86ec03285b123e65a5458c92027d1fb2ae3555878b8113b3ddf"
 dependencies = [
- "console 0.15.1",
+ "console",
  "number_prefix",
  "unicode-width",
 ]
@@ -1269,7 +1299,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cee08a007a59a8adfc96f69738ddf59e374888dfd84b49c4b916543067644d58"
 dependencies = [
- "nom",
+ "nom 5.1.2",
 ]
 
 [[package]]
@@ -1323,6 +1353,24 @@ dependencies = [
  "cxx",
  "cxx-build",
  "system-deps 6.0.2",
+]
+
+[[package]]
+name = "libsystemd"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8144587c71c16756b1055d3dcb0c75cb605a10ecd6523cc33702d5f90902bf6d"
+dependencies = [
+ "hmac",
+ "libc",
+ "log",
+ "nix 0.23.1",
+ "nom 7.1.2",
+ "once_cell",
+ "serde",
+ "sha2",
+ "thiserror",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -1436,6 +1484,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,6 +1572,16 @@ checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "memchr",
  "version_check 0.9.3",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1695,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "ostree-ext"
-version = "0.8.7"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f80902d38a2754402100e8afdb6147ac7f4c93ca14202c3ca9a98c53f81d1d9"
+checksum = "773521fc10d28d5133127efdf2d98423df4d3dc6b909d99d1c61debd87d51af5"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1707,6 +1771,7 @@ dependencies = [
  "cap-tempfile",
  "chrono",
  "cjson",
+ "clap",
  "containers-image-proxy",
  "flate2",
  "fn-error-context",
@@ -1715,6 +1780,7 @@ dependencies = [
  "hex",
  "indicatif 0.17.0",
  "libc",
+ "libsystemd",
  "oci-spec",
  "once_cell",
  "openssl",
@@ -1723,7 +1789,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "structopt",
  "tar",
  "tempfile",
  "term_size",
@@ -2090,7 +2155,7 @@ dependencies = [
  "cap-std-ext",
  "cap-tempfile",
  "chrono",
- "clap 3.2.6",
+ "clap",
  "curl",
  "cxx",
  "either",
@@ -2278,6 +2343,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,39 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "strum"
@@ -2376,6 +2422,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -2486,15 +2538,6 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -2721,6 +2764,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2776,6 +2825,15 @@ checksum = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
 
 [[package]]
 name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "uuid"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
@@ -2794,12 +2852,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version-compare"

--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -213,7 +213,7 @@ fn gv_nevra_to_string(pkg: &glib::Variant) -> String {
 pub async fn container_encapsulate(args: &[&str]) -> Result<()> {
     let args = args.iter().skip(1);
     let opt = ContainerEncapsulateOpts::parse_from(args);
-    let repo = &ostree_ext::cli::parse_repo(opt.repo.as_str())?;
+    let repo = &ostree_ext::cli::parse_repo(&opt.repo)?;
     let (root, rev) = repo.read_commit(opt.ostree_ref.as_str(), gio::NONE_CANCELLABLE)?;
     let pkglist = {
         let cancellable = gio::Cancellable::new();

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -184,6 +184,7 @@ pub mod ffi {
             cancellable: Pin<&mut GCancellable>,
             imgref: &str,
         ) -> Result<Box<ContainerImageState>>;
+        fn container_prune(repo: &OstreeRepo, cancellable: &GCancellable) -> Result<()>;
         fn query_container_image_commit(
             repo: &OstreeRepo,
             c: &str,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -184,9 +184,9 @@ pub mod ffi {
             cancellable: Pin<&mut GCancellable>,
             imgref: &str,
         ) -> Result<Box<ContainerImageState>>;
-        fn query_container_image(
-            repo: Pin<&mut OstreeRepo>,
-            imgref: &str,
+        fn query_container_image_commit(
+            repo: &OstreeRepo,
+            c: &str,
         ) -> Result<Box<ContainerImageState>>;
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -174,6 +174,7 @@ pub mod ffi {
         pub merge_commit: String,
         pub is_layered: bool,
         pub image_digest: String,
+        pub version: String,
     }
 
     // sysroot_upgrade.rs

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -188,6 +188,7 @@ pub mod ffi {
             repo: &OstreeRepo,
             c: &str,
         ) -> Result<Box<ContainerImageState>>;
+        fn purge_refspec(repo: &OstreeRepo, refspec: &str) -> Result<()>;
     }
 
     // core.rs

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -154,8 +154,7 @@ pub(crate) fn purge_refspec(repo: &crate::FFIOstreeRepo, imgref: &str) -> CxxRes
     tracing::debug!("Purging {imgref}");
     if let Ok(cref) = OstreeImageReference::try_from(imgref) {
         // It's a container, use the ostree-ext APIs to prune it.
-        let iref = &cref.imgref;
-        ostree_container::store::remove_images(repo, [iref])?;
+        ostree_container::store::remove_image(repo, &cref.imgref)?;
         layer_prune(repo, None)?;
     } else if ostree::validate_checksum_string(imgref).is_ok() {
         // Nothing to do here

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -118,13 +118,11 @@ pub(crate) fn pull_container(
 }
 
 /// C++ wrapper for querying image state; requires a pulled image
-pub(crate) fn query_container_image(
-    mut repo: Pin<&mut crate::FFIOstreeRepo>,
-    imgref: &str,
+pub(crate) fn query_container_image_commit(
+    repo: &crate::FFIOstreeRepo,
+    imgcommit: &str,
 ) -> CxxResult<Box<crate::ffi::ContainerImageState>> {
-    let repo = &repo.gobj_wrap();
-    let imgref = &OstreeImageReference::try_from(imgref)?;
-    let state = ostree_container::store::query_image(repo, imgref)?
-        .ok_or_else(|| anyhow::anyhow!("Failed to find image {}", imgref))?;
+    let repo = &repo.glib_reborrow();
+    let state = ostree_container::store::query_image_commit(repo, imgcommit)?;
     Ok(Box::new(state.into()))
 }

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -18,11 +18,20 @@ use tokio::sync::mpsc::Receiver;
 
 impl From<Box<ostree_container::store::LayeredImageState>> for crate::ffi::ContainerImageState {
     fn from(s: Box<ostree_container::store::LayeredImageState>) -> crate::ffi::ContainerImageState {
+        let version = s
+            .configuration
+            .as_ref()
+            .and_then(|c| c.config().as_ref())
+            .and_then(|c| c.labels().as_ref())
+            .and_then(|l| l.get("version"))
+            .cloned()
+            .unwrap_or_default();
         crate::ffi::ContainerImageState {
             base_commit: s.base_commit,
             merge_commit: s.merge_commit,
             is_layered: s.is_layered,
             image_digest: s.manifest_digest,
+            version,
         }
     }
 }

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -126,3 +126,34 @@ pub(crate) fn query_container_image_commit(
     let state = ostree_container::store::query_image_commit(repo, imgcommit)?;
     Ok(Box::new(state.into()))
 }
+
+/// Remove a refspec, which can be either an ostree branch or a container image.
+pub(crate) fn purge_refspec(repo: &crate::FFIOstreeRepo, imgref: &str) -> CxxResult<()> {
+    let repo = &repo.glib_reborrow();
+    tracing::debug!("Purging {imgref}");
+    if let Ok(cref) = OstreeImageReference::try_from(imgref) {
+        // It's a container, use the ostree-ext APIs to prune it.
+        let iref = &cref.imgref;
+        ostree_container::store::remove_images(repo, [iref])?;
+        let n = ostree_container::store::gc_image_layers(repo)?;
+        tracing::debug!("Pruned {n} layers");
+    } else if ostree::validate_checksum_string(imgref).is_ok() {
+        // Nothing to do here
+    } else {
+        match ostree::parse_refspec(imgref) {
+            Ok((remote, ostreeref)) => {
+                repo.set_ref_immediate(
+                    remote.as_ref().map(|s| s.as_str()),
+                    &ostreeref,
+                    None,
+                    ostree::gio::NONE_CANCELLABLE,
+                )?;
+            }
+            Err(e) => {
+                // For historical reasons, we ignore errors here
+                tracing::warn!("{e}");
+            }
+        }
+    }
+    Ok(())
+}

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -117,18 +117,25 @@ pub(crate) fn pull_container(
     Ok(Box::new(r))
 }
 
+pub(crate) fn layer_prune(
+    repo: &ostree::Repo,
+    cancellable: Option<&ostree::gio::Cancellable>,
+) -> Result<()> {
+    if let Some(c) = cancellable {
+        c.set_error_if_cancelled()?;
+    }
+    tracing::debug!("pruning image layers");
+    let n_pruned = ostree_ext::container::store::gc_image_layers(repo)?;
+    systemd::journal::print(6, &format!("Pruned container image layers: {n_pruned}"));
+    Ok(())
+}
+
 /// Run a prune of container image layers.
 pub(crate) fn container_prune(
     repo: &crate::FFIOstreeRepo,
     cancellable: &crate::FFIGCancellable,
 ) -> CxxResult<()> {
-    let repo = &repo.glib_reborrow();
-    let cancellable = &cancellable.glib_reborrow();
-    cancellable.set_error_if_cancelled()?;
-    tracing::debug!("pruning image layers");
-    let n_pruned = ostree_ext::container::store::gc_image_layers(repo)?;
-    systemd::journal::print(6, &format!("Pruned container image layers: {n_pruned}"));
-    Ok(())
+    layer_prune(&repo.glib_reborrow(), Some(&cancellable.glib_reborrow())).map_err(Into::into)
 }
 
 /// C++ wrapper for querying image state; requires a pulled image
@@ -149,8 +156,7 @@ pub(crate) fn purge_refspec(repo: &crate::FFIOstreeRepo, imgref: &str) -> CxxRes
         // It's a container, use the ostree-ext APIs to prune it.
         let iref = &cref.imgref;
         ostree_container::store::remove_images(repo, [iref])?;
-        let n = ostree_container::store::gc_image_layers(repo)?;
-        tracing::debug!("Pruned {n} layers");
+        layer_prune(repo, None)?;
     } else if ostree::validate_checksum_string(imgref).is_ok() {
         // Nothing to do here
     } else {

--- a/src/daemon/rpmostree-sysroot-core.cxx
+++ b/src/daemon/rpmostree-sysroot-core.cxx
@@ -214,6 +214,8 @@ rpmostree_syscore_cleanup (OstreeSysroot *sysroot, OstreeRepo *repo, GCancellabl
   /* Refs for the live state */
   ROSCXX_TRY (applylive_sync_ref (*sysroot), error);
 
+  CXX_TRY (rpmostreecxx::container_prune (*repo, *cancellable), error);
+
   /* And do a prune */
   guint64 freed_space;
   gint n_objects_total, n_objects_pruned;

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -214,7 +214,8 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot, OstreeDeployment
     case rpmostreecxx::RefspecType::Container:
       {
         g_variant_dict_insert (dict, "container-image-reference", "s", refspec);
-        CXX_TRY_VAR (state, rpmostreecxx::query_container_image_commit (*repo, base_checksum), error);
+        CXX_TRY_VAR (state, rpmostreecxx::query_container_image_commit (*repo, base_checksum),
+                     error);
         g_variant_dict_insert (dict, "container-image-reference-digest", "s",
                                state->image_digest.c_str ());
         if (state->version.size () > 0)

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -214,7 +214,7 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot, OstreeDeployment
     case rpmostreecxx::RefspecType::Container:
       {
         g_variant_dict_insert (dict, "container-image-reference", "s", refspec);
-        CXX_TRY_VAR (state, rpmostreecxx::query_container_image (*repo, refspec), error);
+        CXX_TRY_VAR (state, rpmostreecxx::query_container_image_commit (*repo, base_checksum), error);
         g_variant_dict_insert (dict, "container-image-reference-digest", "s",
                                state->image_digest.c_str ());
         if (state->version.size () > 0)

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -217,6 +217,8 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot, OstreeDeployment
         CXX_TRY_VAR (state, rpmostreecxx::query_container_image (*repo, refspec), error);
         g_variant_dict_insert (dict, "container-image-reference-digest", "s",
                                state->image_digest.c_str ());
+        if (state->version.size () > 0)
+          g_variant_dict_insert (dict, "version", "s", state->version.c_str ());
       }
       break;
     case rpmostreecxx::RefspecType::Checksum:

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -1597,19 +1597,9 @@ deploy_transaction_execute (RpmostreedTransaction *transaction, GCancellable *ca
         return FALSE;
 
       /* Are we rebasing?  May want to delete the previous ref */
-      if (self->refspec && !(deploy_has_bool_option (self, "skip-purge")))
+      if (self->refspec && !(deploy_has_bool_option (self, "skip-purge")) && old_refspec)
         {
-          g_autofree char *remote = NULL;
-          g_autofree char *ref = NULL;
-
-          /* The actual rebase has already succeeded, so ignore errors. */
-          if (old_refspec && ostree_parse_refspec (old_refspec, &remote, &ref, NULL))
-            {
-              /* Note: In some cases the source origin ref may not actually
-               * exist; say the admin did a cleanup, or the OS expects post-
-               * install configuration like subscription-manager. */
-              (void)ostree_repo_set_ref_immediate (repo, remote, ref, NULL, cancellable, NULL);
-            }
+          CXX_TRY (rpmostreecxx::purge_refspec (*repo, old_refspec), error);
         }
 
       /* Always write out an update variant on vanilla upgrades since it's clearly the most

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -39,6 +39,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     # Take the existing ostree commit, and export it to a container image, then rebase to it.
 
     checksum=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
+    v0=$(rpm-ostree status --json | jq -r '.deployments[0].version')
     rm ${image_dir} -rf
     
     # Since we're switching OS update stream, turn off zincati
@@ -53,6 +54,9 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
 
     rpm-ostree status | tee out.txt
     assert_file_has_content_literal out.txt 'Digest: sha256:'
+
+    v1=$(rpm-ostree status --json | jq -r '.deployments[0].version')
+    assert_streq "${v0}" "${v1}"
 
     # Test rebasing back to ostree https://github.com/coreos/rpm-ostree/issues/3677
     rpm-ostree rebase "$checksum"

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -54,6 +54,8 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
 
     rpm-ostree status | tee out.txt
     assert_file_has_content_literal out.txt 'Digest: sha256:'
+    ostree container image list --repo=/ostree/repo | tee imglist.txt
+    assert_streq "$(wc -l < imglist.txt)" 1
 
     v1=$(rpm-ostree status --json | jq -r '.deployments[0].version')
     assert_streq "${v0}" "${v1}"
@@ -183,6 +185,8 @@ EOF
     derived=oci:$image_dir:derived
     skopeo copy containers-storage:localhost/fcos-derived $derived
     rpm-ostree rebase --experimental ostree-unverified-image:$derived
+    ostree container image list --repo=/ostree/repo | tee imglist.txt
+    assert_streq "$(wc -l < imglist.txt)" 1
     rm $image_dir -rf
     /tmp/autopkgtest-reboot 3
     ;;


### PR DESCRIPTION
Add version to status even for containers

Kind of embarrassing we didn't do this yet.  I hit this
while working on adapting zincati to update from containers.

(cherry picked from commit 1bab8ab2b1b85428f706b458b142d94c42bff832)

---

daemon: Query container image commit

If a container image reference is pruned, we must not error
out when computing the status.  The deployment roots will hold
a strong reference to the deployed commit, so query via the commit
digest to find metadata about the pulled container image.

(cherry picked from commit e2aee762c0a63d8c6630c3b0a8f761002376dfa3)

---

Update to ostree-ext 0.8.10

This includes fixes for image GC.

---

When rebasing, prune previous container by default

When using `rpm-ostree rebase` on ostree branch names, by
default we prune the previous branch/ref to avoid leaking
space (i.e. requiring the user/admin to manually prune it).
We do have the `--skip-purge` option to suppress this behavior.

When we added the container bits, we ignored this at the time.
But we really need to do this by default, for the same reasons
around avoiding space leakage.

(cherry picked from commit 904e111d3e0021a6ccd8d1f2e1e25514d438221c)

---

Prune container image layers during cleanup too

This will handle cleaning up correctly after e.g. `rpm-ostree cleanup -p`.

Closes: https://github.com/coreos/rpm-ostree/issues/4179
(cherry picked from commit 84a7b4776122c30719cf4e2330602b0a89758d96)

---

sysroot: Centralize layer prune + logging

We had duplicate "prune image layers and log the result"
logic; centralize that so we consistently get the number of layers
pruned in the journal.

(cherry picked from commit af7d0b6af9958f8b03f858fa8e8f080c37b81340)

---

upgrade: Make image pruning idempotent

The `remove_image()` API is already idempotent, let's use that
to handle the case where the user manually pruned the image.

(cherry picked from commit 5121c564300d00b6166578a15a9616a3ede23f32)

---

