### PR TITLE
bwrap: Pass mutability flag, not unified core

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -2012,7 +2012,8 @@ extern "C"
 
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$bubblewrap_run_sync (
       ::std::int32_t rootfs_dfd, ::rust::Vec< ::rust::String> const &args, bool capture_stdout,
-      bool unified_core, ::rust::Vec< ::std::uint8_t> *return$) noexcept;
+      ::rpmostreecxx::BubblewrapMutability mutability,
+      ::rust::Vec< ::std::uint8_t> *return$) noexcept;
 
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$bubblewrap_new (
       ::std::int32_t rootfs_fd, ::rust::Box< ::rpmostreecxx::Bubblewrap> *return$) noexcept;
@@ -2066,6 +2067,9 @@ extern "C"
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$Bubblewrap$run (::rpmostreecxx::Bubblewrap &self,
                                           ::rpmostreecxx::GCancellable const &cancellable) noexcept;
+
+  ::rpmostreecxx::BubblewrapMutability
+  rpmostreecxx$cxxbridge1$mutability_for_unified_core (bool unified_core) noexcept;
 
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$usroverlay_entrypoint (::rust::Vec< ::rust::String> const &args) noexcept;
@@ -3469,11 +3473,11 @@ bubblewrap_selftest ()
 
 ::rust::Vec< ::std::uint8_t>
 bubblewrap_run_sync (::std::int32_t rootfs_dfd, ::rust::Vec< ::rust::String> const &args,
-                     bool capture_stdout, bool unified_core)
+                     bool capture_stdout, ::rpmostreecxx::BubblewrapMutability mutability)
 {
   ::rust::MaybeUninit< ::rust::Vec< ::std::uint8_t> > return$;
   ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$bubblewrap_run_sync (
-      rootfs_dfd, args, capture_stdout, unified_core, &return$.value);
+      rootfs_dfd, args, capture_stdout, mutability, &return$.value);
   if (error$.ptr)
     {
       throw ::rust::impl< ::rust::Error>::error (error$);
@@ -3597,6 +3601,12 @@ Bubblewrap::run (::rpmostreecxx::GCancellable const &cancellable)
     {
       throw ::rust::impl< ::rust::Error>::error (error$);
     }
+}
+
+::rpmostreecxx::BubblewrapMutability
+mutability_for_unified_core (bool unified_core) noexcept
+{
+  return rpmostreecxx$cxxbridge1$mutability_for_unified_core (unified_core);
 }
 
 void

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1773,13 +1773,16 @@ void bubblewrap_selftest ();
 
 ::rust::Vec< ::std::uint8_t> bubblewrap_run_sync (::std::int32_t rootfs_dfd,
                                                   ::rust::Vec< ::rust::String> const &args,
-                                                  bool capture_stdout, bool unified_core);
+                                                  bool capture_stdout,
+                                                  ::rpmostreecxx::BubblewrapMutability mutability);
 
 ::rust::Box< ::rpmostreecxx::Bubblewrap> bubblewrap_new (::std::int32_t rootfs_fd);
 
 ::rust::Box< ::rpmostreecxx::Bubblewrap>
 bubblewrap_new_with_mutability (::std::int32_t rootfs_fd,
                                 ::rpmostreecxx::BubblewrapMutability mutability);
+
+::rpmostreecxx::BubblewrapMutability mutability_for_unified_core (bool unified_core) noexcept;
 
 void usroverlay_entrypoint (::rust::Vec< ::rust::String> const &args);
 

