### PR TITLE
Revert "compose: Inject our static tmpfiles.d dropins earlier"

### DIFF
--- a/ci/prow/fcos-e2e.sh
+++ b/ci/prow/fcos-e2e.sh
@@ -9,12 +9,7 @@ ls -al /usr/bin/rpm-ostree
 rpm-ostree --version
 cd $(mktemp -d)
 cosa init https://github.com/coreos/fedora-coreos-config/
-# let's turn on stateoverlays in this test since CoreOS CI already
-# covers the off path
-echo -e '\nopt-usrlocal: "stateoverlay"\n' >> src/config/manifest.yaml
 cp /cosa/component-rpms/*.rpm overrides/rpm
-# XXX: temporarily import new ostree until it makes it into FCOS
-(cd overrides/rpm && curl -L --remote-name-all https://kojipkgs.fedoraproject.org//packages/ostree/2024.2/1.fc39/x86_64/ostree-{,libs-}2024.2-1.fc39.x86_64.rpm)
 cosa fetch
 cosa build
 cosa kola run 'ext.rpm-ostree.*'

--- a/rust/src/passwd.rs
+++ b/rust/src/passwd.rs
@@ -106,9 +106,6 @@ pub fn passwd_cleanup(rootfs_dfd: i32) -> Result<()> {
 /// in /usr/etc at this point), and splitting it into two streams: a new
 /// /etc/passwd that just contains the root entry, and /usr/lib/passwd which
 /// contains everything else.
-///
-/// Note: the presence of /usr/lib/passwd is used in postprocess_final() to make
-/// it idempotent. See related comment there.
 #[context("Migrating 'passwd' to /usr/lib")]
 pub fn migrate_passwd_except_root(rootfs_dfd: i32) -> CxxResult<()> {
     static ETCSRC_PATH: &str = "usr/etc/passwd";

--- a/tests/kolainst/destructive/state-overlays
+++ b/tests/kolainst/destructive/state-overlays
@@ -1,8 +1,13 @@
 #!/bin/bash
+
 ## kola:
 ##   tags: "needs-internet"
 
-set -xeuo pipefail
+set -euo pipefail
+
+# NOTE: This is disabled until https://github.com/coreos/rpm-ostree/issues/4879
+# is re-enabled.
+exit 0
 
 . ${KOLA_EXT_DATA}/libtest.sh
 
@@ -31,7 +36,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
       rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2024-6c7480dd2f
     fi
 
-    # FCOS doesn't enable opt-usrlocal = stateoverlay yet. It's on in Prow CI though.
+    # FCOS doesn't enable opt-usrlocal = stateoverlay. It's on in Prow CI though.
     # Just check the treefile so we do the right thing regardless of CoreOS CI
     # or Prow.
     if test "$(jq -r '.["opt-usrlocal"]' /usr/share/rpm-ostree/treefile.json)" = null; then
@@ -40,14 +45,14 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
 [Service]
 Environment=RPMOSTREE_EXPERIMENTAL_FORCE_OPT_USRLOCAL_OVERLAY=1
 EOF
+    fi
 
-      # This script itself is in /usr/local, so we need to move it back on top
-      # of the overlay if we used the hack. This simultaneously demos one way
-      # upgrading nodes could retain content if we turn on opt-usrlocal-overlays
-      # in FCOS.
-      cat > /etc/systemd/system/move-usr-local.service <<EOF
+    # This script itself is in /usr/local, so we need to move it back on top
+    # of the overlay. This simultaneously demos one way upgrading nodes could
+    # retain content if we turn on opt-usrlocal-overlays in FCOS.
+    cat > /etc/systemd/system/move-usr-local.service <<EOF
 [Unit]
-Description=Move Previous /usr/local Content Back Into /usr/local
+Description=Move Previous /usr/local content back into /usr/local
 After=local-fs.target
 After=systemd-tmpfiles-setup.service
 Before=kola-runext.service
@@ -63,10 +68,9 @@ RemainAfterExit=yes
 [Install]
 WantedBy=multi-user.target
 EOF
-      systemctl daemon-reload
-      systemctl restart rpm-ostreed
-      systemctl enable move-usr-local.service
-    fi
+    systemctl daemon-reload
+    systemctl restart rpm-ostreed
+    systemctl enable move-usr-local.service
 
     rpm-ostree install test-opt
 


### PR DESCRIPTION
This reverts commit e1e78cf9df902d895a7fce9dc719726c283e9d03.

It breaks idempotency with osbuild.

Closes: https://github.com/coreos/rpm-ostree/issues/4879
