### PR TITLE
Add `Recommends=` knob in rpm-ostreed.conf

### DIFF
--- a/man/rpm-ostreed.conf.xml
+++ b/man/rpm-ostreed.conf.xml
@@ -106,6 +106,13 @@ Boston, MA 02111-1307, USA.
         overlays or regeneration). Defaults to false.</para>
         </listitem>
       </varlistentry>
+      <varlistentry>
+        <term><varname>Recommends=</varname></term>
+
+        <listitem>
+        <para>When layering, whether to install weak dependencies. Defaults to true.</para>
+        </listitem>
+      </varlistentry>
     <!--
       <varlistentry>
         <term><varname>OptionName=</varname></term>

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1800,6 +1800,7 @@ struct Treefile final : public ::rust::Opaque
   importer_flags (::rust::Str pkg_name) const noexcept;
   ::rust::String write_repovars (::std::int32_t workdir_dfd_raw) const;
   void set_releasever (::rust::Str releasever);
+  void set_recommends (bool val);
   void enable_repo (::rust::Str repo);
   void disable_repo (::rust::Str repo);
   void validate_for_container () const;
@@ -2687,6 +2688,10 @@ extern "C"
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$Treefile$set_releasever (::rpmostreecxx::Treefile &self,
                                                    ::rust::Str releasever) noexcept;
+
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$Treefile$set_recommends (::rpmostreecxx::Treefile &self,
+                                                   bool val) noexcept;
 
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$Treefile$enable_repo (::rpmostreecxx::Treefile &self,
                                                                      ::rust::Str repo) noexcept;
