### PR TITLE
treefile: Add enablerepo/disablerepo/setreleasever cli options

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1746,6 +1746,9 @@ struct Treefile final : public ::rust::Opaque
   ::rust::Box< ::rpmostreecxx::RpmImporterFlags>
   importer_flags (::rust::Str pkg_name) const noexcept;
   ::rust::String write_repovars (::std::int32_t workdir_dfd_raw) const;
+  bool set_releasever (::rust::Str releasever);
+  bool enable_repo (::rust::Str repo);
+  bool disable_repo (::rust::Str repo);
   void validate_for_container () const;
   ::rpmostreecxx::Refspec get_base_refspec () const noexcept;
   void rebase (::rust::Str new_refspec, ::rust::Str custom_origin_url,
@@ -2615,6 +2618,18 @@ extern "C"
   rpmostreecxx$cxxbridge1$Treefile$write_repovars (const ::rpmostreecxx::Treefile &self,
                                                    ::std::int32_t workdir_dfd_raw,
                                                    ::rust::String *return$) noexcept;
+
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$Treefile$set_releasever (::rpmostreecxx::Treefile &self,
+                                                   ::rust::Str releasever, bool *return$) noexcept;
+
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$Treefile$enable_repo (::rpmostreecxx::Treefile &self,
+                                                                     ::rust::Str repo,
+                                                                     bool *return$) noexcept;
+
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$Treefile$disable_repo (::rpmostreecxx::Treefile &self, ::rust::Str repo,
+                                                 bool *return$) noexcept;
 
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$Treefile$validate_for_container (
       const ::rpmostreecxx::Treefile &self) noexcept;
@@ -5185,6 +5200,45 @@ Treefile::write_repovars (::std::int32_t workdir_dfd_raw) const
   ::rust::MaybeUninit< ::rust::String> return$;
   ::rust::repr::PtrLen error$
       = rpmostreecxx$cxxbridge1$Treefile$write_repovars (*this, workdir_dfd_raw, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
+}
+
+bool
+Treefile::set_releasever (::rust::Str releasever)
+{
+  ::rust::MaybeUninit<bool> return$;
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$Treefile$set_releasever (*this, releasever, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
+}
+
+bool
+Treefile::enable_repo (::rust::Str repo)
+{
+  ::rust::MaybeUninit<bool> return$;
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$Treefile$enable_repo (*this, repo, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
+}
+
+bool
+Treefile::disable_repo (::rust::Str repo)
+{
+  ::rust::MaybeUninit<bool> return$;
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$Treefile$disable_repo (*this, repo, &return$.value);
   if (error$.ptr)
     {
       throw ::rust::impl< ::rust::Error>::error (error$);

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1528,6 +1528,9 @@ struct Treefile final : public ::rust::Opaque
   ::rust::Box< ::rpmostreecxx::RpmImporterFlags>
   importer_flags (::rust::Str pkg_name) const noexcept;
   ::rust::String write_repovars (::std::int32_t workdir_dfd_raw) const;
+  bool set_releasever (::rust::Str releasever);
+  bool enable_repo (::rust::Str repo);
+  bool disable_repo (::rust::Str repo);
   void validate_for_container () const;
   ::rpmostreecxx::Refspec get_base_refspec () const noexcept;
   void rebase (::rust::Str new_refspec, ::rust::Str custom_origin_url,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -602,7 +602,9 @@ pub mod ffi {
         fn sanitycheck_externals(&self) -> Result<()>;
         fn importer_flags(&self, pkg_name: &str) -> Box<RpmImporterFlags>;
         fn write_repovars(&self, workdir_dfd_raw: i32) -> Result<String>;
-
+        fn set_releasever(&mut self, releasever: &str) -> Result<()>;
+        fn enable_repo(&mut self, repo: &str) -> Result<()>;
+        fn disable_repo(&mut self, repo: &str) -> Result<()>;
         // these functions are more related to derivation
         fn validate_for_container(&self) -> Result<()>;
         fn get_base_refspec(&self) -> Refspec;

--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -46,6 +46,9 @@ static gboolean opt_uninstall_all;
 static gboolean opt_unchanged_exit_77;
 static gboolean opt_lock_finalization;
 static gboolean opt_force_replacefiles;
+static char **opt_enable_repo;
+static char **opt_disable_repo;
+static char **opt_release_ver;
 
 static GOptionEntry option_entries[]
     = { { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
@@ -63,6 +66,12 @@ static GOptionEntry option_entries[]
           "If no overlays were changed, exit 77", NULL },
         { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization,
           "Prevent automatic deployment finalization on shutdown", NULL },
+        { "enablerepo", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_enable_repo,
+          "Enable the repository based on the repo id", NULL },
+        { "disablerepo", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_disable_repo,
+          "Only disabling all (*) repositories is supported currently", NULL },
+        { "releasever", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_release_ver, "Set the releasever",
+          NULL },
         { NULL } };
 
 static GOptionEntry uninstall_option_entry[]
@@ -235,6 +244,21 @@ rpmostree_builtin_install (int argc, char **argv, RpmOstreeCommandInvocation *in
               rust::Vec v = { rust::String (pkg) };
               CXX_TRY (treefile->add_packages (v, true), error);
             }
+        }
+      for (char **it = opt_enable_repo; it && *it; it++)
+        {
+          auto repo = rust::Str (*it);
+          treefile->enable_repo (repo);
+        }
+      for (char **it = opt_disable_repo; it && *it; it++)
+        {
+          auto repo = rust::Str (*it);
+          treefile->disable_repo (repo);
+        }
+      for (char **it = opt_release_ver; it && *it; it++)
+        {
+          auto ver = rust::Str (*it);
+          treefile->set_releasever (ver);
         }
       return rpmostree_container_rebuild (*treefile, cancellable, error);
     }


### PR DESCRIPTION
Add --enablerepo=, --disablerepo and --setreleasever cli options. This options are only honored on the container path.

Closes: https://github.com/coreos/rpm-ostree/issues/4293