### PR TITLE
app: Add a global `-q/--quiet` flag

### DIFF
--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -128,6 +128,7 @@ static RpmOstreeCommand commands[] = {
 };
 
 static gboolean opt_version;
+static gboolean opt_quiet;
 static gboolean opt_force_peer;
 static char *opt_sysroot;
 static gchar **opt_install;
@@ -135,6 +136,8 @@ static gchar **opt_uninstall;
 
 static GOptionEntry global_entries[] = { { "version", 0, 0, G_OPTION_ARG_NONE, &opt_version,
                                            "Print version information and exit", NULL },
+                                         { "quiet", 'q', 0, G_OPTION_ARG_NONE, &opt_quiet,
+                                           "Avoid printing most informational messages", NULL },
                                          { NULL } };
 
 static GOptionEntry daemon_entries[]
@@ -210,6 +213,13 @@ client_throw_non_ostree_host_error (GError **error)
 }
 
 } /* namespace */
+
+// Returns TRUE if the global quiet flag was specified
+bool
+rpmostree_global_quiet (void)
+{
+  return opt_quiet;
+}
 
 gboolean
 rpmostree_option_context_parse (GOptionContext *context, const GOptionEntry *main_entries,

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -63,6 +63,8 @@ BUILTINPROTO (initramfs_etc);
 
 #undef BUILTINPROTO
 
+bool rpmostree_global_quiet (void);
+
 gboolean rpmostree_option_context_parse (GOptionContext *context, const GOptionEntry *main_entries,
                                          int *argc, char ***argv,
                                          RpmOstreeCommandInvocation *invocation,

--- a/src/daemon/rpm-ostreed-automatic.service
+++ b/src/daemon/rpm-ostreed-automatic.service
@@ -5,5 +5,4 @@ ConditionPathExists=/run/ostree-booted
 
 [Service]
 Type=simple
-ExecStart=rpm-ostree upgrade --trigger-automatic-update-policy
-StandardOutput=null
+ExecStart=rpm-ostree upgrade --quiet --trigger-automatic-update-policy


### PR DESCRIPTION
This replaces the need for `StandardOutput=null` in the automatic upgrade unit, and can also be used for custom upgrade units, such as that proposed in
https://github.com/coreos/fedora-coreos-docs/pull/540
