### PR TITLE
scripts: Ignore filesystem.transfiletriggerin

### DIFF
--- a/rust/src/scripts.rs
+++ b/rust/src/scripts.rs
@@ -77,6 +77,9 @@ static IGNORED_PKG_SCRIPTS: phf::Set<&'static str> = phf_set! {
     "systemd.transfiletriggerin",
     // https://bugzilla.redhat.com/show_bug.cgi?id=1473402
     "man-db.transfiletriggerin",
+    // See https://gitlab.com/fedora/bootc/tracker/-/issues/29 - we don't need
+    // any of this.
+    "filesystem.transfiletriggerin",
     // https://src.fedoraproject.org/rpms/nfs-utils/pull-request/1
     "nfs-utils.post",
     // There is some totally insane stuff going on here in RHEL7


### PR DESCRIPTION
This is all about migrations and hacks, which we don't need since every filesystem tree is constructed fresh.

xref https://gitlab.com/fedora/bootc/tracker/-/issues/29
