### PR TITLE
ci: Uninstall kexec harder

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -91,7 +91,7 @@ rpm-ostree install ignition.rpm
 rpm -q ignition
 
 # And verify it's uninstalled
-dnf -y uninstall kexec-tools
+dnf -y uninstall kexec-tools kdump-utils makedumpfile
 if rpm -q kexec-tools; then fatal "failed to remove kexec-tools"; fi
 
 # test replacement by Koji URL


### PR DESCRIPTION
Per https://github.com/coreos/rpm-ostree/pull/5014#issuecomment-2223849471

"kdump-utils is a separate package now and requires kexec-tools."
