### PR TITLE
compose: Allow missing `repos` key and add `--source-root` flag

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -31,9 +31,10 @@ It supports the following parameters:
    secret key must be in the home directory of the building user.  Defaults to
    none.
 
- * `repos`: array of strings, mandatory: Names of yum repositories to
+ * `repos`: array of strings, optional: Names of yum repositories to
    use, from any files that end in `.repo`, in the same directory as
-   the treefile.  `rpm-ostree compose tree` does not use the system
+   the treefile. If missing, all yum repos enabled by default are used.
+   `rpm-ostree compose tree` does not use the system
    `/etc/yum.repos.d`, because it's common to want to compose a target
    system distinct from the one the host sytem is running.
 

--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -78,6 +78,11 @@ struct Opt {
     /// Directory to use for caching downloaded packages and other data
     cachedir: Option<Utf8PathBuf>,
 
+    #[clap(long)]
+    #[clap(value_parser)]
+    /// Rootfs to use for resolving releasever if unset
+    source_root: Option<Utf8PathBuf>,
+
     /// Container authentication file
     #[clap(long)]
     #[clap(value_parser)]
@@ -268,6 +273,10 @@ pub(crate) fn compose_image(args: Vec<String>) -> CxxResult<()> {
 
     let commitid_path = tempdir.join("commitid");
     let changed_path = tempdir.join("changed");
+
+    if let Some(ref path) = opt.source_root {
+        compose_args_extra.extend(["--source-root", path.as_str()]);
+    }
 
     let s = self_command()
         .args(&[

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1463,11 +1463,6 @@ impl Treefile {
 
     /// Do some upfront semantic checks we can do beyond just the type safety serde provides.
     fn validate_base_config(config: &TreeComposeConfig) -> Result<()> {
-        if config.base.repos.is_none() && config.base.lockfile_repos.is_none() {
-            return Err(anyhow!(
-                r#"Treefile has neither "repos" nor "lockfile-repos""#
-            ));
-        }
         if config
             .base
             .repovars

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -55,6 +55,7 @@ static gboolean pull_local_into_target_repo (OstreeRepo *src_repo, OstreeRepo *d
 static char *opt_workdir;
 static gboolean opt_workdir_tmpfs;
 static char *opt_cachedir;
+static char *opt_source_root;
 static gboolean opt_download_only;
 static gboolean opt_download_only_rpms;
 static gboolean opt_force_nocache;
@@ -104,6 +105,8 @@ static GOptionEntry install_option_entries[]
         { "cache-only", 0, 0, G_OPTION_ARG_NONE, &opt_cache_only,
           "Assume cache is present, do not attempt to update it", NULL },
         { "cachedir", 0, 0, G_OPTION_ARG_STRING, &opt_cachedir, "Cached state", "CACHEDIR" },
+        { "source-root", 0, 0, G_OPTION_ARG_STRING, &opt_source_root,
+          "Rootfs to use for resolving releasever if unset", "PATH" },
         { "download-only", 0, 0, G_OPTION_ARG_NONE, &opt_download_only,
           "Like --dry-run, but download and import RPMs as well; requires --cachedir", NULL },
         { "download-only-rpms", 0, 0, G_OPTION_ARG_NONE, &opt_download_only_rpms,
@@ -340,7 +343,8 @@ install_packages (RpmOstreeTreeComposeContext *self, gboolean *out_unmodified,
 
   {
     g_autofree char *tmprootfs_abspath = glnx_fdrel_abspath (rootfs_dfd, ".");
-    if (!rpmostree_context_setup (self->corectx, tmprootfs_abspath, NULL, cancellable, error))
+    if (!rpmostree_context_setup (self->corectx, tmprootfs_abspath, opt_source_root, cancellable,
+                                  error))
       return FALSE;
   }
 

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -710,8 +710,9 @@ rpmostree_context_setup (RpmOstreeContext *self, const char *install_root, const
        * the server-side we always require `repos` anyway. */
       bool disabled_all_repos = false;
 
-      /* NB: missing "repos" --> let libdnf figure it out for itself (we're likely doing a
-       * client-side compose where we want to use /etc/yum.repos.d/) */
+      /* NB: if we're missing "repos" then default to all enabled repos. Note
+       * this is independent of what reposdir is, which is different between the
+       * compose side (e.g. git repo) and the client-side (/etc/yum.repos.d) */
       auto repos = self->treefile_rs->get_repos ();
       g_debug ("Found %u repos", (guint)repos.size ());
       if (!repos.empty ())

--- a/tests/compose/test-misc-tweaks.sh
+++ b/tests/compose/test-misc-tweaks.sh
@@ -6,7 +6,6 @@ dn=$(cd "$(dirname "$0")" && pwd)
 . "${dn}/libcomposetest.sh"
 
 # Add a local rpm-md repo so we can mutate local test packages
-treefile_append "repos" '["test-repo"]'
 # test `recommends: true` (test-basic[-unified] test the false path)
 build_rpm foobar recommends foobar-rec
 build_rpm foobar-rec
@@ -30,7 +29,16 @@ build_rpm barbaz \
           install "mkdir -p %{buildroot}/etc && echo shared file data > %{buildroot}/etc/sharedfile"
 
 echo gpgcheck=0 >> yumrepo.repo
+# Notice here we _don't_ add test-repo to the treefile in this test. Instead we
+# set it to enabled in the repo file. This verifies that found yum repos enabled
+# in their config are used by default when `repos:` is missing.
+echo "enabled=1" >> yumrepo.repo
+mv config/cache.repo .
+echo "enabled=1" >> cache.repo
+rm config/*.repo
 ln "$PWD/yumrepo.repo" config/yumrepo.repo
+ln "$PWD/cache.repo" config/cache.repo
+treefile_del "repos"
 # the top-level manifest doesn't have any packages, so just set it
 treefile_append "packages" $'["\'foobar >= 0.5\' quuz \'corge < 2.0\' barbar barbaz thirdpartymodules"]'
 


### PR DESCRIPTION
Both of those are motivated by the fedora-bootc use case to clean up the container-native compose path. See individual commit messages.

Related: https://gitlab.com/fedora/bootc/tracker/-/issues/39