### PR TITLE
cliwrap: make `install-to-root` idempotent

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -42,9 +42,7 @@ fi
 rm "${origindir}/clienterror.yaml"
 rpm-ostree ex rebuild
 
-if ! test -x /usr/bin/yum; then
-    rpm-ostree cliwrap install-to-root /
-fi
+rpm-ostree cliwrap install-to-root /
 
 # Test a critical path package
 yum -y install cowsay && yum clean all

--- a/rust/src/cliwrap.rs
+++ b/rust/src/cliwrap.rs
@@ -90,8 +90,12 @@ fn install_to_root(args: &[&str]) -> Result<()> {
         .map(Utf8Path::new)
         .ok_or_else(|| anyhow!("Missing required argument: ROOTDIR"))?;
     let rootdir = &Dir::open_ambient_dir(root, cap_std::ambient_authority())?;
-    write_wrappers(rootdir, None)?;
-    println!("Successfully enabled cliwrap for {root}");
+    if rootdir.is_dir(CLIWRAP_DESTDIR) {
+        println!("cliwrap already enabled for {root}");
+    } else {
+        write_wrappers(rootdir, None)?;
+        println!("Successfully enabled cliwrap for {root}");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Right now, if a system is already cliwrapped, doing `install-to-root` will incorrectly think the already wrapped entrypoints are the real binaries and do the wrong thing.

Fix this by checking if the directory holding wrapped binaries already exists. If yes, then no-op.