### PR TITLE
spec: Add `Requires: /usr/bin/setpriv`

### DIFF
--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -135,6 +135,7 @@ Requires: fuse
 # For container functionality
 # https://github.com/coreos/rpm-ostree/issues/3286
 Requires: skopeo
+Requires: /usr/bin/setpriv
 
 Requires: %{name}-libs%{?_isa} = %{version}-%{release}
 


### PR DESCRIPTION
Otherwise, minimal environments like Anaconda might omit this. xref https://github.com/rhinstaller/anaconda/pull/4561#issuecomment-1442494914
