### PR TITLE
core: Don't try to load rpm IMA sigs client side unless requested

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1504,6 +1504,7 @@ struct ParsedRevision final
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporterFlags
 struct RpmImporterFlags final : public ::rust::Opaque
 {
+  bool is_ima_enabled () const noexcept;
   ~RpmImporterFlags () = delete;
 
 private:
@@ -2231,6 +2232,9 @@ extern "C"
 
   ::rpmostreecxx::RpmImporterFlags *
   rpmostreecxx$cxxbridge1$rpm_importer_flags_new_empty () noexcept;
+
+  bool rpmostreecxx$cxxbridge1$RpmImporterFlags$is_ima_enabled (
+      const ::rpmostreecxx::RpmImporterFlags &self) noexcept;
   ::std::size_t rpmostreecxx$cxxbridge1$RpmImporter$operator$sizeof () noexcept;
   ::std::size_t rpmostreecxx$cxxbridge1$RpmImporter$operator$alignof () noexcept;
 
@@ -4144,6 +4148,12 @@ rpm_importer_flags_new_empty () noexcept
 {
   return ::rust::Box< ::rpmostreecxx::RpmImporterFlags>::from_raw (
       rpmostreecxx$cxxbridge1$rpm_importer_flags_new_empty ());
+}
+
+bool
+RpmImporterFlags::is_ima_enabled () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$RpmImporterFlags$is_ima_enabled (*this);
 }
 
 ::std::size_t

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1286,6 +1286,7 @@ struct ParsedRevision final
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporterFlags
 struct RpmImporterFlags final : public ::rust::Opaque
 {
+  bool is_ima_enabled () const noexcept;
   ~RpmImporterFlags () = delete;
 
 private:

--- a/rust/src/importer.rs
+++ b/rust/src/importer.rs
@@ -39,6 +39,12 @@ pub fn rpm_importer_flags_new_empty() -> Box<RpmImporterFlags> {
     Box::new(RpmImporterFlags::empty())
 }
 
+impl RpmImporterFlags {
+    pub(crate) fn is_ima_enabled(&self) -> bool {
+        self.contains(Self::IMA)
+    }
+}
+
 #[derive(Debug)]
 pub struct RpmImporter {
     // Hashset of all file entries marked as 'doc' in an RPM;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -369,6 +369,7 @@ pub mod ffi {
     extern "Rust" {
         type RpmImporterFlags;
         fn rpm_importer_flags_new_empty() -> Box<RpmImporterFlags>;
+        fn is_ima_enabled(self: &RpmImporterFlags) -> bool;
 
         type RpmImporter;
         fn rpm_importer_new(

--- a/src/libpriv/rpmostree-importer.h
+++ b/src/libpriv/rpmostree-importer.h
@@ -44,7 +44,8 @@ RpmOstreeImporter *rpmostree_importer_new_take_fd (int *fd, OstreeRepo *repo, Dn
                                                    OstreeSePolicy *sepolicy,
                                                    GCancellable *cancellable, GError **error);
 
-gboolean rpmostree_importer_read_metainfo (int fd, Header *out_header, gsize *out_cpio_offset,
+gboolean rpmostree_importer_read_metainfo (int fd, rpmostreecxx::RpmImporterFlags &flags,
+                                           Header *out_header, gsize *out_cpio_offset,
                                            rpmfi *out_fi, GError **error);
 
 gboolean rpmostree_importer_run (RpmOstreeImporter *unpacker, char **out_commit,


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=2177225

This is really a no-op on rhel9 and current Fedora, but trying to land the code here so we can have it run through CI, and then backport to rhel8.
