### PR TITLE
add polkit as needed service

### DIFF
--- a/src/daemon/rpm-ostreed.service
+++ b/src/daemon/rpm-ostreed.service
@@ -3,6 +3,7 @@ Description=rpm-ostree System Management Daemon
 Documentation=man:rpm-ostree(1)
 ConditionPathExists=/ostree
 RequiresMountsFor=/boot
+After=polkit.service
 
 [Service]
 # See similar code in rpm-ostree-countme.service


### PR DESCRIPTION
The authorization is dependent on polkit and the rpm-ostree shall be checking the polkit before it starts
