### PR TITLE
Clarify version query syntax usage in treefile doc

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -73,8 +73,18 @@ It supports the following parameters:
    however, virtual provides are also supported.
    For convenience when writing YAML/JSON, entries in this list will also be split by
    whitespace.  Finally, another syntax special case is that surrounding the entry
-   with quotes `'` will suppress this whitespace split, and that in turn makes it possible to use version query
-   syntax such as `'podman >= 4.1'`.
+   with single quotes (`'`) as part of the string will suppress this whitespace split, and that in turn makes it possible
+   to use version query syntax (`podman >= 4.1`).
+
+   Example:
+
+   ```yaml
+   packages:
+     - ca-certificates
+     - efitools pesign sbsigntools
+     - "'podman >= 4.1'"
+     - kernel-6.9.11-100.fc39
+   ```
 
  * `packages-$basearch`: Array of strings, optional: Set of installed packages, used
     only if $basearch matches the target architecture name.


### PR DESCRIPTION
Clarify with example how to use the `packages` keyword in treefile syntax reference doc, especially the version query syntax that requires special non-obvious quoting.

---

My whole team of developers have all independently believed the version query syntax was broken because it wasn't clearly communicated in this doc how the single quotes needed to be used. The only example or reference we've found that clarified it was in a closed Issue about different code paths for handling `install` vs `compose` needing to be merged.