### PR TITLE
importer: Drop non-root files in CPIO check

### DIFF
--- a/rust/src/importer.rs
+++ b/rust/src/importer.rs
@@ -346,16 +346,9 @@ fn tweak_imported_file_info(file_info: &FileInfo, ro_executables: bool) {
 #[context("Analyzing {}", path)]
 fn import_filter(
     path: &str,
-    file_info: &FileInfo,
+    _file_info: &FileInfo,
     skip_extraneous: bool,
 ) -> Result<RepoCommitFilterResult> {
-    // Sanity check that RPM isn't using CPIO id fields.
-    let uid = file_info.attribute_uint32("unix::uid");
-    let gid = file_info.attribute_uint32("unix::gid");
-    if uid != 0 || gid != 0 {
-        bail!("Unexpected non-root owned path (marked as {}:{})", uid, gid);
-    }
-
     // Skip some empty lock files, they are known to cause problems:
     // https://github.com/projectatomic/rpm-ostree/pull/1002
     if path.starts_with("/usr/etc/selinux") && path.ends_with(".LOCK") {


### PR DESCRIPTION
rpm upstream did
https://github.com/rpm-software-management/rpm/commit/0f957330f24cdb2510e0bbdface54ffa8064b8ce

The file metadata is still duplicated in the header, and *that* seems unlikely to change soon.  So we can just safely drop this "sanity check".

Closes: https://github.com/coreos/rpm-ostree/issues/4437
