### PR TITLE
container-encapsulate: make build_mapping_recurse significantly faster

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1216,6 +1216,11 @@ public:
     str.repr = repr;
     return str;
   }
+  static repr::Fat
+  repr (Str str) noexcept
+  {
+    return str.repr;
+  }
 };
 
 template <typename T> class impl<Slice<T> > final
@@ -2811,6 +2816,9 @@ extern "C"
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$complete_rpm_layering (::std::int32_t rootfs) noexcept;
 
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$deduplicate_tmpfiles_entries (::std::int32_t rootfs) noexcept;
+
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$passwd_cleanup (::std::int32_t rootfs) noexcept;
 
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$migrate_group_except_root (
@@ -2939,9 +2947,6 @@ extern "C"
 
   void rpmostreecxx$cxxbridge1$cache_branch_to_nevra (::rust::Str nevra,
                                                       ::rust::String *return$) noexcept;
-
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$deduplicate_tmpfiles_entries (::std::int32_t rootfs) noexcept;
 
   ::std::uint32_t
   rpmostreecxx$cxxbridge1$CxxGObjectArray$length (::rpmostreecxx::CxxGObjectArray &self) noexcept
@@ -3238,24 +3243,6 @@ extern "C"
   }
 
   ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$RpmTs$packages_providing_file (
-      ::rpmostreecxx::RpmTs const &self, ::rust::Str path,
-      ::rust::Vec< ::rust::String> *return$) noexcept
-  {
-    ::rust::Vec< ::rust::String> (::rpmostreecxx::RpmTs::*packages_providing_file$) (::rust::Str)
-        const
-        = &::rpmostreecxx::RpmTs::packages_providing_file;
-    ::rust::repr::PtrLen throw$;
-    ::rust::behavior::trycatch (
-        [&] {
-          new (return$)::rust::Vec< ::rust::String> ((self.*packages_providing_file$) (path));
-          throw$.ptr = nullptr;
-        },
-        ::rust::detail::Fail (throw$));
-    return throw$;
-  }
-
-  ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$RpmTs$package_meta (::rpmostreecxx::RpmTs const &self, ::rust::Str name,
                                               ::rpmostreecxx::PackageMeta **return$) noexcept
   {
@@ -3297,12 +3284,28 @@ extern "C"
     new (return$)::rust::Vec< ::std::uint64_t> ((self.*changelogs$) ());
   }
 
-  ::std::string const *
+  ::rust::repr::Fat
   rpmostreecxx$cxxbridge1$PackageMeta$src_pkg (::rpmostreecxx::PackageMeta const &self) noexcept
   {
-    ::std::string const &(::rpmostreecxx::PackageMeta::*src_pkg$) () const
+    ::rust::Str (::rpmostreecxx::PackageMeta::*src_pkg$) () const
         = &::rpmostreecxx::PackageMeta::src_pkg;
-    return &(self.*src_pkg$) ();
+    return ::rust::impl< ::rust::Str>::repr ((self.*src_pkg$) ());
+  }
+
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$PackageMeta$provided_paths (
+      ::rpmostreecxx::PackageMeta const &self, ::rust::Vec< ::rust::String> *return$) noexcept
+  {
+    ::rust::Vec< ::rust::String> (::rpmostreecxx::PackageMeta::*provided_paths$) () const
+        = &::rpmostreecxx::PackageMeta::provided_paths;
+    ::rust::repr::PtrLen throw$;
+    ::rust::behavior::trycatch (
+        [&] {
+          new (return$)::rust::Vec< ::rust::String> ((self.*provided_paths$) ());
+          throw$.ptr = nullptr;
+        },
+        ::rust::detail::Fail (throw$));
+    return throw$;
   }
 
   ::rust::repr::PtrLen
@@ -5689,6 +5692,16 @@ complete_rpm_layering (::std::int32_t rootfs)
 }
 
 void
+deduplicate_tmpfiles_entries (::std::int32_t rootfs)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$deduplicate_tmpfiles_entries (rootfs);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
+}
+
+void
 passwd_cleanup (::std::int32_t rootfs)
 {
   ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$passwd_cleanup (rootfs);
@@ -6093,16 +6106,6 @@ cache_branch_to_nevra (::rust::Str nevra) noexcept
   ::rust::MaybeUninit< ::rust::String> return$;
   rpmostreecxx$cxxbridge1$cache_branch_to_nevra (nevra, &return$.value);
   return ::std::move (return$.value);
-}
-
-void
-deduplicate_tmpfiles_entries (::std::int32_t rootfs)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$deduplicate_tmpfiles_entries (rootfs);
-  if (error$.ptr)
-    {
-      throw ::rust::impl< ::rust::Error>::error (error$);
-    }
 }
 } // namespace rpmostreecxx
 
@@ -6818,6 +6821,5 @@ Vec< ::rpmostreecxx::LockedPackage>::truncate (::std::size_t len)
 {
   return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$truncate (this, len);
 }
