### PR TITLE
Revert ".gitignore: add clangd-related files"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,7 +106,3 @@
 /tests/check/test-lib-introspection.sh.trs
 /tests/kola
 _libs
-
-# for clangd: https://clangd.llvm.org/installation#project-setup
-/compile_commands.json
-/.cache


### PR DESCRIPTION
This reverts commit 4dfe6864cae0e351f67f51ba82a273a66f5475da.

It's cleaner for developers who use clangd to keep these entries in a repo-level exclude list or user-level `.gitignore` file.