### PR TITLE
shadow: Adjust all deployments

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1008,7 +1008,7 @@ mod normalization;
 mod origin;
 mod ostree_prepareroot;
 pub(crate) use self::origin::*;
-mod passwd;
+pub mod passwd;
 use passwd::*;
 mod console_progress;
 pub(crate) use self::console_progress::*;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -28,6 +28,7 @@ async fn inner_async_main(args: Vec<String>) -> Result<i32> {
             match *arg {
                 // Add custom Rust commands here, and also in `libmain.cxx` if user-visible.
                 "countme" => rpmostree_rust::countme::entrypoint(args).map(|_| 0),
+                "fix-shadow-perms" => rpmostree_rust::passwd::fix_shadow_perms_entrypoint(args).map(|_| 0),
                 "cliwrap" => rpmostree_rust::cliwrap::entrypoint(args).map(|_| 0),
                 // A hidden wrapper to intercept some binaries in RPM scriptlets.
                 "scriptlet-intercept" => builtins::scriptlet_intercept::entrypoint(args).map(|_| 0),

--- a/src/daemon/rpm-ostree-fix-shadow-mode.service
+++ b/src/daemon/rpm-ostree-fix-shadow-mode.service
@@ -3,17 +3,21 @@
 # This makes sure to fix permissions on systems that were deployed with the wrong permissions.
 Description=Update permissions for /etc/shadow
 Documentation=https://github.com/coreos/rpm-ostree-ghsa-2m76-cwhg-7wv6
-ConditionPathExists=!/etc/.rpm-ostree-shadow-mode-fixed.stamp
+# This new stamp file is written by the Rust code, and obsoletes
+# the old /etc/.rpm-ostree-shadow-mode-fixed.stamp
+ConditionPathExists=!/etc/.rpm-ostree-shadow-mode-fixed2.stamp
 ConditionPathExists=/run/ostree-booted
+# Because we read the sysroot
+RequiresMountsFor=/boot
 # Make sure this is started before any unprivileged (interactive) user has access to the system.
 Before=systemd-user-sessions.service
 
 [Service]
 Type=oneshot
-ExecStart=chmod --verbose 0000 /etc/shadow /etc/gshadow
-ExecStart=-chmod --verbose 0000 /etc/shadow- /etc/gshadow-
-ExecStart=touch /etc/.rpm-ostree-shadow-mode-fixed.stamp
+ExecStart=rpm-ostree fix-shadow-perms
 RemainAfterExit=yes
+# So we can remount /sysroot writable in our own namespace
+MountFlags=slave
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/kolainst/destructive/shadow
+++ b/tests/kolainst/destructive/shadow
@@ -1,0 +1,80 @@
+#!/bin/bash
+#
+# Copyright (C) 2024 Red Hat Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. ${KOLA_EXT_DATA}/libtest.sh
+
+set -x
+
+cd $(mktemp -d)
+
+service=rpm-ostree-fix-shadow-mode.service
+stamp=/etc/.rpm-ostree-shadow-mode-fixed2.stamp
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+"")
+
+libtest_prepare_fully_offline
+libtest_enable_repover 0
+
+systemctl status ${service} || true
+rm -vf /etc/.rpm-ostree-shadow-mode*
+chmod 0644 /etc/gshadow
+
+# Verify running the service once fixes things
+systemctl restart $service
+assert_has_file "${stamp}"
+assert_streq "$(stat -c '%f' /etc/gshadow)" 8000
+
+# Now *undo* the fix, so that the current (then old) deployment
+# is broken still, and ensure after reboot that it's fixed
+# in both.
+
+chmod 0644 /etc/gshadow
+rm -vf /etc/.rpm-ostree*
+
+booted_commit=$(rpm-ostree status --json | jq -r '.deployments[0].checksum')
+ostree refs ${booted_commit} --create vmcheck2
+rpm-ostree rebase :vmcheck2
+
+/tmp/autopkgtest-reboot "1"
+;;
+"1")
+
+systemctl status $service
+assert_has_file "${stamp}"
+
+verified=0
+for f in $(ls /ostree/deploy/*/deploy/*/etc/{,g}shadow{,-}); do
+    verified=$(($verified + 1))
+    assert_streq "$(stat -c '%f' $f)" 8000
+    echo "ok ${f}"
+done
+assert_streq "$verified" 8
+
+journalctl -b -u $service --grep="Adjusted shadow files in deployment" | tee out.txt
+assert_streq "$(wc -l < out.txt)" 2
+
+echo "ok shadow"
+
+;;
+*) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+
+esac


### PR DESCRIPTION
It was pointed out that in the previous change here we missed the fact that the previous deployments were accessible.

- Move the logic into Rust, adding unit tests
- Change the code to iterate over all deployments
- Add an integration test too

Note: A likely future enhancement here will be to finally deny unprivileged access to non-default roots; cc
https://github.com/ostreedev/ostree/issues/3211
