### PR TITLE
spec: Do not build on ix86 for fedora

### DIFF
--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -11,9 +11,10 @@ URL: https://github.com/coreos/rpm-ostree
 # in the upstream git.  It also contains vendored Rust sources.
 Source0: https://github.com/coreos/rpm-ostree/releases/download/v%{version}/rpm-ostree-%{version}.tar.xz
 
+# See https://github.com/coreos/fedora-coreos-tracker/issues/1716
 # ostree not on i686 for RHEL 10
 # https://github.com/containers/composefs/pull/229#issuecomment-1838735764
-%if 0%{?rhel} >= 10
+%if 0%{?fedora} || 0%{?rhel} >= 10
 ExcludeArch:    %{ix86}
 %endif
 

--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -1,10 +1,10 @@
 # The canonical copy of this spec file is upstream at:
-# https://github.com/coreos/rpm-ostree/blob/main/packaging/rpm-ostree.spec.in
+# https://github.com/coreos/rpm-ostree/blob/main/packaging/rpm-ostree.spec
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
 Version: 2024.7
-Release: %autorelease
+Release: 1%{?dist}
 License: LGPL-2.0-or-later
 URL: https://github.com/coreos/rpm-ostree
 # This tarball is generated via "cd packaging && make -f Makefile.dist-packaging dist-snapshot"


### PR DESCRIPTION
spec: Do not build on ix86 for fedora

---

spec: %autorelease can't be resolved by COPR

Fix RPM pakcage name issue like
`rpm-ostree-2024.8.28.g3c9febff-%autorelease.x86_64.rpm`