### PR TITLE
ci: Make sure cxx code is clang-formatted

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -60,6 +60,7 @@ versionid=$(. /usr/lib/os-release && echo $VERSION_ID)
 case $versionid in
   36) module=cri-o:1.23/default;;
   37) module=cri-o:1.24/default;;
+  38) module=cri-o:1.25/default;;
   *) assert_not_reached "Unsupported Fedora version: $versionid";;
 esac
 rpm-ostree ex module install "${module}"
@@ -79,18 +80,26 @@ case $versionid in
   36)
     url_suffix=2.13.0/5.fc36/x86_64/ignition-2.13.0-5.fc36.x86_64.rpm
     # 2.14.0
-    koji_url=https://koji.fedoraproject.org/koji/buildinfo?buildID=1967836
-    koji_kernel_url=https://koji.fedoraproject.org/koji/buildinfo?buildID=1970749
+    koji_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=1967836"
+    koji_kernel_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=1970749"
     kver=5.17.11
     krev=300
     ;;
   37)
     url_suffix=2.14.0/3.fc37/x86_64/ignition-2.14.0-3.fc37.x86_64.rpm
     # 2.14.0-4
-    koji_url=https://koji.fedoraproject.org/koji/buildinfo?buildID=2013062
-    koji_kernel_url=https://koji.fedoraproject.org/koji/buildinfo?buildID=2084352
+    koji_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=2013062"
+    koji_kernel_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=2084352"
     kver=6.0.7
     krev=301
+    ;;
+  38)
+    url_suffix=2.15.0/2.fc38/x86_64/ignition-2.15.0-2.fc38.x86_64.rpm
+    # 2.15.0-3
+    koji_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=2158585"
+    koji_kernel_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=2174317"
+    kver=6.2.8
+    krev=300
     ;;
   *) fatal "Unsupported Fedora version: $versionid";;
 esac

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -95,7 +95,7 @@ public:
 
   bool operator== (const String &) const noexcept;
   bool operator!= (const String &) const noexcept;
-  bool operator<(const String &) const noexcept;
+  bool operator< (const String &) const noexcept;
   bool operator<= (const String &) const noexcept;
   bool operator> (const String &) const noexcept;
   bool operator>= (const String &) const noexcept;
@@ -150,7 +150,7 @@ public:
 
   bool operator== (const Str &) const noexcept;
   bool operator!= (const Str &) const noexcept;
-  bool operator<(const Str &) const noexcept;
+  bool operator< (const Str &) const noexcept;
   bool operator<= (const Str &) const noexcept;
   bool operator> (const Str &) const noexcept;
   bool operator>= (const Str &) const noexcept;
@@ -251,7 +251,7 @@ public:
 
   bool operator== (const iterator &) const noexcept;
   bool operator!= (const iterator &) const noexcept;
-  bool operator<(const iterator &) const noexcept;
+  bool operator< (const iterator &) const noexcept;
   bool operator<= (const iterator &) const noexcept;
   bool operator> (const iterator &) const noexcept;
   bool operator>= (const iterator &) const noexcept;
@@ -454,7 +454,7 @@ Slice<T>::iterator::operator!= (const iterator &other) const noexcept
 
 template <typename T>
 bool
-Slice<T>::iterator::operator<(const iterator &other) const noexcept
+Slice<T>::iterator::operator< (const iterator &other) const noexcept
 {
   return this->pos < other.pos;
 }

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -94,7 +94,7 @@ public:
 
   bool operator== (const String &) const noexcept;
   bool operator!= (const String &) const noexcept;
-  bool operator<(const String &) const noexcept;
+  bool operator< (const String &) const noexcept;
   bool operator<= (const String &) const noexcept;
   bool operator> (const String &) const noexcept;
   bool operator>= (const String &) const noexcept;
@@ -149,7 +149,7 @@ public:
 
   bool operator== (const Str &) const noexcept;
   bool operator!= (const Str &) const noexcept;
-  bool operator<(const Str &) const noexcept;
+  bool operator< (const Str &) const noexcept;
   bool operator<= (const Str &) const noexcept;
   bool operator> (const Str &) const noexcept;
   bool operator>= (const Str &) const noexcept;
@@ -250,7 +250,7 @@ public:
 
   bool operator== (const iterator &) const noexcept;
   bool operator!= (const iterator &) const noexcept;
-  bool operator<(const iterator &) const noexcept;
+  bool operator< (const iterator &) const noexcept;
   bool operator<= (const iterator &) const noexcept;
   bool operator> (const iterator &) const noexcept;
   bool operator>= (const iterator &) const noexcept;
@@ -453,7 +453,7 @@ Slice<T>::iterator::operator!= (const iterator &other) const noexcept
 
 template <typename T>
 bool
-Slice<T>::iterator::operator<(const iterator &other) const noexcept
+Slice<T>::iterator::operator< (const iterator &other) const noexcept
 {
   return this->pos < other.pos;
 }

--- a/rust/cxx.h
+++ b/rust/cxx.h
@@ -84,7 +84,7 @@ public:
 
   bool operator== (const String &) const noexcept;
   bool operator!= (const String &) const noexcept;
-  bool operator<(const String &) const noexcept;
+  bool operator< (const String &) const noexcept;
   bool operator<= (const String &) const noexcept;
   bool operator> (const String &) const noexcept;
   bool operator>= (const String &) const noexcept;
