### PR TITLE
Support RPMs installing in `/opt` and `/usr/local`

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -85,7 +85,7 @@ librpmostreeinternals_la_CXXFLAGS = $(AM_CXXFLAGS) $(sanitizer_flags) $(rpmostre
 librpmostreeinternals_la_LIBADD = $(rpmostree_common_libs)
 
 privdatadir=$(pkglibdir)
-privdata_DATA = src/app/rpm-ostree-0-integration.conf src/app/rpm-ostree-0-integration-opt-usrlocal.conf
+privdata_DATA = src/app/rpm-ostree-0-integration.conf src/app/rpm-ostree-0-integration-opt-usrlocal.conf src/app/rpm-ostree-0-integration-opt-usrlocal-compat.conf
 
 # Propagate automake verbose mode
 cargo_build = $(cargo) build $(if $(subst 0,,$(V)),--verbose,)

--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -479,3 +479,9 @@ version of `rpm-ostree`.
    names to use when substituting variables in yum repo files. The `releasever`
    variable name is invalid. Use the `releasever` key instead. The `basearch`
    name is invalid; it is filled in automatically.
+ * `opt-usrlocal-overlays`: boolean, optional: Defaults to `false`.  By
+   default, `/opt` and `/usr/local` are symlinks to subdirectories in `/
+   var`. This prevents the ability to compose with packages that install in
+   those directories. If enabled, RPMs with `/opt` and `/usr/local` content
+   are allowed; client-side, both paths are writable overlay directories on.
+   Requires libostree v2023.9+.

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1774,6 +1774,7 @@ struct Treefile final : public ::rust::Opaque
   ::rpmostreecxx::RepoMetadataTarget get_repo_metadata_target () const noexcept;
   bool rpmdb_backend_is_target () const noexcept;
   bool should_normalize_rpmdb () const noexcept;
+  bool get_opt_usrlocal_overlays () const noexcept;
   ::rust::Vec< ::rust::String> get_files_remove_regex (::rust::Str package) const noexcept;
   ::rust::String get_checksum (::rpmostreecxx::OstreeRepo const &repo) const;
   ::rust::String get_ostree_ref () const noexcept;
@@ -2641,6 +2642,9 @@ extern "C"
       ::rpmostreecxx::Treefile const &self) noexcept;
 
   bool rpmostreecxx$cxxbridge1$Treefile$should_normalize_rpmdb (
+      ::rpmostreecxx::Treefile const &self) noexcept;
+
+  bool rpmostreecxx$cxxbridge1$Treefile$get_opt_usrlocal_overlays (
       ::rpmostreecxx::Treefile const &self) noexcept;
 
   void rpmostreecxx$cxxbridge1$Treefile$get_files_remove_regex (
@@ -5255,6 +5259,12 @@ bool
 Treefile::should_normalize_rpmdb () const noexcept
 {
   return rpmostreecxx$cxxbridge1$Treefile$should_normalize_rpmdb (*this);
+}
+
+bool
+Treefile::get_opt_usrlocal_overlays () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$Treefile$get_opt_usrlocal_overlays (*this);
 }
 
 ::rust::Vec< ::rust::String>

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1556,6 +1556,7 @@ struct Treefile final : public ::rust::Opaque
   ::rpmostreecxx::RepoMetadataTarget get_repo_metadata_target () const noexcept;
   bool rpmdb_backend_is_target () const noexcept;
   bool should_normalize_rpmdb () const noexcept;
+  bool get_opt_usrlocal_overlays () const noexcept;
   ::rust::Vec< ::rust::String> get_files_remove_regex (::rust::Str package) const noexcept;
   ::rust::String get_checksum (::rpmostreecxx::OstreeRepo const &repo) const;
   ::rust::String get_ostree_ref () const noexcept;

--- a/rust/src/importer.rs
+++ b/rust/src/importer.rs
@@ -392,7 +392,7 @@ fn path_is_ostree_compliant(path: &str) -> bool {
         return true;
     }
 