-
 } // namespace cxxbridge1
 } // namespace rust

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -2015,6 +2015,8 @@ bool prepare_rpm_layering (::std::int32_t rootfs, ::rust::Str merge_passwd_dir);
 
 void complete_rpm_layering (::std::int32_t rootfs);
 
+void deduplicate_tmpfiles_entries (::std::int32_t rootfs);
+
 void passwd_cleanup (::std::int32_t rootfs);
 
 void migrate_group_except_root (::std::int32_t rootfs,
@@ -2057,6 +2059,4 @@ void lockfile_write (::rust::Str filename, ::rpmostreecxx::CxxGObjectArray &pack
 void origin_validate_roundtrip (::rpmostreecxx::GKeyFile const &kf) noexcept;
 
 ::rust::String cache_branch_to_nevra (::rust::Str nevra) noexcept;
-
-void deduplicate_tmpfiles_entries (::std::int32_t rootfs);
 } // namespace rpmostreecxx

--- a/rust/src/fsutil.rs
+++ b/rust/src/fsutil.rs
@@ -1,0 +1,140 @@
+//! Helpers for working with an ostree filesystem
+
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use camino::{Utf8Path, Utf8PathBuf};
+use ostree_ext::{gio, ostree, prelude::*};
+use std::{collections::HashMap, path::Component};
+
+#[derive(Debug, Clone)]
+pub struct ResolvedOstreePaths {
+    pub path: ostree::RepoFile,
+    pub symlink_target: Option<ostree::RepoFile>,
+}
+
+impl ResolvedOstreePaths {
+    /// If the resolved file is itself a symlink, returns the
+    /// file it points to. Otherwise just returns the resolved file.
+    pub fn real_file(&self) -> &ostree::RepoFile {
+        self.symlink_target.as_ref().unwrap_or(&self.path)
+    }
+}
+
+/// Given a path and an ostree filesystem root, resolves
+/// the path to a real file on the filesystem, including
+/// resolving symlinks in the path's directory tree.
+///
+/// Returns a pair of the resolved path and in the case where
+/// the path points to a symlink, it also includes the resolved
+/// symlink target.
+pub fn resolve_ostree_paths<'a>(
+    path: &Utf8Path,
+    fsroot: &ostree::RepoFile,
+    cache: &'a mut HashMap<Utf8PathBuf, ResolvedOstreePaths>,
+) -> Option<ResolvedOstreePaths> {
+    assert!(path.is_absolute());
+
+    // Recurse until root
+    if path.parent() == None {
+        return Some(ResolvedOstreePaths {
+            path: fsroot.clone(),
+            symlink_target: None,
+        });
+    }
+
+    // Check the cache for this path
+    if let Some(cache_hit) = cache.get(path) {
+        return Some(cache_hit.clone());
+    }
+
+    // Resolve our parent, then resolve ourselves as a direct child
+    if let Some(parent) = resolve_ostree_paths(path.parent().unwrap(), fsroot, cache) {
+        let child_file = parent
+            .real_file()
+            .child(path.file_name().unwrap())
+            .downcast::<ostree::RepoFile>()
+            .unwrap();
+
+        if !child_file.query_exists(gio::Cancellable::NONE) {
+            return None;
+        }
+
+        let child_info = child_file
+            .query_info("*", gio::FileQueryInfoFlags::NONE, gio::Cancellable::NONE)
+            .expect("failed to get fs info");
+
+        // If this path is a symlink, figure out what it points to
+        let remapped_target =
+            if child_info.has_attribute("standard::is-symlink") && child_info.is_symlink() {
+                let link_target = child_info.symlink_target().unwrap();
+
+                // Due to a bug in OSTree's Gio.File implementation, we cannot
+                // just do `parent.resolve_relative_path` here as it doesn't correctly
+                // resolve to an absolute path.
+                // So instead we'll handle '.' and '..' chunks ourselves and normalize the
+                // resulting path.
+                if !link_target.is_absolute() {
+                    let mut target_path = path.parent().unwrap().to_owned();
+
+                    for item in link_target.components() {
+                        match item {
+                            Component::ParentDir => {
+                                target_path.pop();
+                            }
+                            Component::Normal(name) => {
+                                target_path.push(Utf8Path::new(&name.to_string_lossy()));
+                            }
+                            Component::CurDir => {}
+                            _ => panic!("unhandled component type"),
+                        };
+                    }
+
+                    resolve_ostree_paths(&target_path, fsroot, cache)
+                } else {
+                    resolve_ostree_paths(Utf8Path::from_path(&link_target).unwrap(), fsroot, cache)
+                }
+            } else {
+                None
+            };
+
+        let result = ResolvedOstreePaths {
+            path: child_file.clone(),
+            symlink_target: remapped_target.map(|f| f.real_file().clone()),
+        };
+
+        // If this path is or points to a directory, add it to the cache to speed up future lookups
+        if result.real_file().is_dir() {
+            cache.insert(path.to_owned(), result.clone());
+        }
+
+        return Some(result);
+    }
+
+    None
+}
+
+pub trait FileHelpers {
+    fn is_dir(&self) -> bool;
+    fn is_regular(&self) -> bool;
+    fn is_symlink(&self) -> bool;
+}
+
+impl<T> FileHelpers for T
+where
+    T: IsA<gio::File>,
+{
+    fn is_dir(&self) -> bool {
+        self.query_file_type(gio::FileQueryInfoFlags::NONE, gio::Cancellable::NONE)
+            == gio::FileType::SymbolicLink
+    }
+
+    fn is_regular(&self) -> bool {
+        self.query_file_type(gio::FileQueryInfoFlags::NONE, gio::Cancellable::NONE)
+            == gio::FileType::Regular
+    }
+
+    fn is_symlink(&self) -> bool {
+        self.query_file_type(gio::FileQueryInfoFlags::NONE, gio::Cancellable::NONE)
+            == gio::FileType::SymbolicLink
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -906,14 +906,14 @@ pub mod ffi {
         fn rpmdb_package_name_list(dfd: i32, path: String) -> Result<Vec<String>>;
 
         // Methods on RpmTs
-        fn packages_providing_file(self: &RpmTs, path: &str) -> Result<Vec<String>>;
         fn package_meta(self: &RpmTs, name: &str) -> Result<UniquePtr<PackageMeta>>;
 
         // Methods on PackageMeta
         fn size(self: &PackageMeta) -> u64;
         fn buildtime(self: &PackageMeta) -> u64;
         fn changelogs(self: &PackageMeta) -> Vec<u64>;
-        fn src_pkg(self: &PackageMeta) -> &CxxString;
+        fn src_pkg(self: &PackageMeta) -> &str;
+        fn provided_paths(self: &PackageMeta) -> Result<Vec<String>>;
     }
 
     // rpmostree-package-variants.h
@@ -959,6 +959,7 @@ mod extensions;
 pub(crate) use extensions::*;
 #[cfg(feature = "fedora-integration")]
 mod fedora_integration;
+mod fsutil;
 mod history;
 pub use self::history::*;
 mod importer;

--- a/src/libpriv/rpmostree-refts.h
+++ b/src/libpriv/rpmostree-refts.h
@@ -48,34 +48,26 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (RpmOstreeRefTs, rpmostree_refts_unref);
 namespace rpmostreecxx
 {
 
-struct PackageMeta
+class PackageMeta
 {
-  uint64_t _size;
-  uint64_t _buildtime;
-  rust::Vec<uint64_t> _changelogs;
-  std::string _src_pkg;
+public:
+  PackageMeta (::Header h);
+  ~PackageMeta ();
 
-  uint64_t
-  size () const
-  {
-    return _size;
-  };
-  uint64_t
-  buildtime () const
-  {
-    return _buildtime;
-  };
-  rust::Vec<uint64_t>
-  changelogs () const
-  {
-    return _changelogs;
-  };
+  uint64_t size () const;
 
-  const std::string &
-  src_pkg () const
-  {
-    return _src_pkg;
-  };
+  uint64_t buildtime () const;
+
+  rust::Vec<uint64_t> changelogs () const;
+
+  rust::Str src_pkg () const;
+
+  rust::String nevra () const;
+
+  rust::Vec<rust::String> provided_paths () const;
+
+private:
+  ::Header _h;
 };
 
 // A simple C++ wrapper for a librpm C type, so we can expose it to Rust via cxx.rs.
@@ -85,7 +77,6 @@ public:
   RpmTs (::RpmOstreeRefTs *ts);
   ~RpmTs ();
   rpmts get_ts () const;
-  rust::Vec<rust::String> packages_providing_file (const rust::Str path) const;
   std::unique_ptr<PackageMeta> package_meta (const rust::Str package) const;
 
 private:


### PR DESCRIPTION
While toying around with building my own custom FCOS builds, I noticed that running `cosa build container` with a package set similar to Silverblue's resulted in ~2hr builds, the vast majority of which was in the "Building package mapping" task. After this change, the runtime on my build shrank to ~15 mins.

`$ time cosa build container`
**Before**
```
real    10m47.769s
user    52m14.763s
sys     46m38.546s
```

**After**
```
real    15m37.333s
user    2m38.751s
sys     0m14.410s
```

The speedup is accomplished by avoiding the need to query the rpmdb for every file. Instead the rpmdb is walked to build a cache of the files to providing packages, so that when the ostree filesystem is walked later it can just check the cache. The cache is structured similarly to rpm's internals, where paths are maintained as separate basename and dirname entries. Additionally, like rpm, the paths are considered equivalent if the dirnames resolve to the same path (rpm uses `stat` to compare inodes, this implementation resolves the symlinks). This results in output that is effectively equivalent to the previous implementation while being substantially faster.

To minimize memory overhead maintaining the file mapping, a simple string cache is also added.

Closes: https://github.com/coreos/rpm-ostree/issues/4880