### PR TITLE
sysuers: fix error if running `groupadd` with `-f`

### DIFF
--- a/rust/src/builtins/scriptlet_intercept/groupadd.rs
+++ b/rust/src/builtins/scriptlet_intercept/groupadd.rs
@@ -46,7 +46,12 @@ fn cli_cmd() -> Command {
     Command::new(name)
         .bin_name(name)
         .about("create a new group")
-        .arg(Arg::new("force").short('f').long("force"))
+        .arg(
+            Arg::new("force")
+                .short('f')
+                .long("force")
+                .action(ArgAction::SetTrue),
+        )
         .arg(
             Arg::new("gid")
                 .short('g')


### PR DESCRIPTION
According to Colin's pointer, this is to fix the error when running `rpm-ostree install libvirt` in container,
```
bash# env RPMOSTREE_EXP_BRIDGE_SYSUSERS=1 rpm-ostree install libvirt
...
+ test -v RPMOSTREE_EXP_BRIDGE_SYSUSERS
+ rpm-ostree scriptlet-intercept groupadd -- /sbin/groupadd -f -g 107 -r qemu
error: a value is required for '--force <force>' but none was supplied

For more information, try '--help'.
```