### PR TITLE
 compose: If repos is unset, use global ones 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,14 +2200,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.8",
- "regex-syntax 0.8.5",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2221,13 +2221,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2238,9 +2238,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ paste = "1.0"
 phf = { version = "0.11", features = ["macros"] }
 rand = "0.8.5"
 rayon = "1.10.0"
-regex = "1.11"
+regex = "1.10"
 reqwest = { version = "0.12", features = ["native-tls", "blocking", "gzip"] }
 rpmostree-client = { path = "rust/rpmostree-client", version = "0.1.0" }
 rust-ini = "0.21.1"

--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -27,9 +27,9 @@ It supports the following parameters:
    secret key must be in the home directory of the building user.  Defaults to
    none.
 
- * `repos`: array of strings, mandatory: Names of yum repositories to
+ * `repos`: array of strings, optional: Names of yum repositories to
    use, from any files that end in `.repo`, in the same directory as
-   the treefile.  `rpm-ostree compose tree` does not use the system
+   the treefile. If specified, `rpm-ostree compose tree` does not use the system
    `/etc/yum.repos.d`, because it's common to want to compose a target
    system distinct from the one the host sytem is running.
 

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1383,11 +1383,6 @@ impl Treefile {
 
     /// Do some upfront semantic checks we can do beyond just the type safety serde provides.
     fn validate_base_config(config: &TreeComposeConfig) -> Result<()> {
-        if config.base.repos.is_none() && config.base.lockfile_repos.is_none() {
-            return Err(anyhow!(
-                r#"Treefile has neither "repos" nor "lockfile-repos""#
-            ));
-        }
         if config
             .base
             .repovars

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -505,6 +505,7 @@ static void
 disable_all_repos (RpmOstreeContext *context)
 {
   GPtrArray *sources = dnf_context_get_repos (context->dnfctx);
+  g_debug ("Disabling %u known repos", sources->len);
   for (guint i = 0; i < sources->len; i++)
     {
       auto src = static_cast<DnfRepo *> (sources->pdata[i]);
@@ -659,7 +660,9 @@ rpmostree_context_setup (RpmOstreeContext *self, const char *install_root, const
   else if (releasever.length () > 0)
     dnf_context_set_release_ver (self->dnfctx, releasever.c_str ());
 
+  g_debug ("install_root: %s", install_root);
   dnf_context_set_install_root (self->dnfctx, install_root);
+  g_debug ("source_root: %s", source_root);
   dnf_context_set_source_root (self->dnfctx, source_root);
 
   /* Hackaround libdnf logic, ensuring that `/etc/dnf/vars` gets sourced
@@ -723,6 +726,11 @@ rpmostree_context_setup (RpmOstreeContext *self, const char *install_root, const
             }
           if (!enable_repos (self, repos, error))
             return FALSE;
+        }
+      else
+        {
+          GPtrArray *sources = dnf_context_get_repos (self->dnfctx);
+          g_debug ("global repositories known: %u", sources->len);
         }
 
       /* only enable lockfile-repos if we actually have a lockfile so we don't even waste


### PR DESCRIPTION
Part of https://gitlab.com/fedora/bootc/tracker/-/issues/32

This will simplify the hacks we have in Containerfile there.
As part of this intended UX, the repositories come from the
global set.

Signed-off-by: Colin Walters <walters@verbum.org>