### PR TITLE
output: More daemon-side progress debugging

### DIFF
--- a/src/libpriv/rpmostree-output.h
+++ b/src/libpriv/rpmostree-output.h
@@ -35,6 +35,9 @@ enum class ProgressType
 
 void output_message (rust::Str msg);
 
+// Implementation detail of Progress
+guint64 _output_alloc_serial (void);
+
 struct Progress
 {
 public:
@@ -52,7 +55,9 @@ public:
   {
     ptype = t;
     ended = false;
+    serial = _output_alloc_serial ();
   }
+  guint64 serial;
   ProgressType ptype;
   bool ended;
 };


### PR DESCRIPTION
- Allocate a unique serial per Progress instance
- Output the serial alongside the text, which is really a unique string format that will tell us where in the code it's being called
- Add `g_debug()` output with both in the constructors, and just the serial in other methods

This should help us figure out on the daemon side which specific code is trying to do a percent progress while we have a plain task.

cc https://github.com/coreos/rpm-ostree/issues/4284
