### PR TITLE
Pin bootc to a git tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 [[package]]
 name = "bootc-lib"
 version = "0.1.0"
-source = "git+https://github.com/containers/bootc.git?branch=main#4b9728ca0b472006fd8c132cddb27409a8fe06b0"
+source = "git+https://github.com/containers/bootc.git?tag=v0.1#d7309b6523d64631726506dfcad52d50b2bb92e7"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ rpm = "4"
 anyhow = "1.0.69"
 binread = "2.2.0"
 bitflags = "2.3"
-bootc = { git = "https://github.com/containers/bootc.git", branch = "main", package = "bootc-lib"}
+bootc = { git = "https://github.com/containers/bootc.git", tag = "v0.1", package = "bootc-lib"}
 camino = "1.1.6"
 cap-std-ext = "2.0"
 cap-std = { version = "1.0.3", features = ["fs_utf8"] }


### PR DESCRIPTION
We had a problem in the previous release with having bootc float on a git commit because it ends up meaning "whatever happens to be on the developer's machine" when cutting a release, which is not OK from a reproducibility PoV.

Dependabot I think can help us update this.
