### PR TITLE
main: Update ostree-ext, add provisional-repair entrypoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "ostree-ext"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a690495144c18cb333a67a2ec61dd008831710bbd37804cfa79ab93b51146a6f"
+checksum = "8511513a60fa0c20a84ba8d30255286687c848bec21d24cd3dd4d16ecf48123b"
 dependencies = [
  "anyhow",
  "async-compression 0.3.15",

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -132,6 +132,7 @@ install-rpmostree-hook:
 	install -m 0755 -t $(DESTDIR)$(bindir) rpm-ostree
 	install -d -m 0755 $(ostreeextdir)
 	ln -Tsr -f $(DESTDIR)$(bindir)/rpm-ostree $(ostreeextdir)/ostree-ima-sign 
+	ln -Tsr -f $(DESTDIR)$(bindir)/rpm-ostree $(ostreeextdir)/ostree-provisional-repair 
 	ln -Tsr -f $(DESTDIR)$(bindir)/rpm-ostree $(ostreeextdir)/ostree-container
 INSTALL_EXEC_HOOKS += install-rpmostree-hook
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -53,7 +53,9 @@ async fn dispatch_ostree_ext(args: Vec<String>) -> Result<i32> {
 /// Dispatch multicall binary to relevant logic, based on callname from `argv[0]`.
 async fn dispatch_multicall(callname: String, args: Vec<String>) -> Result<i32> {
     match callname.as_str() {
-        "ostree-container" | "ostree-ima-sign" => dispatch_ostree_ext(args).await,
+        "ostree-container" | "ostree-ima-sign" | "ostree-provisional-repair" => {
+            dispatch_ostree_ext(args).await
+        }
         _ => inner_async_main(args).await, // implicitly includes "rpm-ostree"
     }
 }


### PR DESCRIPTION
This updates us to vendor the provisional-repair code.  One can now run `ostree provisional-repair` directly.

(Yes, it's very confusing how in rpm-ostree, we vendor the ostree-ext
 source, and then install a wrapper symlink which tells the main
 (C) `ostree` binary to call back into us... but it's how the
 `ostree container` stuff has been working for a long time)