--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -473,19 +473,14 @@ pub(crate) fn bubblewrap_run_sync(
     rootfs_dfd: i32,
     args: &Vec<String>,
     capture_stdout: bool,
-    unified_core: bool,
+    mutability: BubblewrapMutability,
 ) -> CxxResult<Vec<u8>> {
     let rootfs_dfd = unsafe { &crate::ffiutil::ffi_dirfd(rootfs_dfd)? };
     let tempetc = crate::core::prepare_tempetc_guard(rootfs_dfd.as_raw_fd())?;
-    let mutability = if unified_core {
-        BubblewrapMutability::RoFiles
-    } else {
-        BubblewrapMutability::MutateFreely
-    };
     let mut bwrap = Bubblewrap::new_with_mutability(rootfs_dfd, mutability)?;
 
-    if unified_core {
-        bwrap.bind_read("var", "/var");
+    if mutability != BubblewrapMutability::MutateFreely {
+        bwrap.bind_read("var", "/var")
     } else {
         bwrap.bind_readwrite("var", "/var")
     }

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -506,8 +506,12 @@ fn compose_postprocess_scripts(
         )?;
         println!("Executing `postprocess` inline script '{}'", i);
         let child_argv = vec![binpath.to_string()];
-        let _ =
-            bwrap::bubblewrap_run_sync(rootfs_dfd.as_raw_fd(), &child_argv, false, unified_core)?;
+        let _ = bwrap::bubblewrap_run_sync(
+            rootfs_dfd.as_raw_fd(),
+            &child_argv,
+            false,
+            BubblewrapMutability::for_unified_core(unified_core),
+        )?;
         rootfs_dfd.remove_file(target_binpath)?;
     }
 
@@ -531,7 +535,7 @@ fn compose_postprocess_scripts(
             rootfs_dfd.as_raw_fd(),
             child_argv,
             false,
-            unified_core,
+            BubblewrapMutability::for_unified_core(unified_core),
         )
         .context("Executing postprocessing script")?;
 

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -97,7 +97,12 @@ pub(crate) fn run_depmod(rootfs_dfd: i32, kver: &str, unified_core: bool) -> Cxx
         .into_iter()
         .map(|s| s.to_string())
         .collect();
-    let _ = crate::bwrap::bubblewrap_run_sync(rootfs_dfd, &args, false, unified_core)?;
+    let _ = crate::bwrap::bubblewrap_run_sync(
+        rootfs_dfd,
+        &args,
+        false,
+        crate::ffi::BubblewrapMutability::for_unified_core(unified_core),
+    )?;
     Ok(())
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -20,6 +20,7 @@ mod cxxrsutil;
 mod ffiutil;
 pub(crate) mod ffiwrappers;
 pub(crate) use cxxrsutil::*;
+use ffi::BubblewrapMutability;
 
 /// APIs defined here are automatically bridged between Rust and C++ using https://cxx.rs/
 ///
@@ -123,7 +124,7 @@ pub mod ffi {
             rootfs_dfd: i32,
             args: &Vec<String>,
             capture_stdout: bool,
-            unified_core: bool,
+            mutability: BubblewrapMutability,
         ) -> Result<Vec<u8>>;
 
         fn bubblewrap_new(rootfs_fd: i32) -> Result<Box<Bubblewrap>>;
@@ -148,6 +149,8 @@ pub mod ffi {
         fn setup_compat_var(&mut self) -> Result<()>;
 
         fn run(&mut self, cancellable: &GCancellable) -> Result<()>;
+
+        fn mutability_for_unified_core(unified_core: bool) -> BubblewrapMutability;
     }
 
     // builtins/apply_live.rs
@@ -925,6 +928,19 @@ pub mod ffi {
             cancellable: &GCancellable,
         ) -> Result<*mut GVariant>;
     }
+}
+
+impl BubblewrapMutability {
+    pub(crate) fn for_unified_core(unified_core: bool) -> Self {
+        if unified_core {
+            Self::RoFiles
+        } else {
+            Self::MutateFreely
+        }
+    }
+}
+pub(crate) fn mutability_for_unified_core(unified_core: bool) -> BubblewrapMutability {
+    BubblewrapMutability::for_unified_core(unified_core)
 }
 
 pub mod builtins;

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -390,16 +390,20 @@ postprocess_final (int rootfs_dfd, rpmostreecxx::Treefile &treefile, gboolean un
         /* Now regenerate SELinux policy so that postprocess scripts from users and from us
          * (e.g. the /etc/default/useradd incision) that affect it are baked in. */
         rust::Vec child_argv = { rust::String ("semodule"), rust::String ("-nB") };
-        ROSCXX_TRY (bubblewrap_run_sync (rootfs_dfd, child_argv, false, (bool)unified_core_mode),
-                    error);
+        ROSCXX_TRY (
+            bubblewrap_run_sync (rootfs_dfd, child_argv, false,
+                                 rpmostreecxx::mutability_for_unified_core (unified_core_mode)),
+            error);
       }
 
       /* Temporary workaround for https://github.com/openshift/os/issues/1036. */
       {
         rust::Vec child_argv
             = { rust::String ("semodule"), rust::String ("-n"), rust::String ("--refresh") };
-        ROSCXX_TRY (bubblewrap_run_sync (rootfs_dfd, child_argv, false, (bool)unified_core_mode),
-                    error);
+        ROSCXX_TRY (
+            bubblewrap_run_sync (rootfs_dfd, child_argv, false,
+                                 rpmostreecxx::mutability_for_unified_core (unified_core_mode)),
+            error);
       }
     }
 


### PR DESCRIPTION
We have two `bool` values here and that's a code smell.  I was going to add another option and we definitely don't want three bools.

We already have an enum here related to what's going on, so change things to use it.
