### PR TITLE
Tmpfiles handle old cache

### DIFF
--- a/rust/src/tmpfiles.rs
+++ b/rust/src/tmpfiles.rs
@@ -26,13 +26,11 @@ pub fn deduplicate_tmpfiles_entries(tmprootfs_dfd: i32) -> CxxResult<()> {
     // scan all rpm-ostree auto generated entries and save
     let tmpfiles_dir = tmprootfs_dfd
         .open_dir(RPMOSTREE_TMPFILESD)
-        .context("readdir {RPMOSTREE_TMPFILESD}")?;
+        .context(RPMOSTREE_TMPFILESD)?;
     let mut rpmostree_tmpfiles_entries = read_tmpfiles(&tmpfiles_dir)?;
 
     // remove autovar.conf first, then scan all system entries and save
-    let tmpfiles_dir = tmprootfs_dfd
-        .open_dir(TMPFILESD)
-        .context("readdir {TMPFILESD}")?;
+    let tmpfiles_dir = tmprootfs_dfd.open_dir(TMPFILESD).context(TMPFILESD)?;
 
     if tmpfiles_dir.try_exists(AUTOVAR_PATH)? {
         tmpfiles_dir.remove_file(AUTOVAR_PATH)?;


### PR DESCRIPTION
tmpfiles: Fix error contexts

We weren't actually formatting these, so the error looks like:
`error: Deduplicate tmpfiles entries: readdir {RPMOSTREE_TMPFILESD}: No such file or directory (os error 2)`

It's simpler to just not format.

---

tmpfiles: Handle old caches

I actually did get bitten by having an old cache where
there's nothing in the `RPMOSTREE_TMPFILESD` dir.

Just handle the case where the directory doesn't exist.
For good measure, also gracefully no-op if the destination tmpfiles.d
directory doesn't exist.

---

