### PR TITLE
Update ostree-ext, use version API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "ostree-ext"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9769916b732af63bfff896c7c38ffde16c3d7a2d860efaaae25d046d9f4a13"
+checksum = "773669f87dca1eb4ee6fbad40bb9664f6b8ba2b64903a3d586e6e8f9b34c7b09"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -125,9 +125,10 @@ fn fetch_previous_metadata(
         .get(INPUTHASH_KEY)
         .ok_or_else(|| anyhow!("Missing config label {INPUTHASH_KEY}"))?
         .to_owned();
+    let version = ostree_container::version_for_config(&config).map(ToOwned::to_owned);
     Ok(ImageMetadata {
         manifest,
-        version: labels.get("version").map(ToOwned::to_owned),
+        version,
         inputhash,
     })
 }

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -21,10 +21,8 @@ impl From<Box<ostree_container::store::LayeredImageState>> for crate::ffi::Conta
         let version = s
             .configuration
             .as_ref()
-            .and_then(|c| c.config().as_ref())
-            .and_then(|c| c.labels().as_ref())
-            .and_then(|l| l.get("version"))
-            .cloned()
+            .and_then(|c| ostree_container::version_for_config(c))
+            .map(ToOwned::to_owned)
             .unwrap_or_default();
         crate::ffi::ContainerImageState {
             base_commit: s.base_commit,


### PR DESCRIPTION
In preparation for https://github.com/ostreedev/ostree-rs-ext/pull/454
