### PR TITLE
compose: Add additional debuginfo

### DIFF
--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -284,9 +284,13 @@ pub(crate) fn compose_image(args: Vec<String>) -> CxxResult<()> {
         .args(opt.offline.then(|| "--cache-only"))
         .args(compose_args_extra)
         .arg(opt.manifest.as_str())
-        .status()?;
-    if !s.success() {
-        return Err(anyhow::anyhow!("compose tree failed: {:?}", s).into());
+        .output()?;
+    if !s.status.success() {
+        return Err(anyhow::anyhow!(
+            "compose tree failed: {:?}",
+            std::str::from_utf8(&s.stderr).unwrap()
+        )
+        .into());
     }
 
     if !changed_path.exists() {
@@ -337,9 +341,13 @@ pub(crate) fn compose_image(args: Vec<String>) -> CxxResult<()> {
                 .map(|s| s.as_str())
                 .unwrap_or_else(|| target_imgref.as_str()),
         ])
-        .status()?;
-    if !s.success() {
-        return Err(anyhow::anyhow!("container-encapsulate failed: {:?}", s).into());
+        .output()?;
+    if !s.status.success() {
+        return Err(anyhow::anyhow!(
+            "container-encapsulate failed: {:?}",
+            std::str::from_utf8(&s.stderr).unwrap()
+        )
+        .into());
     }
 
     if let Some(tempdest) = tempdest {


### PR DESCRIPTION
When running `compose image` failed, get: `error: compose tree failed: ExitStatus(unix_wait_status(256))`, it is not easy to understand, this is to add some additional debuginfo when get error.

For example:
`error: compose tree failed: "error: bwrap test failed, see <https://github.com/coreos/rpm-ostree/pull/429>: Failed to execute child process “bwrap” (No such file or directory)\n" `