### PR TITLE
spec: Drop rust-toolset requires on RHEL

### DIFF
--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -19,13 +19,9 @@ ExcludeArch:    %{ix86}
 %endif
 
 BuildRequires: make
-%if 0%{?rhel}
-BuildRequires: rust-toolset
-%else
 BuildRequires: rust-packaging
 BuildRequires: cargo
 BuildRequires: rust
-%endif
 
 # Enable ASAN + UBSAN
 %bcond_with sanitizers


### PR DESCRIPTION
Trying to install the build dependencies in current c9s hits:
```
Error: Transaction test error:
  file /usr/lib/rpm/fileattrs/cargo_vendor.attr from install of rust-toolset-1.82.0-1.el9.noarch conflicts with file from package cargo-rpm-macros-26.2-1.el9.noarch
```

which is clearly a bug in the packaging but it seems rust-toolset is dead, so let's stop using it.

https://issues.redhat.com/browse/RHEL-67475
