### PR TITLE
disable downloading filelists by default

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -397,7 +397,7 @@ install_packages (RpmOstreeTreeComposeContext *self, gboolean *out_unmodified,
         }
     }
 
-  if (!rpmostree_context_prepare (self->corectx, cancellable, error))
+  if (!rpmostree_context_prepare (self->corectx, TRUE, cancellable, error))
     return FALSE;
 
   rpmostree_print_transaction (dnfctx);
@@ -1685,7 +1685,7 @@ rpmostree_compose_builtin_extensions (int argc, char **argv, RpmOstreeCommandInv
 
 #undef TMP_EXTENSIONS_ROOTFS
 
-  if (!rpmostree_context_prepare (ctx, cancellable, error))
+  if (!rpmostree_context_prepare (ctx, FALSE, cancellable, error))
     return FALSE;
 
   if (!glnx_shutil_mkdir_p_at (AT_FDCWD, opt_extensions_output_dir, 0755, cancellable, error))

--- a/src/daemon/rpm-ostreed.service
+++ b/src/daemon/rpm-ostreed.service
@@ -28,3 +28,5 @@ TimeoutStartSec=5m
 # with the rpm-ostree user.
 ExecStart=+rpm-ostree start-daemon
 ExecReload=rpm-ostree reload
+# disable/enable downloading filelists
+Environment="DOWNLOAD_FILELISTS=false"

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -953,7 +953,7 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable, 
 
   if (rpmostree_origin_has_any_packages (self->computed_origin))
     {
-      if (!rpmostree_context_prepare (self->ctx, cancellable, error))
+      if (!rpmostree_context_prepare (self->ctx, FALSE, cancellable, error))
         return FALSE;
       self->layering_type = RPMOSTREE_SYSROOT_UPGRADER_LAYERING_RPMMD_REPOS;
 
@@ -967,7 +967,7 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable, 
        * See comment in rpmostree_origin_may_require_local_assembly(). */
       if (rpmostree_origin_has_modules_enable (self->computed_origin))
         {
-          if (!rpmostree_context_prepare (self->ctx, cancellable, error))
+          if (!rpmostree_context_prepare (self->ctx, FALSE, cancellable, error))
             return FALSE;
         }
       rpmostree_context_set_is_empty (self->ctx);

--- a/src/libpriv/rpmostree-container.cxx
+++ b/src/libpriv/rpmostree-container.cxx
@@ -59,7 +59,7 @@ rpmostree_container_rebuild (rpmostreecxx::Treefile &treefile, GCancellable *can
   if (!rpmostree_context_setup (ctx, "/", "/", cancellable, error))
     return FALSE;
 
-  if (!rpmostree_context_prepare (ctx, cancellable, error))
+  if (!rpmostree_context_prepare (ctx, FALSE, cancellable, error))
     return FALSE;
 
   if (!rpmostree_context_download (ctx, cancellable, error))

--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -73,6 +73,8 @@ struct _RpmOstreeContext
 
   GHashTable *fileoverride_pkgs; /* set of nevras */
 
+  gboolean filelists_exist;
+
   std::optional<rust::Box<rpmostreecxx::LockfileConfig> > lockfile;
   gboolean lockfile_strict;
 

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -134,8 +134,8 @@ gboolean rpmostree_context_download_metadata (RpmOstreeContext *context,
                                               GCancellable *cancellable, GError **error);
 
 /* This API allocates an install context, use with one of the later ones */
-gboolean rpmostree_context_prepare (RpmOstreeContext *self, GCancellable *cancellable,
-                                    GError **error);
+gboolean rpmostree_context_prepare (RpmOstreeContext *self, gboolean enable_filelists,
+                                    GCancellable *cancellable, GError **error);
 
 GPtrArray *rpmostree_context_get_packages (RpmOstreeContext *self);
 
@@ -165,6 +165,10 @@ gboolean rpmostree_context_import (RpmOstreeContext *self, GCancellable *cancell
 
 gboolean rpmostree_context_force_relabel (RpmOstreeContext *self, GCancellable *cancellable,
                                           GError **error);
+
+gboolean rpmostree_context_get_filelists_exist (RpmOstreeContext *);
+
+void rpmostree_context_set_filelists_exist (RpmOstreeContext *, gboolean filelists_exist);
 
 typedef enum
 {

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -537,5 +537,5 @@ rpmostree_busctl_call_os() {
   stateroot=$(rpm-ostree status --booted --json | jq -r '.deployments[0].osname')
   ospath=/org/projectatomic/rpmostree1/${stateroot//-/_}
   busctl call org.projectatomic.rpmostree1 $ospath \
-    org.projectatomic.rpmostree1.OS "$@"
+    org.projectatomic.rpmostree1.OS "$@" --timeout=240s
 }

--- a/tests/kolainst/destructive/filelists
+++ b/tests/kolainst/destructive/filelists
@@ -1,0 +1,178 @@
+#!/bin/bash
+## kola:
+##   timeoutMin: 30
+##   tags: "needs-internet"
+##   minMemory: 2048
+
+set -xeuo pipefail
+
+. ${KOLA_EXT_DATA}/libtest.sh
+cd "$(mktemp -d)"
+
+
+# get the base filelists which exist before any package is installed
+(find / -name "*-filelists.*" > base_filelists.txt) || true
+
+# install a regular rpm, which should not install filelists
+rpm-ostree install htop
+(find / -name "*-filelists.*" > post_install_filelists.txt) || true
+STATUS="$(cmp base_filelists.txt post_install_filelists.txt; echo $?)"
+if [[ $STATUS -ne 0 ]]; then
+    echo "Failure 1: Filelists differ after installing htop"
+    exit 1
+fi
+
+# run rpm-ostree refresh-md, which should not install filelists
+rpm-ostree refresh-md
+(find / -name "*-filelists.*" > post_refresh_filelists.txt) || true
+STATUS="$(cmp base_filelists.txt post_refresh_filelists.txt; echo $?)"
+if [[ $STATUS -ne 0 ]]; then
+    echo "Failure 2: Filelists differ after running rpm-ostree refresh-md"
+    exit 1
+fi
+
+rpm-ostree cleanup -p
+rpm-ostree cleanup -m
+
+# install with filename, which should install filelists
+rpm-ostree install /usr/bin/htop
+(find / -name "*-filelists.*" > post_install_filelists.txt) || true
+STATUS="$(cmp base_filelists.txt post_install_filelists.txt; echo $?)"
+if [[ $STATUS -eq 0 ]]; then
+    echo "Failure 3: Filelists did not change after installing /usr/bin/htop"
+    exit 1
+fi
+
+# run rpm-ostree refresh-md, which should keep the installed filelists
+rpm-ostree refresh-md
+(find / -name "*-filelists.*" > post_refresh_filelists.txt) || true
+STATUS="$(cmp post_install_filelists.txt post_refresh_filelists.txt; echo $?)"
+if [[ $STATUS -ne 0 ]]; then
+    echo "Failure 4: Filelists differ after running rpm-ostree refresh-md"
+    exit 1
+fi
+
+rpm-ostree cleanup -p
+rpm-ostree cleanup -m
+
+# check that calling the following commands do not install filelists
+rpmostree_busctl_call_os ListRepos
+(find / -name "*-filelists.*" > post_call_filelists.txt) || true
+STATUS="$(cmp base_filelists.txt post_call_filelists.txt; echo $?)"
+if [[ $STATUS -ne 0 ]]; then
+    echo "Failure 5: Filelists differ after calling ListRepos"
+    exit 1
+fi
+
+rpm-ostree cleanup -m
+
+rpmostree_busctl_call_os WhatProvides as 1 provided-testing-daemon
+(find / -name "*-filelists.*" > post_call_filelists.txt) || true
+STATUS="$(cmp -s base_filelists.txt post_call_filelists.txt; echo $?)"
+if [[ $STATUS -ne 0 ]]; then
+    echo "Failure 6: Filelists differ after calling WhatProvides"
+    exit 1
+fi
+
+rpm-ostree cleanup -m
+
+rpm-ostree cleanup -m
+
+rpmostree_busctl_call_os GetPackages as 1 testdaemon 
+(find / -name "*-filelists.*" > post_call_filelists.txt) || true
+STATUS="$(cmp base_filelists.txt post_call_filelists.txt; echo $?)"
+if [[ $STATUS -ne 0 ]]; then
+    echo "Failure 7: Filelists differ after calling GetPackages"
+    exit 1
+fi
+
+rpm-ostree cleanup -m
+
+rpmostree_busctl_call_os Search as 1 testdaemon
+(find / -name "*-filelists.*" > post_call_filelists.txt) || true
+STATUS="$(cmp base_filelists.txt post_call_filelists.txt; echo $?)"
+if [[ $STATUS -ne 0 ]]; then
+    echo "Failure 8: Filelists differ after calling Search"
+    exit 1
+fi
+
+rpm-ostree cleanup -m
+
+# disable filelist optimization and test that default behaviour is restored
+mkdir -p /etc/systemd/system/rpm-ostreed.service.d
+cat > /etc/systemd/system/rpm-ostreed.service.d/filelists.conf << EOF
+[Service]
+Environment="DOWNLOAD_FILELISTS=true"
+EOF
+systemctl daemon-reload
+systemctl restart rpm-ostreed.service
+
+rpm-ostree install htop
+(find / -name "*-filelists.*" > post_install_filelists.txt) || true
+STATUS="$(cmp base_filelists.txt post_install_filelists.txt; echo $?)"
+if [[ $STATUS -eq 0 ]]; then
+    echo "Failure 9: Filelists were not downloaded after installing htop"
+    exit 1
+fi
+
+rpm-ostree cleanup -p
+rpm-ostree cleanup -m
+
+rpm-ostree install /usr/bin/htop
+(find / -name "*-filelists.*" > post_install_filelists.txt) || true
+STATUS="$(cmp base_filelists.txt post_install_filelists.txt; echo $?)"
+if [[ $STATUS -eq 0 ]]; then
+    echo "Failure 10: Filelists were not downloaded after installing /usr/bin/htop"
+    exit 1
+fi
+
+rpm-ostree cleanup -p
+rpm-ostree cleanup -m
+
+rpm-ostree refresh-md
+(find / -name "*-filelists.*" > post_refresh_filelists.txt) || true
+STATUS="$(cmp base_filelists.txt post_refresh_filelists.txt; echo $?)"
+if [[ $STATUS -eq 0 ]]; then
+    echo "Failure 11: Filelists were not downloaded after running rpm-ostree refresh-md"
+    exit 1
+fi
+
+rpm-ostree cleanup -m
+
+rpmostree_busctl_call_os ListRepos
+(find / -name "*-filelists.*" > post_call_filelists.txt) || true
+STATUS="$(cmp base_filelists.txt post_call_filelists.txt; echo $?)"
+if [[ $STATUS -ne 0 ]]; then
+    echo "Failure 12: Filelists differ after calling ListRepos"
+    exit 1
+fi
+
+rpm-ostree cleanup -m
+
+rpmostree_busctl_call_os WhatProvides as 1 provided-testing-daemon
+(find / -name "*-filelists.*" > post_call_filelists.txt) || true
+STATUS="$(cmp base_filelists.txt post_call_filelists.txt; echo $?)"
+if [[ $STATUS -eq 0 ]]; then
+    echo "Failure 13: Filelists were not downloaded after calling WhatProvides"
+    exit 1
+fi
+
+rpm-ostree cleanup -m
+
+rpmostree_busctl_call_os GetPackages as 1 testdaemon 
+(find / -name "*-filelists.*" > post_call_filelists.txt) || true
+STATUS="$(cmp base_filelists.txt post_call_filelists.txt; echo $?)"
+if [[ $STATUS -eq 0 ]]; then
+    echo "Failure 14: Filelists were not downloaded after calling GetPackages"
+    exit 1
+fi
+
+rpm-ostree cleanup -m
+
+rpmostree_busctl_call_os Search as 1 testdaemon
+(find / -name "*-filelists.*" > post_call_filelists.txt) || true
+STATUS="$(cmp base_filelists.txt post_call_filelists.txt; echo $?)"
+if [[ $STATUS -eq 0 ]]; then
+    echo "Failure 15: Filelists were not downloaded after calling Search"
+    exit 1
+fi


### PR DESCRIPTION
Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1643

Disable filelists from being downloaded by default for Fedora 40. Adds
the `DNF_CONTEXT_SETUP_SACK_FLAG_SKIP_FILELISTS` where applicable,
which prevents the filelists from being downloaded.

For the changes in `rpmostree_context_prepare()`, disabling filelists is
conditional on whether a filepath was specified for `rpm-ostree install`
(ie. rpm-ostree install /usr/bin/htop).

For the changes in refresh_md_transaction_execute(), `rpm-ostree
refresh-md` will not download filelists if they were not previously
downloaded. If they were previously downloaded, the filelists will be
updated.

Since there are many functions affected by this change, the option to
return to the previous filelist behaviour is also implemented. This is
done by adding:

```
[Service]
Environment="DOWNLOAD_FILELISTS=true"
```
in a newly created conf file under /etc/systemd/system/rpm-ostreed.service.d
For example: /etc/systemd/system/rpm-ostreed.service.d/filelists.conf