### PR TITLE
scripts: Ignore kernel-redhat `%posttrans` scripts

### DIFF
--- a/rust/src/scripts.rs
+++ b/rust/src/scripts.rs
@@ -21,7 +21,9 @@ static IGNORED_PKG_SCRIPTS: phf::Set<&'static str> = phf_set! {
     // XXX: we should probably change this to instead ignore based on the kernel virtual Provides
     "kernel.posttrans",
     "kernel-core.posttrans",
+    "kernel-redhat-core.posttrans",
     "kernel-debug-core.posttrans",
+    "kernel-redhat-debug-core.posttrans",
     "kernel-automotive-core.posttrans",
     "kernel-automotive-debug-core.posttrans",
     "kernel-automotive-debug-modules.posttrans",


### PR DESCRIPTION
Red Hat is planning to rename the kernel package to `kernel-redhat` in a future minor release of RHEL 9 (see related fedmag post[[1]]).

Extend the `%posttrans` hack to cover these new packages.

[1]: https://fedoramagazine.org/changes-eln-kernel-rpm-nvr/