### PR TITLE
composepost: Support rootfs.transient=yes

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -970,6 +970,7 @@ pub(crate) use self::modularity::*;
 mod nameservice;
 mod normalization;
 mod origin;
+mod ostree_prepareroot;
 pub(crate) use self::origin::*;
 mod passwd;
 use passwd::*;

--- a/rust/src/ostree_prepareroot.rs
+++ b/rust/src/ostree_prepareroot.rs
@@ -1,0 +1,50 @@
+//! Logic related to parsing ostree-prepare-root.conf.
+//!
+
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::io::BufReader;
+use std::io::Read;
+
+use anyhow::{Context, Result};
+use camino::Utf8Path;
+use cap_std::fs::Dir;
+use cap_std_ext::dirext::CapStdExtDirExt;
+use ostree_ext::glib;
+use ostree_ext::keyfileext::KeyFileExt;
+
+pub(crate) const CONF_PATH: &str = "ostree/prepare-root.conf";
+
+pub(crate) fn load_config(rootfs: &Dir) -> Result<Option<glib::KeyFile>> {
+    let kf = glib::KeyFile::new();
+    for path in ["etc", "usr/lib"].into_iter().map(Utf8Path::new) {
+        let path = &path.join(CONF_PATH);
+        if let Some(fd) = rootfs
+            .open_optional(path)
+            .with_context(|| format!("Opening {path}"))?
+        {
+            let mut fd = BufReader::new(fd);
+            let mut buf = String::new();
+            fd.read_to_string(&mut buf)
+                .with_context(|| format!("Reading {path}"))?;
+            kf.load_from_data(&buf, glib::KeyFileFlags::NONE)
+                .with_context(|| format!("Parsing {path}"))?;
+            tracing::debug!("Loaded {path}");
+            return Ok(Some(kf));
+        }
+    }
+    tracing::debug!("No {CONF_PATH} found");
+    Ok(None)
+}
+
+/// Query whether the target root has the `root.transient` key
+/// which sets up a transient overlayfs.
+pub(crate) fn transient_root_enabled(rootfs: &Dir) -> Result<bool> {
+    if let Some(config) = load_config(rootfs)? {
+        Ok(config
+            .optional_bool("root", "transient")?
+            .unwrap_or_default())
+    } else {
+        Ok(false)
+    }
+}

--- a/tests/compose/test-rootfs-transient.sh
+++ b/tests/compose/test-rootfs-transient.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -xeuo pipefail
+
+dn=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=libcomposetest.sh
+. "${dn}/libcomposetest.sh"
+
+# Add a local rpm-md repo so we can mutate local test packages
+treefile_append "repos" '["test-repo"]'
+build_rpm prepare-root-config \
+          files "/usr/lib/ostree/prepare-root.conf" \
+          install "mkdir -p %{buildroot}/usr/lib/ostree && echo -e '[root]\ntransient=true' > %{buildroot}/usr/lib/ostree/prepare-root.conf"
+
+echo gpgcheck=0 >> yumrepo.repo
+ln "$PWD/yumrepo.repo" config/yumrepo.repo
+# the top-level manifest doesn't have any packages, so just set it
+treefile_append "packages" '["prepare-root-config"]'
+
+# Do the compose
+runcompose
+echo "ok compose"
+
+ostree --repo=${repo} ls ${treeref} /opt > ls.txt
+assert_file_has_content ls.txt 'd00755  *0  *0  *0  */opt'
+echo "ok opt is directory with transient rootfs"


### PR DESCRIPTION
This pairs with https://github.com/ostreedev/ostree/pull/3114

Basically we want to detect the case where the OS has opted-in to this new mode and *not* symlink things.

I originally thought we could implement this by just moving all the toplevel directories, but then I hit on the fact that because the `filesystem` package is creating all the toplevel directories in lua script which we ignore...that doesn't work.

So we need to keep making them by hand.
