### PR TITLE
Bump to containers-image-proxy 0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ source = "git+https://github.com/containers/bootc.git?branch=main#4b9728ca0b4720
 dependencies = [
  "anyhow",
  "camino",
- "cap-std-ext 2.0.0",
+ "cap-std-ext",
  "clap",
  "fn-error-context",
  "gvariant",
@@ -339,16 +339,6 @@ dependencies = [
 
 [[package]]
 name = "cap-std-ext"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8031eb6e1061d0bdabe0c14eb6c37f02e2ee3621976782881eb0f666ab4673ce"
-dependencies = [
- "cap-tempfile",
- "rustix 0.36.13",
-]
-
-[[package]]
-name = "cap-std-ext"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6012b1e726e3e3ccf8151e2dc9cb454e593e0e7623b0e35464f5e62a15158c27"
@@ -367,17 +357,6 @@ dependencies = [
  "rand",
  "rustix 0.37.20",
  "uuid 1.3.2",
-]
-
-[[package]]
-name = "capctl"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdc32a78afc325d71a48d13084f1c3ddf67cc5dc06c6e5439a8630b14612cad"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -521,20 +500,20 @@ dependencies = [
 
 [[package]]
 name = "containers-image-proxy"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc8ef9cc4d183f3bfd3c232f304286b91cff5c9aa35665ea2e89499e1e0d021"
+checksum = "7e023a208ccb5df25f251218748df523293f650e406d682e203bb9ddeb5b98b0"
 dependencies = [
  "anyhow",
- "cap-std-ext 1.0.3",
+ "cap-std-ext",
  "cap-tempfile",
- "capctl",
  "fn-error-context",
  "futures-util",
  "libc",
  "nix 0.26.2",
  "oci-spec",
  "once_cell",
+ "rustix 0.37.20",
  "semver",
  "serde",
  "serde_json",
@@ -1854,12 +1833,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
@@ -2229,7 +2202,7 @@ dependencies = [
  "async-compression 0.3.15",
  "bitflags 1.3.2",
  "camino",
- "cap-std-ext 2.0.0",
+ "cap-std-ext",
  "cap-tempfile",
  "chrono",
  "clap",
@@ -2679,7 +2652,7 @@ dependencies = [
  "camino",
  "cap-primitives",
  "cap-std",
- "cap-std-ext 2.0.0",
+ "cap-std-ext",
  "chrono",
  "clap",
  "containers-image-proxy",
@@ -2740,22 +2713,6 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
-name = "rustix"
-version = "0.36.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a38f9520be93aba504e8ca974197f46158de5dcaa9fa04b57c57cd6a679d658"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "itoa",
- "libc",
- "linux-raw-sys 0.1.4",
- "once_cell",
- "windows-sys 0.45.0",
-]
 
 [[package]]
 name = "rustix"


### PR DESCRIPTION
To pick up the critical fix in https://github.com/containers/containers-image-proxy-rs/pull/52/commits/95da872de1464d67fe38a1ccbb98e6f22087a189

Also happily this seems to drop out some now redundant dependencies.
