### PR TITLE
Release 2024.9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2024])
-m4_define([release_version], [8])
+m4_define([release_version], [9])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2024.7
+Version: 2024.9
 Release: 1%{?dist}
 License: LGPL-2.0-or-later
 URL: https://github.com/coreos/rpm-ostree


### PR DESCRIPTION
v2024.9

This release has multiple dependency updates and CI fixes, additionally there are 3 notable changes:
* We deprecated cliwrap https://github.com/coreos/rpm-ostree/pull/5088
* Add initial kickstart support https://github.com/coreos/rpm-ostree/pull/5119
* Support custom origins for digested pullspecs https://github.com/coreos/rpm-ostree/pull/5120
      
```
Aashish Radhakrishnan (1):
      packaging/rpm-ostree.spec: Drop rust_arches

Colin Walters (15):
      sysroot: Add total layer count to output
      Deprecate cliwrap
      Move dracut code from cliwrap to initramfs module
      scripts: Ignore filesystem.transfiletriggerin
      Revert "build(deps): bump regex from 1.10.6 to 1.11.0"
      treefile: Add an `edition`
      treefile: Add finalize.d as experimental
      compose: Initial kickstart support
      treefile: Add ignore-devices
      core: Don't add composefs metadata client side
      Update ostree-ext to 0.15.3
      ci: Adapt to dnf5's builddep incompatibility
      tests: Drop layering-fedorainfra
      core: List all other repos when we fail to find a repo
      spec: Drop rust-toolset requires on RHEL

Emmanuel Ferdman (1):
      docs: update `rpm-ostreed.service` reference

Gerard Ryan (1):
      Fix doc wording & typo

HuijingHei (4):
      spec: Do not build on ix86 for fedora
      spec: %autorelease can't be resolved by COPR
      test: update kolet path to `/usr/local/bin`
      Bump ostree-ext to 0.15.1

Jonathan Lebon (11):
      rust/core: Add util function to check for digest pullspec
      daemon/transaction-types: Lookup custom origin options earlier
      daemon/transaction-types: Support custom origins for digested pullspecs
      daemon/deployment-utils: Always add custom origin to deployment variant
      app/status: Print custom origin for digested pullspecs as well
      tests: Check custom origin with digest pullspec
      compose: Allow missing `repos` key
      compose: add `--source-root` option
      docs/administrator: document `status --json` and requested packages
      compose: Print transaction when composing extensions
      treefile: Support variable substitution in metadata

Joseph Marrero Corchado (7):
      packaging/rpm-ostree.spec: Update fuse conditional
      ci: stop building with clang
      test-container: Bump to f41
      packaging: Require bootc
      tests: Updates for f41
      Revert "packaging: Require bootc"
      Release 2024.9


```

## New Contributors

* @aaradhak made their first contribution in https://github.com/coreos/rpm-ostree/pull/5089
* @emmanuel-ferdman made their first contribution in https://github.com/coreos/rpm-ostree/pull/5113
* @grdryn made their first contribution in https://github.com/coreos/rpm-ostree/pull/5099

**Full Changelog**: https://github.com/coreos/rpm-ostree/compare/v2024.8...v2024.9

