### PR TITLE
build-sys: Use new `tier = 2` from cargo-vendor-filterer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ publish = false
 
 # See https://github.com/cgwalters/cargo-vendor-filterer
 [package.metadata.vendor-filter]
-platforms = ["x86_64-unknown-linux-gnu", "s390x-unknown-linux-gnu"]
+platforms = ["*-unknown-linux-gnu"]
+tier = "2"
 all-features = true
 exclude-crate-paths = [ { name = "libz-sys", exclude = "src/zlib" },
                         { name = "libz-sys", exclude = "src/zlib-ng" },


### PR DESCRIPTION
This is nicer than having a hardcoded list.
