### PR TITLE
main: Don't write colors to non-ttys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,6 +2148,7 @@ dependencies = [
  "futures",
  "indicatif",
  "indoc",
+ "is-terminal",
  "libc",
  "libdnf-sys",
  "maplit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ fn-error-context = "0.2.0"
 futures = "0.3.25"
 indoc = "2.0.1"
 indicatif = "0.17.3"
+is-terminal = "0.4"
 libc = "0.2.137"
 libdnf-sys = { path = "rust/libdnf-sys", version = "0.1.0" }
 maplit = "1.0"

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use anyhow::{Context, Result};
+use is_terminal::IsTerminal;
 use nix::sys::signal;
 use rpmostree_rust::builtins;
 use std::ffi::OsString;
@@ -137,7 +138,12 @@ fn print_error(e: anyhow::Error) {
     // See discussion in CxxResult for why we use this format
     let msg = format!("{:#}", e);
     // Print the error: prefix in red if we're on a tty
-    let stderr = termcolor::BufferWriter::stderr(termcolor::ColorChoice::Auto);
+    let colored = if std::io::stderr().is_terminal() {
+        termcolor::ColorChoice::Auto
+    } else {
+        termcolor::ColorChoice::Never
+    };
+    let stderr = termcolor::BufferWriter::stderr(colored);
     let stderrbuf = {
         let mut stderrbuf = stderr.buffer();
         let _ =


### PR DESCRIPTION
I somehow missed this footgun in the docs for https://docs.rs/termcolor/latest/termcolor/

Motivated by seeing ANSI escapes in the MCD logs.

