### PR TITLE
ci: trigger `differential-shellcheck` workflow on `push`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,7 +244,6 @@ jobs:
   # Doc: https://github.com/redhat-plumbers-in-action/differential-shellcheck#usage
   differential-shellcheck:
     name: Differential ShellCheck
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     steps:
@@ -253,7 +252,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v3
+        uses: redhat-plumbers-in-action/differential-shellcheck@v4
         with:
           severity: warning
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Also, update `differential-shellcheck` to the latest version (`v4.0.2`) - https://github.com/redhat-plumbers-in-action/differential-shellcheck/releases Push events are supported since `v4.0.0`.

Fixes:
- https://github.com/redhat-plumbers-in-action/differential-shellcheck/issues/215
- https://github.com/redhat-plumbers-in-action/differential-shellcheck/issues/222

This should get rid of annoying messages from the `github-code-scanning` bot.

![Screenshot from 2023-03-22 07-00-32](https://user-images.githubusercontent.com/2879818/226815668-36272095-4f1d-4465-a0e8-f317b0abfc52.png)