### PR TITLE
Release 2024.6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2024])
-m4_define([release_version], [5])
+m4_define([release_version], [6])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2024.5
+Version: 2024.6
 Release: 1%{?dist}
 License: LGPL-2.0-or-later
 URL: https://github.com/coreos/rpm-ostree


### PR DESCRIPTION
```
Colin Walters (2):
      Remove modularity support entrypoints
      container: Add spinner/progress for layer fetches

HuijingHei (1):
      kargs: keep spaces in double quotes

Jonathan Lebon (5):
      docs/treefile.md: Document postprocess script ordering
      daemon: use new finalization APIs
      ci/test-container: move URL definitions to the top
      core: also wrap `kernel-install` for scriptlets
      packaging: drop `.in` extension on `rpm-ostree.spec.in`

Joseph Marrero (2):
      Release 2024.6
      rpm-ostree-fix-shadow-mode.service: don't run if OS is not installed

Luke Yang (3):
      Various Fedora 40 fixes
      Update to f40 kernel
      Disable downloading filelists by default

Timothée Ravier (6):
      docs/HACKING: Add example for ostree-rs-ext crate development
      update-check: Print unreliability warning on stderr
      deployment_utils: Also add version to cached update
      docs/HACKING: Update crate patching example
      container-update-check: Validate version in manifest diff
      deployment_utils: Fix version for cached container update

Yaakov Selkowitz (1):
      rpm-ostree.spec.in: Update rust macro usage
```