### PR TITLE
treefile: Support variable substitution in `metadata`

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -26,6 +26,7 @@ It supports the following parameters:
  * `metadata`: Mapping of strings to values, optional.  This can be used
    for other tools to insert arbitrary metadata into the treefile which
    they parse later, for example via `rpm-ostree compose tree --print-metadata-json`.
+   All (top-level) objects of type string support variable substitution.
 
  * `gpg-key` (or `gpg_key`): string, optional: Key ID for GPG signing; the
    secret key must be in the home directory of the building user.  Defaults to


### PR DESCRIPTION
I want to stop abusing the `rojig` key in the CoreOS treefiles. But before we can switch over to `metadata`, we need variable substitution supported there too.

Note the `metadata` key can have arbitrarily nested values. For now, we just implement variable substitution for the first level of values since that's all we need.