### PR TITLE
libpriv: Stop digging in private libcap internals

### DIFF
--- a/rust/src/lockfile.rs
+++ b/rust/src/lockfile.rs
@@ -10,7 +10,6 @@
 /* Copied and adapted from: treefile.rs
  */
 
-pub use self::ffi::*;
 use crate::utils;
 use anyhow::{anyhow, bail, Result};
 use cap_std_ext::cap_std;
@@ -24,7 +23,6 @@ use std::path::Path;
 use std::pin::Pin;
 
 use crate::cxxrsutil::CxxResult;
-use libdnf_sys::*;
 
 /// Given a lockfile filename, parse it
 fn lockfile_parse<P: AsRef<Path>>(filename: P) -> Result<LockfileConfig> {

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -3692,7 +3692,9 @@ apply_rpmfi_overrides (RpmOstreeContext *self, int tmprootfs_dfd, DnfPackage *pk
       /* the chown clears away file caps, so reapply it here */
       if (have_fcaps)
         {
-          g_autoptr (GVariant) xattrs = rpmostree_fcap_to_xattr_variant (fcaps);
+          g_autoptr (GVariant) xattrs = rpmostree_fcap_to_xattr_variant (fcaps, error);
+          if (!xattrs)
+            return FALSE;
           if (!glnx_dfd_name_set_all_xattrs (tmprootfs_dfd, fn, xattrs, cancellable, error))
             return glnx_prefix_error (error, "%s", fn);
         }

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -117,8 +117,8 @@ gint rpmostree_pkg_array_compare (DnfPackage **p_pkg1, DnfPackage **p_pkg2);
 
 void rpmostree_print_transaction (DnfContext *context);
 
-GVariant *rpmostree_fcap_to_ostree_xattr (const char *fcap);
-GVariant *rpmostree_fcap_to_xattr_variant (const char *fcap);
+GVariant *rpmostree_fcap_to_ostree_xattr (const char *fcap, GError **error);
+GVariant *rpmostree_fcap_to_xattr_variant (const char *fcap, GError **error);
 
 typedef enum
 {


### PR DESCRIPTION
When handling file caps, we need to be able to get the actual xattr
bytes. Currently, libcap doesn't provide a public API for this.
Meanwhile, we've been hacking around this by redefining internal libcap
structs and using internal fields. This is extremely brittle since any
change to the struct will break us.

And this is exactly what happened in the libcap currently in rawhide. A
new field was added to the struct:

https://git.kernel.org/pub/scm/libs/libcap/libcap.git//commit/?id=aca076443591ba18438b60e41294b59a324daf04

This patch works around the lack of a public API a different way: we
allocate an `O_TMPFILE`, set caps on it, then read back the xattr. This
is more heavyweight but few binaries actually have file caps anyway. It
also requires `CAP_SETFCAP`, but that's already the case today since the
assembly code also applies them to checked out files on-disk.

No new tests for this; we have existing coverage for file caps. That
coverage would've caught this if we ran CI against rawhide.

Closes #4765