### PR TITLE
core: Further loosen lockfile handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@
 /tests/check/test-lib-introspection.sh.trs
 /tests/kola
 _libs
+
+# for clangd: https://clangd.llvm.org/installation#project-setup
+/compile_commands.json
+/.cache

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1179,7 +1179,7 @@ class Fail final
   ::rust::repr::PtrLen &throw$;
 
 public:
-  Fail (::rust::repr::PtrLen &throw$) : throw$ (throw$) {}
+  Fail (::rust::repr::PtrLen &throw$) noexcept : throw$ (throw$) {}
   void operator() (const char *) noexcept;
   void operator() (const std::string &) noexcept;
 };
@@ -1891,7 +1891,6 @@ struct LockedPackage final
 struct LockfileConfig final : public ::rust::Opaque
 {
   ::rust::Vec< ::rpmostreecxx::LockedPackage> get_locked_packages () const;
-  ::rust::Vec< ::rpmostreecxx::LockedPackage> get_locked_src_packages () const;
   ~LockfileConfig () = delete;
 
 private:
@@ -2844,10 +2843,6 @@ extern "C"
                                           ::rpmostreecxx::CxxGObjectArray &rpmmd_repos) noexcept;
 
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$LockfileConfig$get_locked_packages (
-      const ::rpmostreecxx::LockfileConfig &self,
-      ::rust::Vec< ::rpmostreecxx::LockedPackage> *return$) noexcept;
-
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$LockfileConfig$get_locked_src_packages (
       const ::rpmostreecxx::LockfileConfig &self,
       ::rust::Vec< ::rpmostreecxx::LockedPackage> *return$) noexcept;
 
