### PR TITLE
packaging/spec.in: Enable rpm-ostree-countme.timer following presets

### DIFF
--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -234,6 +234,16 @@ $PYTHON autofiles.py > files.devel \
   '%{_datadir}/gtk-doc/html/*' \
   '%{_datadir}/gir-1.0/*-1.0.gir'
 
+# Setup rpm-ostree-countme.timer according to presets
+%post
+%systemd_post rpm-ostree-countme.timer
+
+%preun
+%systemd_preun rpm-ostree-countme.timer
+
+%postun
+%systemd_postun_with_restart rpm-ostree-countme.timer
+
 %files -f files
 %doc COPYING.GPL COPYING.LGPL LICENSE README.md
 


### PR DESCRIPTION
Use systemd macros to enable/disable the rpm-ostree-countme.timer unit following the global systemd presets.

This fixes the timer enablement on systems that do no preset-all like Fedora CoreOS.

See: https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_systemd