### PR TITLE
Use cap-tempfile via cap-std-ext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,6 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "cap-std-ext 2.0.0",
- "cap-tempfile",
  "chrono",
  "clap",
  "containers-image-proxy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ containers-image-proxy = "0.5.1"
 # Explicitly force on libc
 rustix = { version = "0.37", features = ["use-libc"] }
 cap-primitives = "1.0.3"
-cap-tempfile = "1.0.15"
 chrono = { version = "0.4.26", features = ["serde"] }
 clap = { version = "4.3", features = ["derive"] }
 cxx = "1.0.101"

--- a/rust/src/builtins/scriptlet_intercept/groupadd.rs
+++ b/rust/src/builtins/scriptlet_intercept/groupadd.rs
@@ -135,6 +135,7 @@ fn generate_sysusers_fragment(rootdir: &Dir, groupname: &str, gid: Option<u32>) 
 #[cfg(test)]
 mod test {
     use super::*;
+    use cap_std_ext::cap_tempfile;
     use std::io::Read;
 
     #[test]

--- a/rust/src/builtins/scriptlet_intercept/useradd.rs
+++ b/rust/src/builtins/scriptlet_intercept/useradd.rs
@@ -193,6 +193,7 @@ fn generate_sysusers_fragment(
 #[cfg(test)]
 mod test {
     use super::*;
+    use cap_std_ext::cap_tempfile;
     use std::io::Read;
 
     #[test]

--- a/rust/src/builtins/scriptlet_intercept/usermod.rs
+++ b/rust/src/builtins/scriptlet_intercept/usermod.rs
@@ -105,6 +105,7 @@ pub(crate) fn generate_sysusers_fragment(
 #[cfg(test)]
 mod test {
     use super::*;
+    use cap_std_ext::cap_tempfile;
     use std::io::Read;
 
     #[test]

--- a/rust/src/cliwrap.rs
+++ b/rust/src/cliwrap.rs
@@ -197,6 +197,7 @@ pub(crate) fn cliwrap_destdir() -> String {
 mod tests {
     use super::*;
     use anyhow::Context;
+    use cap_std_ext::cap_tempfile;
     use std::path::Path;
 
     fn file_contains(

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -1245,7 +1245,7 @@ fn hardlink_recurse(
 mod tests {
     use super::*;
     use cap_std::fs::{Dir, DirBuilder};
-    use cap_std_ext::cap_std;
+    use cap_std_ext::{cap_std, cap_tempfile};
 
     #[test]
     fn stripany() {

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -355,6 +355,7 @@ mod test {
     use super::*;
     use crate::capstdext::dirbuilder_from_mode;
     use anyhow::Result;
+    use cap_std_ext::cap_tempfile;
 
     #[test]
     fn etcguard() -> Result<()> {

--- a/rust/src/dirdiff.rs
+++ b/rust/src/dirdiff.rs
@@ -222,6 +222,7 @@ pub(crate) fn diff(src: &Dir, dest: &Dir) -> Result<Diff> {
 mod test {
     use super::*;
     use cap_std::fs::Permissions;
+    use cap_std_ext::cap_tempfile;
     use std::os::unix::fs::PermissionsExt;
 
     #[test]

--- a/rust/src/initramfs.rs
+++ b/rust/src/initramfs.rs
@@ -154,6 +154,7 @@ pub(crate) fn initramfs_overlay_generate(
 #[cfg(test)]
 mod test {
     use super::*;
+    use cap_std_ext::cap_tempfile;
 
     #[test]
     fn test_initramfs_overlay() -> Result<()> {

--- a/rust/src/passwd.rs
+++ b/rust/src/passwd.rs
@@ -12,6 +12,7 @@ use cap_std::fs::Dir;
 use cap_std::fs::OpenOptions;
 use cap_std_ext::cap_std;
 use cap_std_ext::cap_std::fs::Permissions;
+use cap_std_ext::cap_tempfile;
 use cap_std_ext::dirext::CapStdExtDirExt;
 use fn_error_context::context;
 use gio::prelude::*;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -2919,6 +2919,7 @@ impl TreeComposeConfig {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+    use cap_std_ext::cap_tempfile;
     use indoc::indoc;
     use std::io::Cursor;
 


### PR DESCRIPTION
This works better with dependabot because there's only one thing to bump.

At the time, I thought cap-std would stay at 1.0 for the forseeable future, but that didn't happen.

xref https://github.com/bytecodealliance/cap-std/commit/963eebf3ab52b04a2e8b9ba88ce6308bbed5cbd0#r121651362
