### PR TITLE
ci/upgrade: disable `zincati.service` in config.bu

### DIFF
--- a/ci/prow/e2e-upgrades.sh
+++ b/ci/prow/e2e-upgrades.sh
@@ -33,6 +33,10 @@ storage:
     - path: /etc/ostree/auth.json
       contents:
         local: auth.json
+systemd:
+  units:
+    - name: zincati.service
+      enable: false
 EOF
 butane -d . < config.bu > config.ign
 


### PR DESCRIPTION
Try to fix
```
kola -p qemu run --append-ignition config.ign --oscontainer ostree-unverified-registry:xxx --qemu-image ./fedora-coreos-38.20231002.3.1-qemu.x86_64.qcow2 ext.rpm-ostree.upgrades --output-dir /logs/artifacts/kola
=== RUN   ext.rpm-ostree.upgrades
2023-10-23T08:12:31Z platform: some systemd units failed: zincati.service
```
