### PR TITLE
rust/bwrap: log `fusermount -u` errors to stderr

### DIFF
--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -136,7 +136,7 @@ impl Drop for RoFilesMount {
             })
             .err()
             .map(|e| {
-                systemd::journal::print(4, &format!("{}", e));
+                eprintln!("{}", e);
             })
             .is_none();
         if !success {


### PR DESCRIPTION
I believe cosa is hitting an error in this code path, but we can't inspect the error because there's no journald running in supermin:

https://github.com/coreos/coreos-assembler/issues/3848

We don't gain much by printing this error to the journal since it shouldn't be very common. Print it on stderr instead where it's more likely to have visibility.