### PR TITLE
compose: Also propagate ex-{fsverity,composefs}

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -2121,6 +2121,10 @@ extern "C"
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$compose_image (::rust::Vec< ::rust::String> *args) noexcept;
 
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$configure_build_repo_from_target (
+      const ::rpmostreecxx::OstreeRepo &build_repo,
+      const ::rpmostreecxx::OstreeRepo &target_repo) noexcept;
+
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$compose_prepare_rootfs (::std::int32_t src_rootfs_dfd,
                                                   ::std::int32_t dest_rootfs_dfd,
@@ -3834,6 +3838,18 @@ compose_image (::rust::Vec< ::rust::String> args)
 {
   ::rust::ManuallyDrop< ::rust::Vec< ::rust::String> > args$ (::std::move (args));
   ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$compose_image (&args$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
+}
+
+void
+configure_build_repo_from_target (const ::rpmostreecxx::OstreeRepo &build_repo,
+                                  const ::rpmostreecxx::OstreeRepo &target_repo)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$configure_build_repo_from_target (build_repo, target_repo);
   if (error$.ptr)
     {
       throw ::rust::impl< ::rust::Error>::error (error$);

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1800,6 +1800,9 @@ bool commit_has_matching_sepolicy (const ::rpmostreecxx::GVariant &commit,
 
 void compose_image (::rust::Vec< ::rust::String> args);
 
+void configure_build_repo_from_target (const ::rpmostreecxx::OstreeRepo &build_repo,
+                                       const ::rpmostreecxx::OstreeRepo &target_repo);
+
 void compose_prepare_rootfs (::std::int32_t src_rootfs_dfd, ::std::int32_t dest_rootfs_dfd,
                              ::rpmostreecxx::Treefile &treefile);
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -243,6 +243,11 @@ pub mod ffi {
     // compose.rs
     extern "Rust" {
         fn compose_image(args: Vec<String>) -> Result<()>;
+
+        fn configure_build_repo_from_target(
+            build_repo: &OstreeRepo,
+            target_repo: &OstreeRepo,
+        ) -> Result<()>;
     }
 
     // composepost.rs

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -694,32 +694,10 @@ rpm_ostree_compose_context_new (const char *treefile_pathstr, const char *basear
       if (!self->build_repo)
         return glnx_prefix_error (error, "Creating repo-build");
 
-      OstreeRepo *cache_repos[2] = { self->pkgcache_repo, self->build_repo };
-
-      GKeyFile *src_config = ostree_repo_get_config (self->repo);
-      // g_key_file_get_boolean has broken GError API
-      g_autoptr (GError) temp_error = NULL;
-      gboolean src_fsync = g_key_file_get_boolean (src_config, "core", "fsync", &temp_error);
-      if (!temp_error && !src_fsync)
-        {
-          gboolean did_disable = FALSE;
-          for (guint i = 0; i < G_N_ELEMENTS (cache_repos); i++)
-            {
-              OstreeRepo *cacherepo = cache_repos[i];
-              g_autoptr (GKeyFile) cache_config = ostree_repo_copy_config (cacherepo);
-              gboolean fsync = g_key_file_get_boolean (cache_config, "core", "fsync", &temp_error);
-              if (temp_error || fsync)
-                {
-                  did_disable = TRUE;
-                  g_key_file_set_boolean (cache_config, "core", "fsync", FALSE);
-                  if (!ostree_repo_write_config (cacherepo, cache_config, error))
-                    return FALSE;
-                }
-              g_clear_error (&temp_error);
-            }
-          if (did_disable)
-            g_print ("Disabled fsync on cache repositories\n");
-        }
+      CXX_TRY (rpmostreecxx::configure_build_repo_from_target (*self->pkgcache_repo, *self->repo),
+               error);
+      CXX_TRY (rpmostreecxx::configure_build_repo_from_target (*self->build_repo, *self->repo),
+               error);
 
       /* Note special handling of this aliasing in rpm_ostree_tree_compose_context_free() */
       self->workdir_dfd = self->workdir_tmp.fd;


### PR DESCRIPTION
compose: Oxidize bits propagating `core.fsync`

Prep for synchronizing the composefs keys too, but also
on general principle.

---

compose: Also propagate ex-{fsverity,composefs}

To aid https://github.com/ostreedev/ostree/pull/2640

---

