### PR TITLE
Two unimportant clang-analyzer fixes

### DIFF
--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -386,6 +386,10 @@ rpmostree_builtin_search (int argc, char **argv, RpmOstreeCommandInvocation *inv
           else if (strcmp (key, "summary") == 0)
             g_variant_get (value, "s", &summary);
         }
+      // The server must have sent these
+      g_assert (name);
+      g_assert (query);
+      g_assert (summary);
 
       if (!query_set.count (query))
         {

--- a/src/daemon/rpmostreed-os.cxx
+++ b/src/daemon/rpmostreed-os.cxx
@@ -108,6 +108,7 @@ os_authorize_method (GDBusInterfaceSkeleton *interface, GDBusMethodInvocation *i
       = rpmostreed_sysroot_get_polkit_authority (sysroot, &local_error);
   if (!authority)
     {
+      g_assert (local_error);
       g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
                                              "Failed to load polkit: %s", local_error->message);
       return FALSE;

--- a/src/daemon/rpmostreed-sysroot.cxx
+++ b/src/daemon/rpmostreed-sysroot.cxx
@@ -529,6 +529,7 @@ sysroot_authorize_method (GDBusInterfaceSkeleton *interface, GDBusMethodInvocati
           = rpmostreed_sysroot_get_polkit_authority (self, &local_error);
       if (!authority)
         {
+          g_assert (local_error);
           g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
                                                  "Failed to load polkit: %s", local_error->message);
           return FALSE;


### PR DESCRIPTION
sysroot: Silence clang-analyzer warning

I think this is another case of clang-analyzer not understanding
the "GError rules"; it's getting confused by the `NULL` checks here
and thinking that if `authority == NULL` it's possible `error == NULL`
too.  But it can't see into the implementation of libpolkit.

---

pkg-builtins: Add assertions to quiet clang-analyzer

In theory, the server could have not sent this data.  Add
assertions to require this.

---

