### PR TITLE
status: Fix possibly uninitialized warning

### DIFF
--- a/src/app/rpmostree-builtin-status.cxx
+++ b/src/app/rpmostree-builtin-status.cxx
@@ -421,7 +421,7 @@ print_daemon_state (RPMOSTreeSysroot *sysroot_proxy, GCancellable *cancellable, 
     {
       g_print ("AutomaticUpdates: %s", policy);
 
-      AutoUpdateSdState state;
+      AutoUpdateSdState state = AUTO_UPDATE_SDSTATE_TIMER_UNKNOWN;
       g_autofree char *last_run = NULL;
       g_print ("; ");
       GDBusConnection *connection = g_dbus_proxy_get_connection (G_DBUS_PROXY (sysroot_proxy));


### PR DESCRIPTION
I don't think this is really reachable; current gcc just can't prove that if we return `TRUE` that we always set it.
