### PR TITLE
A few minor updates for tmpfiles code

### DIFF
--- a/rust/src/tmpfiles.rs
+++ b/rust/src/tmpfiles.rs
@@ -37,14 +37,11 @@ pub fn deduplicate_tmpfiles_entries(tmprootfs_dfd: i32) -> CxxResult<()> {
     if tmpfiles_dir.try_exists(AUTOVAR_PATH)? {
         tmpfiles_dir.remove_file(AUTOVAR_PATH)?;
     }
-    let system_tmpfiles_entries = read_tmpfiles(&tmpfiles_dir)?
-        .into_iter()
-        .map(|v| v.0)
-        .collect::<std::collections::HashSet<_>>();
+    let system_tmpfiles_entries = read_tmpfiles(&tmpfiles_dir)?;
 
     // remove duplicated entries in auto-generated tmpfiles.d,
     // which are already in system tmpfiles
-    for key in system_tmpfiles_entries.into_iter() {
+    for (key, _) in system_tmpfiles_entries {
         rpmostree_tmpfiles_entries.retain(|k, _value| k != &key);
     }
 

--- a/rust/src/tmpfiles.rs
+++ b/rust/src/tmpfiles.rs
@@ -27,7 +27,7 @@ pub fn deduplicate_tmpfiles_entries(tmprootfs_dfd: i32) -> CxxResult<()> {
     let tmpfiles_dir = tmprootfs_dfd
         .open_dir(RPMOSTREE_TMPFILESD)
         .context("readdir {RPMOSTREE_TMPFILESD}")?;
-    let mut rpmostree_tmpfiles_entries = save_tmpfile_entries(&tmpfiles_dir)?
+    let mut rpmostree_tmpfiles_entries = read_tmpfiles(&tmpfiles_dir)?
         .map(|s| {
             let entry = tmpfiles_entry_get_path(&s.as_str())?;
             anyhow::Ok((entry.to_string(), s.to_string()))
@@ -42,7 +42,7 @@ pub fn deduplicate_tmpfiles_entries(tmprootfs_dfd: i32) -> CxxResult<()> {
     if tmpfiles_dir.try_exists(AUTOVAR_PATH)? {
         tmpfiles_dir.remove_file(AUTOVAR_PATH)?;
     }
-    let system_tmpfiles_entries = save_tmpfile_entries(&tmpfiles_dir)?
+    let system_tmpfiles_entries = read_tmpfiles(&tmpfiles_dir)?
         .map(|s| {
             let entry = tmpfiles_entry_get_path(&s.as_str())?;
             anyhow::Ok(entry.to_string())
@@ -69,7 +69,7 @@ pub fn deduplicate_tmpfiles_entries(tmprootfs_dfd: i32) -> CxxResult<()> {
 }
 
 // #[context("Scan all tmpfiles conf and save entries")]
-fn save_tmpfile_entries(tmpfiles_dir: &Dir) -> Result<impl Iterator<Item = String>> {
+fn read_tmpfiles(tmpfiles_dir: &Dir) -> Result<impl Iterator<Item = String>> {
     let entries = tmpfiles_dir
         .entries()?
         .filter_map(|name| {

--- a/rust/src/tmpfiles.rs
+++ b/rust/src/tmpfiles.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result};
 use cap_std::fs::{Dir, Permissions};
 use cap_std_ext::dirext::CapStdExtDirExt;
 use fn_error_context::context;
-use std::collections::{HashMap, HashSet};
+use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::os::unix::prelude::PermissionsExt;
 use std::path::Path;
@@ -40,7 +40,7 @@ pub fn deduplicate_tmpfiles_entries(tmprootfs_dfd: i32) -> CxxResult<()> {
     let system_tmpfiles_entries = read_tmpfiles(&tmpfiles_dir)?
         .into_iter()
         .map(|v| v.0)
-        .collect::<HashSet<_>>();
+        .collect::<std::collections::HashSet<_>>();
 
     // remove duplicated entries in auto-generated tmpfiles.d,
     // which are already in system tmpfiles
@@ -64,7 +64,7 @@ pub fn deduplicate_tmpfiles_entries(tmprootfs_dfd: i32) -> CxxResult<()> {
 /// Read all tmpfiles.d entries in the target directory, and return a mapping
 /// from (file path) => (single tmpfiles.d entry line)
 #[context("Read systemd tmpfiles.d")]
-fn read_tmpfiles(tmpfiles_dir: &Dir) -> Result<HashMap<String, String>> {
+fn read_tmpfiles(tmpfiles_dir: &Dir) -> Result<BTreeMap<String, String>> {
     tmpfiles_dir
         .entries()?
         .filter_map(|name| {


### PR DESCRIPTION
tmpfiles: Rename reader function

---

tmpfiles: Change `read_tmpfiles` to return a direct hashmap

While returning an iterator was more elegant, it makes
error handling much more difficult *and* we had intermediate
`collects()` that meant it wasn't really lazy.

Trying to remove the intermediate `collect` runs into borrowing
issues (on the input `&Dir`) and this isn't a high performance
path so doing the more obvious simpler thing is better.

---

tmpfiles: Collect into a BTreeMap for reproducibility

I hit a test failure in one run because HashMap is not ordered
predictably.

---

tmpfiles: Drop intermediate re-allocation

Since we're now returning a direct map we don't need
to convert to a set, we can just ignore the values when iterating.

---

