### PR TITLE
deployment_utils: Fix version for cached container update

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1422,6 +1422,8 @@ struct ExportedManifestDiff final
   ::std::uint64_t n_added;
   // The size of total number of added packages in the next upgrade
   ::std::uint64_t added_size;
+  // The version of the next upgrade
+  ::rust::String version;
 
   using IsRelocatable = ::std::true_type;
 };

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1199,6 +1199,8 @@ struct ExportedManifestDiff final
   ::std::uint64_t n_added;
   // The size of total number of added packages in the next upgrade
   ::std::uint64_t added_size;
+  // The version of the next upgrade
+  ::rust::String version;
 
   using IsRelocatable = ::std::true_type;
 };

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -208,6 +208,8 @@ pub mod ffi {
         pub n_added: u64,
         /// The size of total number of added packages in the next upgrade
         pub added_size: u64,
+        /// The version of the next upgrade
+        pub version: String,
     }
 
     #[derive(Debug, PartialEq, Eq)]

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -25,7 +25,10 @@ impl From<Box<ostree_container::store::LayeredImageState>> for crate::ffi::Conta
             .cached_update
             .map(|c| {
                 let diff = ManifestDiff::new(&s.manifest, &c.manifest);
-                export_diff(&diff)
+                let version = ostree_container::version_for_config(&c.config)
+                    .map(ToOwned::to_owned)
+                    .unwrap_or_default();
+                export_diff(&diff, version)
             })
             .unwrap_or_default();
         crate::ffi::ContainerImageState {
@@ -226,7 +229,7 @@ pub(crate) fn check_container_update(
 
 /// Unfortunately we can't export external types into our C++ bridge, so manually copy things
 /// to another copy of the struct.
-fn export_diff(diff: &ManifestDiff) -> ExportedManifestDiff {
+fn export_diff(diff: &ManifestDiff, version: String) -> ExportedManifestDiff {
     ExportedManifestDiff {
         initialized: true,
         total: diff.total,
@@ -235,6 +238,7 @@ fn export_diff(diff: &ManifestDiff) -> ExportedManifestDiff {
         removed_size: diff.removed_size,
         n_added: diff.n_added,
         added_size: diff.added_size,
+        version,
     }
 }
 

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -786,7 +786,9 @@ rpmostreed_update_generate_variant (OstreeDeployment *booted_deployment,
               auto state = rpmostreecxx::query_container_image_commit (*repo, current_checksum);
               container_changed
                   = rpmostreecxx::deployment_add_manifest_diff (*dict, state->cached_update_diff);
-              g_variant_dict_insert (dict, "version", "s", state->version.c_str ());
+              if (state->cached_update_diff.version.size () > 0)
+                g_variant_dict_insert (dict, "version", "s",
+                                       state->cached_update_diff.version.c_str ());
               g_debug ("container changed: %d", container_changed);
             }
           catch (std::exception &e)

--- a/tests/kolainst/destructive/container-update-check
+++ b/tests/kolainst/destructive/container-update-check
@@ -53,7 +53,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     cd ${td}
 cat > Containerfile << EOF
 FROM localhost/fcos
-# RUN rpm-ostree install man
+LABEL org.opencontainers.image.version 1
 EOF
 
     touched_resolv_conf=0
@@ -91,6 +91,7 @@ EOF
 cat > Containerfile << EOF
 FROM localhost/fcos
 RUN rpm-ostree install man
+LABEL org.opencontainers.image.version 2
 EOF
 
   touched_resolv_conf=0
@@ -119,7 +120,7 @@ EOF
   assert_file_has_content_literal out.txt '"total-size":'
   assert_file_has_content_literal out.txt '"total":'
   assert_file_has_content_literal out.txt '"added-size":'
-  assert_file_has_content_literal out.txt '"version":'
-  assert_file_has_content_literal out.txt '"origin":'
+  assert_file_has_content_literal out.txt '"version": "2"'
+  assert_file_has_content_literal out.txt '"origin": "ostree-unverified-image:containers-storage:localhost/fcos-derived"'
 
 esac


### PR DESCRIPTION
container-update-check: Validate version in manifest diff

---

deployment_utils: Fix version for cached container update

Previous change used the version of the current deployment instead of
the one from the pending container update.

Store the new version alongside the manifest diff to be able to return
it as part of the cached update logic.

Fixes: https://github.com/coreos/rpm-ostree/pull/4923
Fixes: https://github.com/coreos/rpm-ostree/issues/4711