### PR TITLE
Revert "build(deps): bump regex from 1.10.6 to 1.11.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,14 +2200,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.8",
- "regex-syntax 0.8.5",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2221,13 +2221,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2238,9 +2238,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ paste = "1.0"
 phf = { version = "0.11", features = ["macros"] }
 rand = "0.8.5"
 rayon = "1.10.0"
-regex = "1.11"
+regex = "1.10"
 reqwest = { version = "0.12", features = ["native-tls", "blocking", "gzip"] }
 rpmostree-client = { path = "rust/rpmostree-client", version = "0.1.0" }
 rust-ini = "0.21.1"


### PR DESCRIPTION
This reverts commit c46951f2d9ae896cbcd24bceed7c2e4930d44400.

I get a conflict now, this appears to be a case of independent PRs working together but conflicting after merge.

```
$ cargo check
error: failed to select a version for `regex`.
    ... required by package `oci-spec v0.7.0`
    ... which satisfies dependency `oci-spec = "^0.7.0"` (locked to 0.7.0) of package `containers-image-proxy v0.7.0`
    ... which satisfies dependency `containers-image-proxy = "^0.7.0"` (locked to 0.7.0) of package `ostree-ext v0.15.2`
    ... which satisfies dependency `ostree-ext = "^0.15"` (locked to 0.15.2) of package `rpmostree-rust v0.1.0 (/var/home/walters/src/github/coreos/rpm-ostree)`
versions that meet the requirements `~1.10.5` are: 1.10.6, 1.10.5

all possible versions conflict with previously selected packages.

  previously selected package `regex v1.11.0`
    ... which satisfies dependency `regex = "^1.11"` (locked to 1.11.0) of package `rpmostree-rust v0.1.0 (/var/home/walters/src/github/coreos/rpm-ostree)`

failed to select a version for `regex` which could resolve this conflict
```