### PR TITLE
Fix `rpm-ostree -h usroverlay` segfault

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -2028,6 +2028,9 @@ extern "C"
                                           const ::rpmostreecxx::GCancellable &cancellable) noexcept;
 
   ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$usroverlay_entrypoint (const ::rust::Vec< ::rust::String> &args) noexcept;
+
+  ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$applylive_entrypoint (const ::rust::Vec< ::rust::String> &args) noexcept;
 
   ::rust::repr::PtrLen
@@ -3528,6 +3531,16 @@ void
 Bubblewrap::run (const ::rpmostreecxx::GCancellable &cancellable)
 {
   ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Bubblewrap$run (*this, cancellable);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
+}
+
+void
+usroverlay_entrypoint (const ::rust::Vec< ::rust::String> &args)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$usroverlay_entrypoint (args);
   if (error$.ptr)
     {
       throw ::rust::impl< ::rust::Error>::error (error$);

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1741,6 +1741,8 @@ void bubblewrap_selftest ();
 bubblewrap_new_with_mutability (::std::int32_t rootfs_fd,
                                 ::rpmostreecxx::BubblewrapMutability mutability);
 
+void usroverlay_entrypoint (const ::rust::Vec< ::rust::String> &args);
+
 void applylive_entrypoint (const ::rust::Vec< ::rust::String> &args);
 
 void applylive_finish (const ::rpmostreecxx::OstreeSysroot &sysroot);

--- a/rust/src/builtins/usroverlay.rs
+++ b/rust/src/builtins/usroverlay.rs
@@ -7,7 +7,7 @@ use clap::Command;
 use std::os::unix::prelude::CommandExt;
 
 /// Directly exec(ostree admin unlock) - does not return on success.
-pub fn entrypoint(args: &[&str]) -> Result<()> {
+pub fn usroverlay_entrypoint(args: &Vec<String>) -> Result<()> {
     let cmd = cli_cmd();
     cmd.get_matches_from(args.iter().skip(1));
 

--- a/rust/src/builtins/usroverlay.rs
+++ b/rust/src/builtins/usroverlay.rs
@@ -3,37 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use anyhow::{Context, Result};
-use clap::Command;
 use std::os::unix::prelude::CommandExt;
 
 /// Directly exec(ostree admin unlock) - does not return on success.
 pub fn usroverlay_entrypoint(args: &Vec<String>) -> Result<()> {
-    let cmd = cli_cmd();
-    cmd.get_matches_from(args.iter().skip(1));
-
     let exec_err = std::process::Command::new("ostree")
         .args(&["admin", "unlock"])
+        .args(args.into_iter().skip(1))
         .exec();
-
     // This is only reached if the `exec()` above failed; otherwise
     // execution got transferred to `ostree` at that point.
     Err(exec_err).context("Failed to execute 'ostree admin unlock'")
-}
-
-/// CLI parser, handle --help and error on extra arguments.
-fn cli_cmd() -> Command {
-    Command::new("rpm-ostree usroverlay")
-        .bin_name("rpm-ostree usroverlay")
-        .long_version("")
-        .long_about("Apply a transient overlayfs to /usr")
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_clap_cmd() {
-        cli_cmd().debug_assert()
-    }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -899,10 +899,10 @@ pub mod ffi {
 }
 
 pub mod builtins;
-pub(crate) use crate::builtins::usroverlay::usroverlay_entrypoint;
 pub(crate) use crate::builtins::apply_live::*;
 pub(crate) use crate::builtins::compose::commit::*;
 pub(crate) use crate::builtins::compose::*;
+pub(crate) use crate::builtins::usroverlay::usroverlay_entrypoint;
 mod bwrap;
 pub(crate) use bwrap::*;
 pub mod client;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -152,6 +152,7 @@ pub mod ffi {
 
     // builtins/apply_live.rs
     extern "Rust" {
+        fn usroverlay_entrypoint(args: &Vec<String>) -> Result<()>;
         fn applylive_entrypoint(args: &Vec<String>) -> Result<()>;
         fn applylive_finish(sysroot: &OstreeSysroot) -> Result<()>;
     }
@@ -898,6 +899,7 @@ pub mod ffi {
 }
 
 pub mod builtins;
+pub(crate) use crate::builtins::usroverlay::usroverlay_entrypoint;
 pub(crate) use crate::builtins::apply_live::*;
 pub(crate) use crate::builtins::compose::commit::*;
 pub(crate) use crate::builtins::compose::*;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -30,8 +30,6 @@ async fn inner_async_main(args: Vec<String>) -> Result<i32> {
                 // Add custom Rust commands here, and also in `libmain.cxx` if user-visible.
                 "countme" => rpmostree_rust::countme::entrypoint(args).map(|_| 0),
                 "cliwrap" => rpmostree_rust::cliwrap::entrypoint(args).map(|_| 0),
-                // The `unlock` is a hidden alias for "ostree CLI compatibility"
-                "usroverlay" | "unlock" => builtins::usroverlay::entrypoint(args).map(|_| 0),
                 // A hidden wrapper to intercept some binaries in RPM scriptlets.
                 "scriptlet-intercept" => builtins::scriptlet_intercept::entrypoint(args).map(|_| 0),
                 // This is a deprecated entrypoint

--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -38,6 +38,17 @@
 
 #include "libglnx.h"
 
+static gboolean
+dispatch_usroverlay (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+                     GCancellable *cancellable, GError **error)
+{
+  rust::Vec<rust::String> rustargv;
+  for (int i = 0; i < argc; i++)
+    rustargv.push_back (std::string (argv[i]));
+  CXX_TRY (rpmostreecxx::usroverlay_entrypoint (rustargv), error);
+  return TRUE;
+}
+
 static RpmOstreeCommand commands[] = {
   { "compose",
     static_cast<RpmOstreeBuiltinFlags> (RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD
@@ -91,7 +102,12 @@ static RpmOstreeCommand commands[] = {
   { "scriptlet-intercept", static_cast<RpmOstreeBuiltinFlags> (RPM_OSTREE_BUILTIN_FLAG_HIDDEN),
     "Intercept some commands used by RPM scriptlets", NULL },
   { "usroverlay", static_cast<RpmOstreeBuiltinFlags> (RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT),
-    "Apply a transient overlayfs to /usr", NULL },
+    "Apply a transient overlayfs to /usr", dispatch_usroverlay },
+  // Alias for ostree compatibility
+  { "unlock",
+    static_cast<RpmOstreeBuiltinFlags> (RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT
+                                        | RPM_OSTREE_BUILTIN_FLAG_HIDDEN),
+    "Apply a transient overlayfs to /usr", dispatch_usroverlay },
   /* Legacy aliases */
   { "pkg-add", static_cast<RpmOstreeBuiltinFlags> (RPM_OSTREE_BUILTIN_FLAG_HIDDEN), NULL,
     rpmostree_builtin_install },

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -26,6 +26,13 @@ for verb in container ima-sign; do
 done
 echo "ok multicall corectly set up and working"
 
+# Verify that we process arguments correctly
+rpm-ostree usroverlay --help >out.txt
+assert_file_has_content out.txt "ostree admin unlock"
+rm -f out.txt
+rpm-ostree -h usroverlay >out.txt
+assert_file_has_content out.txt "ostree admin unlock"
+
 # make sure that package-related entries are always present,
 # even when they're empty.
 # Validate there's no live state by default.


### PR DESCRIPTION
main: Move usroverlay parsing back to C++ consistently

Otherwise, we end up segfaulting because
`rpm-ostree -h usroverlay` confuses things.

Unfortunately, if we expose it publicly in our help text
it needs to have a C++ trampoline.

---

usroverlay: Pass arguments to `ostree admin unlock`

So that `--help` works.

Closes: https://github.com/coreos/rpm-ostree/issues/4508

---

