### PR TITLE
core: also wrap `kernel-install` for scriptlets

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -66,6 +66,11 @@ fi
 rm "${origindir}/clienterror.yaml"
 rpm-ostree ex rebuild
 
+# test kernel installs *before* enabling cliwrap
+rpm-ostree override replace $koji_kernel_url
+# test that the new initramfs was generated
+test -f /usr/lib/modules/${kver}-${krev}.fc${versionid}.x86_64/initramfs.img
+
 rpm-ostree cliwrap install-to-root /
 
 # Test a critical path package
@@ -118,10 +123,6 @@ rpm -q strace
 # the continuous build's version has the git rev, prefixed with g
 rpm -q afterburn | grep g
 rpm -q afterburn-dracut | grep g
-
-rpm-ostree override replace $koji_kernel_url
-# test that the new initramfs was generated
-test -f /usr/lib/modules/${kver}-${krev}.fc${versionid}.x86_64/initramfs.img
 
 # test --enablerepo --disablerepo --releasever
 rpm-ostree --releasever=38 --disablerepo="*" \

--- a/src/libpriv/kernel-install-wrapper.sh
+++ b/src/libpriv/kernel-install-wrapper.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+# Used in the container layering path to make kernel replacements Just Work
+# without having to enable cliwrap first. If cliwrap is enabled, then this will
+# technically override the cliwrap wrapper, but the script is exactly the same.
+# This wrapper is technically also installed when doing client-side layering,
+# but we already ignore kernel scriptlets there anyway.
+# See also https://github.com/coreos/rpm-ostree/issues/4949
+
+exec /usr/bin/rpm-ostree cliwrap kernel-install "$@"


### PR DESCRIPTION
It's confusing right now how specifically for the kernel, one has to use this obscure `rpm-ostree cliwrap install-to-root /` command to make it work. Let's just always enable it: in the client-side layering case, we don't run kernel scriptlets anyway so the wrapper is unused, and in the container case, this will allow users to not have to enable cliwrap and have it leak into their derived image.

I guess in theory, this should also allow us to *stop* ignoring kernel scriptlets and rely on this instead, though let's leave that for a separate investigation.

Closes: #4949