### PR TITLE
compose: Two minor cleanups

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -2170,7 +2170,7 @@ extern "C"
       bool unified_core) noexcept;
 
   ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$compose_postprocess_final (::std::int32_t rootfs_dfd) noexcept;
+  rpmostreecxx$cxxbridge1$compose_postprocess_final_pre (::std::int32_t rootfs_dfd) noexcept;
 
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$convert_var_to_tmpfiles_d (
       ::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable const &cancellable) noexcept;
@@ -3959,9 +3959,9 @@ compose_postprocess (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefi
 }
 
 void
-compose_postprocess_final (::std::int32_t rootfs_dfd)
+compose_postprocess_final_pre (::std::int32_t rootfs_dfd)
 {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$compose_postprocess_final (rootfs_dfd);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$compose_postprocess_final_pre (rootfs_dfd);
   if (error$.ptr)
     {
       throw ::rust::impl< ::rust::Error>::error (error$);

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -2172,6 +2172,9 @@ extern "C"
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$compose_postprocess_final_pre (::std::int32_t rootfs_dfd) noexcept;
 
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$compose_postprocess_final (
+      ::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile) noexcept;
+
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$convert_var_to_tmpfiles_d (
       ::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable const &cancellable) noexcept;
 
@@ -2179,9 +2182,6 @@ extern "C"
   rpmostreecxx$cxxbridge1$rootfs_prepare_links (::std::int32_t rootfs_dfd) noexcept;
 
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$workaround_selinux_cross_labeling (
-      ::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable &cancellable) noexcept;
-
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$prepare_rpmdb_base_location (
       ::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable &cancellable) noexcept;
 
   ::rust::repr::PtrLen
@@ -3969,6 +3969,17 @@ compose_postprocess_final_pre (::std::int32_t rootfs_dfd)
 }
 
 void
+compose_postprocess_final (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$compose_postprocess_final (rootfs_dfd, treefile);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
+}
+
+void
 convert_var_to_tmpfiles_d (::std::int32_t rootfs_dfd,
                            ::rpmostreecxx::GCancellable const &cancellable)
 {
@@ -3996,17 +4007,6 @@ workaround_selinux_cross_labeling (::std::int32_t rootfs_dfd,
 {
   ::rust::repr::PtrLen error$
       = rpmostreecxx$cxxbridge1$workaround_selinux_cross_labeling (rootfs_dfd, cancellable);
-  if (error$.ptr)
-    {
-      throw ::rust::impl< ::rust::Error>::error (error$);
-    }
-}
-
-void
-prepare_rpmdb_base_location (::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable &cancellable)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$prepare_rpmdb_base_location (rootfs_dfd, cancellable);
   if (error$.ptr)
     {
       throw ::rust::impl< ::rust::Error>::error (error$);

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1842,6 +1842,9 @@ void compose_postprocess (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &t
 
 void compose_postprocess_final_pre (::std::int32_t rootfs_dfd);
 
+void compose_postprocess_final (::std::int32_t rootfs_dfd,
+                                ::rpmostreecxx::Treefile const &treefile);
+
 void convert_var_to_tmpfiles_d (::std::int32_t rootfs_dfd,
                                 ::rpmostreecxx::GCancellable const &cancellable);
 
@@ -1849,9 +1852,6 @@ void rootfs_prepare_links (::std::int32_t rootfs_dfd);
 
 void workaround_selinux_cross_labeling (::std::int32_t rootfs_dfd,
                                         ::rpmostreecxx::GCancellable &cancellable);
-
-void prepare_rpmdb_base_location (::std::int32_t rootfs_dfd,
-                                  ::rpmostreecxx::GCancellable &cancellable);
 
 void compose_postprocess_rpm_macro (::std::int32_t rootfs_dfd);
 

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1840,7 +1840,7 @@ void composepost_nsswitch_altfiles (::std::int32_t rootfs_dfd);
 void compose_postprocess (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile,
                           ::rust::Str next_version, bool unified_core);
 
-void compose_postprocess_final (::std::int32_t rootfs_dfd);
+void compose_postprocess_final_pre (::std::int32_t rootfs_dfd);
 
 void convert_var_to_tmpfiles_d (::std::int32_t rootfs_dfd,
                                 ::rpmostreecxx::GCancellable const &cancellable);

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -1028,14 +1028,11 @@ fn workaround_selinux_cross_labeling_recurse(
     Ok(())
 }
 
-pub fn prepare_rpmdb_base_location(
-    rootfs_dfd: i32,
-    cancellable: Pin<&mut crate::FFIGCancellable>,
-) -> CxxResult<()> {
+/// This is the nearly the last code executed before we run `ostree commit`.
+pub fn compose_postprocess_final(rootfs_dfd: i32, _treefile: &Treefile) -> CxxResult<()> {
     let rootfs = unsafe { &crate::ffiutil::ffi_dirfd(rootfs_dfd)? };
-    let cancellable = &cancellable.gobj_wrap();
 
-    hardlink_rpmdb_base_location(rootfs, Some(cancellable))?;
+    hardlink_rpmdb_base_location(rootfs, None)?;
     Ok(())
 }
 

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -310,7 +310,7 @@ pub(crate) fn postprocess_cleanup_rpmdb(rootfs_dfd: i32) -> CxxResult<()> {
 /// it as the bits of that function that we've chosen to implement in Rust.
 /// It takes care of all things that are really required to use rpm-ostree
 /// on the target host.
-pub fn compose_postprocess_final(rootfs_dfd: i32) -> CxxResult<()> {
+pub fn compose_postprocess_final_pre(rootfs_dfd: i32) -> CxxResult<()> {
     let rootfs_dfd = unsafe { &crate::ffiutil::ffi_dirfd(rootfs_dfd)? };
     // These tasks can safely run in parallel, so just for fun we do so via rayon.
     let tasks = [

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -289,7 +289,7 @@ pub mod ffi {
             next_version: &str,
             unified_core: bool,
         ) -> Result<()>;
-        fn compose_postprocess_final(rootfs_dfd: i32) -> Result<()>;
+        fn compose_postprocess_final_pre(rootfs_dfd: i32) -> Result<()>;
         fn convert_var_to_tmpfiles_d(rootfs_dfd: i32, cancellable: &GCancellable) -> Result<()>;
         fn rootfs_prepare_links(rootfs_dfd: i32) -> Result<()>;
         fn workaround_selinux_cross_labeling(

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -290,13 +290,10 @@ pub mod ffi {
             unified_core: bool,
         ) -> Result<()>;
         fn compose_postprocess_final_pre(rootfs_dfd: i32) -> Result<()>;
+        fn compose_postprocess_final(rootfs_dfd: i32, treefile: &Treefile) -> Result<()>;
         fn convert_var_to_tmpfiles_d(rootfs_dfd: i32, cancellable: &GCancellable) -> Result<()>;
         fn rootfs_prepare_links(rootfs_dfd: i32) -> Result<()>;
         fn workaround_selinux_cross_labeling(
-            rootfs_dfd: i32,
-            cancellable: Pin<&mut GCancellable>,
-        ) -> Result<()>;
-        fn prepare_rpmdb_base_location(
             rootfs_dfd: i32,
             cancellable: Pin<&mut GCancellable>,
         ) -> Result<()>;

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -462,8 +462,8 @@ postprocess_final (int rootfs_dfd, rpmostreecxx::Treefile &treefile, gboolean un
         return glnx_prefix_error (error, "During kernel processing");
     }
 
-  /* we're composing a new tree; copy the rpmdb to the base location */
-  ROSCXX_TRY (prepare_rpmdb_base_location (rootfs_dfd, *cancellable), error);
+  /* And now the penultimate postprocessing */
+  ROSCXX_TRY (compose_postprocess_final (rootfs_dfd, treefile), error);
 
   return TRUE;
 }

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -381,7 +381,7 @@ postprocess_final (int rootfs_dfd, rpmostreecxx::Treefile &treefile, gboolean un
 
   auto selinux = treefile.get_selinux ();
 
-  ROSCXX_TRY (compose_postprocess_final (rootfs_dfd), error);
+  ROSCXX_TRY (compose_postprocess_final_pre (rootfs_dfd), error);
 
   if (selinux)
     {


### PR DESCRIPTION
Prep for other work.

---

compose: Rename postprocess_final to postprocess_final_pre

Because...it's not actually final.  Prep for adding a "really final"
function.

---

compose: Reintroduce postprocess_final

Subsubming the rpmdb function that was already there; prep for
doing more at that stage.

---

