### PR TITLE
Release 2024.7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2024])
-m4_define([release_version], [6])
+m4_define([release_version], [7])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2024.6
+Version: 2024.7
 Release: 1%{?dist}
 License: LGPL-2.0-or-later
 URL: https://github.com/coreos/rpm-ostree


### PR DESCRIPTION
v2024.7


This is mainly a bugfix release and oen new feature:

    #4974 Add `Recommends=` knob in rpm-ostreed.conf

One notable bugfix comming from ostree-rs-ext https://github.com/ostreedev/ostree-rs-ext/pull/648 fixes Processing deferred hardlinks.


# Other changes

````
Benno Rice (1):
      packaging: Use git timestamp as mtime for vendored files

Colin Walters (2):
      Remove all modularity support
      ci: Uninstall kexec harder

Jonathan Lebon (3):
      README: reflect development status
      Add `Recommends=` knob in rpm-ostreed.conf
      ci/test-container: Stop using f38 packages

Jordan Webb (2):
      rust/src/scripts.rs: ignore posttrans for ELRepo's kernel-lt and kernel-ml
      Add `arch` as a parameter to `package_meta`

Mike (1):
      Clarify version query syntax usage in treefile doc

Timothée Ravier (1):
      ci: Add SPDX-License-Identifier: Apache-2.0 OR MIT
```

## New Contributors

* @jordemort made their first contribution in https://github.com/coreos/rpm-ostree/pull/4982
* @mtalexan made their first contribution in https://github.com/coreos/rpm-ostree/pull/5028

**Full Changelog**: https://github.com/coreos/rpm-ostree/compare/v2024.6...v2024.7
