### PR TITLE
packaging/rpm-ostree.spec: add libzstd-devel BuildRequires

### DIFF
--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -60,6 +60,8 @@ BuildRequires: pkgconfig(libarchive)
 BuildRequires: pkgconfig(libsystemd)
 BuildRequires: libcap-devel
 BuildRequires: libattr-devel
+# Needed by the ostree-ext crate
+BuildRequires: libzstd-devel
 
 # We currently interact directly with librepo (libdnf below also pulls it in,
 # but duplicating to be clear)


### PR DESCRIPTION
After the initial changes to ostree-ext introducing support for
zstd:chunked, which can be found in this pull request:
https://github.com/ostreedev/ostree-rs-ext/pull/615,
an additional PR modified the dependency on zstd during build
time to use pkg-config.
You can review these changes in the pull request:
https://github.com/ostreedev/ostree-rs-ext/pull/628.

These updates also required modifications to bootc, detailed in
this pull request: https://github.com/containers/bootc/pull/586.
This commit mirrors those changes in rpm-ostree.

With these changes, it will be possible to build RPMs on systems
that do not have zstd-devel pre-installed in the build root.