### PR TITLE
lockfile: add SRPM name in metadata field

### DIFF
--- a/rust/libdnf-sys/cxx/libdnf.hpp
+++ b/rust/libdnf-sys/cxx/libdnf.hpp
@@ -63,6 +63,11 @@ public:
   {
     return rust::String (::dnf_package_get_arch (pkg));
   };
+  rust::String
+  get_sourcerpm ()
+  {
+    return rust::String (::dnf_package_get_sourcerpm (pkg));
+  };
 };
 
 std::unique_ptr<DnfPackage> dnf_package_from_ptr (FFIDnfPackage *pkg) noexcept;

--- a/rust/libdnf-sys/lib.rs
+++ b/rust/libdnf-sys/lib.rs
@@ -53,6 +53,7 @@ pub mod ffi {
         fn get_name(self: Pin<&mut DnfPackage>) -> String;
         fn get_evr(self: Pin<&mut DnfPackage>) -> String;
         fn get_arch(self: Pin<&mut DnfPackage>) -> String;
+        fn get_sourcerpm(self: Pin<&mut DnfPackage>) -> String;
         /// SAFETY: This can only be called on a valid pointer
         unsafe fn dnf_package_from_ptr(pkg: *mut FFIDnfPackage) -> UniquePtr<DnfPackage>;
 


### PR DESCRIPTION
As part of Bodhi gating, we need to deal with source RPM names and not binary RPMs. E.g. Bodhi CI messages include Koji NVRs, not binary RPMs. Having to do the translation between SRPM and RPM is expensive because you need either repodata or e.g. bring up a VM and query the rpmdb.

Instead, just have rpm-ostree output the SRPM name as a metadata field in the output lockfile. cosa already saves this and outputs it in the build dir so it ends up in S3 and is much easier to work with.

Obviously there's some redundancy there since every binary RPM from the same source RPM will have the same field. But it doesn't seem worth extending the schema for it instead of just working with it as is.

Related: https://github.com/coreos/fedora-coreos-tracker/issues/1617