### PR TITLE
Port to clap v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,13 +305,37 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.25",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+dependencies = [
+ "clap_builder",
+ "clap_derive 4.2.0",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex 0.4.1",
+ "strsim",
 ]
 
 [[package]]
@@ -279,6 +352,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +371,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "cmake"
@@ -305,6 +396,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console"
@@ -1729,7 +1826,7 @@ dependencies = [
  "cap-std-ext",
  "cap-tempfile",
  "chrono",
- "clap",
+ "clap 3.2.25",
  "containers-image-proxy",
  "flate2",
  "fn-error-context",
@@ -2123,7 +2220,7 @@ dependencies = [
  "cap-std-ext",
  "cap-tempfile",
  "chrono",
- "clap",
+ "clap 4.2.7",
  "containers-image-proxy",
  "cxx",
  "either",
@@ -2812,6 +2909,12 @@ name = "utf8-cstr"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ rustix = { version = "0.36", features = ["use-libc"] }
 cap-primitives = "1.0.3"
 cap-tempfile = "1.0.1"
 chrono = { version = "0.4.23", features = ["serde"] }
-clap = { version = "3.2.23", features = ["derive"] }
+clap = { version = "4.2", features = ["derive"] }
 cxx = "1.0.82"
 envsubst = "0.2.1"
 either = "1.8.1"

--- a/rust/src/builtins/usroverlay.rs
+++ b/rust/src/builtins/usroverlay.rs
@@ -21,7 +21,7 @@ pub fn entrypoint(args: &[&str]) -> Result<()> {
 }
 
 /// CLI parser, handle --help and error on extra arguments.
-fn cli_cmd() -> Command<'static> {
+fn cli_cmd() -> Command {
     Command::new("rpm-ostree usroverlay")
         .bin_name("rpm-ostree usroverlay")
         .long_version("")

--- a/rust/src/cliwrap/rpm.rs
+++ b/rust/src/cliwrap/rpm.rs
@@ -6,10 +6,11 @@ use crate::cliwrap::cliutil;
 use crate::cliwrap::RunDisposition;
 use crate::ffi::SystemHostType;
 
-fn new_rpm_app() -> Command<'static> {
+fn new_rpm_app() -> Command {
     let name = "cli-ostree-wrapper-rpm";
     Command::new(name)
         .bin_name(name)
+        .disable_version_flag(true)
         .version("0.1")
         .about("Wrapper for rpm")
         .arg(Arg::new("verify").short('V').long("verify"))
@@ -21,7 +22,6 @@ fn new_rpm_app() -> Command<'static> {
         .arg(
             Arg::new("package")
                 .help("package")
-                .takes_value(true)
                 .action(clap::ArgAction::Append),
         )
 }
@@ -64,7 +64,9 @@ fn disposition(host: SystemHostType, argv: &[&str]) -> Result<RunDisposition> {
     let app = new_rpm_app();
     let matches = match app.try_get_matches_from(std::iter::once(&"rpm").chain(argv.iter())) {
         Ok(v) => v,
-        Err(e) if e.kind() == clap::ErrorKind::DisplayVersion => return Ok(RunDisposition::Ok),
+        Err(e) if e.kind() == clap::error::ErrorKind::DisplayVersion => {
+            return Ok(RunDisposition::Ok)
+        }
         Err(_) => {
             return Ok(RunDisposition::Warn);
         }


### PR DESCRIPTION
This Just Worked for the derive case, but man the builder/imperative path is painful.

This will pair with https://github.com/ostreedev/ostree-rs-ext/pull/381 so that we only have one version of clap in our depchain.