### PR TITLE
packaging/rpm-ostree.spec: Update fuse conditional

### DIFF
--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -143,7 +143,7 @@ Requires: bubblewrap
 # However our code is just calling fuse's fusermount.
 # We are updating our spec and code based on the discusion on:
 # https://github.com/coreos/rpm-ostree/pull/5047
-%if 0%{?rhel} && 0%{?el} <= 9
+%if %{defined rhel} && 0%{?rhel} < 10
 Requires: fuse
 %else
 Requires: fuse3


### PR DESCRIPTION
0%{?rhel} matches rhel derived family distros `el` check seem to break the condition

https://gitlab.com/redhat/centos-stream/rpms/rpm-ostree/-/merge_requests/57#note_2093239477