### PR TITLE
Make output handling thread-local

### DIFF
--- a/src/libpriv/rpmostree-output.h
+++ b/src/libpriv/rpmostree-output.h
@@ -81,7 +81,8 @@ typedef enum
 
 void rpmostree_output_default_handler (RpmOstreeOutputType type, void *data, void *opaque);
 
-void rpmostree_output_set_callback (void (*cb) (RpmOstreeOutputType, void *, void *), void *);
+typedef void (*OutputCallback) (RpmOstreeOutputType, void *, void *);
+void rpmostree_output_set_callback (OutputCallback cb, void *);
 
 typedef struct
 {


### PR DESCRIPTION
This is needed because for transactions (which are always run in a thread today) we want output to go to the transaction's DBus progress.  But for other methods which are not transactions, we don't have a channel for status reporting, so output needs to
continue to go to the journal.   If we mix these two things due to
concurrent method invocations, the client may get confused and crash.

Closes: https://github.com/coreos/rpm-ostree/issues/4284
