### PR TITLE
rpm-ostree-fix-shadow-mode.service: don't run if OS is not installed

### DIFF
--- a/src/daemon/rpm-ostree-fix-shadow-mode.service
+++ b/src/daemon/rpm-ostree-fix-shadow-mode.service
@@ -7,6 +7,8 @@ Documentation=https://github.com/coreos/rpm-ostree-ghsa-2m76-cwhg-7wv6
 # the old /etc/.rpm-ostree-shadow-mode-fixed.stamp
 ConditionPathExists=!/etc/.rpm-ostree-shadow-mode-fixed2.stamp
 ConditionPathExists=/run/ostree-booted
+# Filter out non-traditional ostree setups (e.g. live boots)
+ConditionKernelCommandLine=ostree
 # Because we read the sysroot
 RequiresMountsFor=/boot
 # Make sure this is started before any unprivileged (interactive) user has access to the system.


### PR DESCRIPTION
fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1722