### PR TITLE
Bump to ostree-ext 0.11.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2221,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "ostree-ext"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962494b87897a77ac092f321666ad383af7289707479d7612f681c1c657cb57a"
+checksum = "35e5fef7847d469bfffdc14800d9e76bf5c21acb136429c613ed2728b7f2d6a4"
 dependencies = [
  "anyhow",
  "async-compression 0.3.15",

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -80,6 +80,7 @@ async fn pull_container_async(
     output_message(&format!("Pulling manifest: {}", &imgref));
     let config = default_container_pull_config(imgref)?;
     let mut imp = ImageImporter::new(repo, imgref, config).await?;
+    imp.require_bootable();
     let layer_progress = imp.request_progress();
     let prep = match imp.prepare().await? {
         PrepareResult::AlreadyPresent(r) => return Ok(r.into()),


### PR DESCRIPTION
To pull in several recent fixes.

Note that we now need to `require_bootable` when importing.
