### PR TITLE
rust/src/scripts.rs: ignore posttrans for kernel-rt-core

### DIFF
--- a/rust/src/scripts.rs
+++ b/rust/src/scripts.rs
@@ -23,6 +23,7 @@ static IGNORED_PKG_SCRIPTS: phf::Set<&'static str> = phf_set! {
     "kernel-core.posttrans",
     "kernel-debug-core.posttrans",
     "kernel-automotive-core.posttrans",
+    "kernel-rt-core.posttrans",
     // Additionally ignore posttrans scripts for the Oracle Linux `kernel-uek` package
     "kernel-uek.posttrans",
     // Legacy workaround


### PR DESCRIPTION
Ignore posttrans for kernel-rt-core which is used on OCP/RHCOS.