### PR TITLE
daemon: Make failure to query base image non-fatal

### DIFF
--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -688,9 +688,15 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy, GVariant *child, gint ind
           break;
         case rpmostreecxx::RefspecType::Container:
           {
-            g_assert (g_variant_dict_lookup (dict, "container-image-reference-digest", "s",
-                                             &container_image_reference_digest));
-            g_print ("%s", origin_refspec);
+            if (g_variant_dict_lookup (dict, "container-image-reference-digest", "s",
+                                       &container_image_reference_digest))
+              {
+                g_print ("%s", origin_refspec);
+              }
+            else
+              {
+                g_print ("(error fetching image metadata)");
+              }
           }
           break;
         }


### PR DESCRIPTION
We had a GC bug which then propagates into a hard daemon failure right now because we try to gather data on all deployments.

Make this non-fatal; we should try to stumble forward as much as possible so that one can e.g. perform an upgrade operation.

(cherry picked from commit 8dd45f293afc1ca32b42bda86dde47c66e652dda)
