### PR TITLE
Add --compare-with-build to cli

### DIFF
--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -138,12 +138,12 @@ fn fetch_previous_metadata(
 }
 
 #[derive(Debug, Default)]
-struct ManifestDiff {
-    removed: Vec<oci_spec::image::Descriptor>,
-    added: Vec<oci_spec::image::Descriptor>,
+pub struct ManifestDiff {
+    pub removed: Vec<oci_spec::image::Descriptor>,
+    pub added: Vec<oci_spec::image::Descriptor>,
 }
 
-fn manifest_diff(src: &ImageManifest, dest: &ImageManifest) -> ManifestDiff {
+pub fn manifest_diff(src: &ImageManifest, dest: &ImageManifest) -> ManifestDiff {
     let src_layers = src
         .layers()
         .iter()


### PR DESCRIPTION
This is a prep PR to completing https://github.com/coreos/rpm-ostree/issues/4247. It allows one to diff the layers of current encapsulated build to any other build.
