### PR TITLE
rust/src/scripts.rs: ignore posttrans for ELRepo's kernel-lt and kernel-ml

### DIFF
--- a/rust/src/scripts.rs
+++ b/rust/src/scripts.rs
@@ -43,6 +43,13 @@ static IGNORED_PKG_SCRIPTS: phf::Set<&'static str> = phf_set! {
     // Additionally ignore posttrans scripts for the Oracle Linux `kernel-uek` and `kernel-uek-core` packages
     "kernel-uek.posttrans",
     "kernel-uek-core.posttrans",
+    // Additionally ignore posttrans scripts for ELRepo's `kernel-lt` and `kernel-ml` packages
+    "kernel-lt.posttrans",
+    "kernel-lt-core.posttrans",
+    "kernel-lt-modules.posttrans",
+    "kernel-ml.posttrans",
+    "kernel-ml-core.posttrans",
+    "kernel-ml-modules.posttrans",
     // Legacy workaround
     "glibc-headers.prein",
     // workaround for old bug?


### PR DESCRIPTION
This adds the posttrans scripts from [ELRepo's](https://elrepo.org/) `kernel-lt` and `kernel-ml` packages to the list of scripts to skip. These packages contain an LTS kernel and a mainline kernel from kernel.org built for RHEL.