### PR TITLE
ci/test-container.sh: use f37 ignition for replace test

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -58,8 +58,6 @@ versionid=$(. /usr/lib/os-release && echo $VERSION_ID)
 # Let's start by trying to install a bona fide module.
 # NOTE: If changing this also change the layering-modules test
 case $versionid in
-  36) module=cri-o:1.23/default;;
-  37) module=cri-o:1.24/default;;
   38) module=cri-o:1.25/default;;
   *) assert_not_reached "Unsupported Fedora version: $versionid";;
 esac
@@ -77,16 +75,8 @@ fi
 versionid=$(grep -E '^VERSION_ID=' /etc/os-release)
 versionid=${versionid:11} # trim off VERSION_ID=
 case $versionid in
-  37)
-    url_suffix=2.14.0/3.fc37/x86_64/ignition-2.14.0-3.fc37.x86_64.rpm
-    # 2.14.0-4
-    koji_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=2013062"
-    koji_kernel_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=2084352"
-    kver=6.0.7
-    krev=301
-    ;;
   38)
-    url_suffix=2.15.0/2.fc38/x86_64/ignition-2.15.0-2.fc38.x86_64.rpm
+    url_suffix=2.15.0/4.fc37/x86_64/ignition-2.15.0-4.fc37.x86_64.rpm
     # 2.15.0-3
     koji_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=2158585"
     koji_kernel_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=2174317"


### PR DESCRIPTION
- Use the fedora 37 ignition rpm for the override replace test
- Drop f36 and f37 tests

Took some of what @cgwalters did on #4496 that would need to be rebased after this.