### PR TITLE
core: Add composefs digest for local commits too

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,7 +81,7 @@ PKG_PROG_PKG_CONFIG
 dnl Remember to update AM_CPPFLAGS in Makefile.am when bumping GIO req.
 PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 dnl These are the dependencies of the public librpmostree-1.0.0 shared library
-PKG_CHECK_MODULES(PKGDEP_LIBRPMOSTREE, [gio-unix-2.0 >= 2.50.0 json-glib-1.0 ostree-1 >= 2022.7 rpm >= 4.16])
+PKG_CHECK_MODULES(PKGDEP_LIBRPMOSTREE, [gio-unix-2.0 >= 2.50.0 json-glib-1.0 ostree-1 >= 2023.6 rpm >= 4.16])
 dnl And these additional ones are used by for the rpmostreeinternals C/C++ library
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [polkit-gobject-1 libarchive])
 

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -4713,9 +4713,12 @@ rpmostree_context_commit (RpmOstreeContext *self, const char *parent,
         if (!ostree_commit_metadata_for_bootable (root, metadata_dict, cancellable, error))
           return FALSE;
       }
-    g_autoptr (GVariant) metadata = g_variant_dict_end (metadata_dict);
+    if (!ostree_repo_commit_add_composefs_metadata (self->ostreerepo, 0, metadata_dict,
+                                                    (OstreeRepoFile *)root, cancellable, error))
+      return glnx_prefix_error (error, "Adding composefs metadata");
 
     {
+      g_autoptr (GVariant) metadata = g_variant_dict_end (metadata_dict);
       if (!ostree_repo_write_commit (self->ostreerepo, parent, "", "", metadata,
                                      OSTREE_REPO_FILE (root), &ret_commit_checksum, cancellable,
                                      error))

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -838,17 +838,9 @@ rpmostree_compose_commit (int rootfs_fd, OstreeRepo *repo, const char *parent_re
   // Unfortunately these API takes GVariantDict, not GVariantBuilder, so convert
   g_autoptr (GVariantDict) metadata_dict = g_variant_dict_new (src_metadata);
 
-#if OSTREE_CHECK_VERSION(2023, 4)
-  g_autoptr (GError) local_error = NULL;
-  if (!ostree_repo_commit_add_composefs_metadata (
-          repo, 0, metadata_dict, (OstreeRepoFile *)root_tree, cancellable, &local_error)
-      && !g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED))
-    {
-      g_propagate_prefixed_error (error, util::move_nullify (local_error),
-                                  "Adding composefs metadata");
-      return FALSE;
-    }
-#endif
+  if (!ostree_repo_commit_add_composefs_metadata (repo, 0, metadata_dict,
+                                                  (OstreeRepoFile *)root_tree, cancellable, error))
+    return glnx_prefix_error (error, "Adding composefs metadata");
 
   if (!container)
     {

--- a/tests/kolainst/destructive/layering-local
+++ b/tests/kolainst/destructive/layering-local
@@ -76,6 +76,9 @@ fi
 ostree show --print-metadata-key=ostree.bootable ${booted_commit} >out.txt
 assert_file_has_content_literal out.txt 'true'
 echo "ok bootable metadata"
+ostree show --print-metadata-key=ostree.composefs.digest.v0 ${booted_commit} >out.txt
+assert_file_has_content_literal out.txt 'byte'
+echo "ok composefs metadata on client generated commit"
 
 # check we could uninstall the package using either its NEVRA or name
 rpm-ostree uninstall foo-1.2-3.x86_64


### PR DESCRIPTION
This pairs with https://github.com/coreos/rpm-ostree/pull/4495/commits/dbe78217c0205dad372c84b2cf0a299003787952 where we generate composefs metadata for base images.

It's going to be useful to do it for client side builds too, so that we can treat them symmetrically.  It doesn't have a very high cost, just a metadata traversal.
