### PR TITLE
core: Error out instead of aborting on reinstalls

### DIFF
--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -1466,7 +1466,18 @@ check_goal_solution (RpmOstreeContext *self, GPtrArray *removed_pkgnames,
    * for it anyway so that we get a bug report in case it somehow happens. */
   {
     g_autoptr (GPtrArray) packages = dnf_goal_get_packages (goal, DNF_PACKAGE_INFO_REINSTALL, -1);
-    g_assert_cmpint (packages->len, ==, 0);
+    if (packages->len > 0)
+      {
+        g_autoptr (GString) buf = g_string_new ("");
+        for (guint i = 0; i < packages->len; i++)
+          {
+            if (i > 0)
+              g_string_append_c (buf, ' ');
+            auto pkg = static_cast<DnfPackage *> (packages->pdata[i]);
+            g_string_append (buf, dnf_package_get_name (pkg));
+          }
+        return glnx_throw (error, "Request to reinstall exact base package versions: %s", buf->str);
+      }
   }
 
   /* Look at UPDATE and DOWNGRADE, and see whether they're doing what we expect */


### PR DESCRIPTION
I think originally something higher level was intending to catch this "reinstall exact base package version" case, but it's way simpler to just return a clear error here instead of crashing.

Assertions should only be used for things we're *pretty sure* can't be reached and particularly when it may be a hard to recover from internal consistency error.  That's not the case here.

Closes: https://github.com/coreos/rpm-ostree/issues/4141
