### PR TITLE
Move dracut code from cliwrap to initramfs module

### DIFF
--- a/rust/src/cliwrap/kernel_install.rs
+++ b/rust/src/cliwrap/kernel_install.rs
@@ -1,15 +1,12 @@
 // If not running on container continue the current path.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-use crate::cliwrap;
 use crate::cliwrap::cliutil;
-use anyhow::{anyhow, Context, Result};
+use anyhow::Result;
 use camino::Utf8Path;
 use cap_std::fs::FileType;
 use cap_std::fs_utf8::Dir as Utf8Dir;
 use cap_std_ext::cap_std;
 use fn_error_context::context;
-use std::os::fd::AsRawFd;
-use std::process::Command;
 
 /// Primary entrypoint to running our wrapped `kernel-install` handling.
 #[context("rpm-ostree kernel-install wrapper")]
@@ -42,7 +39,7 @@ pub(crate) fn main(argv: &[&str]) -> Result<()> {
     }
     if let Some(k) = new_kernel {
         undo_systemctl_wrap()?;
-        run_dracut(&k)?;
+        crate::initramfs::run_dracut(&k)?;
         redo_systemctl_wrap()?;
     }
     Ok(())
@@ -61,52 +58,5 @@ fn redo_systemctl_wrap() -> Result<()> {
     let bin_path = Utf8Dir::open_ambient_dir("usr/bin", cap_std::ambient_authority())?;
     bin_path.rename("systemctl", &bin_path, "systemctl.rpmostreesave")?;
     bin_path.rename("systemctl.backup", &bin_path, "systemctl")?;
-    Ok(())
-}
-
-#[context("Running dracut")]
-fn run_dracut(kernel_dir: &str) -> Result<()> {
-    let root_fs = Utf8Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
-    let tmp_dir = tempfile::tempdir()?;
-    let tmp_initramfs_path = tmp_dir.path().join("initramfs.img");
-
-    let cliwrap_dracut = Utf8Path::new(cliwrap::CLIWRAP_DESTDIR).join("dracut");
-    let dracut_path = cliwrap_dracut
-        .exists()
-        .then(|| cliwrap_dracut)
-        .unwrap_or_else(|| Utf8Path::new("dracut").to_owned());
-    // If changing this, also look at changing rpmostree-kernel.cxx
-    let res = Command::new(dracut_path)
-        .args(&[
-            "--no-hostonly",
-            "--kver",
-            kernel_dir,
-            "--reproducible",
-            "-v",
-            "--add",
-            "ostree",
-            "-f",
-        ])
-        .arg(&tmp_initramfs_path)
-        .status()?;
-    if !res.success() {
-        return Err(anyhow!(
-            "Failed to generate initramfs (via dracut) for kernel: {kernel_dir}: {:?}",
-            res
-        ));
-    }
-    let f = std::fs::OpenOptions::new()
-        .write(true)
-        .append(true)
-        .open(&tmp_initramfs_path)?;
-    crate::initramfs::append_dracut_random_cpio(f.as_raw_fd())?;
-    drop(f);
-    let utf8_tmp_dir_path = Utf8Path::from_path(tmp_dir.path().strip_prefix("/")?)
-        .context("Error turning Path to Utf8Path")?;
-    root_fs.rename(
-        utf8_tmp_dir_path.join("initramfs.img"),
-        &root_fs,
-        (Utf8Path::new("lib/modules").join(kernel_dir)).join("initramfs.img"),
-    )?;
     Ok(())
 }


### PR DESCRIPTION
Prep for handling kernel-install in a different way, where we add a drop-in that is invoked by the existing binary instead of intercepting it entirely.

No functional changes intended (yet).
