### PR TITLE
libpriv/scripts: support files in transfiletriggerin patterns

### DIFF
--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -632,7 +632,13 @@ write_subdir (int dfd, const char *path, GString *prefix, FILE *f, guint *inout_
   glnx_autofd int target_dfd = glnx_opendirat_with_errno (dfd, path, TRUE);
   if (target_dfd < 0)
     {
-      if (errno != ENOENT)
+      if (errno == ENOTDIR)
+        {
+          if (!write_filename (f, prefix, error))
+            return FALSE;
+          (*inout_n_matched)++;
+        }
+      else if (errno != ENOENT)
         return glnx_throw_errno_prefix (error, "opendirat");
       /* Not early return */
       return TRUE;

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -153,7 +153,8 @@ license_combos="zlib-rpm systemd-tar-rpm sed-tzdata"
 license_un_combos="zlib systemd-rpm"
 vm_build_rpm scriptpkg4 \
              transfiletriggerin "/usr/share/licenses/zlib /usr/share/licenses/rpm" 'sort >/usr/share/transfiletriggerin-license-zlib-rpm.txt' \
-             transfiletriggerun "/usr/share/licenses/zlib" 'sort >/usr/share/transfiletriggerun-license-zlib.txt'
+             transfiletriggerun "/usr/share/licenses/zlib" 'sort >/usr/share/transfiletriggerun-license-zlib.txt' \
+             transfiletriggerin2 "/usr/share/licenses/xz/COPYING" 'cat > /usr/share/transfiletriggerin-license-file-xz.txt'
 vm_build_rpm scriptpkg5 \
              transfiletriggerin "/usr/share/licenses/systemd /usr/share/licenses/rpm /usr/share/licenses/tar" 'sort >/usr/share/transfiletriggerin-license-systemd-tar-rpm.txt' \
              transfiletriggerun "/usr/share/licenses/systemd /usr/share/licenses/rpm" 'sort >/usr/share/transfiletriggerun-license-systemd-rpm.txt' \
@@ -171,6 +172,7 @@ done
 for combo in ${license_un_combos}; do
     vm_cmd test '!' -f /usr/share/licenses/transfiletriggerun-license-${combo}.txt
 done
+vm_cmd grep /usr/share/licenses/xz/COPYING /usr/share/transfiletriggerin-license-file-xz.txt
 # We really need a reset command to go back to the base layer
 vm_rpmostree uninstall scriptpkg{4,5}
 echo "ok transfiletriggerin"


### PR DESCRIPTION
The file trigger pattern isn't necessarily a directory. It seems just like a generic pattern applied to all file entries in the header of the packages being installed. (Technically we need to support globs in there too but we're currently not doing.)

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2269247