### PR TITLE
daemon/transaction-types: Support custom origins for digested pullspecs

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -192,6 +192,8 @@ public:
   Slice () noexcept;
   Slice (T *, std::size_t count) noexcept;
 
+  template <typename C> explicit Slice (C &c) : Slice (c.data (), c.size ()) {}
+
   Slice &operator= (const Slice<T> &) &noexcept = default;
   Slice &operator= (Slice<T> &&) &noexcept = default;
 
@@ -2165,6 +2167,8 @@ extern "C"
 
   bool rpmostreecxx$cxxbridge1$is_container_image_reference (::rust::Str refspec) noexcept;
 
+  bool rpmostreecxx$cxxbridge1$is_container_image_digest_reference (::rust::Str refspec) noexcept;
+
   ::rpmostreecxx::RefspecType
   rpmostreecxx$cxxbridge1$refspec_classify (::rust::Str refspec) noexcept;
 
@@ -3880,6 +3884,12 @@ bool
 is_container_image_reference (::rust::Str refspec) noexcept
 {
   return rpmostreecxx$cxxbridge1$is_container_image_reference (refspec);
+}
+
+bool
+is_container_image_digest_reference (::rust::Str refspec) noexcept
+{
+  return rpmostreecxx$cxxbridge1$is_container_image_digest_reference (refspec);
 }
 
 ::rpmostreecxx::RefspecType

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -191,6 +191,8 @@ public:
   Slice () noexcept;
   Slice (T *, std::size_t count) noexcept;
 
+  template <typename C> explicit Slice (C &c) : Slice (c.data (), c.size ()) {}
+
   Slice &operator= (const Slice<T> &) &noexcept = default;
   Slice &operator= (Slice<T> &&) &noexcept = default;
 
@@ -1839,6 +1841,8 @@ void run_depmod (::std::int32_t rootfs_dfd, ::rust::Str kver, bool unified_core)
 void log_treefile (::rpmostreecxx::Treefile const &tf) noexcept;
 
 bool is_container_image_reference (::rust::Str refspec) noexcept;
+
+bool is_container_image_digest_reference (::rust::Str refspec) noexcept;
 
 ::rpmostreecxx::RefspecType refspec_classify (::rust::Str refspec) noexcept;
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -262,6 +262,7 @@ pub mod ffi {
         fn log_treefile(tf: &Treefile);
 
         fn is_container_image_reference(refspec: &str) -> bool;
+        fn is_container_image_digest_reference(refspec: &str) -> bool;
         fn refspec_classify(refspec: &str) -> RefspecType;
 
         fn verify_kernel_hmac(rootfs: i32, moddir: &str) -> Result<()>;

--- a/src/daemon/rpmostreed-deployment-utils.cxx
+++ b/src/daemon/rpmostreed-deployment-utils.cxx
@@ -237,11 +237,6 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot, OstreeDeployment
     case rpmostreecxx::RefspecType::Checksum:
       {
         g_variant_dict_insert (dict, "origin", "s", refspec);
-        auto custom_origin_url = rpmostree_origin_get_custom_url (origin);
-        auto custom_origin_description = rpmostree_origin_get_custom_description (origin);
-        if (!custom_origin_url.empty ())
-          g_variant_dict_insert (dict, "custom-origin", "(ss)", custom_origin_url.c_str (),
-                                 custom_origin_description.c_str ());
       }
       break;
     case rpmostreecxx::RefspecType::Ostree:
@@ -268,6 +263,12 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot, OstreeDeployment
       }
       break;
     }
