### PR TITLE
Cargo.toml: Exclude idna/tests for vendor tarball

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ exclude-crate-paths = [ { name = "libz-sys", exclude = "src/zlib" },
                         { name = "rustix", exclude = "src/imp/linux_raw" },
                         # Test files that include binaries
                         { name = "system-deps", exclude = "src/tests" },
+                        # Test files that include invalid Unicode code points
+                        { name = "idna", exclude = "tests" },
                       ]
 
 # This currently needs to duplicate the libraries in configure.ac


### PR DESCRIPTION
Exclude test files from the `idna` create that we don't need for rpm-ostree. Those test fiels include invalid Unicode code points for testing and that triggers rpminspect checks for Fedora RPM packaging.

Fixes: https://github.com/coreos/rpm-ostree/issues/4760
See: https://github.com/servo/rust-url/blob/master/idna/tests/IdnaTestV2.txt