### PR TITLE
tests/upgrades: Disable zincati

### DIFF
--- a/ci/prow/kola/upgrades
+++ b/ci/prow/kola/upgrades
@@ -17,6 +17,8 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     
     test "$expected_image" = "$booted_image"
 
+    systemctl mask --now zincati
+
     rpm-ostree upgrade >out.txt
     grep -qF 'No upgrade available' out.txt
 


### PR DESCRIPTION
Not doing so resulted in a flake because zincati was repeatedly restarting.
