### PR TITLE
Add an `exp` verb

### DIFF
--- a/rust/src/experimental.rs
+++ b/rust/src/experimental.rs
@@ -1,0 +1,67 @@
+//! Handling for the `rpm-ostree exp` verb, which will be the successor to `ex`.
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+#[derive(Debug, Subcommand)]
+enum ContainerCommand {
+    Diff {
+        /// The source/original image
+        from: String,
+
+        /// The target/destination image
+        to: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    Container {
+        #[clap(subcommand)]
+        command: ContainerCommand,
+    },
+}
+
+#[derive(Debug, Parser)]
+/// Experimental subcommands; there are no stability guarantees.
+///
+/// Typically these are useful for debugging/introspection.
+struct Exp {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+impl ContainerCommand {
+    async fn run(self) -> Result<()> {
+        match self {
+            ContainerCommand::Diff { from, to } => {
+                let proxy = containers_image_proxy::ImageProxy::new().await?;
+                let prev_manifest = {
+                    let oi = &proxy.open_image(&from).await?;
+                    proxy.fetch_manifest(oi).await?.1
+                };
+                let new_manifest = {
+                    let oi = &proxy.open_image(&to).await?;
+                    proxy.fetch_manifest(oi).await?.1
+                };
+
+                let diff = ostree_ext::container::manifest_diff(&prev_manifest, &new_manifest);
+                diff.print();
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Command {
+    async fn run(self) -> Result<()> {
+        match self {
+            Command::Container { command } => command.run().await,
+        }
+    }
+}
+
+pub async fn entrypoint(args: Vec<String>) -> Result<()> {
+    let args = Exp::parse_from(args.into_iter().skip(1));
+    args.command.run().await
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -918,6 +918,7 @@ pub(crate) use deployment_utils::*;
 mod dirdiff;
 pub mod failpoints;
 use failpoints::*;
+pub mod experimental;
 mod extensions;
 pub(crate) use extensions::*;
 #[cfg(feature = "fedora-integration")]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -19,6 +19,19 @@ use termcolor::WriteColor;
 // those, and if there's something we don't know about, invoke the C++
 // main().
 async fn inner_async_main(args: Vec<String>) -> Result<i32> {
+    if let Some(argv1) = args.get(1) {
+        // CLI verbs matched here are native Rust async functions.  However, they will
+        // currently *not* show up in rpm-ostree --help.  Which today limits them to the
+        // `exp` function here.
+        match argv1.as_str() {
+            "exp" => {
+                return rpmostree_rust::experimental::entrypoint(args)
+                    .await
+                    .map(|()| 0);
+            }
+            _ => { /* fallthrough */ }
+        }
+    }
     // Everything below here is a blocking API, and run on a worker thread so
     // that the main thread is dedicated to the Tokio reactor.
     tokio::task::spawn_blocking(move || -> Result<i32, anyhow::Error> {


### PR DESCRIPTION
Often now when I want to add some quick new experimental entrypoint the ergonomic hit from having to write C++ and pass through the arguments via the existing `ex` is painful.

Actually today, almost all the `ex` bits are in Rust natively, so we could fix that.  However, that'd be some nontrivial code churn.

Add a new `exp` verb that is natively in Rust to start, and add a `container diff` command that just exposes the logic we landed in ostree-ext for this.  I will use this to evaluate the new chunking work.
