### PR TITLE
ci(fix): add missing permissions - `security-events`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -246,6 +246,9 @@ jobs:
     name: Differential ShellCheck
     runs-on: ubuntu-latest
 
+    permissions:
+      security-events: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Permissions `security-events: write` are required to upload scan results (SARIF) to GitHub successfully.

doc: https://github.com/redhat-plumbers-in-action/differential-shellcheck#usage

This should hopefully finally fix the issue:
- https://github.com/redhat-plumbers-in-action/differential-shellcheck/issues/222

/cc @cgwalters I'm sorry, I missed this detail the first time around.

logs: https://github.com/coreos/rpm-ostree/actions/runs/4519749017/jobs/7960410287#step:4:35

follow-up to:
- https://github.com/coreos/rpm-ostree/pull/4345