### PR TITLE
ci: minor fix with upgrades

### DIFF
--- a/ci/prow/Dockerfile.fcos
+++ b/ci/prow/Dockerfile.fcos
@@ -7,4 +7,4 @@ RUN ./ci/build.sh && make install DESTDIR=$(pwd)/install && tar -C install -czf 
 
 FROM quay.io/fedora/fedora-coreos:testing-devel
 COPY --from=builder /srv/install.tar /tmp
-RUN tar -xvf /tmp/install.tar && ostree container commit 
+RUN tar -C / -xvf /tmp/install.tar && ostree container commit

--- a/ci/prow/kola/upgrades
+++ b/ci/prow/kola/upgrades
@@ -25,6 +25,9 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     rpm -q moby-engine
     test '!' -f /etc/somenewfile
 
+    # do override remove with new rpm-ostree
+    rpm-ostree override remove vim-minimal
+
     upgrade_image=$(cat /etc/upgrade-image)
     rpm-ostree rebase ${upgrade_image}
     /tmp/autopkgtest-reboot 1
@@ -42,6 +45,11 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
       exit 1
     fi
     test -f /etc/somenewfile
+
+    if rpm -q vim-minimal 2>/dev/null; then
+      echo "found package expected to be removed"
+      exit 1
+    fi
 
     echo "ok e2e upgrade"
     ;;


### PR DESCRIPTION
`ci/prow/Dockerfile.fcos` is to build the `target` container image that installs a build from git into the Fedora CoreOS image (which is used by `e2e-upgrades` test), then do upgrade testing with the new rpm-ostree. Fix the minor issue to install rpm-ostree to the right directory.
