### PR TITLE
core: Fix Coverity WRAPPER_ESCAPE

### DIFF
--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -1782,7 +1782,8 @@ rpmostree_context_prepare (RpmOstreeContext *self, gboolean enable_filelists,
           auto pkg = "";
           for (auto &pkg_str : packages)
             {
-              pkg = std::string (pkg_str).c_str ();
+              auto pkg_buf = std::string (pkg_str);
+              pkg = pkg_buf.c_str ();
               char *query = strchr ((char *)pkg, '/');
               if (query)
                 {


### PR DESCRIPTION
This should fix:

```
32. rpm-ostree-2024.7/src/libpriv/rpmostree-core.cxx:1786:15: use_after_free: Using internal representation of destroyed object temporary of type "std::string".
```
