### PR TITLE
packaging: Write to target/ &&  ci: Add autovendor flow

### DIFF
--- a/.github/workflows/autovendor.yml
+++ b/.github/workflows/autovendor.yml
@@ -1,0 +1,24 @@
+# Automatically generate a vendor.tar.zstd on pushes to git main.
+name: Auto-vendor artifact
+
+permissions:
+  actions: read
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  vendor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install vendor tool
+        run: cargo install cargo-vendor-filterer
+      - name: Run
+        run: mkdir -p target && cd cli && cargo vendor-filterer --format=tar.zstd --prefix=vendor/ ../target/vendor.tar.zst
+      - uses: actions/upload-artifact@v3
+        with:
+          name: vendor.tar.zst
+          path: target/vendor.tar.zst

--- a/packaging/make-git-snapshot.sh
+++ b/packaging/make-git-snapshot.sh
@@ -27,7 +27,7 @@ ls -al ${TARFILE_TMP}
     tar -A -f ${TARFILE_TMP} submodule.tar
     rm submodule.tar
 done
-disttmp=.dist-tmp
+disttmp=target/dist-tmp
 tmpd=${TOP}/$disttmp
 trap cleanup EXIT
 function cleanup () {


### PR DESCRIPTION
packaging: Write to target/

This is already under `.gitignore` and ensures that things watching
for changes like IDEs won't transiently see temporary files.

---

ci: Add autovendor flow

This aids reproducibility to have an auto-generated vendor
snapshot that we save reliably.

---

