### PR TITLE
[rhel8] Temporarily transition rpmdb to bdb

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -325,6 +325,16 @@ fn stage_container_rpm_files(rpms: Vec<File>) -> CxxResult<Vec<String>> {
     Ok(r)
 }
 
+/// Return the filename used for the RPM database of the given type.
+pub(crate) fn filename_for_rpmdb_type(t: &str) -> Option<&'static str> {
+    match t {
+        // TODO: Dedup this with libdnf code (and really librpm code)
+        "bdb" => Some("Packages"),
+        "sqlite" => Some("rpmdb.sqlite"),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -190,6 +190,7 @@ pub mod ffi {
             c: &str,
         ) -> Result<Box<ContainerImageState>>;
         fn purge_refspec(repo: &OstreeRepo, refspec: &str) -> Result<()>;
+        fn handle_rpmdb_transition(rootfs_dfd: i32) -> Result<()>;
     }
 
     // core.rs
@@ -760,6 +761,7 @@ pub mod ffi {
             last_version: &str,
         ) -> Result<String>;
         fn testutil_validate_cxxrs_passthrough(repo: Pin<&mut OstreeRepo>) -> i32;
+        fn util_get_rpmdb_format() -> String;
     }
 
     unsafe extern "C++" {
@@ -875,8 +877,8 @@ mod client;
 pub(crate) use client::*;
 pub mod cliwrap;
 pub mod container;
-pub use container::*;
 pub use cliwrap::*;
+pub use container::*;
 mod composepost;
 pub mod countme;
 pub(crate) use composepost::*;

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -924,6 +924,8 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable, 
   if (!checkout_base_tree (self, cancellable, error))
     return FALSE;
 
+  CXX_TRY (rpmostreecxx::handle_rpmdb_transition (self->tmprootfs_dfd), error);
+
   self->ctx = rpmostree_context_new_client (self->repo);
 
   g_autofree char *tmprootfs_abspath = glnx_fdrel_abspath (self->tmprootfs_dfd, ".");

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -70,6 +70,7 @@ G_DECLARE_FINAL_TYPE (RpmOstreeContext, rpmostree_context, RPMOSTREE, CONTEXT, G
 namespace rpmostreecxx
 {
 void core_libdnf_process_global_init ();
+rust::String core_get_rpmdb_format ();
 }
 
 RpmOstreeContext *rpmostree_context_new_base (OstreeRepo *repo);

--- a/src/libpriv/rpmostree-util.cxx
+++ b/src/libpriv/rpmostree-util.cxx
@@ -23,6 +23,7 @@
 #include <gio/gunixoutputstream.h>
 #include <glib-unix.h>
 #include <json-glib/json-glib.h>
+#include <rpm/rpmmacro.h>
 #include <stdio.h>
 #include <string.h>
 #include <systemd/sd-journal.h>
@@ -259,6 +260,14 @@ int
 testutil_validate_cxxrs_passthrough (OstreeRepo &repo) noexcept
 {
   return ostree_repo_get_dfd (&repo);
+}
+
+// Return a string containing the default RPM backend format (e.g. sqlite, bdb)
+rust::String
+util_get_rpmdb_format () noexcept
+{
+  g_autofree char *buf = rpmExpand ("%{?_db_backend}", NULL);
+  return rust::String (buf);
 }
 
 } /* namespace */

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -184,7 +184,7 @@ rust::String util_next_version (rust::Str auto_version_prefix, rust::Str version
                                 rust::Str last_version);
 
 int testutil_validate_cxxrs_passthrough (OstreeRepo &repo) noexcept;
-
+rust::String util_get_rpmdb_format () noexcept;
 }
 
 // Below here is C code


### PR DESCRIPTION


This is aiming to fix https://issues.redhat.com/browse/OCPBUGS-7275

Basically to handle the rpmdb transition from bdb to sqlite seamlessly,
we need to down-convert because for bad historical reasons we
use the *host* rpm stack to do writes; and here the host only
can write to bdb.

So on the next boot after an upgrade with layered packages, we will
be in a situation where the host rpmdb is bdb - this is the same
as a traditional dnf/yum system.

Where things diverge is that there the `rpmdb-migrate.service`
will kick in and mutate the system live.  In our case, such mutation
conflicts with our philosophy and technology.  What will happen
for us instead is that because we always start from the new base
image, we'll detect that host preferred rpmdb is `sqlite`, the
target is `sqlite`, and just proceed with the new base image
sqlite db.

I got myself confused a bit into thinking our bdb database would
persist, but it doesn't.

---

