### PR TITLE
CVE-2024-2905: passwd: create /etc/[g]shadow with mode 0 & unit: chmod /etc/[g]shadow[-] to 0000

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -60,6 +60,7 @@ systemdunit_service_file_names = \
 	rpm-ostreed-automatic.service \
 	rpm-ostree-bootstatus.service \
 	rpm-ostree-countme.service \
+	rpm-ostree-fix-shadow-mode.service \
 	$(NULL)
 
 systemdunit_service_files = $(addprefix $(srcdir)/src/daemon/,$(systemdunit_service_file_names))

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -237,6 +237,11 @@ $PYTHON autofiles.py > files.devel \
 # Setup rpm-ostree-countme.timer according to presets
 %post
 %systemd_post rpm-ostree-countme.timer
+# Only enable on rpm-ostree based systems and manually force unit enablement to
+# explicitly ignore presets for this security fix
+if [ -e /run/ostree-booted ]; then
+    ln -snf /usr/lib/systemd/system/rpm-ostree-fix-shadow-mode.service  /usr/lib/systemd/system/multi-user.target.wants/
+fi
 
 %preun
 %systemd_preun rpm-ostree-countme.timer

--- a/src/daemon/rpm-ostree-fix-shadow-mode.service
+++ b/src/daemon/rpm-ostree-fix-shadow-mode.service
@@ -1,0 +1,19 @@
+[Unit]
+# rpm-ostree v2023.6 introduced a permission issue on `/etc/[g]shadow[-]`.
+# This makes sure to fix permissions on systems that were deployed with the wrong permissions.
+Description=Update permissions for /etc/shadow
+Documentation=https://github.com/coreos/rpm-ostree-ghsa-2m76-cwhg-7wv6
+ConditionPathExists=!/etc/.rpm-ostree-shadow-mode-fixed.stamp
+ConditionPathExists=/run/ostree-booted
+# Make sure this is started before any unprivileged (interactive) user has access to the system.
+Before=systemd-user-sessions.service
+
+[Service]
+Type=oneshot
+ExecStart=chmod --verbose 0000 /etc/shadow /etc/gshadow
+ExecStart=-chmod --verbose 0000 /etc/shadow- /etc/gshadow-
+ExecStart=touch /etc/.rpm-ostree-shadow-mode-fixed.stamp
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/compose/libbasic-test.sh
+++ b/tests/compose/libbasic-test.sh
@@ -22,6 +22,11 @@ validate_passwd group
 ostree --repo=${repo} ls ${treeref} /usr/etc/passwd > passwd.txt
 assert_file_has_content_literal passwd.txt '00644 '
 
+ostree --repo=${repo} ls ${treeref} /usr/etc/shadow > shadow.txt
+assert_file_has_content_literal shadow.txt '00000 '
+ostree --repo=${repo} ls ${treeref} /usr/etc/gshadow > gshadow.txt
+assert_file_has_content_literal gshadow.txt '00000 '
+
 ostree --repo=${repo} cat ${treeref} /usr/etc/default/useradd > useradd.txt
 assert_file_has_content_literal useradd.txt HOME=/var/home
 


### PR DESCRIPTION
passwd: create `/etc/[g]shadow` with mode 0

Because of how our composes work, we need to manually inject
passwd-related things before installing packages. A somewhat recent
regression in that area made it so that the `/etc/shadow` and
`/etc/gshadow` files were created with default permissions (0644), which
meant they were world readable.

Fix this by explicitly setting their modes to 0. Ideally, we would rely
on the canonical permissions set in the `setup` package here, but it's
tricky to fix that without reworking how we install `setup` and handle
`passwd` treefile options.

Fixes fdb879c8 ("passwd: sync `etc/{,g}shadow` according to
`etc/{passwd,group}`").

Fixes #4401

---

unit: chmod /etc/[g]shadow[-] to 0000

fdb879c introduced a regression where /etc/[g]shadow[-] files where
created with default permissions: 0644

This unit chmods /etc/shadow, /etc/gshadow and backup copies to 0000
before interactive login is allowed on a system.

This will fix the systems that were deployed with the above issue.

We keep the stamp in /etc to account for the case where a deployment
with this unit is rolled back. If we used /var, the stamp would have
stayed but the fix would not be re-applied on the next update.

---

This fixes CVE-2024-2905. Advisory to be published soon.