### PR TITLE
app/status: Fix printing commits without rpmmd-repos metadata

### DIFF
--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -489,10 +489,7 @@ print_commit (const char *key, const char *checksum, gboolean host_endian, guint
   g_autoptr (GVariant) reposdata = g_variant_dict_lookup_value (
       commit_meta, "rpmostree.rpmmd-repos", G_VARIANT_TYPE ("aa{sv}"));
 
-  if (!reposdata)
-    return;
-
-  const guint n = g_variant_n_children (reposdata);
+  const guint n = reposdata ? g_variant_n_children (reposdata) : 0;
   if (n == 0 || !opt_verbose)
     {
       /* no repos to print, so this is just a pure kv print */

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -26,6 +26,10 @@ set -x
 
 # More miscellaneous tests
 
+# Verify that the commit is printed in the output
+vm_rpmostree status > status.txt
+assert_file_has_content status.txt 'Commit:'
+
 # Locked finalization
 booted_csum=$(vm_get_booted_csum)
 commit=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck)


### PR DESCRIPTION
This hits RHEL for Edge on 8.7

I tested that upgrading rpm-ostree to 2022.13(which includes this fix) fixes the issue on RHEL for EDGE.
