### PR TITLE
upgrade-test: add 2 upgrades test

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -77,4 +77,12 @@ cosaPod(runAsUser: 0, memory: "${mem}Mi", cpu: "${nhosts}") {
       archiveArtifacts allowEmptyArchive: true, artifacts: 'vmcheck-logs.tar.xz'
     }
   }
+  stage("kola-upgrades") {
+    unstash 'rpms'
+    shwrap("""
+      coreos-installer download -p qemu -f qcow2.xz -s testing --decompress
+      mv rpm-ostree-[0-9]*.rpm rpm-ostree-libs-[0-9]*.rpm /usr/lib/coreos-assembler/tests/kola/rpm-ostree/destructive/data/      
+    """)
+    kola(cosaDir: "${env.WORKSPACE}", extraArgs: "--qemu-image ./fedora-coreos*.qcow2 --tag rpm-ostree-upgrade ext.rpm-ostree.destructive.client-layering-upgrade")
+  }
 }

--- a/ci/prow/kola/upgrades
+++ b/ci/prow/kola/upgrades
@@ -3,6 +3,7 @@
 ## kola:
 ##   timeoutMin: 30
 ##   tags: "needs-internet"
+##   minMemory: 2048
 #
 # Copyright (C) 2022 Red Hat, Inc.
 
@@ -25,6 +26,14 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     rpm -q moby-engine
     test '!' -f /etc/somenewfile
 
+    # do client layerring tests using new rpm-ostree on old build
+    # https://github.com/coreos/rpm-ostree/pull/4727 and https://github.com/coreos/rpm-ostree/pull/4746
+    rpm-ostree install vim-filesystem
+    rpm-ostree override remove vim-minimal
+    rpm-ostree kargs --append foo=bar
+    touch /etc/foobar.conf
+    rpm-ostree initramfs --enable --arg=-I --arg=/etc/foobar.conf
+
     upgrade_image=$(cat /etc/upgrade-image)
     rpm-ostree rebase ${upgrade_image}
     /tmp/autopkgtest-reboot 1
@@ -42,6 +51,17 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
       exit 1
     fi
     test -f /etc/somenewfile
+
+    rpm -q vim-filesystem
+    if rpm -q vim-minimal 2>/dev/null; then
+      echo "found package expected to be removed"
+      exit 1
+    fi
+    cat /proc/cmdline > cmdlinekargs.txt
+    grep foo=bar cmdlinekargs.txt
+    
+    lsinitrd "/usr/lib/modules/$(uname -r)/initramfs.img" > lsinitrd.txt
+    grep etc/foobar.conf lsinitrd.txt
 
     echo "ok e2e upgrade"
     ;;

--- a/tests/kolainst/destructive/client-layering-upgrade
+++ b/tests/kolainst/destructive/client-layering-upgrade
@@ -1,0 +1,107 @@
+#!/bin/bash
+## kola:
+##   # This test reboots a lot, does layering tests, etc.
+##   timeoutMin: 30
+##   minMemory: 1536
+##   requiredTag: rpm-ostree-upgrade
+##   tags: needs-internet
+##   description: Do client-side layering tests on old build, then upgrade 
+##     rpm-ostree to new version, then upgrade to another new update.
+
+# Start old build, do client-side layering tests, and upgrade to new 
+# rpm-ostree, reboot;
+# then upgrade to another update, reboot;
+# after booted, check the status, finished.
+
+
+set -xeuo pipefail
+
+. ${KOLA_EXT_DATA}/libtest.sh
+
+. /etc/os-release
+case $VERSION_ID in
+  39) kernel_release=6.5.6-300.fc39.x86_64
+    koji_kernel_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=2302642"
+  ;;
+  *) echo "Unsupported Fedora version: $VERSION_ID"
+    exit 1
+  ;;
+esac
+
+# Do client-side layering tests includes:
+# kernel override, initramfs args, initramfs-etc, layering, overrides
+client_side_layering_tests()
+{
+  # override kernel
+  # copy test code from test-override-kernel.sh
+  current=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
+  rpm-ostree db list "${current}" > current-dblist.txt
+  if grep -qF $kernel_release current-dblist.txt; then
+    echo "Should not find $kernel_release in current deployment"
+    exit 1
+  fi
+
+  grep -E '^ kernel-[0-9]' current-dblist.txt  | sed -e 's,^ *,,' > orig-kernel.txt
+  test "$(wc -l < orig-kernel.txt)" == "1"
+  #orig_kernel=$(cat orig-kernel.txt)
+
+  rpm-ostree override replace $koji_kernel_url
+
+  rpm-ostree kargs --append foo=bar
+
+  touch /etc/foobar.conf
+  rpm-ostree initramfs --enable --arg=-I --arg=/etc/foobar.conf
+
+  rpm-ostree override remove moby-engine
+  rpm-ostree install --cache-only ${KOLA_EXT_DATA}/rpm-repos/0/packages/x86_64/foo-1.2-3.x86_64.rpm
+}
+
+# Check client-side layering tests results
+client_side_layering_checking()
+{
+  rpm-ostree status
+
+  test "$(uname -r)" == $kernel_release
+
+  cat /proc/cmdline > cmdlinekargs.txt
+  grep "foo=bar" cmdlinekargs.txt
+
+  lsinitrd "/usr/lib/modules/$(uname -r)/initramfs.img" > lsinitrd.txt
+  grep "etc/foobar.conf" lsinitrd.txt
+  
+  if rpm -q moby-engine 2>/dev/null; then
+    echo "found package expected to be removed"
+    exit 1
+  fi
+  rpm -q foo
+}
+
+cd "$(mktemp -d)"
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+    rpm-ostree --version
+    systemctl mask --now zincati
+
+    client_side_layering_tests
+    # update rpm-ostree
+    ls ${KOLA_EXT_DATA}/rpm-ostree*
+    rpm-ostree override replace ${KOLA_EXT_DATA}/rpm-ostree*
+    /tmp/autopkgtest-reboot 1
+    ;;
+  "1")
+    client_side_layering_checking
+    echo "ok client-side layering tests and upgrade rpm-ostree"
+
+    checksum=$(rpm-ostree status --json | jq -r '.deployments[0]."base-checksum"')
+    ostree refs ${checksum} --create kola
+    rpm-ostree rebase :kola
+
+    /tmp/autopkgtest-reboot 2    
+    ;;
+  "2")
+    client_side_layering_checking
+    echo "ok upgrade to another update"
+    ;;
+  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac


### PR DESCRIPTION
Enhance 2 upgrade tests:

- `kolainst`: Do client-side layering tests on old build, then upgrade
rpm-ostree to new version, then upgrade to another new update.
- `prow/e2e-upgrades`: Start old build with upgraded rpm-ostree,
do layering tests, then upgrade to another new update.

Fixes: https://github.com/coreos/rpm-ostree/issues/4776