### PR TITLE
Deprecate cliwrap

### DIFF
--- a/docs/cliwrap.md
+++ b/docs/cliwrap.md
@@ -3,7 +3,13 @@ parent: Experimental features
 nav_order: 1
 ---
 
-# Wrapping other CLI entrypoints
+# DEPRECATED: Wrapping other CLI entrypoints
+
+**This functionality is now deprecated and slated for removal**. 
+
+The below text documents the functionality as it exists today for historical reference.
+
+---
 
 A simple way to describe the goal of rpm-ostree is to convert the default model for operating system updates to be "image based".
 

--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -156,7 +156,8 @@ It supports the following parameters:
     rpm-ostree will replace binaries such as `/usr/bin/rpm` with
     wrappers that intercept unsafe operations, or adjust functionality.
 
-    The default is `false` out of conservatism; you likely want to enable this.
+    This is deprecated and we now plan to land relevant functionality
+    in the upstream projects.
 
  * `cliwrap-binaries`: array of strings, optional.  An explicit list of binaries
     to enable `cliwrap`.  The current allowed set contains just one value: `kernel-install`.

--- a/rust/src/cliwrap.rs
+++ b/rust/src/cliwrap.rs
@@ -85,6 +85,9 @@ pub fn entrypoint(args: &[&str]) -> Result<()> {
 
 /// Write wrappers to the target root filesystem.
 fn install_to_root(args: &[&str]) -> Result<()> {
+    crate::client::warn_future_incompatibility(
+        "cliwrap is deprecated; the replacement path is to get functionality into the relevant upstream projects.",
+    );
     let root = args
         .get(0)
         .map(Utf8Path::new)

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1460,6 +1460,10 @@ impl Treefile {
             deprecated = true;
             eprintln!("warning: initramfs-args is deprecated, use /etc/dracut.conf.d")
         }
+        if self.get_cliwrap() {
+            deprecated = true;
+            eprintln!("warning: cliwrap is deprecated and slated for removal");
+        }
         if deprecated {
             std::thread::sleep(std::time::Duration::from_secs(3));
         }


### PR DESCRIPTION
I'm looking at handling kernel overrides:
- https://github.com/coreos/rpm-ostree/issues/4726
- https://gitlab.com/fedora/bootc/tracker/-/issues/22

And I think the cliwrap thing turned out to be the wrong approach for this.

There's consensus now it was the wrong approach, so deprecate it.
