### PR TITLE
packaging/rpm-ostree.spec: Drop rust_arches

### DIFF
--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -11,8 +11,6 @@ URL: https://github.com/coreos/rpm-ostree
 # in the upstream git.  It also contains vendored Rust sources.
 Source0: https://github.com/coreos/rpm-ostree/releases/download/v%{version}/rpm-ostree-%{version}.tar.xz
 
-ExclusiveArch: %{rust_arches}
-
 # ostree not on i686 for RHEL 10
 # https://github.com/containers/composefs/pull/229#issuecomment-1838735764
 %if 0%{?rhel} >= 10


### PR DESCRIPTION
rust_arches are no longer needed or required for building on Fedora or RHEL 

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1716


