### PR TITLE
install/uninstall: Error out with --enablerepo on booted host

### DIFF
--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -264,6 +264,14 @@ rpmostree_builtin_install (int argc, char **argv, RpmOstreeCommandInvocation *in
         }
       return rpmostree_container_rebuild (*treefile, cancellable, error);
     }
+  else
+    {
+      // This very much relates to https://github.com/coreos/rpm-ostree/issues/2326 etc.
+      if (opt_enable_repo)
+        return glnx_throw (error, "--enablerepo currently only works in a container build");
+      if (opt_disable_repo)
+        return glnx_throw (error, "--disablerepo currently only works in a container build");
+    }
 
   return pkg_change (invocation, sysroot_proxy, FALSE, (const char *const *)argv,
                      (const char *const *)opt_uninstall, cancellable, error);

--- a/tests/kolainst/nondestructive/misc.sh
+++ b/tests/kolainst/nondestructive/misc.sh
@@ -80,6 +80,11 @@ if rpm-ostree ex rebuild 2>err.txt; then
 fi
 assert_file_has_content_literal err.txt 'error: This command can only run in an OSTree container'
 
+if rpm-ostree install --enablerepo=blah foo 2>err.txt; then
+    fatal "enablerepo should not have worked"
+fi
+assert_file_has_content err.txt 'enablerepo currently only works in a container build'
+
 rpm-ostree status --jsonpath '$.deployments[0].booted' > jsonpath.txt
 assert_file_has_content_literal jsonpath.txt 'true'
 echo "ok jsonpath"


### PR DESCRIPTION
These only work in the container flow today, for anti-hysteresis reasons.
