### PR TITLE
kargs: run `delete-if-present` and `append-if-missing` failed when there is existing `key`

### DIFF
--- a/tests/vmcheck/test-kernel-args.sh
+++ b/tests/vmcheck/test-kernel-args.sh
@@ -178,6 +178,28 @@ vm_rpmostree kargs --delete-if-present=PACKAGE3=TEST3 --unchanged-exit-77 || rc=
 assert_streq $rc 77
 echo "ok exit 77 when unchanged kargs with unchanged-exit-77"
 
+# Test append-if-missing and delete-if-present for existing key
+vm_rpmostree kargs --append-if-missing=PACKAGE4=TEST4
+vm_rpmostree kargs > kargs.txt
+assert_file_has_content_literal kargs.txt 'PACKAGE4=TEST4'
+vm_rpmostree kargs --append-if-missing=PACKAGE4=NEWTEST
+vm_rpmostree kargs > kargs.txt
+assert_file_has_content_literal kargs.txt 'PACKAGE4=NEWTEST'
+vm_rpmostree kargs --delete-if-present=PACKAGE4=TEST --unchanged-exit-77 || rc=$?
+assert_streq $rc 77
+echo "ok for append-if-missing and delete-if-present with existing key"
+
+# Test corner case for append and append-if-missing with the same value
+vm_rpmostree kargs --append=foo --append-if-missing=foo
+vm_rpmostree kargs > kargs.txt
+assert_not_file_has_content_literal kargs.txt 'foo foo'
+assert_file_has_content_literal kargs.txt 'foo'
+vm_rpmostree kargs --append-if-missing=bar=foo --append-if-missing=bar=foo
+vm_rpmostree kargs > kargs.txt
+assert_not_file_has_content_literal kargs.txt 'bar=foo bar=foo'
+assert_file_has_content_literal kargs.txt 'bar=foo'
+echo "ok for append and append-if-missing with the same value"
+
 # Test for 'rpm-ostree kargs --editor'.
 vm_rpmostree kargs > kargs.txt
 assert_not_file_has_content_literal kargs.txt 'nonexisting'


### PR DESCRIPTION
Revert part of https://github.com/coreos/rpm-ostree/commit/1a1ef139d41d49d0907cc18d402a9ca8ba0e6de5

`ostree_kernel_args_delete_if_present()` calls
`ostree_kernel_args_contains()` which only looks at the `key`
part, which makes `delete-if-present` failed when there is
existing `key`. `append-if-missing` will hit the same problem.
```
]# rpm-ostree kargs --append=crashkernel=1G
]# rpm-ostree kargs
... crashkernel=1G
]# rpm-ostree kargs --unchanged-exit-77 --delete-if-present=crashkernel=auto
error: No karg 'crashkernel=auto' found
]# rpm-ostree kargs --unchanged-exit-77 --append-if-missing=crashkernel=auto
No changes.
```

And fix corner case when `append` and `append-if-missing` with
the same value which will append twice.

Fixes: https://github.com/coreos/rpm-ostree/issues/4718