+
+  auto custom_origin_url = rpmostree_origin_get_custom_url (origin);
+  auto custom_origin_description = rpmostree_origin_get_custom_description (origin);
+  if (!custom_origin_url.empty ())
+    g_variant_dict_insert (dict, "custom-origin", "(ss)", custom_origin_url.c_str (),
+                           custom_origin_description.c_str ());
 
   g_variant_dict_insert (dict, "packages", "^as", layered_pkgs);
   g_variant_dict_insert_value (dict, "base-removals", removed_base_pkgs);

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -61,6 +61,17 @@ change_origin_refspec (GVariantDict *options, OstreeSysroot *sysroot, RpmOstreeO
 
   auto current_refspec = rpmostree_origin_get_refspec (origin);
 
+  const char *custom_origin_url = NULL;
+  const char *custom_origin_description = NULL;
+  g_variant_dict_lookup (options, "custom-origin", "(&s&s)", &custom_origin_url,
+                         &custom_origin_description);
+  if (custom_origin_url && *custom_origin_url)
+    {
+      g_assert (custom_origin_description);
+      if (!*custom_origin_description)
+        return glnx_throw (error, "Invalid custom-origin");
+    }
+
   switch (refspectype)
     {
     case rpmostreecxx::RefspecType::Container:
@@ -105,16 +116,6 @@ change_origin_refspec (GVariantDict *options, OstreeSysroot *sysroot, RpmOstreeO
 
   if (new_refspectype == rpmostreecxx::RefspecType::Checksum)
     {
-      const char *custom_origin_url = NULL;
-      const char *custom_origin_description = NULL;
-      g_variant_dict_lookup (options, "custom-origin", "(&s&s)", &custom_origin_url,
-                             &custom_origin_description);
-      if (custom_origin_url && *custom_origin_url)
-        {
-          g_assert (custom_origin_description);
-          if (!*custom_origin_description)
-            return glnx_throw (error, "Invalid custom-origin");
-        }
       rpmostree_origin_set_rebase_custom (origin, new_refspec, custom_origin_url,
                                           custom_origin_description);
     }

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -76,7 +76,15 @@ change_origin_refspec (GVariantDict *options, OstreeSysroot *sysroot, RpmOstreeO
     {
     case rpmostreecxx::RefspecType::Container:
       {
-        rpmostree_origin_set_rebase (origin, refspec);
+        // only pay attention to the custom origin stuff if using a pinned digest
+        if (!rpmostreecxx::is_container_image_digest_reference (refspec))
+          {
+            custom_origin_url = NULL;
+            custom_origin_description = NULL;
+          }
+
+        rpmostree_origin_set_rebase_custom (origin, refspec, custom_origin_url,
+                                            custom_origin_description);
 
         if (current_refspec.kind == rpmostreecxx::RefspecType::Container
             && strcmp (current_refspec.refspec.c_str (), refspec) == 0)

--- a/tests/kolainst/destructive/container-rebase-upgrade
+++ b/tests/kolainst/destructive/container-rebase-upgrade
@@ -29,15 +29,20 @@ set -x
 libtest_prepare_offline
 cd "$(mktemp -d)"
 
-image=quay.io/fedora/fedora-coreos:stable
-image_pull=ostree-remote-registry:fedora:$image
+image=quay.io/fedora/fedora-coreos
+image_tag=testing-devel
+digest=$(skopeo inspect -n docker://$image:$image_tag | jq -r .Digest)
+image_pull=ostree-remote-registry:fedora:$image@$digest
 
 systemctl mask --now zincati
 # Test for https://github.com/ostreedev/ostree/issues/3228
 rpm-ostree kargs --append "foo=\"a b c\""
 rpm-ostree kargs > kargs.txt
 assert_file_has_content_literal kargs.txt "foo=\"a b c\""
-rpm-ostree rebase --experimental ${image_pull}
+# also test custom origin stuff
+rpm-ostree rebase "${image_pull}" --custom-origin-description "Fedora CoreOS $image_tag stream" --custom-origin-url "$image:$image_tag"
+rpm-ostree status > status.txt
+assert_file_has_content_literal status.txt "$image:$image_tag" "Fedora CoreOS $image_tag stream"
 rpm-ostree upgrade
 # This provokes
 # https://github.com/coreos/rpm-ostree/issues/4107


### PR DESCRIPTION
Having a digested pullspec is the container flow equivalent of an
ostree checksum origin. So having a custom origin in that case is useful
there for the same reasons (i.e. it means that something else is likely
managing the host and we want to reflect that info in the origin).

We're thinking of using this in FCOS when we move from OSTree to OCI
for updates.