### PR TITLE
core: Don't add composefs metadata client side

### DIFF
--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -4802,9 +4802,6 @@ rpmostree_context_commit (RpmOstreeContext *self, const char *parent,
         if (!ostree_commit_metadata_for_bootable (root, metadata_dict, cancellable, error))
           return FALSE;
       }
-    if (!ostree_repo_commit_add_composefs_metadata (self->ostreerepo, 0, metadata_dict,
-                                                    (OstreeRepoFile *)root, cancellable, error))
-      return glnx_prefix_error (error, "Adding composefs metadata");
 
     {
       g_autoptr (GVariant) metadata = g_variant_dict_end (metadata_dict);

--- a/tests/kolainst/destructive/layering-local
+++ b/tests/kolainst/destructive/layering-local
@@ -95,9 +95,10 @@ fi
 ostree show --print-metadata-key=ostree.bootable ${booted_commit} >out.txt
 assert_file_has_content_literal out.txt 'true'
 echo "ok bootable metadata"
-ostree show --print-metadata-key=ostree.composefs.digest.v0 ${booted_commit} >out.txt
-assert_file_has_content_literal out.txt 'byte'
-echo "ok composefs metadata on client generated commit"
+if ostree show --print-metadata-key=ostree.composefs.digest.v0 ${booted_commit} 2>err.txt; then
+  fatal "found ostree.composefs.digest.v0"
+fi
+echo "ok no composefs metadata on client generated commit"
 
 # check we could uninstall the package using either its NEVRA or name
 rpm-ostree uninstall foo-1.2-3.x86_64


### PR DESCRIPTION
This effectively reverts https://github.com/coreos/rpm-ostree/pull/4594/commits/c1156001c096c261bc5c41ab56da7a3b0f476656

I was wrong, if we don't have fsverity today on the repo (a common case) then this entails a full read of all files. For more information see https://github.com/ostreedev/ostree/pull/3326
