### PR TITLE
passwd: sync `etc/{,g}shadow` according to `etc/{passwd,group}`

### DIFF
--- a/rust/src/passwd.rs
+++ b/rust/src/passwd.rs
@@ -315,8 +315,8 @@ fn passwd_compose_prep_impl(
     rootfs.create_dir_with(dest, &db)?;
 
     // TODO(lucab): consider reworking these to avoid boolean results.
-    let found_passwd_data = data_from_json(rootfs, treefile, dest, "passwd")?;
-    let found_groups_data = data_from_json(rootfs, treefile, dest, "group")?;
+    let found_passwd_data = write_data_from_treefile(rootfs, treefile, dest, "passwd")?;
+    let found_groups_data = write_data_from_treefile(rootfs, treefile, dest, "group")?;
 
     // We should error if we are getting passwd data from JSON and group from
     // previous commit, or vice versa, as that'll confuse everyone when it goes
@@ -340,7 +340,9 @@ fn passwd_compose_prep_impl(
     Ok(())
 }
 
-fn data_from_json(
+// This function writes the static passwd/group data from the treefile to the
+// target root filesystem.
+fn write_data_from_treefile(
     rootfs: &Dir,
     treefile: &mut Treefile,
     dest_path: &str,


### PR DESCRIPTION
passwd: Rename func `data_from_json` to `write_data_from_treefile`

---

passwd: sync `etc/{,g}shadow` according to `etc/{passwd,group}`

Refer to https://github.com/coreos/rpm-ostree/issues/49#issuecomment-1612626563, do testing:
1. Remove bin line in group and passwd
2. Build FCOS, see logs:
```
systemd.post: Creating group 'bin' with GID 1.
systemd.post: Creating user 'bin' (bin) with UID 1 and GID 1.
systemd.post: /etc/gshadow: Group "bin" already exists.
```

According to @cgwalters 's pointer:

The above log will lead systemd-sysusers (during systemd.post)
exit early before saving the updated `/etc/{passwd,group}` refer
to [code](https://github.com/systemd/systemd/blob/main/src/sysusers/sysusers.c#L820), and bin user/group will not be saved finally.

The root cause is that `gshadow` is not consistent with group,
`gshadow` is from setup, and we override group according to https://github.com/coreos/fedora-coreos-config/blob/testing-devel/manifests/group.

The `shadow` is also from setup, and is not consistent with
passwd, we should also sync it.


Fix https://github.com/coreos/fedora-coreos-tracker/issues/1525

---

passwd: add `enum PasswdKind`

Refer to https://github.com/coreos/rpm-ostree/pull/4503/commits/d8dc9605747f1b7fb51adc25b6ea828227f27199
