### PR TITLE
Change "enable replacement" error text to "allow replacement" to match command-line interface

### DIFF
--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -431,14 +431,14 @@ pub(crate) fn transaction_apply_live(
     if !allow_replacement {
         if pkgdiff.n_removed() > 0 {
             return Err(anyhow!(
-                "packages would be removed: {}, enable replacement to override",
+                "packages would be removed: {}, allow replacement to override",
                 pkgdiff.n_removed()
             )
             .into());
         }
         if pkgdiff.n_modified() > 0 {
             return Err(anyhow!(
-                "packages would be changed: {}, enable replacement to override",
+                "packages would be changed: {}, allow replacement to override",
                 pkgdiff.n_modified()
             )
             .into());

--- a/tests/kolainst/destructive/apply-live
+++ b/tests/kolainst/destructive/apply-live
@@ -90,7 +90,7 @@ rpmostree_assert_status '.deployments|length == 2' \
 if rpm-ostree apply-live 2>err.txt; then
     fatal "live-removed foo"
 fi
-assert_file_has_content_literal err.txt 'packages would be removed: 1, enable replacement to override'
+assert_file_has_content_literal err.txt 'packages would be removed: 1, allow replacement to override'
 # Ensure remote error is stripped
 assert_not_file_has_content_literal err.txt 'GDBus.Error'
 rpm-ostree ex livefs --allow-replacement | tee out.txt


### PR DESCRIPTION
I'm a very happy rpm-ostree user on Fedora Silverblue, but sometimes when I want to make a live change to my system with:
```
rpm-ostree install -A blah
```
I'll get an error message like:
```
error: packages would be changed: 34, enable replacement to override
```
and then I think oh, I have to pass that override so I do
```
sudo rpm-ostree apply-live --enable-replacement
```
*but* the argument is not `--enable-replacement`, it is in fact `--allow-replacement`.

This PR changes that error text to more closely match the correct command-line argument needed to override the error, so the error would now be:
```
error: packages would be changed: 34, allow replacement to override
```
It's subtle, but I think an ever so slight usability improvement.