### PR TITLE
Support `LockLayering=true` config knob

### DIFF
--- a/man/rpm-ostreed.conf.xml
+++ b/man/rpm-ostreed.conf.xml
@@ -90,6 +90,15 @@ Boston, MA 02111-1307, USA.
         disable auto-exit. Defaults to 60.</para>
         </listitem>
       </varlistentry>
+      <varlistentry>
+        <term><varname>LockLayering=</varname></term>
+
+        <listitem>
+        <para>Controls whether any mutation of the base OSTree commit is
+        supported (for example, package overlays or overrides, initramfs
+        overlays or regeneration). Defaults to false.</para>
+        </listitem>
+      </varlistentry>
     <!--
       <varlistentry>
         <term><varname>OptionName=</varname></term>

--- a/src/daemon/rpm-ostreed.conf
+++ b/src/daemon/rpm-ostreed.conf
@@ -5,3 +5,4 @@
 [Daemon]
 #AutomaticUpdatePolicy=none
 #IdleExitTimeout=60
+#LockLayering=false

--- a/src/daemon/rpmostreed-daemon.h
+++ b/src/daemon/rpmostreed-daemon.h
@@ -61,6 +61,7 @@ gboolean rpmostreed_daemon_reload_config (RpmostreedDaemon *self, gboolean *out_
 gboolean rpmostreed_authorize_method_for_uid0 (GDBusMethodInvocation *invocation);
 
 RpmostreedAutomaticUpdatePolicy rpmostreed_get_automatic_update_policy (RpmostreedDaemon *self);
+gboolean rpmostreed_get_lock_layering (RpmostreedDaemon *self);
 
 G_END_DECLS
 

--- a/tests/kolainst/destructive/initramfs-etc
+++ b/tests/kolainst/destructive/initramfs-etc
@@ -25,7 +25,17 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     mkdir -p /etc/cmdline.d
     echo 'foobar' > /etc/cmdline.d/foobar.conf
 
-    rpm-ostree initramfs-etc --track /etc/cmdline.d/foobar.conf
+    # check that we can't overlay in locked mode
+    cp /etc/rpm-ostreed.conf{,.bak}
+    echo 'LockLayering=true' >> /etc/rpm-ostreed.conf && rpm-ostree reload
+    if rpm-ostree initramfs-etc --track /etc/cmdline.d/foobar.conf 2>out.txt; then
+      fatal "should have failed in locked mode"
+    fi
+    assert_file_has_content_literal out.txt "LockLayering=true"
+    rm out.txt
+    mv /etc/rpm-ostreed.conf{.bak,} && rpm-ostree reload
+
+    rpm-ostree initramfs-etc --track /etc/cmdline.d/foobar.conf 2>out.txt
     rpm-ostree status > status.txt
     assert_file_has_content_literal status.txt "InitramfsEtc: /etc/cmdline.d/foobar.conf"
     rpm-ostree status --json > status.json

--- a/tests/kolainst/destructive/layering-local
+++ b/tests/kolainst/destructive/layering-local
@@ -31,6 +31,16 @@ if rpm -q foo 2>/dev/null; then
   fatal "found foo"
 fi
 
+# check that we can't overlay in locked mode
+cp /etc/rpm-ostreed.conf{,.bak}
+echo 'LockLayering=true' >> /etc/rpm-ostreed.conf && rpm-ostree reload
+if rpm-ostree install ${KOLA_EXT_DATA}/rpm-repos/0/packages/x86_64/foo-1.2-3.x86_64.rpm 2>out.txt; then
+  fatal "should have failed in locked mode"
+fi
+assert_file_has_content_literal out.txt "LockLayering=true"
+rm out.txt
+mv /etc/rpm-ostreed.conf{.bak,} && rpm-ostree reload
+
 # Disable repos, no Internet access should be required
 rm -rf /etc/yum.repos.d/
 # Also disable zincati since we're rebasing


### PR DESCRIPTION
This knob provides an easy way for a sysadmin to disable all package
layering and initramfs customizations without having to muck around
with polkit policies. This has been requested a few times in the past
(and again recently) in environments where we want more safety checks
(e.g. Fedora IoT/RHEL for Edge). There's more we could do of course for
that use case (I think sealing `/etc` has come up, though that probably
belongs better in libostree), but this is low-hanging.

We do this at the upgrader level rather than higher up in the stack to
be sure we catch all paths, but also so that if the feature is enabled
on a system with existing customizations, rpm-ostree still permits doing
a `reset` to bring it back in line.

Closes: #4061