### PR TITLE
Add a `search` CLI verb and DBus API 

### DIFF
--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -329,6 +329,20 @@ Boston, MA 02111-1307, USA.
       </varlistentry>
 
       <varlistentry>
+        <term><command>search</command></term>
+
+        <listitem>
+          <para>
+            Takes one or more query terms as arguments. The packages are
+            searched within the enabled repositories in
+            <filename>/etc/yum.repos.d/</filename>. Packages can be
+            overlayed and removed using the <command>install</command> 
+            and <command>uninstall</command> commands.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><command>rebase</command></term>
 
         <listitem>

--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -73,6 +73,8 @@ static RpmOstreeCommand commands[] = {
     "Overlay additional packages", rpmostree_builtin_install },
   { "uninstall", static_cast<RpmOstreeBuiltinFlags> (RPM_OSTREE_BUILTIN_FLAG_CONTAINER_CAPABLE),
     "Remove overlayed additional packages", rpmostree_builtin_uninstall },
+  { "search", static_cast<RpmOstreeBuiltinFlags> (RPM_OSTREE_BUILTIN_FLAG_CONTAINER_CAPABLE),
+    "Search for packages", rpmostree_builtin_search },
   { "override", static_cast<RpmOstreeBuiltinFlags> (RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD),
     "Manage base package overrides", rpmostree_builtin_override },
   { "reset", static_cast<RpmOstreeBuiltinFlags> (RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS),

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -50,6 +50,7 @@ BUILTINPROTO (internals);
 BUILTINPROTO (container);
 BUILTINPROTO (install);
 BUILTINPROTO (uninstall);
+BUILTINPROTO (search);
 BUILTINPROTO (override);
 BUILTINPROTO (kargs);
 BUILTINPROTO (reset);

--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -31,6 +31,8 @@
 
 #include <gio/gunixfdlist.h>
 
+#include <set>
+
 static char *opt_osname;
 static gboolean opt_reboot;
 static gboolean opt_dry_run;
@@ -309,4 +311,103 @@ rpmostree_builtin_uninstall (int argc, char **argv, RpmOstreeCommandInvocation *
 
   return pkg_change (invocation, sysroot_proxy, FALSE, (const char *const *)opt_install,
                      (const char *const *)argv, cancellable, error);
+}
+
+struct cstrless
+{
+  bool
+  operator() (const gchar *a, const gchar *b) const
+  {
+    return strcmp (a, b) < 0;
+  }
+};
+
+gboolean
+rpmostree_builtin_search (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+                          GCancellable *cancellable, GError **error)
+{
+  GOptionContext *context;
+  glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
+
+  context = g_option_context_new ("PACKAGE [PACKAGE...]");
+  g_option_context_add_main_entries (context, install_option_entry, NULL);
+  g_option_context_add_main_entries (context, uninstall_option_entry, NULL);
+
+  if (!rpmostree_option_context_parse (context, option_entries, &argc, &argv, invocation,
+                                       cancellable, NULL, NULL, &sysroot_proxy, error))
+    return FALSE;
+
+  if (argc < 2)
+    {
+      rpmostree_usage_error (context, "At least one PACKAGE must be specified", error);
+      return FALSE;
+    }
+
+  glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
+
+  if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname, cancellable, &os_proxy, error))
+    return FALSE;
+
+  g_autoptr (GPtrArray) arg_names = g_ptr_array_new ();
+  for (guint i = 1; i < argc; i++)
+    {
+      g_ptr_array_add (arg_names, (char *)argv[i]);
+    }
+  g_ptr_array_add (arg_names, NULL);
+
+  g_autoptr (GVariant) out_packages = NULL;
+
+  if (!rpmostree_os_call_search_sync (os_proxy, (const char *const *)arg_names->pdata,
+                                      &out_packages, cancellable, error))
+    return FALSE;
+
+  g_autoptr (GVariantIter) iter1 = NULL;
+  g_variant_get (out_packages, "aa{sv}", &iter1);
+
+  g_autoptr (GVariantIter) iter2 = NULL;
+  std::set<const gchar *, cstrless> query_set;
+
+  while (g_variant_iter_loop (iter1, "a{sv}", &iter2))
+    {
+      const gchar *key;
+      const gchar *name;
+      const gchar *summary;
+      const gchar *query;
+      const gchar *match_group = "";
+
+      g_autoptr (GVariant) value = NULL;
+
+      while (g_variant_iter_loop (iter2, "{sv}", &key, &value))
+        {
+          if (strcmp (key, "key") == 0)
+            g_variant_get (value, "s", &query);
+          else if (strcmp (key, "name") == 0)
+            g_variant_get (value, "s", &name);
+          else if (strcmp (key, "summary") == 0)
+            g_variant_get (value, "s", &summary);
+        }
+
+      if (!query_set.count (query))
+        {
+          query_set.insert (query);
+
+          if (strcmp (query, "match_group_a") == 0)
+            match_group = "Summary & Name";
+          else if (strcmp (query, "match_group_b") == 0)
+            match_group = "Name";
+          else if (strcmp (query, "match_group_c") == 0)
+            match_group = "Summary";
+
+          g_print ("\n===== %s Matched =====\n", match_group);
+        }
+
+      g_print ("%s : %s\n", name, summary);
+    }
+
+  if (query_set.size () == 0)
+    {
+      g_print ("No matches found.");
+    }
+
+  return TRUE;
 }

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -477,6 +477,12 @@
       <arg type="aa{sv}" name="packages" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantList"/>
     </method>
+    
+    <method name="Search">
+      <arg type="as" name="names" direction="in"/>
+      <arg type="aa{sv}" name="packages" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantList"/>
+    </method>
   </interface>
 
   <interface name="org.projectatomic.rpmostree1.OSExperimental">


### PR DESCRIPTION
Fixes #1877 

Implemented Features:
- Builtin `search` command for rpm-ostree to search for packages within the set of repos (`rpm-ostree search kernel`)
- Allows multiple search terms (`rpm-ostree search kernel python`)
- Allows glob patterns (`rpm-ostree search *kernel`)

Edge cases covered:
- Returns from function when no packages are specified
- Outputs `No matches found.` when no packages match the search query