### PR TITLE
kargs: keep spaces in double quotes

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -1366,7 +1366,11 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
       OstreeBootconfigParser *bootconfig
           = ostree_deployment_get_bootconfig (self->origin_merge_deployment);
       const char *options = ostree_bootconfig_parser_get (bootconfig, "options");
-      self->kargs_strv = g_strsplit (options, " ", -1);
+      /* Fix for https://github.com/ostreedev/ostree/issues/3228,
+       * should keep spaces in quotes as single parameter, related
+       * change in ostree is https://github.com/ostreedev/ostree/pull/3208.
+       */
+      self->kargs_strv = ostree_kernel_args_to_strv (ostree_kernel_args_from_string (options));
     }
 
   // Note that most of the code here operates on ->computed_origin except this.

--- a/tests/kolainst/destructive/container-rebase-upgrade
+++ b/tests/kolainst/destructive/container-rebase-upgrade
@@ -33,6 +33,10 @@ image=quay.io/fedora/fedora-coreos:stable
 image_pull=ostree-remote-registry:fedora:$image
 
 systemctl mask --now zincati
+# Test for https://github.com/ostreedev/ostree/issues/3228
+rpm-ostree kargs --append "foo=\"a b c\""
+rpm-ostree kargs > kargs.txt
+assert_file_has_content_literal kargs.txt "foo=\"a b c\""
 rpm-ostree rebase --experimental ${image_pull}
 rpm-ostree upgrade
 # This provokes


### PR DESCRIPTION
Related change in ostree is https://github.com/ostreedev/ostree/pull/3208.

Fixes: https://github.com/ostreedev/ostree/issues/3228
