### PR TITLE
daemon: Use a socket in `/run`, require non-abstract

### DIFF
--- a/ci/prow/e2e-upgrades.sh
+++ b/ci/prow/e2e-upgrades.sh
@@ -40,6 +40,6 @@ if test -z "${BASE_QEMU_IMAGE:-}"; then
     coreos-installer download -p qemu -f qcow2.xz --decompress
     BASE_QEMU_IMAGE=./"$(echo *.qcow2)"
 fi
-kola run  --append-ignition config.ign --oscontainer ostree-unverified-registry:${TARGET_IMAGE} --qemu-image "${BASE_QEMU_IMAGE}" ext.rpm-ostree.upgrades
+cosa kola run --append-ignition config.ign --oscontainer ostree-unverified-registry:${TARGET_IMAGE} --qemu-image "${BASE_QEMU_IMAGE}" ext.rpm-ostree.upgrades
 
 echo "ok kola upgrades"

--- a/tests/vmcheck/test-cached-rpm-diffs.sh
+++ b/tests/vmcheck/test-cached-rpm-diffs.sh
@@ -68,7 +68,7 @@ run_transaction() {
   sig=$1; shift
   args=$1; shift
   cur=$(vm_get_journal_cursor)
-  vm_run_container --privileged -i -v /var/run/dbus:/var/run/dbus --net=host -- \
+  vm_run_container --privileged -i -v /run:/run/host/run -v /var/run/dbus:/var/run/dbus --net=host -- \
     /bin/bash << EOF
 set -xeuo pipefail
 dnf install -y python3-dbus
@@ -77,6 +77,7 @@ import dbus
 addr = dbus.SystemBus().call_blocking(
   "org.projectatomic.rpmostree1", "$ospath", "org.projectatomic.rpmostree1.OS",
   "$method", "$sig", ($args))
+addr = addr.replace("/run/", "/run/host/run/")
 t = dbus.connection.Connection(addr)
 t.call_blocking(
   "org.projectatomic.rpmostree1", "/",


### PR DESCRIPTION

This fixes https://bugzilla.redhat.com/show_bug.cgi?id=2169622

The new glib changed to use non-abstract sockets by default,
which broke us because we'd slowly grown more isolation, specifically
the daemon has been using `PrivateTmp` for a while and we'd
been relying on abstract sockets to pierce that.

Change to use `/run` which should always be shared by client
and daemon.  While we're here, make it a well-known static path
because there can be only one transaction at a time.

We also do need to explicitly make the socket world-accessible
because that was the semantics of the previous abstract socket.

Also, plug leaks here by ensuring we call `g_dbus_server_stop()`.

(But really we should also change this to be crash safe, probably
 with a temporary directory, but that's a larger change)
