### PR TITLE
Add kernel-uek-core.posttrans to list of ignored package scripts

### DIFF
--- a/rust/src/scripts.rs
+++ b/rust/src/scripts.rs
@@ -40,8 +40,9 @@ static IGNORED_PKG_SCRIPTS: phf::Set<&'static str> = phf_set! {
     "kernel-64k-modules.posttrans",
     "kernel-64k-debug-core.posttrans",
     "kernel-64k-debug-modules.posttrans",
-    // Additionally ignore posttrans scripts for the Oracle Linux `kernel-uek` package
+    // Additionally ignore posttrans scripts for the Oracle Linux `kernel-uek` and `kernel-uek-core` packages
     "kernel-uek.posttrans",
+    "kernel-uek-core.posttrans",
     // Legacy workaround
     "glibc-headers.prein",
     // workaround for old bug?


### PR DESCRIPTION
This PR fixes rpm-ostree on Oracle Linux UEKR7. UEKR7 has a different package layout than UEKR6. In particular, some postinstall scripts that used to run in "kernel-uek" are now run as part of "kernel-uek-core".  This causes rpm-ostree to output lots of errors and eventually fails.

The fix is to add "kernel-uek-core" to the ignore list of posttrans scripts.

Sample snippet of output showing the errors before the fix:
```
rpm-ostree compose tree --unified-core  --repo=./ostree  configs/manifest.yaml
...
⠤ Running posttrans scripts... kernel-uek-core
...
kernel-uek-core.posttrans: cp: setting attributes for '/var/tmp/dracut.HpI4IW/initramfs/shutdown': Operation not supported
kernel-uek-core.posttrans: dracut-install: ERROR: installing '/usr/lib/dracut/modules.d/99shutdown/shutdown.sh' to '/shutdown'
kernel-uek-core.posttrans: dracut: FAILED: /usr/lib/dracut/dracut-install -D /var/tmp/dracut.HpI4IW/initramfs -l /usr/lib/dracut/modules.d/99shutdown/shutdown.sh /shutdown
kernel-uek-core.posttrans: libkmod: kmod_module_get_holders: could not open '/sys/module/vhost_net/holders': No such file or directory
...
```