### PR TITLE
libpriv/systemctl-wrapper allow enable and disable

### DIFF
--- a/src/libpriv/systemctl-wrapper.sh
+++ b/src/libpriv/systemctl-wrapper.sh
@@ -6,7 +6,7 @@
 
 for arg in "$@"; do
     case $arg in
-        preset | --root | --root=*) exec /usr/bin/systemctl.rpmostreesave "$@" ;;
+        preset | --root | --root=* | enable | disable) exec /usr/bin/systemctl.rpmostreesave "$@" ;;
     esac
 done
 echo "rpm-ostree-systemctl: Ignored non-preset command:" "$@"


### PR DESCRIPTION
systemctl also knows how to do those offline, e.g. in rpm scriptlets, so allow those operations



