### PR TITLE
kernel-install: integration

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -59,6 +59,10 @@ It supports the following parameters:
       this for new systems, and systems that don't need to be upgraded
       from very old libostree versions. This is the default for editions 2024
       and above.
+    * "kernel-install": The system is integrated with `/sbin/kernel-install`
+      from systemd. You likely want to additionally pair this with configuring `layout=ostree`
+      in `/usr/lib/kernel/install.conf`, and adding a wrapper script to
+      `/usr/lib/kernel/install.d/05-rpmostree.install`
 
  * `etc-group-members`: Array of strings, optional: Unix groups in this
    list will be stored in `/etc/group` instead of `/usr/lib/group`.  Use

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1783,6 +1783,7 @@ struct Treefile final : public ::rust::Opaque
   bool get_machineid_compat () const noexcept;
   ::rust::Vec< ::rust::String> get_etc_group_members () const noexcept;
   bool get_boot_location_is_modules () const noexcept;
+  bool use_kernel_install () const noexcept;
   bool get_ima () const noexcept;
   ::rust::String get_releasever () const noexcept;
   ::rpmostreecxx::RepoMetadataTarget get_repo_metadata_target () const noexcept;
@@ -2432,7 +2433,8 @@ extern "C"
   ::rpmostreecxx::TokioEnterGuard *
   rpmostreecxx$cxxbridge1$TokioHandle$enter (::rpmostreecxx::TokioHandle const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$script_is_ignored (::rust::Str pkg, ::rust::Str script) noexcept;
+  bool rpmostreecxx$cxxbridge1$script_is_ignored (::rust::Str pkg, ::rust::Str script,
+                                                  bool use_kernel_install) noexcept;
 
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$testutils_entrypoint (::rust::Vec< ::rust::String> *argv) noexcept;
@@ -2631,6 +2633,9 @@ extern "C"
       ::rpmostreecxx::Treefile const &self, ::rust::Vec< ::rust::String> *return$) noexcept;
 
   bool rpmostreecxx$cxxbridge1$Treefile$get_boot_location_is_modules (
+      ::rpmostreecxx::Treefile const &self) noexcept;
+
+  bool rpmostreecxx$cxxbridge1$Treefile$use_kernel_install (
       ::rpmostreecxx::Treefile const &self) noexcept;
 
   bool rpmostreecxx$cxxbridge1$Treefile$get_ima (::rpmostreecxx::Treefile const &self) noexcept;
@@ -4648,9 +4653,9 @@ TokioHandle::enter () const noexcept
 }
 
 bool
-script_is_ignored (::rust::Str pkg, ::rust::Str script) noexcept
+script_is_ignored (::rust::Str pkg, ::rust::Str script, bool use_kernel_install) noexcept
 {
-  return rpmostreecxx$cxxbridge1$script_is_ignored (pkg, script);
+  return rpmostreecxx$cxxbridge1$script_is_ignored (pkg, script, use_kernel_install);
 }
 
 void
@@ -5201,6 +5206,12 @@ bool
 Treefile::get_boot_location_is_modules () const noexcept
 {
   return rpmostreecxx$cxxbridge1$Treefile$get_boot_location_is_modules (*this);
+}
+
+bool
+Treefile::use_kernel_install () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$Treefile$use_kernel_install (*this);
 }
 
 bool

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1560,6 +1560,7 @@ struct Treefile final : public ::rust::Opaque
   bool get_machineid_compat () const noexcept;
   ::rust::Vec< ::rust::String> get_etc_group_members () const noexcept;
   bool get_boot_location_is_modules () const noexcept;
+  bool use_kernel_install () const noexcept;
   bool get_ima () const noexcept;
   ::rust::String get_releasever () const noexcept;
   ::rpmostreecxx::RepoMetadataTarget get_repo_metadata_target () const noexcept;
@@ -1976,7 +1977,7 @@ void history_prune ();
 
 ::rust::Box< ::rpmostreecxx::TokioHandle> tokio_handle_get () noexcept;
 
-bool script_is_ignored (::rust::Str pkg, ::rust::Str script) noexcept;
+bool script_is_ignored (::rust::Str pkg, ::rust::Str script, bool use_kernel_install) noexcept;
 
 void testutils_entrypoint (::rust::Vec< ::rust::String> argv);
 

