### PR TITLE
daemon: use new finalization APIs

### DIFF
--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -166,6 +166,8 @@ pub(crate) fn deployment_populate_variant(
     /* Staging status */
     dict.insert("staged", &deployment.is_staged());
     if deployment.is_staged()
+        // XXX: this should check deployment.is_finalization_locked() too now
+        // but the libostree Rust bindings need to be updated
         && std::path::Path::new("/run/ostree/staged-deployment-locked").exists()
     {
         dict.insert("finalization-locked", &true);

--- a/src/daemon/rpmostree-sysroot-core.h
+++ b/src/daemon/rpmostree-sysroot-core.h
@@ -33,10 +33,6 @@ G_BEGIN_DECLS
 /* The legacy dir, which we will just delete if we find it */
 #define RPMOSTREE_OLD_TMP_ROOTFS_DIR "extensions/rpmostree/commit"
 
-/* Really, this is an OSTree API, but let's consider it hidden for now like the
- * /run/ostree/staged-deployment path and company. */
-#define _OSTREE_SYSROOT_RUNSTATE_STAGED_LOCKED "/run/ostree/staged-deployment-locked"
-
 gboolean rpmostree_syscore_cleanup (OstreeSysroot *sysroot, OstreeRepo *repo,
                                     GCancellable *cancellable, GError **error);
 


### PR DESCRIPTION
Now that we've stabilized and made public deployment finalization APIs,
let's use them.

This also fixes an issue where when creating a locked deployment using
the legacy API (i.e. touching the `/run/ostree/staged-deployment-locked`
file before calling the staging API), if a staged deployment already
exists, libostree would just nuke the lockfile (this behaviour was
introduced in https://github.com/ostreedev/ostree/pull/3077).

In theory the legacy API (via the lockfile) should keep working, but
the core issue is that there's no way for libostree to know if the
lockfile is carried-over state, or was freshly created for the current
invocation.

So let's not try to salvage the legacy API and just move over to the
new one.

We already have finalization tests; they will now test that the new API
functions correctly. But stop looking for the legacy lockfile. We could
instead inspect the staged deployment GVariant, but these checks were
redundant anyway since the tests verify the finalization by actually
rebooting and/or not use `finalize-deployment --allow-unlocked`.

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1691

