### PR TITLE
Revert "main: Drop deprecated `container-encapsulate` entrypoint"

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -34,6 +34,14 @@ async fn inner_async_main(args: Vec<String>) -> Result<i32> {
                 "usroverlay" | "unlock" => builtins::usroverlay::entrypoint(args).map(|_| 0),
                 // A hidden wrapper to intercept some binaries in RPM scriptlets.
                 "scriptlet-intercept" => builtins::scriptlet_intercept::entrypoint(args).map(|_| 0),
+                // This is a deprecated entrypoint
+                "container-encapsulate" => {
+                    rpmostree_rust::client::warn_future_incompatibility(
+                    "This entrypoint is deprecated; use `rpm-ostree compose container-encapsulate` instead",
+                    );
+                    rpmostree_rust::container::container_encapsulate(args_orig).map(|_| 0)
+                    .map_err(anyhow::Error::msg)
+                },
                 // C++ main
                 _ => Ok(rpmostree_rust::ffi::rpmostree_main(args)?),
             }


### PR DESCRIPTION
This reverts commit 2d07002d2e6a3516195a3e413e1047c6a7661365.

It turns out that this is used by osbuild today
https://github.com/osbuild/osbuild/blob/14d31633a4b14878735ed5222befb895b16de2d1/stages/org.osbuild.ostree.encapsulate#L112

We'll do a patch to port to the new API there but let's just carry this for $time where values of $time are probably at least a year.
