### PR TITLE
Add `kola` tests and fix `Name & Summary` search

### DIFF
--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -406,7 +406,7 @@ rpmostree_builtin_search (int argc, char **argv, RpmOstreeCommandInvocation *inv
 
   if (query_set.size () == 0)
     {
-      g_print ("No matches found.");
+      g_print ("No matches found.\n");
     }
 
   return TRUE;

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -101,6 +101,39 @@ rpmostree_busctl_call_os GetPackages as 1 should-not-exist-p-equals-np > out.txt
 assert_file_has_content_literal out.txt 'aa{sv} 0'
 echo "ok dbus GetPackages"
 
+rpmostree_busctl_call_os Search as 1 testdaemon > out.txt
+assert_file_has_content_literal out.txt '"epoch" t 0'
+assert_file_has_content_literal out.txt '"reponame" s "libtest"'
+assert_file_has_content_literal out.txt '"nevra" s "testdaemon'
+rpmostree_busctl_call_os Search as 1 should-not-exist-p-equals-np > out.txt
+assert_file_has_content_literal out.txt 'aa{sv} 0'
+echo "ok dbus Search"
+
+rpm-ostree search testdaemon > out.txt
+assert_file_has_content_literal out.txt '===== Name Matched ====='
+assert_file_has_content_literal out.txt 'testdaemon : awesome-daemon-for-testing'
+echo "ok Search name match"
+
+rpm-ostree search awesome-daemon > out.txt
+assert_file_has_content_literal out.txt '===== Summary Matched ====='
+assert_file_has_content_literal out.txt 'testdaemon : awesome-daemon-for-testing'
+echo "ok Search summary match"
+
+rpm-ostree search testdaemon awesome-daemon > out.txt
+assert_file_has_content_literal out.txt '===== Summary & Name Matched ====='
+assert_file_has_content_literal out.txt 'testdaemon : awesome-daemon-for-testing'
+echo "ok Search name and summary match"
+
+rpm-ostree search "test*" > out.txt
+assert_file_has_content_literal out.txt '===== Summary & Name Matched ====='
+assert_file_has_content_literal out.txt '===== Name Matched ====='
+assert_file_has_content_literal out.txt '===== Summary Matched ====='
+assert_file_has_content_literal out.txt 'testdaemon : awesome-daemon-for-testing'
+assert_file_has_content_literal out.txt 'testpkg-etc : testpkg-etc'
+assert_file_has_content_literal out.txt 'testpkg-post-infinite-loop : testpkg-post-infinite-loop'
+assert_file_has_content_literal out.txt 'testpkg-touch-run : testpkg-touch-run'
+echo "ok Search glob pattern match"
+
 # Verify operations as non-root
 runuser -u core rpm-ostree status
 echo "ok status doesn't require root"


### PR DESCRIPTION
Fixes #1877 

**New Implementations:**
- `kola` tests added
- Duplicate package removal feature fixed
- `Name & Summary` search feature fixed

**As stated in the commit message:**
Previously, the `Name & Summary` search function would only return results that contained ALL search terms within BOTH the name and summary. With this commit, results in which search terms match EITHER the name or summary will be returned. This better matches `dnf`/`yum` CLI functionality.

**Old `Name & Summary` search function:**
```
$ rpm-ostree search python3-jupyroot

===== Name Matched =====
python3-jupyroot : ROOT Jupyter kernel
```
```
$ rpm-ostree search python3-jupyroot kernel

No matches found.
```

**New `Name & Summary` search function:**
```
$ rpm-ostree search python3-jupyroot

===== Name Matched =====
python3-jupyroot : ROOT Jupyter kernel
```
```
$ rpm-ostree search python3-jupyroot kernel

===== Summary & Name Matched =====
python3-jupyroot : ROOT Jupyter kernel
```

