### PR TITLE
ci: Add SPDX-License-Identifier: Apache-2.0 OR MIT

### DIFF
--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # Install build dependencies, run unit tests and installed tests.
 
 # This script is what Prow runs.

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # Install build dependencies and then build.
 
 set -xeuo pipefail

--- a/ci/ci-commitmessage-submodules.sh
+++ b/ci/ci-commitmessage-submodules.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 set -xeuo pipefail
 
 dn=$(dirname $0)

--- a/ci/clang-analyzer.sh
+++ b/ci/clang-analyzer.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # Use the clang static analyzer
 
 set -xeuo pipefail

--- a/ci/clang-build-check.sh
+++ b/ci/clang-build-check.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # Install build dependencies, run unit tests and installed tests.
 
 # This script is what Prow runs.

--- a/ci/codestyle.sh
+++ b/ci/codestyle.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # Tests that validate structure of the source code;
 # can be run without building it.
 set -euo pipefail

--- a/ci/commit-validation.sh
+++ b/ci/commit-validation.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 set -xeuo pipefail
 # Add cheap (non-building) checks here
 dn=$(dirname $0)

--- a/ci/composepost-checks.sh
+++ b/ci/composepost-checks.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # This script expects a coreos-assembler working directory
 # and will validate parts of the generated ostree commit.
 

--- a/ci/container-build-integration.sh
+++ b/ci/container-build-integration.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # Verify container build flows
 set -euo pipefail
 

--- a/ci/coreosci-rpmbuild.sh
+++ b/ci/coreosci-rpmbuild.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 set -euo pipefail
 
 dn=$(dirname $0)

--- a/ci/cosa-build.sh
+++ b/ci/cosa-build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # Build rpm-ostree, using cosa as a buildroot and then
 # override the version inside cosa, then build FCOS
 set -xeuo pipefail

--- a/ci/cosa-overrides.sh
+++ b/ci/cosa-overrides.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # Inject ideally temporary overrides into our cosa build
 # skopeo for containers https://github.com/containers/skopeo/pull/1476
 cd overrides/rpm

--- a/ci/install-cxx.sh
+++ b/ci/install-cxx.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # We use https://cxx.rs to generate C++ and Rust bridge code.  If you change
 # rust/src/lib.rs, you will need to install the tool.
 set -xeuo pipefail

--- a/ci/install-test-deps.sh
+++ b/ci/install-test-deps.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 set -euo pipefail
 dn=$(dirname $0)
 . ${dn}/libbuild.sh

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # Install build dependencies
 
 set -xeuo pipefail

--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
 # OpenShift Prow jobs don't set $HOME, but we need
 # one for cargo right now.

--- a/ci/prow/e2e-upgrades.sh
+++ b/ci/prow/e2e-upgrades.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 set -xeuo pipefail
 
 # Attempt to keep this script in sync with https://github.com/containers/bootc/blob/main/ci/run-kola.sh

--- a/ci/prow/fcos-e2e.sh
+++ b/ci/prow/fcos-e2e.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 set -xeuo pipefail
 
 # Prow jobs don't support adding emptydir today

--- a/ci/prow/kola/upgrades
+++ b/ci/prow/kola/upgrades
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # Verify upgrades pulling from remote (authenticated) registries.
 ## kola:
 ##   timeoutMin: 30

--- a/ci/ridiculous-rhel-devel-workaround.sh
+++ b/ci/ridiculous-rhel-devel-workaround.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 # Builds libsmartcols-devel which libdnf depends on
 #

--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 set -xeuo pipefail
 
 fatal() {

--- a/ci/unit.sh
+++ b/ci/unit.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 set -euo pipefail
 
 dn=$(dirname $0)

--- a/ci/verify-cxx.sh
+++ b/ci/verify-cxx.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # Verify that the cxx-generated C++ code is in sync
 set -xeuo pipefail
 dn=$(dirname $0)

--- a/ci/vmcheck-provision.sh
+++ b/ci/vmcheck-provision.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 # Install build dependencies, run unit tests and installed tests.
 
 set -xeuo pipefail


### PR DESCRIPTION
Explicitly mark all CI scripts as Apache 2.0 or MIT to clarify applicable licenses.

CC authors: @jlebon @cgwalters @HuijingHei @lukewarmtemp @jmarrero @lucab

Other folks in the git log that I have not CC'ed yet (and their commits):
Andreas Hartmann <hartan@7x.de> (685eb168)
Benno Rice <benno.rice@oracle.com> (dc63a249)
Kalev Lember <klember@redhat.com> (184c017b)

Another option is to not include the `ci` directory in the release tarballs.