### PR TITLE
[rhel8] core: Don't try to load rpm IMA sigs client side unless requested

### DIFF
--- a/rust/src/importer.rs
+++ b/rust/src/importer.rs
@@ -39,6 +39,12 @@ pub fn rpm_importer_flags_new_empty() -> Box<RpmImporterFlags> {
     Box::new(RpmImporterFlags::empty())
 }
 
+impl RpmImporterFlags {
+    pub(crate) fn is_ima_enabled(&self) -> bool {
+        self.contains(Self::IMA)
+    }
+}
+
 #[derive(Debug)]
 pub struct RpmImporter {
     // Hashset of all file entries marked as 'doc' in an RPM;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -348,6 +348,7 @@ pub mod ffi {
     extern "Rust" {
         type RpmImporterFlags;
         fn rpm_importer_flags_new_empty() -> Box<RpmImporterFlags>;
+        fn is_ima_enabled(self: &RpmImporterFlags) -> bool;
 
         type RpmImporter;
         fn rpm_importer_new(

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -2731,8 +2731,9 @@ handle_file_dispositions (RpmOstreeContext *self, int tmprootfs_dfd, rpmts ts,
       if (g_hash_table_contains (pkgs_deleted, GUINT_TO_POINTER (off)))
         continue;
 
-      /* try to only load what we need: filenames and colors */
-      rpmfiFlags flags = RPMFI_FLAGS_ONLY_FILENAMES;
+      /* try to only load what we need: filenames and colors.  Also due to
+       * https://bugzilla.redhat.com/show_bug.cgi?id=2177088 we explicitly exclude IMA */
+      rpmfiFlags flags = RPMFI_FLAGS_ONLY_FILENAMES | RPMFI_NOFILESIGNATURES;
       flags &= ~RPMFI_NOFILECOLORS;
 
       g_auto (rpmfi) fi = rpmfiNew (ts, h, RPMTAG_BASENAMES, flags);
@@ -3471,7 +3472,9 @@ get_package_metainfo (RpmOstreeContext *self, const char *path, Header *out_head
   if (!glnx_openat_rdonly (self->tmpdir.fd, path, TRUE, &metadata_fd, error))
     return FALSE;
 
-  return rpmostree_importer_read_metainfo (metadata_fd, out_header, NULL, out_fi, error);
+  // We just care about reading the stuff librpm wants to put in the database, so no IMA etc.
+  auto flags = rpmostreecxx::rpm_importer_flags_new_empty ();
+  return rpmostree_importer_read_metainfo (metadata_fd, *flags, out_header, NULL, out_fi, error);
 }
 
 typedef enum

--- a/src/libpriv/rpmostree-importer.cxx
+++ b/src/libpriv/rpmostree-importer.cxx
@@ -103,8 +103,8 @@ rpmostree_importer_init (RpmOstreeImporter *self)
 }
 
 gboolean
-rpmostree_importer_read_metainfo (int fd, Header *out_header, gsize *out_cpio_offset, rpmfi *out_fi,
-                                  GError **error)
+rpmostree_importer_read_metainfo (int fd, rpmostreecxx::RpmImporterFlags &flags, Header *out_header,
+                                  gsize *out_cpio_offset, rpmfi *out_fi, GError **error)
 {
   g_auto (rpmts) ts = NULL;
   g_auto (FD_t) rpmfd = NULL;
@@ -131,7 +131,10 @@ rpmostree_importer_read_metainfo (int fd, Header *out_header, gsize *out_cpio_of
 
   if (out_fi)
     {
-      ret_fi = rpmfiNew (ts, ret_header, RPMTAG_BASENAMES, RPMFI_NOHEADER | RPMFI_FLAGS_QUERY);
+      rpmfiFlags rpmfi_flags = RPMFI_NOHEADER | RPMFI_FLAGS_QUERY;
+      if (!flags.is_ima_enabled ())
+        rpmfi_flags |= RPMFI_NOFILESIGNATURES;
+      ret_fi = rpmfiNew (ts, ret_header, RPMTAG_BASENAMES, rpmfi_flags);
       ret_fi = rpmfiInit (ret_fi, 0);
     }
 
@@ -235,7 +238,7 @@ rpmostree_importer_new_take_fd (int *fd, OstreeRepo *repo, DnfPackage *pkg,
   if (ar == NULL)
     return NULL;
 
-  if (!rpmostree_importer_read_metainfo (*fd, &hdr, &cpio_offset, &fi, error))
+  if (!rpmostree_importer_read_metainfo (*fd, flags, &hdr, &cpio_offset, &fi, error))
     return (RpmOstreeImporter *)glnx_prefix_error_null (error, "Reading metainfo");
   g_assert (hdr != NULL);
 

--- a/src/libpriv/rpmostree-importer.h
+++ b/src/libpriv/rpmostree-importer.h
@@ -43,7 +43,8 @@ RpmOstreeImporter *rpmostree_importer_new_take_fd (int *fd, OstreeRepo *repo, Dn
                                                    rpmostreecxx::RpmImporterFlags &flags,
                                                    OstreeSePolicy *sepolicy, GError **error);
 
-gboolean rpmostree_importer_read_metainfo (int fd, Header *out_header, gsize *out_cpio_offset,
+gboolean rpmostree_importer_read_metainfo (int fd, rpmostreecxx::RpmImporterFlags &flags,
+                                           Header *out_header, gsize *out_cpio_offset,
                                            rpmfi *out_fi, GError **error);
 
 gboolean rpmostree_importer_run (RpmOstreeImporter *unpacker, char **out_commit,


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=2177225

This is really a no-op on rhel9 and current Fedora, but trying to land the code here so we can have it run through CI, and then backport to rhel8.

(cherry picked from commit 24adf853f876fa97975473392fcc148581486d29)
