### PR TITLE
install: specify sub-commands that are container build only.

### DIFF
--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -69,11 +69,14 @@ static GOptionEntry option_entries[]
         { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization,
           "Prevent automatic deployment finalization on shutdown", NULL },
         { "enablerepo", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_enable_repo,
-          "Enable the repository based on the repo id", NULL },
-        { "disablerepo", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_disable_repo,
-          "Only disabling all (*) repositories is supported currently", NULL },
-        { "releasever", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_release_ver, "Set the releasever",
+          "Enable the repository based on the repo id. Is only supported in a container build.",
           NULL },
+        { "disablerepo", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_disable_repo,
+          "Only disabling all (*) repositories is supported currently. Is only supported in a "
+          "container build.",
+          NULL },
+        { "releasever", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_release_ver,
+          "Set the releasever. Is only supported in a container build.", NULL },
         { NULL } };
 
 static GOptionEntry uninstall_option_entry[]


### PR DESCRIPTION
We should specify on the CLI description of the install sub-commands that releasever, disablerepo & enablerepo only work on a container build. 

This should clear the confusion: https://bugzilla.redhat.com/show_bug.cgi?id=2219097