### PR TITLE
gitmodules: Switch to github for libglnx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libglnx"]
 	path = libglnx
-	url = https://gitlab.gnome.org/GNOME/libglnx.git
+	url = https://github.com/GNOME/libglnx.git
 [submodule "libdnf"]
 	path = libdnf
 	url = https://github.com/rpm-software-management/libdnf


### PR DESCRIPTION
Matches https://github.com/ostreedev/ostree/commit/01a847a2d1c86df57e3e21d11df103eb34cd465a

gitlab.gnome.org is down right now, but it's been somewhat flaky in the past.  Our CI uptime becomes an *intersection* of all systems it depends on, and by cutting out gitlab.gnome.org we increase its reliability.
