### PR TITLE
Update to ostree-ext 0.11.6 && Remove unreferenced container images in cleanup, not rebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,16 +2194,15 @@ dependencies = [
 
 [[package]]
 name = "ostree-ext"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e5fef7847d469bfffdc14800d9e76bf5c21acb136429c613ed2728b7f2d6a4"
+checksum = "2fddb6a46fd0ce94594921d4b37796edda8c45bd239862f6e7429258cd16d423"
 dependencies = [
  "anyhow",
  "async-compression 0.3.15",
  "bitflags 1.3.2",
  "camino",
  "cap-std-ext",
- "cap-tempfile",
  "chrono",
  "clap",
  "containers-image-proxy",

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -2063,9 +2063,8 @@ extern "C"
       ::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable,
       ::rust::Str imgref, ::rust::Box< ::rpmostreecxx::ContainerImageState> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$container_prune (
-      ::rpmostreecxx::OstreeRepo const &repo,
-      ::rpmostreecxx::GCancellable const &cancellable) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$container_prune (::rpmostreecxx::OstreeSysroot const &sysroot) noexcept;
 
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$query_container_image_commit (
       ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str c,
@@ -3659,10 +3658,9 @@ pull_container (::rpmostreecxx::OstreeRepo const &repo,
 }
 
 void
-container_prune (::rpmostreecxx::OstreeRepo const &repo,
-                 ::rpmostreecxx::GCancellable const &cancellable)
+container_prune (::rpmostreecxx::OstreeSysroot const &sysroot)
 {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$container_prune (repo, cancellable);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$container_prune (sysroot);
   if (error$.ptr)
     {
       throw ::rust::impl< ::rust::Error>::error (error$);

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1767,8 +1767,7 @@ void deploy_from_self_entrypoint (::rust::Vec< ::rust::String> args);
 pull_container (::rpmostreecxx::OstreeRepo const &repo,
                 ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref);
 
-void container_prune (::rpmostreecxx::OstreeRepo const &repo,
-                      ::rpmostreecxx::GCancellable const &cancellable);
+void container_prune (::rpmostreecxx::OstreeSysroot const &sysroot);
 
 ::rust::Box< ::rpmostreecxx::ContainerImageState>
 query_container_image_commit (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str c);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -196,7 +196,7 @@ pub mod ffi {
             cancellable: &GCancellable,
             imgref: &str,
         ) -> Result<Box<ContainerImageState>>;
-        fn container_prune(repo: &OstreeRepo, cancellable: &GCancellable) -> Result<()>;
+        fn container_prune(sysroot: &OstreeSysroot) -> Result<()>;
         fn query_container_image_commit(
             repo: &OstreeRepo,
             c: &str,

--- a/src/daemon/rpmostree-sysroot-core.cxx
+++ b/src/daemon/rpmostree-sysroot-core.cxx
@@ -214,7 +214,7 @@ rpmostree_syscore_cleanup (OstreeSysroot *sysroot, OstreeRepo *repo, GCancellabl
   /* Refs for the live state */
   ROSCXX_TRY (applylive_sync_ref (*sysroot), error);
 
-  CXX_TRY (rpmostreecxx::container_prune (*repo, *cancellable), error);
+  CXX_TRY (rpmostreecxx::container_prune (*sysroot), error);
 
   /* And do a prune */
   guint64 freed_space;

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -164,7 +164,8 @@ EOF
     fi
     rpm-ostree rebase ostree-unverified-image:containers-storage:localhost/fcos-derived
     ostree container image list --repo=/ostree/repo | tee imglist.txt
-    assert_streq "$(wc -l < imglist.txt)" 1
+    # We now only prune when the deployment is removed
+    assert_streq "$(wc -l < imglist.txt)" 2
     rm $image_dir -rf
     /tmp/autopkgtest-reboot 3
     ;;
@@ -186,6 +187,11 @@ EOF
     cp /usr/etc/rpm-ostreed.conf /etc
     echo -e "[Daemon]\nAutomaticUpdatePolicy=apply" > /etc/rpm-ostreed.conf
     rpm-ostree reload
+
+    # This should now prune the previous image
+    rpm-ostree cleanup -pr
+    ostree container image list --repo=/ostree/repo | tee imglist.txt
+    assert_streq "$(wc -l < imglist.txt)" 1
 
     # Now revert back to the base image, but keep our layered package foo
     rpm-ostree rebase ostree-unverified-image:containers-storage:localhost/fcos


### PR DESCRIPTION
Update to ostree-ext 0.11.6

---

Remove unreferenced container images in cleanup, not rebase

This allows users to pin a deployment and have the container
image be retained.

Closes: https://github.com/coreos/rpm-ostree/issues/4391

---

