### PR TITLE
cliwrap/rpm: mark `--eval`/`-E` as safe

### DIFF
--- a/rust/src/cliwrap/rpm.rs
+++ b/rust/src/cliwrap/rpm.rs
@@ -20,6 +20,12 @@ fn new_rpm_app() -> Command {
                 .action(clap::ArgAction::Version),
         )
         .arg(
+            Arg::new("eval")
+                .long("eval")
+                .short('E')
+                .action(clap::ArgAction::Set),
+        )
+        .arg(
             Arg::new("package")
                 .help("package")
                 .action(clap::ArgAction::Append),
@@ -125,6 +131,19 @@ mod tests {
     fn test_query_all() -> Result<()> {
         assert_eq!(
             disposition(SystemHostType::OstreeHost, &["-qa"])?,
+            RunDisposition::Ok
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_eval() -> Result<()> {
+        assert_eq!(
+            disposition(SystemHostType::OstreeHost, &["-E", "%{_target_cpu}"])?,
+            RunDisposition::Ok
+        );
+        assert_eq!(
+            disposition(SystemHostType::OstreeHost, &["--eval=%{_target_cpu}}"])?,
             RunDisposition::Ok
         );
         Ok(())


### PR DESCRIPTION
This is sometimes used in scripts to query aspects of the host system.
E.g. this is used by Fedora's pkg-config:

https://src.fedoraproject.org/rpms/pkgconf/blob/95c0bbee/f/pkg-config.in#_6

This in turn gets hit by kdump which runs dracut which has modules that
runs `pkgconf` to query some directory paths.