### PR TITLE
Update timer to be more in-line with dnf-automatic

### DIFF
--- a/src/daemon/rpm-ostreed-automatic.timer
+++ b/src/daemon/rpm-ostreed-automatic.timer
@@ -2,10 +2,13 @@
 Description=rpm-ostree Automatic Update Trigger
 Documentation=man:rpm-ostree(1) man:rpm-ostreed.conf(5)
 ConditionPathExists=/run/ostree-booted
+After=network-online.target
+Wants=network-online.target
 
 [Timer]
 OnBootSec=1h
 OnUnitInactiveSec=1d
+Persistent=true
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
This suggestion would update the timer behaviour of `rpm-ostreed-automatic.timer` to be more in line with the behaviour of `dnf-automatic.timer`.

**Problem Statement**

On a laptop which spends a lot of time in sleep mode, the timer frequency used by `rpm-ostreed-automatic.timer` is so infrequent that the service rarely ends up running.

To solve this, we can add

```ini
Persistent=true
```

This brings the behaviour into line with how `dnf-automatic.timer` works:

https://github.com/rpm-software-management/dnf/blob/69d1f641cda28fc543846524d15ec7291baf3e5a/etc/systemd/dnf-automatic.timer#L10

Just adding this alone can cause issues in environments with slow network bring-up, so we can also add:

```ini
Wants=network-online.target
```

Which also matches the `dnf-automatic.timer` behaviour:

I've also added:

```ini
After=network-online.target
```

as a suggestion here, as the systemd docs [suggest this might be more robust than just using Wants=](https://systemd.io/NETWORK_ONLINE/).