### PR TITLE
daemon: Extend rpm-ostreed.service idle-timeout

### DIFF
--- a/src/daemon/rpmostreed-daemon.h
+++ b/src/daemon/rpmostreed-daemon.h
@@ -68,3 +68,7 @@ namespace rpmostreecxx
 {
 rust::Box<TokioEnterGuard> rpmostreed_daemon_tokio_enter (RpmostreedDaemon *self);
 }
+
+void reset_idle_exit_timer (GDBusConnection *connection, const gchar *sender_name,
+                            const gchar *object_path, const gchar *interface_name,
+                            const gchar *signal_name, GVariant *parameters, gpointer user_data);


### PR DESCRIPTION
When making D-Bus calls to the rpm-ostreed.service, the service will always exit after the specified idle-timeout has passed from when the daemon was first created. Even if D-Bus calls are constantly being made, the idle-timeout will still be enforced.

This commit subscribes to the bus, listening for new calls. If a call is detected, the idle-timeout is reset. The service will only stop after the idle-timeout has passed after the last call to the bus.