### PR TITLE
Replace the mtime of vendored files with the commit timestamp when making a distribution tarball

### DIFF
--- a/packaging/Makefile.dist-packaging
+++ b/packaging/Makefile.dist-packaging
@@ -2,6 +2,7 @@
 
 GITREV = $$(git describe --always --tags)
 GITREV_FOR_PKG = $(shell echo "$(GITREV)" | sed -e 's,-,\.,g' -e 's,^v,,')
+GITTIMESTAMP = $$(git show --no-patch --format=%ci)
 
 srcdir=$(shell dirname `pwd`)
 PACKAGE=rpm-ostree
@@ -10,7 +11,7 @@ PKG_VER = $(PACKAGE)-$(GITREV_FOR_PKG)
 PKG_CLIENT_VER = $(PACKAGE)-client-$(GITREV_FOR_PKG)
 
 dist-snapshot:
-	./make-git-snapshot.sh "$(srcdir)" "$(PKG_VER)" "$(GITREV)"
+	./make-git-snapshot.sh "$(srcdir)" "$(PKG_VER)" "$(GITREV)" "$(GITTIMESTAMP)"
 	rm -f $(PKG_VER).tar.xz
 	xz -T0 $(PKG_VER).tar
 

--- a/packaging/make-git-snapshot.sh
+++ b/packaging/make-git-snapshot.sh
@@ -7,6 +7,8 @@ PKG_VER=$1
 shift
 GITREV=$1
 shift
+GITTIMESTAMP=$1
+shift
 
 TARFILE=${PKG_VER}.tar
 TARFILE_TMP=$(pwd)/${TARFILE}.tmp
@@ -49,7 +51,7 @@ fi
  mkdir -p .cargo
  (cd ${TOP} && ${vendor_cmd} ${tmpd}/vendor | sed -e "s,^directory *=.*,directory = './vendor',") > .cargo/config
  cp ${TOP}/Cargo.lock .
- tar --owner=0 --group=0 --transform="s,^,${PKG_VER}/," -rf ${TARFILE_TMP} * .cargo/
+ tar --owner=0 --group=0 --transform="s,^,${PKG_VER}/," --mtime="${GITTIMESTAMP}" -rf ${TARFILE_TMP} * .cargo/
  )
 
 mv ${TARFILE_TMP} ${TARFILE}


### PR DESCRIPTION
And in this week's entry for the "longest description of the shortest change" competition:

I needed to build a pre-release distribution tarball of rpm-ostree for Reasons™. I noticed, however, that the resulting tarball wasn't consistent:

```console
$ git branch
  jeamland/repeatable-dist
* main
$ git describe
v2024.6-34-ga172e482
$ make -C packaging -f Makefile.dist-packaging dist-snapshot

[copious output]

$ ls -l packaging/rpm-ostree-2024.6.34.ga172e482.tar.xz 
-rw-r--r--. 1 bjrice bjrice 12266796 Jun 19 16:26 packaging/rpm-ostree-2024.6.34.ga172e482.tar.xz
$ sha256sum packaging/rpm-ostree-2024.6.34.ga172e482.tar.xz
61222360cb42aba5eb4ddd9880bb292eda8de6da3c25c646835f26ed493ba571  packaging/rpm-ostree-2024.6.34.ga172e482.tar.xz
$ make -C packaging -f Makefile.dist-packaging dist-snapshot

[copious output]

$ ls -l packaging/rpm-ostree-2024.6.34.ga172e482.tar.xz
-rw-r--r--. 1 bjrice bjrice 12266196 Jun 19 16:27 packaging/rpm-ostree-2024.6.34.ga172e482.tar.xz
$ sha256sum packaging/rpm-ostree-2024.6.34.ga172e482.tar.xz
52b3eab241f117a0bb96f550298551e268f8da7719c4934aab1fd3c6faf7d5fe  packaging/rpm-ostree-2024.6.34.ga172e482.tar.xz
```

What could be going on here? I mean the first guess is that we're leaking a file timestamp into the tarball and sure enough if we check out the first few entries it looks reasonable:

```console
$ tar tvf packaging/rpm-ostree-2024.6.34.ga172e482.tar.xz | head -5
drwxrwxr-x root/root         0 2024-06-18 20:44 rpm-ostree-2024.6.34.ga172e482/
-rw-rw-r-- root/root      2872 2024-06-18 20:44 rpm-ostree-2024.6.34.ga172e482/.cci.jenkinsfile
-rw-rw-r-- root/root       185 2024-06-18 20:44 rpm-ostree-2024.6.34.ga172e482/.clang-format
drwxrwxr-x root/root         0 2024-06-18 20:44 rpm-ostree-2024.6.34.ga172e482/.copr/
-rw-rw-r-- root/root       617 2024-06-18 20:44 rpm-ostree-2024.6.34.ga172e482/.copr/Makefile
```

But if we go looking for something like the current date:

```console
$ tar tvf packaging/rpm-ostree-2024.6.34.ga172e482.tar.xz | grep 2024-06-19 | head -5
-rw-r--r-- root/root     88842 2024-06-19 16:27 rpm-ostree-2024.6.34.ga172e482/Cargo.lock
drwxr-xr-x root/root         0 2024-06-19 16:27 rpm-ostree-2024.6.34.ga172e482/vendor/
drwxr-xr-x root/root         0 2024-06-19 16:27 rpm-ostree-2024.6.34.ga172e482/vendor/addr2line/
drwxr-xr-x root/root         0 2024-06-19 16:27 rpm-ostree-2024.6.34.ga172e482/vendor/addr2line/src/
-rw-r--r-- root/root         0 2024-06-19 16:27 rpm-ostree-2024.6.34.ga172e482/vendor/addr2line/src/lib.rs
```

Hello!

So what I do in this patch is grab the timestamp of the commit we're making the distribution out of and splat the mtime of Cargo.lock and the vendored files with that:

```console
$ git branch
* jeamland/repeatable-dist
  main
$ git describe
v2024.6-35-g51ed3ddb
$ make -C packaging -f Makefile.dist-packaging dist-snapshot

[copious output]

$ ls -l packaging/rpm-ostree-2024.6.35.g51ed3ddb.tar.xz 
-rw-r--r--. 1 bjrice bjrice 12268124 Jun 19 16:33 packaging/rpm-ostree-2024.6.35.g51ed3ddb.tar.xz
$ sha256sum packaging/rpm-ostree-2024.6.35.g51ed3ddb.tar.xz 
b6fb23aa3c1fbd5f4c5722c6fe217683bcbaab227c5ae08937a26ce3cde6244d  packaging/rpm-ostree-2024.6.35.g51ed3ddb.tar.xz
$ make -C packaging -f Makefile.dist-packaging dist-snapshot

[copious output]

$ ls -l packaging/rpm-ostree-2024.6.35.g51ed3ddb.tar.xz
-rw-r--r--. 1 bjrice bjrice 12268124 Jun 19 16:36 packaging/rpm-ostree-2024.6.35.g51ed3ddb.tar.xz
$ sha256sum packaging/rpm-ostree-2024.6.35.g51ed3ddb.tar.xz
b6fb23aa3c1fbd5f4c5722c6fe217683bcbaab227c5ae08937a26ce3cde6244d  packaging/rpm-ostree-2024.6.35.g51ed3ddb.tar.xz
```

Much better.