### PR TITLE
rust: Drop dependency on `memfd`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1891,15 +1891,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
-name = "memfd"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
-dependencies = [
- "rustix 0.37.23",
-]
-
-[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,7 +2644,6 @@ dependencies = [
  "libc",
  "libdnf-sys",
  "maplit",
- "memfd",
  "nix 0.26.4",
  "once_cell",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,6 @@ is-terminal = "0.4"
 libc = "0.2.147"
 libdnf-sys = { path = "rust/libdnf-sys", version = "0.1.0" }
 maplit = "1.0"
-memfd = "0.6.0"
 nix = "0.26.4"
 openssl = "0.10.57"
 once_cell = "1.18.0"

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -1104,10 +1104,7 @@ fn hardlink_rpmdb_base_location(
 fn rewrite_rpmdb_for_target_inner(rootfs_dfd: &Dir, normalize: bool) -> Result<()> {
     let tempetc = crate::core::prepare_tempetc_guard(rootfs_dfd.as_raw_fd())?;
 
-    let mut dbfd = memfd::MemfdOptions::default()
-        .allow_sealing(true)
-        .create("rpmdb")?
-        .into_file();
+    let mut dbfd = cap_std_ext::cap_tempfile::TempFile::new_anonymous(rootfs_dfd)?;
 
     let dbpath_arg = format!("--dbpath=/proc/self/cwd/{}", RPMOSTREE_RPMDB_LOCATION);
     // Fork rpmdb from the *host* rootfs to read the rpmdb back into memory


### PR DESCRIPTION
composepost: Use O_TMPFILE, not memfd

An anonymous tmpfile is strictly better than memfd for a case
like this, where we want to be able to page back to disk if needed
for some reason.

Prep for dropping a dependency on the `memfd` crate.

---

rust: Drop dependency on `memfd`

The immediate motivation here is to ideally get back to one version
of `rustix` - we have just too many versions of `nix` and `rustix`.

The slight additional ergonomics of the `memfd` crate aren't
really worth it over using the already-safe rustix interface
directly.

---

