### PR TITLE
composepost: Add SELinux equivalency rule for /usr/lib/opt → /opt

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -2,8 +2,9 @@ srpm:
 	./ci/installdeps.sh
 	# similar to https://github.com/actions/checkout/issues/760, but for COPR
 	git config --global --add safe.directory '*'
-	# fetch tags so `git describe` gives a nice NEVRA when building the RPM
-	git fetch origin --tags
+	# if we have a git repo with remotes, fetch tags so `git describe` gives a nice NEVRA when
+	# building the RPM
+	if git remote | grep origin; then git fetch origin --tags; fi
 	git submodule update --init --recursive
 	# Our primary CI build goes via RPM rather than direct to binaries
 	# to better test that path, including our vendored spec file, etc.

--- a/ci/prow/Dockerfile
+++ b/ci/prow/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/coreos/fcos-buildroot:testing-devel as builder
 WORKDIR /src
 COPY . .
-RUN ./ci/build.sh && make install DESTDIR=/cosa/component-install
+RUN ./ci/coreosci-rpmbuild.sh  && mkdir -p /cosa/component-rpms && mv rpm-ostree{,-libs}-20*.rpm /cosa/component-rpms
 RUN make -C tests/kolainst install DESTDIR=/cosa/component-tests
 # Uncomment this to fake a build to test the code below
 #RUN mkdir -p /cosa/component-install/usr/bin && echo foo > /cosa/component-install/usr/bin/foo
@@ -12,9 +12,7 @@ USER root
 # Copy binaries from the build
 COPY --from=builder /cosa /cosa
 # Merge them to the real root since we're used at compose time
-# XXX: disabled for now
-# https://github.com/coreos/rpm-ostree/pull/4763#issuecomment-1883686187
-# RUN rsync -rlv /cosa/component-install/ /
+RUN dnf install -y /cosa/component-rpms/*.rpm
 # Merge installed tests
 RUN rsync -rlv /cosa/component-tests/ /
 # Grab all of our ci scripts

--- a/ci/prow/fcos-e2e.sh
+++ b/ci/prow/fcos-e2e.sh
@@ -9,7 +9,7 @@ ls -al /usr/bin/rpm-ostree
 rpm-ostree --version
 cd $(mktemp -d)
 cosa init https://github.com/coreos/fedora-coreos-config/
-rsync -rlv /cosa/component-install/ overrides/rootfs/
+cp /cosa/component-rpms/*.rpm overrides/rpm
 cosa fetch
 cosa build
 cosa kola run 'ext.rpm-ostree.*'

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -381,6 +381,8 @@ fn postprocess_subs_dist(rootfs_dfd: &Dir) -> Result<()> {
             writeln!(w, "/home /var/home")?;
             writeln!(w, "# https://github.com/coreos/rpm-ostree/pull/4640")?;
             writeln!(w, "/usr/etc /etc")?;
+            writeln!(w, "# https://github.com/coreos/rpm-ostree/pull/1795")?;
+            writeln!(w, "/usr/lib/opt /opt")?;
             Ok(())
         })?;
     }

--- a/tests/kolainst/destructive/state-overlays
+++ b/tests/kolainst/destructive/state-overlays
@@ -68,6 +68,7 @@ EOF
     /tmp/autopkgtest-reboot 1
     ;;
   1)
+    test -f /opt/bin/test-opt
     test -f /opt/megacorp/bin/test-opt
     test -f /opt/megacorp/lib/mylib
     test -d /opt/megacorp/state
@@ -75,6 +76,11 @@ EOF
     /opt/megacorp/bin/test-opt > /tmp/out.txt
     assert_file_has_content /tmp/out.txt 'test-opt'
     assert_file_has_content /opt/megacorp/lib/mylib 'lib1'
+
+    stat -c '%C' /opt/bin/test-opt > /tmp/out.txt
+    assert_file_has_content /tmp/out.txt ':bin_t:'
+    stat -c '%C' /opt/megacorp > /tmp/out.txt
+    assert_file_has_content /tmp/out.txt ':usr_t:'
 
     # add some state files
     echo 'foobar' > /opt/megacorp/state/mystate

--- a/tests/kolainst/kolainst-build.sh
+++ b/tests/kolainst/kolainst-build.sh
@@ -98,10 +98,12 @@ build_rpm zincati version 99.99 release 3
 
 # An RPM that installs in /opt
 build_rpm test-opt \
-             install "mkdir -p %{buildroot}/opt/megacorp/{bin,lib,state}
+             install "mkdir -p %{buildroot}/opt/megacorp/{bin,lib,state} %{buildroot}/opt/bin
+                      install %{name} %{buildroot}/opt/bin
                       install %{name} %{buildroot}/opt/megacorp/bin
                       echo lib1 > %{buildroot}/opt/megacorp/lib/mylib" \
-             files "/opt/megacorp"
+             files "/opt/megacorp
+                    /opt/bin/test-opt"
 
 mv ${test_tmpdir}/yumrepo/* ${test_tmpdir}/rpm-repos/${repover}
 


### PR DESCRIPTION
When `/opt` packages get moved to `/usr/lib/opt`, they're not being labeled properly; they get the `lib_t` label instead of `usr_t` (or e.g. `bin_t` for `/opt/bin`).

This apparently works for e.g. Google Chrome (for which the `/usr/lib/opt` translation was added). But with state overlays, the goal is to support all `/opt` packages and things will break without proper labeling.

Add an equivalency rule so that `/usr/lib/opt` is labeled like `/opt. This fixes the SELinux issues that occur when layering Puppet in https://github.com/coreos/rpm-ostree/issues/233#issuecomment-1856720559.

This should probably be upstreamed to SELinux (along with the `/usr/etc` equivalency rule just above).

Side note: in the status quo model where `/opt` is a symlink to `/var/opt`, everything is *also* mislabeled (it gets `var_t`). To be conservative, we don't fix this since presumably this works right now for people writing files there via e.g. Ignition/cloud-init and anyway all that would go away if we move over to state overlays by default in the future.