### PR TITLE
Bump ostree ext &&  Drop isolation when fetching from containers-storage:

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "ostree-ext"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8903d59c4a56794b6ef8a2b11a5674fe85b370f1da33ae34450a6de1e39a20d6"
+checksum = "a690495144c18cb333a67a2ec61dd008831710bbd37804cfa79ab93b51146a6f"
 dependencies = [
  "anyhow",
  "async-compression 0.3.15",

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -56,12 +56,20 @@ async fn layer_progress_print(mut r: Receiver<ImportProgress>) {
     }
 }
 
-fn default_container_pull_config() -> Result<ImageProxyConfig> {
+fn default_container_pull_config(imgref: &OstreeImageReference) -> Result<ImageProxyConfig> {
     let mut cfg = ImageProxyConfig::default();
-    let isolation_systemd = crate::utils::running_in_systemd().then(|| "rpm-ostree");
-    let isolation_default = rustix::process::getuid().is_root().then(|| "nobody");
-    let isolation_user = isolation_systemd.or(isolation_default);
-    ostree_container::merge_default_container_proxy_opts_with_isolation(&mut cfg, isolation_user)?;
+    if imgref.imgref.transport == ostree_container::Transport::ContainerStorage {
+        // Fetching from containers-storage, may require privileges to read files
+        ostree_container::merge_default_container_proxy_opts_with_isolation(&mut cfg, None)?;
+    } else {
+        let isolation_systemd = crate::utils::running_in_systemd().then(|| "rpm-ostree");
+        let isolation_default = rustix::process::getuid().is_root().then(|| "nobody");
+        let isolation_user = isolation_systemd.or(isolation_default);
+        ostree_container::merge_default_container_proxy_opts_with_isolation(
+            &mut cfg,
+            isolation_user,
+        )?;
+    }
     Ok(cfg)
 }
 
@@ -70,7 +78,7 @@ async fn pull_container_async(
     imgref: &OstreeImageReference,
 ) -> Result<ContainerImageState> {
     output_message(&format!("Pulling manifest: {}", &imgref));
-    let config = default_container_pull_config()?;
+    let config = default_container_pull_config(imgref)?;
     let mut imp = ImageImporter::new(repo, imgref, config).await?;
     let layer_progress = imp.request_progress();
     let prep = match imp.prepare().await? {

--- a/src/daemon/rpm-ostreed.service
+++ b/src/daemon/rpm-ostreed.service
@@ -20,10 +20,6 @@ MountFlags=slave
 # and have a system rpm-ostreed-transaction.service that runs privileged
 # but as a subprocess.
 ProtectHome=true
-# Explicitly list paths here which we should never access.  The initial
-# entry here ensures that the skopeo process we fork won't interact with
-# application containers.
-BindReadOnlyPaths=-/var/lib/containers
 NotifyAccess=main
 # Significantly bump this timeout from the default because
 # we do a lot of stuff on daemon startup.

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -162,9 +162,7 @@ EOF
     if test "${touched_resolv_conf}" -eq 1; then
       rm -vf /etc/resolv.conf
     fi
-    derived=oci:$image_dir:derived
-    skopeo copy containers-storage:localhost/fcos-derived $derived
-    rpm-ostree rebase ostree-unverified-image:$derived
+    rpm-ostree rebase ostree-unverified-image:containers-storage:localhost/fcos-derived
     ostree container image list --repo=/ostree/repo | tee imglist.txt
     assert_streq "$(wc -l < imglist.txt)" 1
     rm $image_dir -rf
@@ -181,7 +179,7 @@ EOF
     assert_streq $(rpm -q baz) baz-2.0-1.${arch}
     test -f /usr/bin/baz
     ! rpm -q nano
-    rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"ostree-unverified-image:oci:$image_dir:derived\""
+    rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"ostree-unverified-image:containers-storage:localhost/fcos-derived\""
 
     # We'll test the "apply" automatic updates policy here
     systemctl stop rpm-ostreed
@@ -190,9 +188,7 @@ EOF
     rpm-ostree reload
 
     # Now revert back to the base image, but keep our layered package foo
-    rm "${image_dir}" -rf
-    skopeo copy containers-storage:localhost/fcos ${image}:latest
-    rpm-ostree rebase ostree-unverified-image:${image}:latest
+    rpm-ostree rebase ostree-unverified-image:containers-storage:localhost/fcos
     /tmp/autopkgtest-reboot 4
     ;;
   4) 
@@ -204,7 +200,7 @@ EOF
         fatal "found $p"
       fi
     done
-    rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"ostree-unverified-image:oci:$image_dir:latest\""
+    rpmostree_assert_status ".deployments[0][\"container-image-reference\"] == \"ostree-unverified-image:containers-storage:localhost/fcos\""
     ;;
   *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
 esac


### PR DESCRIPTION
Bump to ostree-ext 0.11.1

Mainly for the pulling from containers-storage fixes.

---

Drop isolation when fetching from containers-storage:

This enables
`rpm-ostree rebase ostree-unverified-image:containers-storage:localhost/mytestimage`

The history here is pretty fun:

- I changed rpm-ostreed to block access to `/var/lib/containers`
  in https://github.com/cgwalters/rpm-ostree/commit/94666faad0d403f5830184d10b1729236d783a41
- We added basic support for fetching from containers-storage in
  https://github.com/ostreedev/ostree-rs-ext/pull/396
  which worked for ostree, but not rpm-ostree because of the above
- Then we changed to isolate skopeo fetches by default
  https://github.com/ostreedev/ostree-rs-ext/pull/413/commits/48dfc0b74dc12bd11b0d697ba5302a6188ad795e
  which broke it in ostree too, but only when running under systemd
  so this wasn't quite caught by our tests
- We fixed the isolation in ostree in
  https://github.com/ostreedev/ostree-rs-ext/pull/492

But finally, we also need to adapt our own distinct isolation setup to
do the same thing *and* we also need to drop the systemd unit
isolation which we don't need anymore because we drop privileges
by default (except when fetching from container-storage)

Closes: https://github.com/coreos/rpm-ostree/issues/4283

---