@@ -5861,19 +5856,6 @@ LockfileConfig::get_locked_packages () const
   ::rust::MaybeUninit< ::rust::Vec< ::rpmostreecxx::LockedPackage> > return$;
   ::rust::repr::PtrLen error$
       = rpmostreecxx$cxxbridge1$LockfileConfig$get_locked_packages (*this, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl< ::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
-}
-
-::rust::Vec< ::rpmostreecxx::LockedPackage>
-LockfileConfig::get_locked_src_packages () const
-{
-  ::rust::MaybeUninit< ::rust::Vec< ::rpmostreecxx::LockedPackage> > return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$LockfileConfig$get_locked_src_packages (*this, &return$.value);
   if (error$.ptr)
     {
       throw ::rust::impl< ::rust::Error>::error (error$);

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1673,7 +1673,6 @@ struct LockedPackage final
 struct LockfileConfig final : public ::rust::Opaque
 {
   ::rust::Vec< ::rpmostreecxx::LockedPackage> get_locked_packages () const;
-  ::rust::Vec< ::rpmostreecxx::LockedPackage> get_locked_src_packages () const;
   ~LockfileConfig () = delete;
 
 private:

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -751,7 +751,6 @@ pub mod ffi {
         ) -> Result<()>;
 
         fn get_locked_packages(&self) -> Result<Vec<LockedPackage>>;
-        fn get_locked_src_packages(&self) -> Result<Vec<LockedPackage>>;
     }
 
     // origin.rs

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -30,7 +30,6 @@
 #include <rpm/rpmmacro.h>
 #include <rpm/rpmsq.h>
 #include <rpm/rpmts.h>
-#include <set>
 #include <systemd/sd-journal.h>
 #include <utility>
 
@@ -1644,42 +1643,9 @@ find_locked_packages (RpmOstreeContext *self, GPtrArray **out_pkgs, GError **err
 
   g_autoptr (GPtrArray) pkgs = g_ptr_array_new_with_free_func ((GDestroyNotify)g_object_unref);
 
-  CXX_TRY_VAR (locked_src_pkgs, (*self->lockfile)->get_locked_src_packages (), error);
-  std::set<rust::String> locked_src_pkgnames;
-  for (auto &pkg : locked_src_pkgs)
-    {
-      g_autofree char *srpm
-          = g_strdup_printf ("%s-%s.src.rpm", pkg.name.c_str (), pkg.evr.c_str ());
-      hy_autoquery HyQuery query = hy_query_create (sack);
-      hy_query_filter (query, HY_PKG_SOURCERPM, HY_EQ, srpm);
-      g_autoptr (GPtrArray) matches = hy_query_run (query);
-      if (matches->len == 0)
-        {
-          return glnx_throw (error, "Couldn't find locked source package '%s-%s'",
-                             pkg.name.c_str (), pkg.evr.c_str ());
-        }
-      for (guint i = 0; i < matches->len; i++)
-        {
-          auto match = static_cast<DnfPackage *> (matches->pdata[i]);
-          /* we could optimize this path outside the loop in the future using the
-           * g_ptr_array_extend_and_steal API, though that's still too new for e.g. el8 */
-          g_ptr_array_add (pkgs, g_object_ref (match));
-        }
-      locked_src_pkgnames.insert (pkg.name);
-    }
-
   CXX_TRY_VAR (locked_pkgs, (*self->lockfile)->get_locked_packages (), error);
   for (auto &pkg : locked_pkgs)
     {
-      /* This essentially makes `source-packages` have higher priority than `packages`. This
-       * isn't technically correct: what we should do in lockfile.rs is to convert
-       * `source-packages` to `packages` *before* merging all the lockfiles, so that e.g. a
-       * `packages` in a higher-level lockfile can override a `source-packages` in a lower
-       * level. For now this is fine because the primary use case is humans typing source
-       * packages where we want it to have the highest precedence. */
-      if (locked_src_pkgnames.count (pkg.name))
-        continue;
-
       hy_autoquery HyQuery query = hy_query_create (sack);
       hy_query_filter (query, HY_PKG_NAME, HY_EQ, pkg.name.c_str ());
       hy_query_filter (query, HY_PKG_EVR, HY_EQ, pkg.evr.c_str ());
@@ -1943,16 +1909,14 @@ rpmostree_context_prepare (RpmOstreeContext *self, GCancellable *cancellable, GE
            * installed which is in the lockfile, it can only pick that NEVRA. To do this, we
            * filter out from the sack all pkgs which don't match. */
 
-          /* map of all packages with names found in the lockfile (note here we derive this
-           * from `locked_pkgs` instead of from the lockfile again to account for
-           * source-packages too (which have been resolved to packages in `locked_pkgs`) */
+          /* map of all packages with names found in the lockfile */
           DnfPackageSet *named_pkgs = dnf_packageset_new (sack);
           Map *named_pkgs_map = dnf_packageset_get_map (named_pkgs);
-          for (guint i = 0; i < locked_pkgs->len; i++)
+          auto locked_pkgs = (*self->lockfile)->get_locked_packages ();
+          for (auto &pkg : locked_pkgs)
             {
-              DnfPackage *pkg = (DnfPackage *)locked_pkgs->pdata[i];
               hy_autoquery HyQuery query = hy_query_create (sack);
-              hy_query_filter (query, HY_PKG_NAME, HY_EQ, dnf_package_get_name (pkg));
+              hy_query_filter (query, HY_PKG_NAME, HY_EQ, pkg.name.c_str ());
               DnfPackageSet *pset = hy_query_run_set (query);
               map_or (named_pkgs_map, dnf_packageset_get_map (pset));
               dnf_packageset_free (pset);

--- a/tests/compose/test-lockfile.sh
+++ b/tests/compose/test-lockfile.sh
@@ -11,20 +11,18 @@ build_rpm test-pkg-common
 build_rpm test-pkg requires test-pkg-common
 build_rpm another-test-pkg-a
 build_rpm another-test-pkg-b
-build_rpm another-test-pkg-c
 
 # The test suite writes to pwd, but we need repos together with the manifests
 # Also we need to disable gpgcheck
 echo gpgcheck=0 >> yumrepo.repo
 ln "$PWD/yumrepo.repo" config/yumrepo.repo
-treefile_append "packages" '["test-pkg", "another-test-pkg-a", "another-test-pkg-b", "another-test-pkg-c"]'
+treefile_append "packages" '["test-pkg", "another-test-pkg-a", "another-test-pkg-b"]'
 
 runcompose --ex-write-lockfile-to="$PWD/versions.lock"
 rpm-ostree --repo=${repo} db list ${treeref} > test-pkg-list.txt
 assert_file_has_content test-pkg-list.txt 'test-pkg-1.0-1.x86_64'
 assert_file_has_content test-pkg-list.txt 'another-test-pkg-a-1.0-1.x86_64'
 assert_file_has_content test-pkg-list.txt 'another-test-pkg-b-1.0-1.x86_64'
-assert_file_has_content test-pkg-list.txt 'another-test-pkg-c-1.0-1.x86_64'
 echo "ok compose"
 
 assert_has_file "versions.lock"
@@ -33,7 +31,6 @@ assert_jq "versions.lock" \
   '.packages["test-pkg-common"].evra = "1.0-1.x86_64"' \
   '.packages["another-test-pkg-a"].evra = "1.0-1.x86_64"' \
   '.packages["another-test-pkg-b"].evra = "1.0-1.x86_64"' \
-  '.packages["another-test-pkg-c"].evra = "1.0-1.x86_64"' \
   '.metadata.rpmmd_repos|length > 0' \
   '.metadata.generated'
 echo "ok lockfile created"
@@ -43,7 +40,6 @@ build_rpm test-pkg-common version 2.0
 build_rpm test-pkg version 2.0 requires test-pkg-common
 build_rpm another-test-pkg-a version 2.0
 build_rpm another-test-pkg-b version 2.0
-build_rpm another-test-pkg-c version 2.0
 runcompose --ex-lockfile="$PWD/versions.lock" |& tee out.txt
 
 rpm-ostree --repo=${repo} db list ${treeref} > test-pkg-list.txt
@@ -51,7 +47,6 @@ assert_file_has_content out.txt 'test-pkg-1.0-1.x86_64'
 assert_file_has_content out.txt 'test-pkg-common-1.0-1.x86_64'
 assert_file_has_content out.txt 'another-test-pkg-a-1.0-1.x86_64'
 assert_file_has_content out.txt 'another-test-pkg-b-1.0-1.x86_64'
-assert_file_has_content out.txt 'another-test-pkg-c-1.0-1.x86_64'
 echo "ok lockfile read"
 
 # now add an override and check that not specifying a digest is allowed
@@ -65,9 +60,6 @@ cat > override.lock <<EOF
     "another-test-pkg-b": {
       "evr": "2.0-1"
     }
-  },
-  "source-packages": {
-    "another-test-pkg-c": "2.0-1"
   }
 }
 EOF
@@ -81,13 +73,11 @@ assert_file_has_content out.txt 'test-pkg-1.0-1.x86_64'
 assert_file_has_content out.txt 'test-pkg-common-1.0-1.x86_64'
 assert_file_has_content out.txt 'another-test-pkg-a-2.0-1.x86_64'
 assert_file_has_content out.txt 'another-test-pkg-b-2.0-1.x86_64'
-assert_file_has_content out.txt 'another-test-pkg-c-2.0-1.x86_64'
 assert_jq versions.lock.new \
   '.packages["test-pkg"].evra = "1.0-1.x86_64"' \
   '.packages["test-pkg-common"].evra = "1.0-1.x86_64"' \
   '.packages["another-test-pkg-a"].evra = "2.0-1.x86_64"' \
-  '.packages["another-test-pkg-b"].evra = "2.0-1.x86_64"' \
-  '.packages["another-test-pkg-c"].evra = "2.0-1.x86_64"'
+  '.packages["another-test-pkg-b"].evra = "2.0-1.x86_64"'
 echo "ok override"
 
 # sanity-check that we can remove packages in relaxed mode

--- a/tests/compose/test-lockfile.sh
+++ b/tests/compose/test-lockfile.sh
@@ -153,14 +153,12 @@ cat > override.lock <<EOF
   }
 }
 EOF
-if runcompose \
+runcompose \
     --ex-lockfile-strict \
     --ex-lockfile="$PWD/versions.lock" \
     --ex-lockfile="$PWD/override.lock" \
-    --dry-run "${treefile}" &>err.txt; then
-  fatal "compose unexpectedly succeeded"
-fi
-assert_file_has_content err.txt "Couldn't find locked package 'unmatched-pkg-1.0-1.x86_64'"
+    --dry-run "${treefile}" &>err.txt
+assert_file_has_content err.txt "warning: Couldn't find locked package 'unmatched-pkg-1.0-1.x86_64'"
 echo "ok strict mode locked pkg missing from rpmmd"
 
 # check that a locked pkg which isn't actually in the repos causes a warning in
@@ -169,7 +167,7 @@ runcompose \
     --ex-lockfile="$PWD/versions.lock" \
     --ex-lockfile="$PWD/override.lock" \
     --dry-run "${treefile}" &>err.txt
-assert_file_has_content err.txt "warning: Couldn't find locked package 'unmatched-pkg'"
+assert_file_has_content err.txt "warning: Couldn't find locked package 'unmatched-pkg-1.0-1.x86_64'"
 echo "ok non-strict mode locked pkg missing from rpmmd"
 
 # test lockfile-repos, i.e. check that a pkg in a lockfile repo with higher


### PR DESCRIPTION
This is a follow-up to 660c7294 ("core: Allow lockfiles to reference
missing package names"). There, we loosened semantics so that locked
package could be ignored if that package name doesn't exist at all in
the repos.

This patch loosens it further so that we don't immediately error out if
the locked package's NEVRA doesn't exist in the repos and instead rely
on the depsolver to error out for us. We still warn if we couldn't find
a locked package to be helpful.

Note the semantics of the lockfile are still maintained. In relaxed
mode, we exclude all packages of the same name as those found in the
lockfile. In strict mode, we exclude all packages not locked. The key
difference with this patch is that if a locked NEVRA couldn't be found
in the repos, it's only an error if the compose needs that package.

I hit this when trying to reuse an x86_64 lockfile in an s390x rawhide
build. For some reason, `grub2-common.noarch` isn't in the official
repos for s390x, but is in the coreos-pool repo for s390x. I think
the handling of `noarch` packages between the two tools that generate
these repos differs. The end result is that `cosa build` on s390x fails
because it can't find the locked `grub2-common` package, which we don't
even need.

A cleaner approach for what we're trying to do with this stuff (cross-
arch content consistency) is to work with snapshotted repodata. Though
even there, we probably would still want a post-compose check that
versions across arches matched. Another approach would be to teach rpm-
ostree to depsolve for multiple basearches in a single invocation and
output the corresponding lockfiles, but that's more complex.

Anyway, this isn't much work and will enable stronger semantics than
we have right now in RHCOS (where we'll eventually get lockfiles) and
rawhide (where we have no plans to add lockfiles).