### PR TITLE
Drop `ex-container` entrypoint

### DIFF
--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -27,17 +27,6 @@ use crate::cxxrsutil::FFIGObjectReWrap;
 use crate::progress::progress_task;
 use crate::CxxResult;
 
-/// Main entrypoint for container
-pub async fn entrypoint(args: &[&str]) -> Result<i32> {
-    // Right now we're only exporting the `container` bits, not tar.  So inject that argument.
-    // And we also need to skip the main arg and the `ex-container` arg.
-    let args = ["rpm-ostree", "container"]
-        .iter()
-        .chain(args.iter().skip(2));
-    ostree_ext::cli::run_from_iter(args).await?;
-    Ok(0)
-}
-
 #[derive(Debug, Parser)]
 struct ContainerEncapsulateOpts {
     #[clap(long)]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -18,20 +18,6 @@ use termcolor::WriteColor;
 // those, and if there's something we don't know about, invoke the C++
 // main().
 async fn inner_async_main(args: Vec<String>) -> Result<i32> {
-    let args_borrowed: Vec<_> = args.iter().map(|s| s.as_str()).collect();
-    let arg = args_borrowed.get(1).copied().unwrap_or("");
-    // Async-native code goes here
-    #[allow(clippy::single_match)]
-    match arg {
-        // TODO(lucab): move consumers to the multicall entrypoint, then drop this.
-        "ex-container" => {
-            rpmostree_rust::client::warn_future_incompatibility(
-                "This entrypoint is deprecated; use `ostree container` instead",
-            );
-            return rpmostree_rust::container::entrypoint(&args_borrowed).await;
-        }
-        _ => {}
-    }
     // Everything below here is a blocking API, and run on a worker thread so
     // that the main thread is dedicated to the Tokio reactor.
     tokio::task::spawn_blocking(move || -> Result<i32, anyhow::Error> {

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -4641,7 +4641,7 @@ rpmostree_context_commit (RpmOstreeContext *self, const char *parent,
 
     auto modflags
         = static_cast<OstreeRepoCommitModifierFlags> (OSTREE_REPO_COMMIT_MODIFIER_FLAGS_NONE);
-    /* For ex-container (bare-user-only), we always need canonical permissions */
+    /* For container (bare-user-only), we always need canonical permissions */
     if (ostree_repo_get_mode (self->ostreerepo) == OSTREE_REPO_MODE_BARE_USER_ONLY)
       modflags = static_cast<OstreeRepoCommitModifierFlags> (
           static_cast<int> (modflags) | OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CANONICAL_PERMISSIONS);

--- a/tests/common/libtestrepos.sh
+++ b/tests/common/libtestrepos.sh
@@ -1,4 +1,4 @@
-# Shared functions for compose/ex-container tests
+# Shared functions for compose/container tests
 #
 # Copyright (C) 2017 Colin Walters <walters@verbum.org>
 #


### PR DESCRIPTION
It's been `ostree container` for a while, I don't think we need this alias anymore.  Searching reveals only usage in old forks of coreos-assembler etc.