-    if path.starts_with("/usr/") && !path.starts_with("/usr/local") {
+    if path.starts_with("/usr/") {
         return true;
     }
 
@@ -491,7 +491,7 @@ mod tests {
             assert_eq!(path_is_ostree_compliant(entry), false, "{}", entry);
         }
 
-        let denied_cases = &["/var", "/etc", "/var/run", "/usr/local", "", "./", "usr/"];
+        let denied_cases = &["/var", "/etc", "/var/run", "", "./", "usr/"];
         for entry in denied_cases {
             assert_eq!(path_is_ostree_compliant(entry), false, "{}", entry);
         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -625,6 +625,7 @@ pub mod ffi {
         fn get_repo_metadata_target(&self) -> RepoMetadataTarget;
         fn rpmdb_backend_is_target(&self) -> bool;
         fn should_normalize_rpmdb(&self) -> bool;
+        fn get_opt_usrlocal_overlays(&self) -> bool;
         fn get_files_remove_regex(&self, package: &str) -> Vec<String>;
         fn get_checksum(&self, repo: &OstreeRepo) -> Result<String>;
         fn get_ostree_ref(&self) -> String;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1412,6 +1412,10 @@ impl Treefile {
         self.parsed.base.rpmdb_normalize.unwrap_or(false)
     }
 
+    pub(crate) fn get_opt_usrlocal_overlays(&self) -> bool {
+        self.parsed.base.opt_usrlocal_overlays.unwrap_or_default()
+    }
+
     pub(crate) fn get_files_remove_regex(&self, package: &str) -> Vec<String> {
         let mut files_to_remove: Vec<String> = Vec::new();
         if let Some(ref packages) = self.parsed.base.remove_from_packages {

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -427,6 +427,7 @@ fn treefile_merge(dest: &mut TreeComposeConfig, src: &mut TreeComposeConfig) {
         documentation,
         boot_location,
         tmp_is_dir,
+        opt_usrlocal_overlays,
         default_target,
         machineid_compat,
         releasever,
@@ -2531,6 +2532,8 @@ pub(crate) struct BaseComposeConfigFields {
     pub(crate) boot_location: Option<BootLocation>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) tmp_is_dir: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) opt_usrlocal_overlays: Option<bool>,
 
     // systemd
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/app/rpm-ostree-0-integration-opt-usrlocal-compat.conf
+++ b/src/app/rpm-ostree-0-integration-opt-usrlocal-compat.conf
@@ -1,0 +1,5 @@
+# Traditionally, /usr/local has been a link to /var/usrlocal and /opt to /var/opt.
+# A new model now is to allow OSTree commit content in those directories. For
+# backwards compatibility, we keep the /var paths but flip the symlinks around.
+L /var/usrlocal - - - - ../usr/local
+L /var/opt - - - - ../usr/lib/opt

--- a/src/app/rpm-ostree-0-integration-opt-usrlocal.conf
+++ b/src/app/rpm-ostree-0-integration-opt-usrlocal.conf
@@ -1,2 +1,5 @@
+# Traditionally, /usr/local has been a link to /var/usrlocal and /opt to /var/opt.
+# A new model now is to allow OSTree commit content in those directories. But
+# this dropin implements the old model.
 d /var/opt 0755 root root -
 d /var/usrlocal 0755 root root -

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -461,12 +461,24 @@ postprocess_final (int rootfs_dfd, rpmostreecxx::Treefile &treefile, gboolean un
                           cancellable, error))
     return FALSE;
 
-  if (!glnx_file_copy_at (pkglibdir_dfd, "rpm-ostree-0-integration-opt-usrlocal.conf", NULL,
-                          rootfs_dfd,
-                          "usr/lib/tmpfiles.d/rpm-ostree-0-integration-opt-usrlocal.conf",
-                          GLNX_FILE_COPY_NOXATTRS, /* Don't take selinux label */
-                          cancellable, error))
-    return FALSE;
+  if (treefile.get_opt_usrlocal_overlays ())
+    {
+      if (!glnx_file_copy_at (
+              pkglibdir_dfd, "rpm-ostree-0-integration-opt-usrlocal-compat.conf", NULL, rootfs_dfd,
+              "usr/lib/tmpfiles.d/rpm-ostree-0-integration-opt-usrlocal-compat.conf",
+              GLNX_FILE_COPY_NOXATTRS, /* Don't take selinux label */
+              cancellable, error))
+        return FALSE;
+    }
+  else
+    {
+      if (!glnx_file_copy_at (pkglibdir_dfd, "rpm-ostree-0-integration-opt-usrlocal.conf", NULL,
+                              rootfs_dfd,
+                              "usr/lib/tmpfiles.d/rpm-ostree-0-integration-opt-usrlocal.conf",
+                              GLNX_FILE_COPY_NOXATTRS, /* Don't take selinux label */
+                              cancellable, error))
+        return FALSE;
+    }
 
   /* Handle kernel/initramfs if we're not doing a container */
   if (!container)

--- a/tests/compose/test-state-overlays.sh
+++ b/tests/compose/test-state-overlays.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -xeuo pipefail
+
+dn=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=libcomposetest.sh
+. "${dn}/libcomposetest.sh"
+
+# Add a local rpm-md repo so we can mutate local test packages
+treefile_append "repos" '["test-repo"]'
+
+# An RPM that installs in /opt
+build_rpm test-opt \
+             install "mkdir -p %{buildroot}/opt/megacorp/bin
+                      install %{name} %{buildroot}/opt/megacorp/bin" \
+             files "/opt/megacorp"
+
+# An RPM that installs in /usr/local
+build_rpm test-usr-local \
+             install "mkdir -p %{buildroot}/usr/local/bin
+                      install %{name} %{buildroot}/usr/local/bin" \
+             files "/usr/local/bin/%{name}"
+
+echo gpgcheck=0 >> yumrepo.repo
+ln "$PWD/yumrepo.repo" config/yumrepo.repo
+
+# the top-level manifest doesn't have any packages, so just set it
+treefile_append "packages" '["test-opt", "test-usr-local"]'
+
+# enable state overlays
+treefile_set "opt-usrlocal-overlays" 'True'
+
+runcompose
+
+# shellcheck disable=SC2154
+ostree --repo="${repo}" ls -R "${treeref}" /usr/lib/opt > opt.txt
+assert_file_has_content opt.txt "/usr/lib/opt/megacorp/bin/test-opt"
+
+ostree --repo="${repo}" ls -R "${treeref}" /usr/local > usr-local.txt
+assert_file_has_content usr-local.txt "/usr/local/bin/test-usr-local"
+
+ostree --repo="${repo}" ls -R "${treeref}" /usr/lib/systemd/system/local-fs.target.requires > local-fs.txt
+assert_file_has_content local-fs.txt "ostree-state-overlay@usr-lib-opt.service"
+assert_file_has_content local-fs.txt "ostree-state-overlay@usr-local.service"
+
+echo "ok /opt and /usr/local RPMs"

--- a/tests/kolainst/destructive/state-overlays
+++ b/tests/kolainst/destructive/state-overlays
@@ -1,0 +1,104 @@
+#!/bin/bash
+## kola:
+##   tags: "needs-internet"
+
+set -euo pipefail
+
+. ${KOLA_EXT_DATA}/libtest.sh
+
+rm -rf /etc/yum.repos.d/*
+cat > /etc/yum.repos.d/vmcheck.repo << EOF
+[test-repo]
+name=test-repo
+baseurl=file:///${KOLA_EXT_DATA}/rpm-repos/0
+gpgcheck=0
+enabled=1
+EOF
+
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+    # switch over to local ref so upgrades are purely about package changes
+    booted_commit=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
+    ostree refs --create kolatest "${booted_commit}"
+    systemctl stop rpm-ostreed
+    unshare -m /bin/bash -c 'mount -o rw,remount /sysroot && sed -i -e "s/refspec=.*/refspec=kolatest/" /ostree/deploy/*/deploy/*.origin'
+
+    # XXX: until ostree v2024.1 hits FCOS
+    ostree_ver=$(rpm -q ostree  --qf '%{version}')
+    if [ "${ostree_ver}" != "2024.1" ] && \
+       [ "$(echo -e "${ostree_ver}\n2024.1" | sort -V | tail -n1)" = "2024.1" ]; then
+      rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2024-6c7480dd2f
+    fi
+
+    # FCOS doesn't enable opt-usrlocal-overlays so use the hack instead
+    mkdir -p /etc/systemd/system/rpm-ostreed.service.d/
+    cat > /etc/systemd/system/rpm-ostreed.service.d/state-overlay.conf <<EOF
+[Service]
+Environment=RPMOSTREE_EXPERIMENTAL_FORCE_OPT_USRLOCAL_OVERLAY=1
+EOF
+
+    # This script itself is in /usr/local, so we need to move it back on top
+    # of the overlay. This simultaneously demos one way upgrading nodes could
+    # retain content if we turn on opt-usrlocal-overlays in FCOS.
+    cat > /etc/systemd/system/move-usr-local.service <<EOF
+[Unit]
+Description=Move Previous /usr/local content back into /usr/local
+After=local-fs.target
+After=systemd-tmpfiles-setup.service
+Before=kola-runext.service
+
+[Service]
+Type=oneshot
+# I previously used rsync here to sync all of /var/usrlocal, but hit SELinux
+# issues; it seems like it runs as rsync_t which can't do things on top of
+# overlay? To investigate...
+ExecStart=cp /var/usrlocal/bin/kola-runext-state-overlays /usr/local/bin/
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload
+    systemctl restart rpm-ostreed
+    systemctl enable move-usr-local.service
+
+    rpm-ostree install test-opt
+
+    /tmp/autopkgtest-reboot 1
+    ;;
+  1)
+    test -f /opt/megacorp/bin/test-opt
+    test -f /opt/megacorp/lib/mylib
+    test -d /opt/megacorp/state
+
+    /opt/megacorp/bin/test-opt > /tmp/out.txt
+    assert_file_has_content /tmp/out.txt 'test-opt'
+    assert_file_has_content /opt/megacorp/lib/mylib 'lib1'
+
+    # add some state files
+    echo 'foobar' > /opt/megacorp/state/mystate
+
+    # change some base files
+    echo 'badlib' > /opt/megacorp/lib/mylib
+    /tmp/autopkgtest-reboot 2
+    ;;
+  2)
+    # check our state is still there
+    assert_file_has_content /opt/megacorp/state/mystate 'foobar'
+    assert_file_has_content /opt/megacorp/lib/mylib 'badlib'
+
+    # upgrade to -2
+    sed -i -e 's,rpm-repos/0,rpm-repos/1,' /etc/yum.repos.d/vmcheck.repo
+    rpm-ostree upgrade
+    /tmp/autopkgtest-reboot 3
+    ;;
+  3)
+    # check our state is still there
+    assert_file_has_content /opt/megacorp/state/mystate 'foobar'
+
+    # but base content has been reset
+    assert_file_has_content /opt/megacorp/lib/mylib 'lib2'
+    ;;
+  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac

--- a/tests/kolainst/kolainst-build.sh
+++ b/tests/kolainst/kolainst-build.sh
@@ -96,6 +96,13 @@ build_module_defaults foomodular \
 build_rpm zincati version 99.99 release 2
 build_rpm zincati version 99.99 release 3
 
+# An RPM that installs in /opt
+build_rpm test-opt \
+             install "mkdir -p %{buildroot}/opt/megacorp/{bin,lib,state}
+                      install %{name} %{buildroot}/opt/megacorp/bin
+                      echo lib1 > %{buildroot}/opt/megacorp/lib/mylib" \
+             files "/opt/megacorp"
+
 mv ${test_tmpdir}/yumrepo/* ${test_tmpdir}/rpm-repos/${repover}
 
 # To test remote override replace update
@@ -111,6 +118,14 @@ build_rpm pkgsystemd \
   install "mkdir -p %{buildroot}/usr/lib/systemd/system 
            install %{name}.service %{buildroot}/usr/lib/systemd/system" \
   files "/usr/lib/systemd/system/%{name}.service"
+
+# to test updates to RPMs that install in /opt
+build_rpm test-opt release 2 \
+             install "mkdir -p %{buildroot}/opt/megacorp/{bin,lib,state}
+                      install %{name} %{buildroot}/opt/megacorp/bin
+                      echo lib2 > %{buildroot}/opt/megacorp/lib/mylib" \
+             files "/opt/megacorp"
+
 mv ${test_tmpdir}/yumrepo/* ${test_tmpdir}/rpm-repos/${repover}
 
 # Create an empty repo when we want to test inability to find a package

--- a/tests/vmcheck/test-layering-basic-1.sh
+++ b/tests/vmcheck/test-layering-basic-1.sh
@@ -79,7 +79,8 @@ vm_build_rpm test-usrlocal \
 if vm_rpmostree install test-usrlocal-1.0 2>err.txt; then
     assert_not_reached "Was able to install a package in /usr/local/"
 fi
-assert_file_has_content err.txt "Unsupported path; see https://github.com/projectatomic/rpm-ostree/issues/233"
+# this error is worse now than it used to be now that we experimentally *do* support /usr/local RPMs
+assert_file_has_content err.txt "opendir(local): No such file or directory"
 
 echo "ok failed to install in /usr/local"
 


### PR DESCRIPTION
This solves the `/opt` problem by using the new state overlay concept in
OSTree: an overlay filesystem is mounted on top of `/usr/lib/opt` and
the upper dir is automatically "rebased" whenever new content comes in.
Concretely, this means that app state is carried forward, all while
allowing the (OSTree-managed) package contents to be updated.

We also solve the `/usr/local` problem the same way. The app state issue
isn't really present there, but `/usr/local` has traditionally been
system state. We want to keep supporting dropping files there all while
also supporting shipping OSTree-owned content.

See also: https://github.com/ostreedev/ostree/issues/3113
Fixes: https://github.com/coreos/rpm-ostree/issues/233