### PR TITLE
Add `kola` test for local dir container deployment

### DIFF
--- a/tests/kolainst/destructive/container-deploy
+++ b/tests/kolainst/destructive/container-deploy
@@ -1,0 +1,46 @@
+#!/bin/bash
+# This test reboots a lot, generates container images, etc.
+# kola: { "timeoutMin": 30 }
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. ${KOLA_EXT_DATA}/libtest.sh
+
+set -x
+
+libtest_prepare_offline
+cd "$(mktemp -d)"
+
+# TODO: It'd be much better to test this via a registry
+image_dir=/var/tmp/fcos
+image=dir:$image_dir
+
+checksum=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
+rm ${image_dir} -rf
+
+# Since we're switching OS update stream, turn off zincati
+systemctl mask --now zincati
+
+ostree container encapsulate --repo=/ostree/repo ${checksum} "${image}"
+
+mkdir /var/tmp/sysroot 
+ostree admin init-fs --modern /var/tmp/sysroot 
+ostree admin os-init fedora-coreos --sysroot /var/tmp/sysroot 
+ostree container image deploy --imgref ostree-unverified-image:dir:/var/tmp/fcos --sysroot /var/tmp/sysroot --stateroot fedora-coreos


### PR DESCRIPTION
This change adds a test for deploying FCOS from a container image stored in a local directory. The test is needed for a change in ostree-rs-ext which adds support for the `dir` transport: https://github.com/ostreedev/ostree-rs-ext/pull/544

In this test, the encapsulate function is used to store the current state of the system to a local directory and is deployed to a temporary sysroot.
