### PR TITLE
ci/test-container.sh: Update f40 kernel to replace

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -15,9 +15,9 @@ case $versionid in
     ignition_url_suffix=2.16.2/2.fc39/x86_64/ignition-2.16.2-2.fc39.x86_64.rpm
     # 2.15.0-3
     koji_ignition_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=2158585"
-    koji_kernel_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=2435097"
+    koji_kernel_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=2436096"
     kver=6.8.5
-    krev=300
+    krev=301
     ;;
   39)
     ignition_url_suffix=2.16.2/1.fc39/x86_64/ignition-2.16.2-1.fc39.x86_64.rpm


### PR DESCRIPTION
The builds used by this test get deleted a few times a year, this replaces the kernel build by a current one.