@@ -5318,6 +5323,16 @@ void
 Treefile::set_releasever (::rust::Str releasever)
 {
   ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Treefile$set_releasever (*this, releasever);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
+}
+
+void
+Treefile::set_recommends (bool val)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Treefile$set_recommends (*this, val);
   if (error$.ptr)
     {
       throw ::rust::impl< ::rust::Error>::error (error$);

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1577,6 +1577,7 @@ struct Treefile final : public ::rust::Opaque
   importer_flags (::rust::Str pkg_name) const noexcept;
   ::rust::String write_repovars (::std::int32_t workdir_dfd_raw) const;
   void set_releasever (::rust::Str releasever);
+  void set_recommends (bool val);
   void enable_repo (::rust::Str repo);
   void disable_repo (::rust::Str repo);
   void validate_for_container () const;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -644,6 +644,7 @@ pub mod ffi {
         fn importer_flags(&self, pkg_name: &str) -> Box<RpmImporterFlags>;
         fn write_repovars(&self, workdir_dfd_raw: i32) -> Result<String>;
         fn set_releasever(&mut self, releasever: &str) -> Result<()>;
+        fn set_recommends(&mut self, val: bool) -> Result<()>;
         fn enable_repo(&mut self, repo: &str) -> Result<()>;
         fn disable_repo(&mut self, repo: &str) -> Result<()>;
         // these functions are more related to derivation

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1293,6 +1293,11 @@ impl Treefile {
         Ok(())
     }
 
+    pub(crate) fn set_recommends(&mut self, val: bool) -> Result<()> {
+        self.parsed.base.recommends = Some(val);
+        Ok(())
+    }
+
     pub(crate) fn get_releasever(&self) -> String {
         self.parsed
             .base

--- a/src/daemon/rpm-ostreed.conf
+++ b/src/daemon/rpm-ostreed.conf
@@ -6,3 +6,4 @@
 #AutomaticUpdatePolicy=none
 #IdleExitTimeout=60
 #LockLayering=false
+#Recommends=true

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -943,6 +943,8 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self, GCancellable *cancellable, 
   {
     g_autoptr (GKeyFile) computed_origin_kf = rpmostree_origin_dup_keyfile (self->computed_origin);
     CXX_TRY_VAR (tf, rpmostreecxx::origin_to_treefile (*computed_origin_kf), error);
+    if (rpmostreed_get_disable_recommends (rpmostreed_daemon_get ()))
+      tf->set_recommends (false);
     self->treefile = std::move (tf);
   }
   rpmostree_context_set_treefile (self->ctx, **self->treefile);

--- a/src/daemon/rpmostreed-daemon.cxx
+++ b/src/daemon/rpmostreed-daemon.cxx
@@ -76,6 +76,7 @@ struct _RpmostreedDaemon
   guint idle_exit_timeout;
   RpmostreedAutomaticUpdatePolicy auto_update_policy;
   gboolean lock_layering;
+  gboolean disable_recommends;
 
   GDBusConnection *connection;
   GDBusObjectManagerServer *object_manager;
@@ -401,6 +402,12 @@ rpmostreed_get_lock_layering (RpmostreedDaemon *self)
   return self->lock_layering;
 }
 
+gboolean
+rpmostreed_get_disable_recommends (RpmostreedDaemon *self)
+{
+  return self->disable_recommends;
+}
+
 /* in-place version of g_ascii_strdown */
 static inline void
 ascii_strdown_inplace (char *str)
@@ -435,6 +442,8 @@ rpmostreed_daemon_reload_config (RpmostreedDaemon *self, gboolean *out_changed, 
    * need to be reloaded if it changes */
   self->idle_exit_timeout = idle_exit_timeout;
   self->lock_layering = get_config_bool (config, "LockLayering", FALSE);
+  /* flip polarity here since default FALSE is less error-prone */
+  self->disable_recommends = !get_config_bool (config, "Recommends", TRUE);
 
   gboolean changed = FALSE;
 

--- a/src/daemon/rpmostreed-daemon.h
+++ b/src/daemon/rpmostreed-daemon.h
@@ -60,6 +60,7 @@ gboolean rpmostreed_daemon_reload_config (RpmostreedDaemon *self, gboolean *out_
 
 RpmostreedAutomaticUpdatePolicy rpmostreed_get_automatic_update_policy (RpmostreedDaemon *self);
 gboolean rpmostreed_get_lock_layering (RpmostreedDaemon *self);
+gboolean rpmostreed_get_disable_recommends (RpmostreedDaemon *self);
 
 G_END_DECLS
 

--- a/tests/kolainst/destructive/layering-local
+++ b/tests/kolainst/destructive/layering-local
@@ -40,8 +40,27 @@ fi
 assert_file_has_content_literal out.txt "LockLayering=true"
 rm out.txt
 mv /etc/rpm-ostreed.conf{.bak,} && rpm-ostree reload
+echo "ok LockLayering"
 
-# Disable repos, no Internet access should be required
+# test recommends
+rm -rf /etc/yum.repos.d/*
+cat > /etc/yum.repos.d/vmcheck.repo << EOF
+[test-repo]
+name=test-repo
+baseurl=file:///${KOLA_EXT_DATA}/rpm-repos/0
+gpgcheck=0
+enabled=1
+EOF
+rpm-ostree install foo-with-rec --dry-run > out.txt
+assert_file_has_content_literal out.txt foo-1.2-3
+cp /etc/rpm-ostreed.conf{,.bak}
+echo 'Recommends=false' >> /etc/rpm-ostreed.conf && rpm-ostree reload
+rpm-ostree install foo-with-rec --dry-run > out.txt
+assert_not_file_has_content_literal out.txt foo-1.2-3
+mv /etc/rpm-ostreed.conf{.bak,} && rpm-ostree reload
+echo "ok Recommends"
+
+# Disable repos, no Internet access should be required for the remaining tests
 rm -rf /etc/yum.repos.d/
 # Also disable zincati since we're rebasing
 systemctl mask --now zincati

--- a/tests/kolainst/kolainst-build.sh
+++ b/tests/kolainst/kolainst-build.sh
@@ -24,6 +24,7 @@ build_rpm baz
 build_rpm baz version 2.0
 build_rpm boo
 build_rpm boo version 2.0
+build_rpm foo-with-rec recommends foo
 # And from here we lose our creativity and name things starting
 # with `testpkg` and grow more content.
 # This one has various files in /etc


### PR DESCRIPTION
We already have a knob for this in the treefile, and we already generate a treefile in the client-side case to hand to the core. So this is just wiring up a knob in the config file to it.

Closes: #718