@@ -144,7 +144,7 @@ public:
 
   bool operator== (const Str &) const noexcept;
   bool operator!= (const Str &) const noexcept;
-  bool operator<(const Str &) const noexcept;
+  bool operator< (const Str &) const noexcept;
   bool operator<= (const Str &) const noexcept;
   bool operator> (const Str &) const noexcept;
   bool operator>= (const Str &) const noexcept;
@@ -246,7 +246,7 @@ public:
 
   bool operator== (const iterator &) const noexcept;
   bool operator!= (const iterator &) const noexcept;
-  bool operator<(const iterator &) const noexcept;
+  bool operator< (const iterator &) const noexcept;
   bool operator<= (const iterator &) const noexcept;
   bool operator> (const iterator &) const noexcept;
   bool operator>= (const iterator &) const noexcept;
@@ -719,7 +719,7 @@ Slice<T>::iterator::operator!= (const iterator &other) const noexcept
 
 template <typename T>
 bool
-Slice<T>::iterator::operator<(const iterator &other) const noexcept
+Slice<T>::iterator::operator< (const iterator &other) const noexcept
 {
   return this->pos < other.pos;
 }

--- a/tests/compose-image.sh
+++ b/tests/compose-image.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Pin to branch for some reproducibility
-BRANCH=f37
+BRANCH=f38
 
 dn=$(cd "$(dirname "$0")" && pwd)
 topsrcdir=$(cd "$dn/.." && pwd)
@@ -32,7 +32,7 @@ cd minimal-test
 cat > minimal.yaml << 'EOF'
 container: true
 recommends: false
-releasever: 37
+releasever: 38
 packages:
   - rootfiles
   - fedora-repos-modular
@@ -60,7 +60,7 @@ mkdir minimal-test
 cd minimal-test
 cat > minimal.yaml << 'EOF'
 boot-location: modules
-releasever: 37
+releasever: 38
 packages:
   - bash
   - rpm
@@ -78,8 +78,12 @@ cd ..
 echo "ok minimal"
 
 # Next, test the full Fedora Silverblue config
-test -d workstation-ostree-config || git clone --depth=1 https://pagure.io/workstation-ostree-config --branch "${BRANCH}"
-
+test -d workstation-ostree-config || git clone --depth=100 https://pagure.io/workstation-ostree-config --branch "${BRANCH}"
+# Temporary workaround while this update hits stable
+# https://pagure.io/workstation-ostree-config/c/7c5245aafe69a2f24572e19e7fd81be713f74af6?branch=f38
+# When removing workaround re-adjust the --depth=100 to --depth=1.
+git -c user.email="composetest@localhost.com" -c user.name="composetest" \
+   -C workstation-ostree-config revert 7c5245aafe69a2f24572e19e7fd81be713f74af6
 rpm-ostree compose image --cachedir=cache --touch-if-changed=changed.stamp --initialize workstation-ostree-config/fedora-silverblue.yaml fedora-silverblue.ociarchive
 skopeo inspect oci-archive:fedora-silverblue.ociarchive
 test -f changed.stamp

--- a/tests/kolainst/destructive/layering-modules
+++ b/tests/kolainst/destructive/layering-modules
@@ -13,6 +13,7 @@ versionid=$(. /usr/lib/os-release && echo $VERSION_ID)
 case $versionid in
   36) module=cri-o:1.23/default;;
   37) module=cri-o:1.24/default;;
+  38) module=cri-o:1.25/default;;
   *) assert_not_reached "Unsupported Fedora version: $versionid";;
 esac
 rpm-ostree ex module install "${module}"

--- a/tests/vmcheck/test-override-kernel.sh
+++ b/tests/vmcheck/test-override-kernel.sh
@@ -41,20 +41,15 @@ versionid=${versionid:11} # trim off VERSION_ID=
 current=$(vm_get_booted_csum)
 vm_cmd rpm-ostree db list "${current}" > current-dblist.txt
 case $versionid in
-  36) kernel_release=5.17.5-300.fc36.x86_64;;
-  37) kernel_release=6.0.7-301.fc37.x86_64;;
+  38) kernel_release=6.2.9-300.fc38.x86_64;;
   *) assert_not_reached "Unsupported Fedora version: $versionid";;
 esac
 assert_not_file_has_content current-dblist.txt $kernel_release
 grep -E '^ kernel-[0-9]' current-dblist.txt  | sed -e 's,^ *,,' > orig-kernel.txt
 assert_streq "$(wc -l < orig-kernel.txt)" "1"
 orig_kernel=$(cat orig-kernel.txt)
-URL_ROOT="https://dl.fedoraproject.org/pub/fedora/linux/releases/$versionid/Everything/x86_64/os/Packages/k"
-if vm_cmd rpm -q kernel-modules-core; then 
-    echo "kernel-modules-core installed.. removing"; remove="--remove kernel-modules-core"; 
-fi
-vm_rpmostree override replace $remove \
-  "$URL_ROOT/kernel{,-core,-modules{,-extra}}-$kernel_release.rpm"
+koji_kernel_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=2178613"
+vm_rpmostree override replace $koji_kernel_url
 new=$(vm_get_pending_csum)
 vm_cmd rpm-ostree db list "${new}" > new-dblist.txt
 assert_file_has_content_literal new-dblist.txt $kernel_release


### PR DESCRIPTION
This fixes the failures seen on: https://github.com/coreos/rpm-ostree/actions/runs/4743787372/jobs/8425291293?pr=4370
