### PR TITLE
Release 2023.12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2023])
-m4_define([release_version], [11])
+m4_define([release_version], [12])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2023.11
+Version: 2023.12
 Release: 1%{?dist}
 License: LGPL-2.0-or-later
 URL: https://github.com/coreos/rpm-ostree


### PR DESCRIPTION
v2023.12

# Release 2023.12

Notable bug fixes are:

- rpm-ostree now will remove duplicate tmpfiles entries #4697
- rpm-ostree now will properly prune container layers #4720

```
Colin Walters (9):
      tmpfiles: Add a unit test
      tmpfiles: Rename reader function
      tmpfiles: Change `read_tmpfiles` to return a direct hashmap
      tmpfiles: Collect into a BTreeMap for reproducibility
      tmpfiles: Drop intermediate re-allocation
      composepost: Support rootfs.transient=yes
      Ensure container image layers are pruned
      tmpfiles: Fix error contexts
      tmpfiles: Handle old caches

HuijingHei (4):
      rpm-ostree-0-integration.conf: remove `/var/lib` tmpfiles entry as it is duplicated in `var.conf`
      rpmostree-postprocess.cxx: remove `var/` in unified core mode
      utils.rs: remove duplicate tmpfiles entries
      tmpfiles.rs: minor update
```

**Full Changelog**: https://github.com/coreos/rpm-ostree/compare/v2023.11...v2023.12