### PR TITLE
A logging fix and attempt to fix the cached-sigs test

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -955,6 +955,6 @@ mod testutils;
 pub(crate) use self::testutils::*;
 mod treefile;
 pub use self::treefile::*;
-pub(crate) mod utils;
+pub mod utils;
 pub use self::utils::*;
 mod variant_utils;

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -232,7 +232,7 @@ static RUNNING_IN_SYSTEMD: Lazy<bool> = Lazy::new(|| {
 /// Checks if the current process is (apparently at least)
 /// running under systemd.  We use this in various places
 /// to e.g. log to the journal instead of printing to stdout.
-pub(crate) fn running_in_systemd() -> bool {
+pub fn running_in_systemd() -> bool {
     *RUNNING_IN_SYSTEMD
 }
 

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -466,7 +466,10 @@ rpmostree_assert_status() {
 journal_poll() {
     timeout=60
     for x in $(seq $timeout); do
-      if journalctl -q -n 1 "$@"; then
+      # We used to use -n 1 here, but that regressed
+      #  https://github.com/systemd/systemd/pull/26476#issuecomment-1465038424
+      out=$(journalctl -q "$@" || true | head -1)
+      if test -n "${out}"; then
         return
       fi
       sleep 1

--- a/tests/kolainst/destructive/cached-sigs
+++ b/tests/kolainst/destructive/cached-sigs
@@ -10,10 +10,18 @@ cd "$(mktemp -d)"
 
 # For this test we want a signed OSTree commit deployed. Check if a sig already
 # exists, otherwise let's self-sign it.
-booted_commit=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
-if ! rpm-ostree status --json | jq -e '.deployments[0].signatures' > /dev/null; then
+rpm-ostree status --json > status.json
+booted_commit=$(jq -r '.deployments[0].checksum' < status.json)
+if ! jq -e '.deployments[0].signatures' < status.json > /dev/null; then
   ostree gpg-sign --gpg-homedir "${KOLA_EXT_DATA}/gpghome" "$booted_commit" "${TEST_GPG_KEYID_1}"
   cp "${KOLA_EXT_DATA}/gpghome/key1.asc" /etc/pki/rpm-gpg/
+fi
+
+# cosa build-fast will not use a refspec; let's synthesize one since it's required for this test
+origin="$(jq -r '.deployments[0].origin' < status.json)"
+if test "${origin}" = "${booted_commit}"; then
+  ostree refs --create dummy:synthetic-ref-for-test "${booted_commit}"
+  ostree admin set-origin dummy https://localhost synthetic-ref-for-test
 fi
 
 systemctl stop rpm-ostreed

--- a/tests/kolainst/destructive/layering-fedorainfra
+++ b/tests/kolainst/destructive/layering-fedorainfra
@@ -19,7 +19,7 @@ rpm-ostree cleanup -p
 rpm-ostree override replace https://koji.fedoraproject.org/koji/buildinfo?buildID=1671410
 
 n_systemd_installed=$(rpm -qa | grep ^systemd | wc -l)
-rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2022-0bbb402870 |& tee out.txt
+rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2023-f72fbc711a |& tee out.txt
 n_systemd_downloaded=$(grep Downloading out.txt | wc -l)
 n_systemd_replaced=$(rpm-ostree db diff | grep systemd | wc -l)
 if [[ $n_systemd_installed != $n_systemd_downloaded ]]; then


### PR DESCRIPTION
main: Don't use timestamps and colors in tracing logs when running in systemd

It's just broken to write colors into the journal.  We also should
omit timestamps because journald already does that.

Motivated specifically by `ext.rpm-ostree.destructive.cached-sigs`
which started failing.

---

cached-sigs: Be compatible with `cosa build-fast`

cosa build-fast will not use a refspec; let's synthesize one since
it's required for this test.

---

libtest: Hack around regression in journalctl

See https://github.com/systemd/systemd/pull/26476#issuecomment-1465038424

A patch to improve `-n/--lines` together with `--grep` broke
our use in combination with `--after-cursor`.  Pipe instead
to `head -1` to hack around this.

---

tests/layering-fedorainfra: Bump to newer systemd

Trying to override with such an old systemd finally broke
due to some file conflicts.

We really need to stop hardcoding this stuff.

---