--- a/rust/src/cliwrap/kernel_install_wrap.rs
+++ b/rust/src/cliwrap/kernel_install_wrap.rs
@@ -3,6 +3,7 @@
 use crate::cliwrap::cliutil;
 use anyhow::Result;
 use camino::Utf8Path;
+use cap_std::fs::Dir as StdDir;
 use cap_std::fs::FileType;
 use cap_std::fs_utf8::Dir as Utf8Dir;
 use cap_std_ext::cap_std;
@@ -39,7 +40,8 @@ pub(crate) fn main(argv: &[&str]) -> Result<()> {
     }
     if let Some(k) = new_kernel {
         undo_systemctl_wrap()?;
-        crate::initramfs::run_dracut(&k)?;
+        let root_fs = StdDir::open_ambient_dir("/", cap_std::ambient_authority())?;
+        crate::initramfs::run_dracut(&root_fs, &k)?;
         redo_systemctl_wrap()?;
     }
     Ok(())

--- a/rust/src/initramfs.rs
+++ b/rust/src/initramfs.rs
@@ -4,7 +4,7 @@
 use crate::cxxrsutil::*;
 use anyhow::{anyhow, Context, Result};
 use camino::Utf8Path;
-use cap_std::fs_utf8::Dir as Utf8Dir;
+use cap_std::fs::Dir;
 use cap_std::io_lifetimes::AsFilelike;
 use cap_std_ext::cap_std;
 use cap_std_ext::prelude::CapStdExtCommandExt;
@@ -185,8 +185,7 @@ pub(crate) fn initramfs_overlay_generate(
 }
 
 #[context("Running dracut")]
