### PR TITLE
deployment_utils: Also add version to cached update

### DIFF
--- a/src/app/rpmostree-builtin-upgrade.cxx
+++ b/src/app/rpmostree-builtin-upgrade.cxx
@@ -201,8 +201,8 @@ rpmostree_builtin_upgrade (int argc, char **argv, RpmOstreeCommandInvocation *in
 
   if (check_or_preview)
     {
-      g_print ("Note: --check and --preview may be unreliable.  See "
-               "https://github.com/coreos/rpm-ostree/issues/1579\n");
+      g_printerr ("Note: --check and --preview may be unreliable.  See "
+                  "https://github.com/coreos/rpm-ostree/issues/1579\n");
       g_autoptr (GVariant) cached_update = NULL;
       if (rpmostree_os_get_has_cached_update_rpm_diff (os_proxy))
         cached_update = rpmostree_os_dup_cached_update (os_proxy);

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -786,6 +786,7 @@ rpmostreed_update_generate_variant (OstreeDeployment *booted_deployment,
               auto state = rpmostreecxx::query_container_image_commit (*repo, current_checksum);
               container_changed
                   = rpmostreecxx::deployment_add_manifest_diff (*dict, state->cached_update_diff);
+              g_variant_dict_insert (dict, "version", "s", state->version.c_str ());
               g_debug ("container changed: %d", container_changed);
             }
           catch (std::exception &e)

--- a/tests/kolainst/destructive/container-update-check
+++ b/tests/kolainst/destructive/container-update-check
@@ -112,4 +112,14 @@ EOF
   assert_file_has_content_literal out.txt 'Removed layers:'
   assert_file_has_content_literal out.txt 'Added layers:'
 
+  rpm-ostree status --json | jq '."cached-update"' > out.txt
+  assert_file_has_content_literal out.txt '"n-added":'
+  assert_file_has_content_literal out.txt '"n-removed":'
+  assert_file_has_content_literal out.txt '"removed-size":'
+  assert_file_has_content_literal out.txt '"total-size":'
+  assert_file_has_content_literal out.txt '"total":'
+  assert_file_has_content_literal out.txt '"added-size":'
+  assert_file_has_content_literal out.txt '"version":'
+  assert_file_has_content_literal out.txt '"origin":'
+
 esac

--- a/tests/vmcheck/test-autoupdate-check.sh
+++ b/tests/vmcheck/test-autoupdate-check.sh
@@ -76,11 +76,11 @@ echo "ok disabled"
 assert_check_preview_rc() {
   local expected_rc=$1; shift
   local rc=0
-  vm_rpmostree upgrade --check > out.txt || rc=$?
+  vm_rpmostree upgrade --check > out.txt 2> err.txt || rc=$?
   assert_streq $rc $expected_rc
-  assert_file_has_content out.txt "Note:.*may be unreliable"
-  vm_rpmostree upgrade --preview > out-verbose.txt || rc=$?
-  assert_file_has_content out-verbose.txt "Note:.*may be unreliable"
+  assert_file_has_content err.txt "Note:.*may be unreliable"
+  vm_rpmostree upgrade --preview > out-verbose.txt 2> err-verbose.txt || rc=$?
+  assert_file_has_content err-verbose.txt "Note:.*may be unreliable"
   assert_streq $rc $expected_rc
 }
 


### PR DESCRIPTION
update-check: Print unreliability warning on stderr

Print warnings on stderr so that we can format the stdout as JSON.

---

deployment_utils: Also add version to cached update

Adding the version of the cached update to `rpm-ostree status --json`
output will make it easier to use it for update checks in Plasma
Discover when updating using Ostree Native Containers.

Fixes: https://github.com/coreos/rpm-ostree/issues/4711