### PR TITLE
compose-image: Add `--initialize-mode`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ camino = "1.1.6"
 cap-std-ext = "3.0"
 cap-primitives = "2"
 cap-std = { version = "2", features = ["fs_utf8"] }
-containers-image-proxy = "0.5.1"
+containers-image-proxy = { version = "0.5.1", features = ["proxy_v0_2_4"] }
 # Explicitly force on libc
 rustix = { version = "0.38", features = ["use-libc", "process", "fs"] }
 chrono = { version = "0.4.30", features = ["serde"] }

--- a/docs/container.md
+++ b/docs/container.md
@@ -146,15 +146,15 @@ In the future, this command may perform more operations.
 There is now an `rpm-ostree compose image` command which generates a new base image using a treefile:
 
 ```
-$ rpm-ostree compose image --initialize --format=ociarchive workstation-ostree-config/fedora-silverblue.yaml fedora-silverblue.ociarchive
+$ rpm-ostree compose image --initialize-mode=if-not-exists --format=ociarchive workstation-ostree-config/fedora-silverblue.yaml fedora-silverblue.ociarchive
 ```
 
-The `--initialize` command here will create a new image unconditionally.  If not provided,
-the target image must exist, and will be used for change detection.  You can also directly push
-to a registry:
+The `--initialize-mode=if-not-exists` command here is what you almost always want: to create
+the image if it doesn't exist, but to otherwise check for changes.  It isn't the default
+for historical reasons.
 
 ```
-$ rpm-ostree compose image --initialize --format=registry workstation-ostree-config/fedora-silverblue.yaml quay.io/example/exampleos:latest
+$ rpm-ostree compose image  --initialize-mode=if-not-exists --format=registry workstation-ostree-config/fedora-silverblue.yaml quay.io/example/exampleos:latest
 ```
 
 ## Converting OSTree commits to new base images

--- a/tests/compose-image.sh
+++ b/tests/compose-image.sh
@@ -44,6 +44,9 @@ repos:
   - fedora  # Intentially using frozen GA repo
 EOF
 cp /etc/yum.repos.d/*.repo .
+if rpm-ostree compose image --cachedir=../cache-container --label=foo=bar --label=baz=blah --initialize-mode=never minimal.yaml minimal.ociarchive 2>/dev/null; then
+  fatal "built an image in --initialize-mode=never"
+fi
 rpm-ostree compose image --cachedir=../cache-container --label=foo=bar --label=baz=blah --initialize minimal.yaml minimal.ociarchive
 skopeo inspect oci-archive:minimal.ociarchive > inspect.json
 test $(jq -r '.Labels["foo"]' < inspect.json) = bar
@@ -72,18 +75,33 @@ repos:
   - fedora  # Intentially using frozen GA repo
 EOF
 cp /etc/yum.repos.d/*.repo .
-rpm-ostree compose image --cachedir=../cache --touch-if-changed=changed.stamp --initialize minimal.yaml minimal.ociarchive
+# Unfortunately, --initialize-mode=if-not-exists is broken with .ociarchive...
+rpm-ostree compose image --cachedir=../cache --touch-if-changed=changed.stamp --initialize-mode=always minimal.yaml minimal.ociarchive
 # TODO actually test this container image
 cd ..
 echo "ok minimal"
 
-# Next, test the full Fedora Silverblue config
+# Next, test the full Fedora Silverblue config, and also using an OCI directory
 test -d workstation-ostree-config || git clone --depth=1 https://pagure.io/workstation-ostree-config --branch "${BRANCH}"
-rpm-ostree compose image --cachedir=cache --touch-if-changed=changed.stamp --initialize workstation-ostree-config/fedora-silverblue.yaml fedora-silverblue.ociarchive
-skopeo inspect oci-archive:fedora-silverblue.ociarchive
+mkdir_oci() {
+  local d
+  d=$1
+  shift
+  mkdir $d
+  echo '{ "imageLayoutVersion": "1.0.0" }' > $d/oci-layout
+  echo '{ "schemaVersion": 2, "mediaType": "application/vnd.oci.image.index.v1+json", "manifests": []}' > $d/index.json
+  mkdir -p $d/blobs/sha256
+}
+destocidir=fedora-silverblue.oci
+rm "${destocidir}" -rf
+mkdir_oci "${destocidir}"
+destimg="${destocidir}:silverblue"
+# Sadly --if-not-exists is broken for oci: too
+rpm-ostree compose image --cachedir=cache --touch-if-changed=changed.stamp --initialize-mode=always --format=oci workstation-ostree-config/fedora-silverblue.yaml "${destimg}"
+skopeo inspect "oci:${destimg}"
 test -f changed.stamp
 rm -f changed.stamp
-rpm-ostree compose image --cachedir=cache --offline --touch-if-changed=changed.stamp workstation-ostree-config/fedora-silverblue.yaml fedora-silverblue.ociarchive | tee out.txt
+rpm-ostree compose image --cachedir=cache --offline --touch-if-changed=changed.stamp --initialize-mode=if-not-exists --format=oci workstation-ostree-config/fedora-silverblue.yaml "${destimg}"| tee out.txt
 test '!' -f changed.stamp
 assert_file_has_content_literal out.txt 'No apparent changes since previous commit'
 


### PR DESCRIPTION
A long time ago I did
https://github.com/containers/skopeo/pull/1757/commits/08b27fc50e4da2501124d573b4a449dfeee260ad in preparation for this change.

Basically this is what we really want to be the default, but couldn't at the time: "Create a new image if one doesn't exist".

For completeness though, we also add support for `always` (which is the existing `--initialize`) as well as `--never` (which ensures we never overwrite an existing image, in case
 someone cares).

However in testing this out: it basically works OK with a registry transport which is the big one, but:

- It just plain doesn't work with `.ociarchive` due to skopeo bugs
- It even more unfortunately doesn't work with `oci` directories and a target image reference; e.g. `--format=oci manifest.yaml oci:foo:sometag`
