### PR TITLE
treefile: Add option to label `/usr/etc` as `/etc`

### DIFF
--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -11,6 +11,11 @@ if [ -z "${SKIP_INSTALLDEPS:-}" ] && test $(id -u) -eq 0; then
     # we have the canonical spec file handy so just builddep from that
     # XXX: use --allowerasing as a temporary hack to ease the migration to libmodulemd2
     time dnf builddep --spec -y packaging/rpm-ostree.spec.in --allowerasing
+
+    osid="$(. /etc/os-release && echo $ID)"
+    if [ "${osid}" == centos ]; then
+        dnf -y update https://kojihub.stream.centos.org/kojifiles/packages/ostree/2023.7/2.el9/$(arch)/ostree-{,libs-,devel-}2023.7-2.el9.$(arch).rpm
+    fi
 fi
 
 mkdir -p target

--- a/configure.ac
+++ b/configure.ac
@@ -81,7 +81,7 @@ PKG_PROG_PKG_CONFIG
 dnl Remember to update AM_CPPFLAGS in Makefile.am when bumping GIO req.
 PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 dnl These are the dependencies of the public librpmostree-1.0.0 shared library
-PKG_CHECK_MODULES(PKGDEP_LIBRPMOSTREE, [gio-unix-2.0 >= 2.50.0 json-glib-1.0 ostree-1 >= 2023.6 rpm >= 4.16])
+PKG_CHECK_MODULES(PKGDEP_LIBRPMOSTREE, [gio-unix-2.0 >= 2.50.0 json-glib-1.0 ostree-1 >= 2023.7 rpm >= 4.16])
 dnl And these additional ones are used by for the rpmostreeinternals C/C++ library
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [polkit-gobject-1 libarchive])
 

--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -138,6 +138,10 @@ It supports the following parameters:
     to the UNIX epoch time to be used as the build timestamp. Currently only
     fully supports the `bdb` backend. Somewhat experimental.
 
+ * `selinux-label-version`: integer, optional:  When set to `1`, this will
+    turn on an ostree flag which labels files in `/usr/etc` as if they were in
+    `/etc`.  This is important to aid in having a "transient" `/etc`.
+
  * `cliwrap`: boolean, optional.  Defaults to `false`.  If enabled,
     rpm-ostree will replace binaries such as `/usr/bin/rpm` with
     wrappers that intercept unsafe operations, or adjust functionality.

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1748,6 +1748,7 @@ struct Treefile final : public ::rust::Opaque
   bool get_documentation () const noexcept;
   bool get_recommends () const noexcept;
   bool get_selinux () const noexcept;
+  ::std::uint32_t get_selinux_label_version () const noexcept;
   ::rust::String get_gpg_key () const noexcept;
   ::rust::String get_automatic_version_suffix () const noexcept;
   bool get_container () const noexcept;
@@ -2587,6 +2588,9 @@ extern "C"
   rpmostreecxx$cxxbridge1$Treefile$get_recommends (::rpmostreecxx::Treefile const &self) noexcept;
 
   bool rpmostreecxx$cxxbridge1$Treefile$get_selinux (::rpmostreecxx::Treefile const &self) noexcept;
+
+  ::std::uint32_t rpmostreecxx$cxxbridge1$Treefile$get_selinux_label_version (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
   void rpmostreecxx$cxxbridge1$Treefile$get_gpg_key (::rpmostreecxx::Treefile const &self,
                                                      ::rust::String *return$) noexcept;
@@ -5131,6 +5135,12 @@ bool
 Treefile::get_selinux () const noexcept
 {
   return rpmostreecxx$cxxbridge1$Treefile$get_selinux (*this);
+}
+
+::std::uint32_t
+Treefile::get_selinux_label_version () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$Treefile$get_selinux_label_version (*this);
 }
 
 ::rust::String

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1530,6 +1530,7 @@ struct Treefile final : public ::rust::Opaque
   bool get_documentation () const noexcept;
   bool get_recommends () const noexcept;
   bool get_selinux () const noexcept;
+  ::std::uint32_t get_selinux_label_version () const noexcept;
   ::rust::String get_gpg_key () const noexcept;
   ::rust::String get_automatic_version_suffix () const noexcept;
   bool get_container () const noexcept;

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -267,15 +267,13 @@ fn postprocess_subs_dist(rootfs_dfd: &Dir) -> Result<()> {
             for line in f.lines() {
                 let line = line?;
                 if line.starts_with("/var/home ") {
-                    w.write_all(b"# https://github.com/projectatomic/rpm-ostree/pull/1754\n")?;
-                    w.write_all(b"# ")?;
+                    writeln!(w, "# https://github.com/projectatomic/rpm-ostree/pull/1754")?;
+                    write!(w, "# ")?;
                 }
-                w.write_all(line.as_bytes())?;
-                w.write_all(b"\n")?;
+                writeln!(w, "{}", line)?;
             }
-            w.write_all(b"# https://github.com/projectatomic/rpm-ostree/pull/1754\n")?;
-            w.write_all(b"/home /var/home")?;
-            w.write_all(b"\n")?;
+            writeln!(w, "# https://github.com/projectatomic/rpm-ostree/pull/1754")?;
+            writeln!(w, "/home /var/home")?;
             Ok(())
         })?;
     }

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -274,6 +274,8 @@ fn postprocess_subs_dist(rootfs_dfd: &Dir) -> Result<()> {
             }
             writeln!(w, "# https://github.com/projectatomic/rpm-ostree/pull/1754")?;
             writeln!(w, "/home /var/home")?;
