### PR TITLE
Release 2023.7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2023])
-m4_define([release_version], [6])
+m4_define([release_version], [7])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2023.6
+Version: 2023.7
 Release: 1%{?dist}
 License: LGPL-2.0-or-later
 URL: https://github.com/coreos/rpm-ostree


### PR DESCRIPTION
v2023.7

# Release 2023.7

This is a bugfix release that includes:

* A bootc-lib fix for https://github.com/containers/bootc/issues/112 which was breaking our builds.
* The fix for https://github.com/coreos/rpm-ostree/issues/4508 which caused segfaults when any flag was passed between the `rpm-ostree` command and `usroverlay` option.

```
Colin Walters (3):
      man: Describe GPG key behavior
      main: Move usroverlay parsing back to C++ consistently
      usroverlay: Pass arguments to `ostree admin unlock`

Joseph Marrero (1):
      Update bootc-lib
```

**Full Changelog**: https://github.com/coreos/rpm-ostree/compare/v2023.6...v2023.7