### PR TITLE
rust: Squash two minor build warnings

### DIFF
--- a/rust/src/tokio_ffi.rs
+++ b/rust/src/tokio_ffi.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 pub(crate) struct TokioHandle(tokio::runtime::Handle);
+#[allow(dead_code)]
 pub(crate) struct TokioEnterGuard<'a>(tokio::runtime::EnterGuard<'a>);
 
 pub(crate) fn tokio_handle_get() -> Box<TokioHandle> {

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -640,17 +640,6 @@ pub(crate) fn calculate_advisories_diff(
     Ok(p as *mut _)
 }
 
-pub(crate) fn print_treepkg_diff(sysroot: &str) {
-    unsafe {
-        crate::ffi::print_treepkg_diff_from_sysroot_path(
-            sysroot,
-            crate::ffi::RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE,
-            0,
-            std::ptr::null_mut(),
-        );
-    }
-}
-
 /// Implementation of https://github.com/rust-lang/rust/issues/82901 until it's stable.
 pub(crate) trait OptionExtGetOrInsertDefault<T> {
     fn ext_get_or_insert_default(&mut self) -> &mut T;


### PR DESCRIPTION
- Suppress a dead code warning on the tokio guard; it's just there for drop semantics.
- Delete an unused function.