+            writeln!(w, "# https://github.com/coreos/rpm-ostree/pull/4640")?;
+            writeln!(w, "/usr/etc /etc")?;
             Ok(())
         })?;
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -607,6 +607,7 @@ pub mod ffi {
         fn get_documentation(&self) -> bool;
         fn get_recommends(&self) -> bool;
         fn get_selinux(&self) -> bool;
+        fn get_selinux_label_version(&self) -> u32;
         fn get_gpg_key(&self) -> String;
         fn get_automatic_version_suffix(&self) -> String;
         fn get_container(&self) -> bool;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -416,6 +416,7 @@ fn treefile_merge(dest: &mut TreeComposeConfig, src: &mut TreeComposeConfig) {
         basearch,
         rojig,
         selinux,
+        selinux_label_version,
         ima,
         gpg_key,
         include,
@@ -1332,6 +1333,10 @@ impl Treefile {
         self.parsed.base.selinux.unwrap_or(true)
     }
 
+    pub(crate) fn get_selinux_label_version(&self) -> u32 {
+        self.parsed.base.selinux_label_version.unwrap_or_default()
+    }
+
     pub(crate) fn get_gpg_key(&self) -> String {
         self.parsed.base.gpg_key.clone().unwrap_or_default()
     }
@@ -1479,6 +1484,10 @@ impl Treefile {
             .unwrap_or_default()
         {
             bail!(r#"Treefile repo var "basearch" invalid; it is automatically filled in"#);
+        }
+        match config.selinux_label_version.unwrap_or_default() {
+            0 | 1 => {}
+            o => anyhow::bail!("Invalid selinux-label-version: {o}"),
         }
         Ok(())
     }
@@ -2472,6 +2481,8 @@ pub(crate) struct BaseComposeConfigFields {
     pub(crate) lockfile_repos: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) selinux: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) selinux_label_version: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) ima: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -34,12 +34,19 @@ gboolean rpmostree_prepare_rootfs_get_sepolicy (int dfd, OstreeSePolicy **out_se
 gboolean rpmostree_rootfs_fixup_selinux_store_root (int rootfs_dfd, GCancellable *cancellable,
                                                     GError **error);
 
+typedef enum
+{
+  RPMOSTREE_SELINUX_MODE_DISABLED,
+  RPMOSTREE_SELINUX_MODE_V0, // Enabled
+  RPMOSTREE_SELINUX_MODE_V1, // Label /usr/etc as /etc
+} RpmOstreeSELinuxMode;
+
 gboolean rpmostree_compose_commit (int rootfs_dfd, OstreeRepo *repo, const char *parent,
                                    GVariant *metadata, GVariant *detached_metadata,
                                    const char *gpg_keyid, gboolean container,
-                                   gboolean enable_selinux, OstreeRepoDevInoCache *devino_cache,
-                                   char **out_new_revision, GCancellable *cancellable,
-                                   GError **error);
+                                   RpmOstreeSELinuxMode selinux,
+                                   OstreeRepoDevInoCache *devino_cache, char **out_new_revision,
+                                   GCancellable *cancellable, GError **error);
 
 G_END_DECLS
 

--- a/tests/compose/test-misc-tweaks.sh
+++ b/tests/compose/test-misc-tweaks.sh
@@ -40,6 +40,7 @@ documentation: true
 EOF
 cat > config/other.yaml <<'EOF'
 recommends: true
+selinux-label-version: 1
 readonly-executables: true
 container-cmd:
   - /usr/bin/bash
@@ -134,6 +135,10 @@ export treefile=${new_treefile}
 # Do the compose
 runcompose
 echo "ok compose"
+
+ostree --repo=${repo} ls -X ${treeref} /usr/etc/sysctl.conf > ls.txt
+assert_file_has_content ls.txt ':system_conf_t:'
+echo "ok selinux-label-version"
 
 # Tests for docs
 ostree --repo=${repo} ls -R ${treeref} /usr/share/man > manpages.txt


### PR DESCRIPTION
Depends on https://github.com/ostreedev/ostree/pull/3063

This is intended for use with https://github.com/ostreedev/ostree/issues/2868 but is conceptually orthogonal to it; we probably want to try switching to this by default actually.
