### PR TITLE
Release 2023.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,8 +2,8 @@ AC_PREREQ([2.63])
 dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
-m4_define([year_version], [2022])
-m4_define([release_version], [19])
+m4_define([year_version], [2023])
+m4_define([release_version], [1])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2022.16
+Version: 2023.1
 Release: 1%{?dist}
 License: LGPLv2+
 URL: https://github.com/coreos/rpm-ostree


### PR DESCRIPTION
v2023.1

## Client

- Log when a client joins an existing transaction.
- Fix local initramfs regeneration on systems composed with
  `boot-location: new`.
- Fix container flow in Turkish locales ( https://github.com/coreos/rpm-ostree/issues/4237 )

## Compose

- Loosen lockfile semantics so that a missing locked package does not trigger
  an error unless the compose requires it.
- Drop support for locking by source packages.

## Internals

- Update workflow actions to Fedora 37.
- Replace unmaintained actions-rs/toolchain with dtolnay/rust-toolchain.
- Add more error-prefixing in passwd, kernel, and cleanup-related paths.
- Add container-based upgrade test via Prow.

```
Benjamin Gilbert (2):
      workflows: update actions to current major versions
      workflows: replace actions-rs/toolchain with dtolnay/rust-toolchain

Colin Walters (8):
      ci: Add infrastructure for use with Prow upgrade testing
      passwd: Add various error prefixing
      sysroot: Log when client joins an existing transaction
      Update to ostree-ext 0.10.4
      tests/upgrades: Disable zincati
      Add a `try_fail_point!` macro and use it in more places
      kernel: Add some error prefixing
      cleanup: Add some error prefixing

Jonathan Lebon (11):
      core: Disable modules earlier
      core: Allow lockfiles to reference missing package names
      libpriv/kernel: fix kver parsing from vmlinuz in /boot and /usr/lib/ostree-boot
      .gitignore: add clangd-related files
      compose: Drop support for `source-packages` in lockfiles
      core: Further loosen lockfile handling
      Revert ".gitignore: add clangd-related files"
      Release 2023.1
```
