### PR TITLE
libpriv/kernel: Add padding between dracut initramfs and random CPIO

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -2341,7 +2341,8 @@ extern "C"
       ::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username,
       ::rust::Str groupname, ::rust::String *return$) noexcept;
 
-  ::rust::repr::Fat rpmostreecxx$cxxbridge1$get_dracut_random_cpio () noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$append_dracut_random_cpio (::std::int32_t fd) noexcept;
 
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$initramfs_overlay_generate (::rust::Vec< ::rust::String> const &files,
@@ -4417,11 +4418,14 @@ tmpfiles_translate (::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_
   return ::std::move (return$.value);
 }
 
-::rust::Slice< ::std::uint8_t const>
-get_dracut_random_cpio () noexcept
+void
+append_dracut_random_cpio (::std::int32_t fd)
 {
-  return ::rust::impl< ::rust::Slice< ::std::uint8_t const> >::slice (
-      rpmostreecxx$cxxbridge1$get_dracut_random_cpio ());
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$append_dracut_random_cpio (fd);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
 }
 
 ::std::int32_t

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1917,7 +1917,7 @@ rpm_importer_new (::rust::Str pkg_name, ::rust::Str ostree_branch,
 ::rust::String tmpfiles_translate (::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info,
                                    ::rust::Str username, ::rust::Str groupname);
 
-::rust::Slice< ::std::uint8_t const> get_dracut_random_cpio () noexcept;
+void append_dracut_random_cpio (::std::int32_t fd);
 
 ::std::int32_t initramfs_overlay_generate (::rust::Vec< ::rust::String> const &files,
                                            ::rpmostreecxx::GCancellable &cancellable);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -436,7 +436,7 @@ pub mod ffi {
 
     // initramfs.rs
     extern "Rust" {
-        fn get_dracut_random_cpio() -> &'static [u8];
+        fn append_dracut_random_cpio(fd: i32) -> Result<()>;
         fn initramfs_overlay_generate(
             files: &Vec<String>,
             cancellable: Pin<&mut GCancellable>,

--- a/src/libpriv/rpmostree-kernel.cxx
+++ b/src/libpriv/rpmostree-kernel.cxx
@@ -580,11 +580,7 @@ rpmostree_run_dracut (int rootfs_dfd, const char *const *argv, const char *kver,
    * https://bugzilla.redhat.com/show_bug.cgi?id=1401444
    * https://bugzilla.redhat.com/show_bug.cgi?id=1380866
    * */
-  auto random_cpio_data = rpmostreecxx::get_dracut_random_cpio ();
-  if (lseek (tmpf.fd, 0, SEEK_END) < 0)
-    return glnx_throw_errno_prefix (error, "lseek");
-  if (glnx_loop_write (tmpf.fd, random_cpio_data.data (), random_cpio_data.length ()) < 0)
-    return glnx_throw_errno_prefix (error, "write");
+  CXX_TRY (rpmostreecxx::append_dracut_random_cpio (tmpf.fd), error);
 
   if (rebuild_from_initramfs)
     (void)unlinkat (rootfs_dfd, rebuild_from_initramfs, 0);

--- a/tests/kolainst/destructive/initramfs-padding
+++ b/tests/kolainst/destructive/initramfs-padding
@@ -1,0 +1,37 @@
+#!/bin/bash
+# kola: { "tags": "needs-internet", "minMemory": 1536 }
+# Test https://github.com/coreos/rpm-ostree/pull/4705
+set -euo pipefail
+
+. ${KOLA_EXT_DATA}/libtest.sh
+cd "$(mktemp -d)"
+
+set -x
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+    cur_initrd=$(ls /boot/ostree/*/initramfs-*.img)
+
+    # check we're not already on lz4
+    (/usr/lib/dracut/skipcpio "${cur_initrd}" || :) | head -c 100 > out.img
+    file out.img > out.img.file
+    assert_not_file_has_content out.img.file "LZ4"
+
+    rpm-ostree install lz4 -A
+    rpm-ostree initramfs --enable --arg='--compress=lz4'
+    /tmp/autopkgtest-reboot reboot
+    ;;
+  "reboot")
+    new_initrd=$(ls -t /boot/ostree/*/initramfs-*.img | head -n 1)
+    (/usr/lib/dracut/skipcpio "${new_initrd}" || :) | head -c 100 > out.new.img
+    file out.new.img > out.new.img.file
+    assert_file_has_content out.new.img.file "LZ4"
+    set +x # so our grepping doesn't get a hit on itself
+    if journalctl --grep 'Initramfs unpacking failed: Decoding failed'; then
+      fatal "Found initramfs unpacking failure in journal"
+    fi
+    ;;
+  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac
+
+echo "ok"


### PR DESCRIPTION
Any arbitrary amount of padding between concatenated CPIOs is allowed:

https://www.kernel.org/doc/Documentation/early-userspace/buffer-format.txt

However, some initramfs decompressors in the kernel expect a minimal amount of padding to detect EOF and allow the kernel outer loop to try out other decompressors for the next payload. This is the case for lz4. This upstream patch allows the lz4 decompressor to treat padding as EOF:

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=2c484419efc09e7234c667aa72698cb79ba8d8ed

But it assumes that the padding is at least 4 bytes.

Since padding doesn't hurt regardless of the compression used, let's just unconditionally add it.

Fixes https://github.com/coreos/rpm-ostree/issues/4683.