### PR TITLE
treefile: Return `.` instead of `""` for parent directory

### DIFF
--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -631,8 +631,7 @@ impl Treefile {
     /// The main treefile creation entrypoint.
     #[instrument]
     fn new_boxed(filename: &Utf8Path, basearch: Option<&str>) -> Result<Box<Treefile>> {
-        let directory = filename
-            .parent()
+        let directory = utils::parent_dir_utf8(filename)
             .ok_or_else(|| anyhow!("{} is not a file path", filename))
             .map(|v| Some(v.to_owned()))?;
         let parsed = treefile_parse_and_process(filename, basearch)?;

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -10,6 +10,7 @@
 use crate::cxxrsutil::*;
 use crate::variant_utils;
 use anyhow::{bail, Context, Result};
+use camino::Utf8Path;
 use glib::Variant;
 use once_cell::sync::Lazy;
 use ostree_ext::prelude::*;
@@ -142,6 +143,13 @@ pub fn create_file<P: AsRef<Path>>(filename: P) -> Result<fs::File> {
 // Surprising we need a wrapper for this... parent() returns a slice of its buffer, so doesn't
 // handle going up relative paths well: https://github.com/rust-lang/rust/issues/36861
 pub fn parent_dir(filename: &Path) -> Option<&Path> {
+    filename
+        .parent()
+        .map(|p| if p.as_os_str() == "" { ".".as_ref() } else { p })
+}
+
+/// Like [`parent_dir`] above but for UTF-8 paths.
+pub fn parent_dir_utf8(filename: &Utf8Path) -> Option<&Utf8Path> {
     filename
         .parent()
         .map(|p| if p.as_os_str() == "" { ".".as_ref() } else { p })


### PR DESCRIPTION
This addresses the root cause of
https://github.com/coreos/rpm-ostree/issues/4029

Basically we were calling `set_repos_dir("")` on the libdnf side and it simply did not handle that, failing to open the directory.

(Though I'm not saying "Closes" since we should still fix the
 file monitoring stuff)

I don't yet know why this seemed to work in some cases but not others though.
