### PR TITLE
packaging/rpm-ostree.spec.in: use SPDX license identifier

### DIFF
--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -5,7 +5,7 @@ Summary: Hybrid image/package system
 Name: rpm-ostree
 Version: 2023.4
 Release: 1%{?dist}
-License: LGPLv2+
+License: LGPL-2.0-or-later
 URL: https://github.com/coreos/rpm-ostree
 # This tarball is generated via "cd packaging && make -f Makefile.dist-packaging dist-snapshot"
 # in the upstream git.  It also contains vendored Rust sources.


### PR DESCRIPTION
Updating the template to follow:
https://docs.fedoraproject.org/en-US/legal/update-existing-packages/
rawhide packages have been updated as well: https://github.com/coreos/fedora-coreos-tracker/issues/1497