### PR TITLE
Add `arch` as a parameter to `package_meta`

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -3246,15 +3246,16 @@ extern "C"
 
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$RpmTs$package_meta (::rpmostreecxx::RpmTs const &self, ::rust::Str name,
+                                              ::rust::Str arch,
                                               ::rpmostreecxx::PackageMeta **return$) noexcept
   {
     ::std::unique_ptr< ::rpmostreecxx::PackageMeta> (::rpmostreecxx::RpmTs::*package_meta$) (
-        ::rust::Str) const
+        ::rust::Str, ::rust::Str) const
         = &::rpmostreecxx::RpmTs::package_meta;
     ::rust::repr::PtrLen throw$;
     ::rust::behavior::trycatch (
         [&] {
-          new (return$)::rpmostreecxx::PackageMeta *((self.*package_meta$) (name).release ());
+          new (return$)::rpmostreecxx::PackageMeta *((self.*package_meta$) (name, arch).release ());
           throw$.ptr = nullptr;
         },
         ::rust::detail::Fail (throw$));

--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -275,8 +275,10 @@ pub fn container_encapsulate(args: Vec<String>) -> CxxResult<()> {
     for pkg in pkglist.iter() {
         let name = pkg.child_value(0);
         let name = name.str().unwrap();
+        let arch = pkg.child_value(4);
+        let arch = arch.str().unwrap();
         let nevra = Rc::from(gv_nevra_to_string(&pkg).into_boxed_str());
-        let pkgmeta = q.package_meta(name)?;
+        let pkgmeta = q.package_meta(name, arch)?;
         let buildtime = pkgmeta.buildtime();
         if let Some((lowid, lowtime)) = lowest_change_time.as_mut() {
             if *lowtime > buildtime {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -914,7 +914,7 @@ pub mod ffi {
         fn rpmdb_package_name_list(dfd: i32, path: String) -> Result<Vec<String>>;
 
         // Methods on RpmTs
-        fn package_meta(self: &RpmTs, name: &str) -> Result<UniquePtr<PackageMeta>>;
+        fn package_meta(self: &RpmTs, name: &str, arch: &str) -> Result<UniquePtr<PackageMeta>>;
 
         // Methods on PackageMeta
         fn size(self: &PackageMeta) -> u64;

--- a/src/libpriv/rpmostree-refts.h
+++ b/src/libpriv/rpmostree-refts.h
@@ -77,7 +77,7 @@ public:
   RpmTs (::RpmOstreeRefTs *ts);
   ~RpmTs ();
   rpmts get_ts () const;
-  std::unique_ptr<PackageMeta> package_meta (const rust::Str package) const;
+  std::unique_ptr<PackageMeta> package_meta (const rust::Str name, const rust::Str arch) const;
 
 private:
   ::RpmOstreeRefTs *_ts;

--- a/tests/compose-image.sh
+++ b/tests/compose-image.sh
@@ -39,6 +39,7 @@ packages:
   - vim-minimal
   - coreutils
   - dnf dnf-yum
+  - glibc glibc.i686
   - sudo
 repos:
   - fedora  # Intentially using frozen GA repo


### PR DESCRIPTION
Without this, `package_meta` is unable to distinguish between copies of the same package installed for different architectures; for example, many systems need both the `x86_64` and `i686` version of glibc.

Fixes https://github.com/coreos/rpm-ostree/issues/4609

--

I realized that simply removing the check as I suggested in https://github.com/coreos/rpm-ostree/issues/4609#issuecomment-2221267196 would be incorrect; this would mean that `package_meta` could potentially return the wrong metadata, if two identically-named packages for different architectures were installed. Instead, this is an attempt to add `arch` as a parameter to `package_meta`, and get it to find the correct metadata. The check is left in place, but should only occur if duplicate packages for the same arch have somehow been installed.