-pub(crate) fn run_dracut(kernel_dir: &str) -> Result<()> {
-    let root_fs = Utf8Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
+pub(crate) fn run_dracut(root_fs: &Dir, kernel_dir: &str) -> Result<()> {
     let tmp_dir = tempfile::tempdir()?;
     let tmp_initramfs_path = tmp_dir.path().join("initramfs.img");
 

--- a/rust/src/kernel_install.rs
+++ b/rust/src/kernel_install.rs
@@ -1,0 +1,121 @@
+//! Integration with the systemd-owned /sbin/kernel-install tooling.
+//!
+//! Note that there's two different phases of kernel handling:
+//!
+//! - build time
+//! - deployment time (owned by ostree)
+//!
+//! This code is wholly concerned with "build time" today. The
+//! "deployment time" logic is owned entirely by ostree.
+//!
+
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use cap_std::fs::Dir;
+use cap_std_ext::cap_std;
+use cap_std_ext::dirext::CapStdExtDirExt;
+use fn_error_context::context;
+
+/// Parsed by kernel-install and set in the environment
+const LAYOUT_VAR: &str = "KERNEL_INSTALL_LAYOUT";
+/// The value we expect to find for layout
+const LAYOUT_OSTREE: &str = "ostree";
+/// What we should emit to skip further processing
+const SKIP: u8 = 77;
+/// The path to the kernel modules
+const MODULES: &str = "usr/lib/modules";
+/// The default name for the initramfs.
+const INITRAMFS: &str = "initramfs.img";
+/// The path to the instal.conf that sets layout.
+const KERNEL_INSTALL_CONF: &str = "/usr/lib/kernel/install.conf";
+
+#[context("Verifying kernel-install layout file")]
+pub fn is_ostree_layout() -> Result<bool> {
+    let install_conf = Path::new(KERNEL_INSTALL_CONF);
+    if !install_conf.is_file() {
+        tracing::debug!("can not read /usr/lib/kernel/install.conf");
+        return Ok(false);
+    }
+    let buff = BufReader::new(
+        File::open(install_conf).context("Failed to open /usr/lib/kernel/install.conf")?,
+    );
+    // Check for "layout=ostree" in the file
+    for line in buff.lines() {
+        let line = line.context("Failed to read line")?;
+        if line.trim() == "layout=ostree" {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+#[context("Adding kernel")]
+fn add(root: &Dir, argv: &[&str]) -> Result<()> {
+    let mut argv_it = argv.iter().copied();
+    let Some(kver) = argv_it.next() else {
+        anyhow::bail!("No kernel version provided");
+    };
+    tracing::debug!("Installing kernel kver={kver}");
+    println!("Generating initramfs");
+    crate::initramfs::run_dracut(root, &kver)?;
+    println!("Running depmod");
+    let st = Command::new("depmod")
+        .args(["-a", kver])
+        .status()
+        .context("Invoking depmod")?;
+    if !st.success() {
+        anyhow::bail!("Failed to run depmod: {st:?}");
+    }
+    Ok(())
+}
+
+#[context("Removing kernel")]
+fn remove(root: &Dir, kver: &str) -> Result<()> {
+    tracing::debug!("Removing kernel kver={kver}");
+    let kdir = format!("{MODULES}/{kver}");
+    let Some(kernel_dir) = root.open_dir_optional(&kdir)? else {
+        return Ok(());
+    };
+    // We generate the initramfs, so remove it if it exists.
+    kernel_dir.remove_file_optional(INITRAMFS)?;
+    Ok(())
+}
+
+/// Primary entrypoint to `/usr/lib/kernel-install.d/05-rpmostree.install`.
+#[context("rpm-ostree kernel-install")]
+pub fn main(argv: &[&str]) -> Result<u8> {
+    let Some(layout) = std::env::var_os(LAYOUT_VAR) else {
+        return Ok(0);
+    };
+    tracing::debug!("The LAYOUT_OSTREE is: {:?}", layout.to_str());
+    if !matches!(layout.to_str(), Some(LAYOUT_OSTREE)) {
+        return Ok(0);
+    }
+    if !ostree_ext::container_utils::is_ostree_container()? {
+        eprintln!(
+            "warning: confused state: {LAYOUT_VAR}={LAYOUT_OSTREE} but not in an ostree container"
+        );
+        return Ok(0);
+    }
+    let root = &Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
+    tracing::debug!("argv={argv:?}");
+    match argv {
+        [_, _, "add", rest @ ..] => {
+            add(root, rest)?;
+            // In the case of adding a new kernel, we intercept everything else
+            // today. In the future we can try to ensure we reuse what bits are there.
+            Ok(SKIP)
+        }
+        [_, _, "remove", kver, ..] => {
+            remove(root, kver)?;
+            Ok(0)
+        }
+        _ => Ok(0),
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -513,7 +513,7 @@ pub mod ffi {
 
     // scripts.rs
     extern "Rust" {
-        fn script_is_ignored(pkg: &str, script: &str) -> bool;
+        fn script_is_ignored(pkg: &str, script: &str, use_kernel_install: bool) -> bool;
     }
 
     // testutils.rs
@@ -627,6 +627,7 @@ pub mod ffi {
         fn get_machineid_compat(&self) -> bool;
         fn get_etc_group_members(&self) -> Vec<String>;
         fn get_boot_location_is_modules(&self) -> bool;
+        fn use_kernel_install(&self) -> bool;
         fn get_ima(&self) -> bool;
         fn get_releasever(&self) -> String;
         fn get_repo_metadata_target(&self) -> RepoMetadataTarget;
@@ -990,6 +991,7 @@ mod initramfs;
 pub(crate) use self::initramfs::*;
 mod isolation;
 mod journal;
+pub mod kernel_install;
 pub(crate) use self::journal::*;
 mod kickstart;
 mod lockfile;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -28,6 +28,7 @@ async fn inner_async_main(args: Vec<String>) -> Result<i32> {
             match *arg {
                 // Add custom Rust commands here, and also in `libmain.cxx` if user-visible.
                 "countme" => rpmostree_rust::countme::entrypoint(args).map(|_| 0),
+                "kernel-install" => rpmostree_rust::kernel_install::main(args).map(Into::into),
                 "fix-shadow-perms" => rpmostree_rust::passwd::fix_shadow_perms_entrypoint(args).map(|_| 0),
                 "cliwrap" => rpmostree_rust::cliwrap::entrypoint(args).map(|_| 0),
                 // A hidden wrapper to intercept some binaries in RPM scriptlets.

--- a/rust/src/scripts.rs
+++ b/rust/src/scripts.rs
@@ -9,14 +9,11 @@
 
 use phf::phf_set;
 
-/// Some RPM scripts we don't want to execute.  A notable example is the kernel ones;
-/// we want rpm-ostree to own running dracut, installing the kernel to /boot etc.
-/// Ideally more of these migrate out, e.g. in the future we should change the kernel
-/// package to do nothing if `/run/ostree-booted` exists.
+/// If we're not using boot-location: kernel-install, then we take over the
+/// kernel RPM scripts.
 ///
 /// NOTE FOR GIT history: This list used to live in src/libpriv/rpmostree-script-gperf.gperf
-static IGNORED_PKG_SCRIPTS: phf::Set<&'static str> = phf_set! {
-    "glibc.prein",
+static IGNORED_KERNEL_SCRIPTS: phf::Set<&'static str> = phf_set! {
     // We take over depmod/dracut etc.  It's `kernel` in C7 and kernel-core in F25+
     // XXX: we should probably change this to instead ignore based on the kernel virtual Provides
     "kernel.posttrans",
@@ -50,6 +47,10 @@ static IGNORED_PKG_SCRIPTS: phf::Set<&'static str> = phf_set! {
     "kernel-ml.posttrans",
     "kernel-ml-core.posttrans",
     "kernel-ml-modules.posttrans",
+};
+
+static IGNORED_PKG_SCRIPTS: phf::Set<&'static str> = phf_set! {
+    "glibc.prein",
     // Legacy workaround
     "glibc-headers.prein",
     // workaround for old bug?
@@ -90,8 +91,41 @@ static IGNORED_PKG_SCRIPTS: phf::Set<&'static str> = phf_set! {
 
 /// Returns true if we should simply ignore (not execute) an RPM script.
 /// The format is <packagename>.<script>
-pub(crate) fn script_is_ignored(pkg: &str, script: &str) -> bool {
+pub(crate) fn script_is_ignored(pkg: &str, script: &str, use_kernel_install: bool) -> bool {
     let script = script.trim_start_matches('%');
     let pkgscript = format!("{}.{}", pkg, script);
-    IGNORED_PKG_SCRIPTS.contains(pkgscript.as_str())
+    if IGNORED_PKG_SCRIPTS.contains(&pkgscript) {
+        return true;
+    }
+    if !use_kernel_install {
+        return IGNORED_KERNEL_SCRIPTS.contains(&pkgscript);
+    }
+    return false;
+}
+
+#[cfg(test)]
+mod test {
+    use crate::script_is_ignored;
+
+    #[test]
+    fn test_script_is_ignored() {
+        let ignored = ["microcode_ctl.post", "vagrant.prein"];
+        let not_ignored = ["foobar.post", "systemd.posttrans"];
+        let kernel_ignored = ["kernel-automotive-core.posttrans"];
+        for v in ignored {
+            let (pkg, script) = v.split_once('.').unwrap();
+            assert!(script_is_ignored(pkg, script, false));
+            assert!(script_is_ignored(pkg, script, true));
+        }
+        for v in not_ignored {
+            let (pkg, script) = v.split_once('.').unwrap();
+            assert!(!script_is_ignored(pkg, script, false));
+            assert!(!script_is_ignored(pkg, script, true));
+        }
+        for v in kernel_ignored {
+            let (pkg, script) = v.split_once('.').unwrap();
+            assert!(script_is_ignored(pkg, script, false));
+            assert!(!script_is_ignored(pkg, script, true));
+        }
+    }
 }

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1352,8 +1352,15 @@ impl Treefile {
     pub(crate) fn get_boot_location_is_modules(&self) -> bool {
         match self.parsed.base.boot_location.unwrap_or_default() {
             BootLocation::New => false,
-            BootLocation::Modules => true,
+            BootLocation::Modules | BootLocation::KernelInstall => true,
         }
+    }
+
+    pub(crate) fn use_kernel_install(&self) -> bool {
+        matches!(
+            self.parsed.base.boot_location.unwrap_or_default(),
+            BootLocation::KernelInstall
+        )
     }
 
     pub(crate) fn get_etc_group_members(&self) -> Vec<String> {
@@ -2077,6 +2084,7 @@ pub(crate) enum BootLocation {
     #[default]
     New,
     Modules,
+    KernelInstall,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -3362,6 +3370,14 @@ pub(crate) mod tests {
                 - 12
                 - 34
         "});
+    }
+
+    #[test]
+    fn basic_boot_kernel_install() {
+        let treefile = append_and_parse(indoc! {"
+            boot-location: kernel-install
+        "});
+        assert!(treefile.base.boot_location.unwrap() == BootLocation::KernelInstall);
     }
 
     pub(crate) fn new_test_treefile<'a, 'b>(

--- a/src/libpriv/rpmostree-scripts.h
+++ b/src/libpriv/rpmostree-scripts.h
@@ -41,17 +41,17 @@ typedef enum
   RPMOSTREE_SCRIPT_POSTTRANS,
 } RpmOstreeScriptKind;
 
-gboolean rpmostree_script_txn_validate (DnfPackage *package, Header hdr, GCancellable *cancellable,
-                                        GError **error);
+gboolean rpmostree_script_txn_validate (DnfPackage *package, Header hdr, bool use_kernel_install,
+                                        GCancellable *cancellable, GError **error);
 
 gboolean rpmostree_script_run_sync (DnfPackage *pkg, Header hdr, RpmOstreeScriptKind kind,
                                     int rootfs_fd, GLnxTmpDir *var_lib_rpm_statedir,
-                                    gboolean enable_rofiles, guint *out_n_run,
-                                    GCancellable *cancellable, GError **error);
+                                    gboolean enable_rofiles, gboolean use_kernel_install,
+                                    guint *out_n_run, GCancellable *cancellable, GError **error);
 
 gboolean rpmostree_transfiletriggers_run_sync (Header hdr, int rootfs_fd, gboolean enable_rofiles,
-                                               guint *out_n_run, GCancellable *cancellable,
-                                               GError **error);
+                                               gboolean use_kernel_install, guint *out_n_run,
+                                               GCancellable *cancellable, GError **error);
 
 gboolean rpmostree_deployment_sanitycheck_true (int rootfs_fd, GCancellable *cancellable,
                                                 GError **error);


### PR DESCRIPTION
incorporates #5097 
closes: https://github.com/coreos/rpm-ostree/issues/4726

This will pair with: https://gitlab.com/fedora/bootc/base-images/-/merge_requests/62 which makes the integration work.

This builds and works on the following Containerfile.

Need to figure out how to properly deal with the commented out code still.

```
FROM $image
RUN curl -O -L -k https://kojipkgs.fedoraproject.org//packages/kernel/6.12.0/0.rc1.20241005git27cc6fdf7201.22.fc42/x86_64/kernel-6.12.0-0.rc1.20241005git27cc6fdf7201.22.fc42.x86_64.rpm && \
 curl -O -L -k https://kojipkgs.fedoraproject.org//packages/kernel/6.12.0/0.rc1.20241005git27cc6fdf7201.22.fc42/x86_64/kernel-core-6.12.0-0.rc1.20241005git27cc6fdf7201.22.fc42.x86_64.rpm && \
 curl -O -L -k https://kojipkgs.fedoraproject.org//packages/kernel/6.12.0/0.rc1.20241005git27cc6fdf7201.22.fc42/x86_64/kernel-modules-6.12.0-0.rc1.20241005git27cc6fdf7201.22.fc42.x86_64.rpm && \
 curl -O -L -k https://kojipkgs.fedoraproject.org//packages/kernel/6.12.0/0.rc1.20241005git27cc6fdf7201.22.fc42/x86_64/kernel-modules-core-6.12.0-0.rc1.20241005git27cc6fdf7201.22.fc42.x86_64.rpm && \
 curl -O -L -k https://kojipkgs.fedoraproject.org//packages/kernel/6.12.0/0.rc1.20241005git27cc6fdf7201.22.fc42/x86_64/kernel-modules-extra-6.12.0-0.rc1.20241005git27cc6fdf7201.22.fc42.x86_64.rpm

ADD target/debug/rpm-ostree /usr/bin/rpm-ostree
RUN dnf install -y /kernel*
```