### PR TITLE
tree-wide: `cargo clippy --fix` + a few manual warning fixes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ fn detect_fedora_feature() -> Result<()> {
         return Ok(());
     }
     let p = std::process::Command::new("sh")
-        .args(&["-c", ". /usr/lib/os-release && echo ${ID}"])
+        .args(["-c", ". /usr/lib/os-release && echo ${ID}"])
         .stdout(std::process::Stdio::piped())
         .output()?;
     let out = std::str::from_utf8(&p.stdout).ok().map(|s| s.trim());

--- a/rust/src/builtins/apply_live.rs
+++ b/rust/src/builtins/apply_live.rs
@@ -32,16 +32,16 @@ fn get_args_variant(sysroot: &ostree::Sysroot, opts: &Opts) -> Result<glib::Vari
         if opts.reset {
             return Err(anyhow!("Cannot specify both --target and --reset"));
         }
-        r.insert(live::OPT_TARGET, &target.as_str());
+        r.insert(live::OPT_TARGET, target.as_str());
     } else if opts.reset {
         let booted = sysroot.require_booted_deployment()?;
         // Unwrap safety: This can't return NULL
         let csum = booted.csum();
-        r.insert(live::OPT_TARGET, &csum.as_str());
+        r.insert(live::OPT_TARGET, csum.as_str());
     }
 
     if opts.allow_replacement {
-        r.insert(live::OPT_REPLACE, &true);
+        r.insert(live::OPT_REPLACE, true);
     }
 
     Ok(r.end())
@@ -97,15 +97,15 @@ pub(crate) fn applylive_finish(sysroot: &crate::ffi::OstreeSysroot) -> CxxResult
     } else {
         let lib_diff = ostree_ext::diff::diff(
             repo,
-            &booted_commit,
-            &live_state.commit.as_str(),
+            booted_commit,
+            live_state.commit.as_str(),
             Some("/usr/lib/systemd/system"),
         )?;
 
         let etc_diff = ostree_ext::diff::diff(
             repo,
-            &booted_commit,
-            &live_state.commit.as_str(),
+            booted_commit,
+            live_state.commit.as_str(),
             Some("/usr/etc/systemd/system"),
         )?;
 
@@ -129,7 +129,7 @@ pub(crate) fn applylive_finish(sysroot: &crate::ffi::OstreeSysroot) -> CxxResult
         crate::ffi::output_message(
             "Successfully updated running filesystem tree; Following services may need to be restarted:");
         for service in changed {
-            crate::ffi::output_message(&format!("{}", service.strip_prefix('/').unwrap()));
+            crate::ffi::output_message(service.strip_prefix('/').unwrap());
         }
     }
     Ok(())

--- a/rust/src/builtins/compose/mod.rs
+++ b/rust/src/builtins/compose/mod.rs
@@ -61,7 +61,7 @@ fn legacy_prepare_dev(rootfs: &Dir) -> Result<()> {
         // file so it can use `fchmod()` which may fail for special things like `/dev/tty`.
         // We have no concerns about following symlinks because we know we just created
         // the device and there are no concurrent writers.
-        rustix::fs::chmodat(&dest_dir.as_fd(), nodename, mode, AtFlags::empty())
+        rustix::fs::chmodat(dest_dir.as_fd(), nodename, mode, AtFlags::empty())
             .with_context(|| format!("Setting permissions of target {}", nodename))?;
     }
     smoketest_dev_null(dest_dir)?;

--- a/rust/src/builtins/scriptlet_intercept/useradd.rs
+++ b/rust/src/builtins/scriptlet_intercept/useradd.rs
@@ -53,7 +53,7 @@ pub(crate) fn entrypoint(args: &[&str]) -> Result<()> {
     if let Some(groups) = supplementary_groups {
         for group in groups {
             crate::builtins::scriptlet_intercept::usermod::generate_sysusers_fragment(
-                &rootdir, username, &group,
+                &rootdir, username, group,
             )?;
         }
     }

--- a/rust/src/builtins/usroverlay.rs
+++ b/rust/src/builtins/usroverlay.rs
@@ -8,8 +8,8 @@ use std::os::unix::prelude::CommandExt;
 /// Directly exec(ostree admin unlock) - does not return on success.
 pub fn usroverlay_entrypoint(args: &Vec<String>) -> Result<()> {
     let exec_err = std::process::Command::new("ostree")
-        .args(&["admin", "unlock"])
-        .args(args.into_iter().skip(1))
+        .args(["admin", "unlock"])
+        .args(args.iter().skip(1))
         .exec();
     // This is only reached if the `exec()` above failed; otherwise
     // execution got transferred to `ostree` at that point.

--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -138,7 +138,7 @@ impl Drop for RoFilesMount {
             return;
         };
         // We need to unmount before letting the tempdir cleanup run.
-        let success = Command::new(get_fusermount_path().unwrap().to_string())
+        let success = Command::new(get_fusermount_path().unwrap())
             .arg("-u")
             .arg(tempdir.path())
             .status()

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -177,7 +177,7 @@ pub(crate) fn client_start_daemon() -> CxxResult<()> {
     // invocations against the restart limit, so query the status
     // first.
     let activeres = Command::new("systemctl")
-        .args(&["is-active", "rpm-ostreed"])
+        .args(["is-active", "rpm-ostreed"])
         .output()?;
     // Explicitly don't check the error return value, we don't want to
     // hard fail on it.
@@ -188,11 +188,11 @@ pub(crate) fn client_start_daemon() -> CxxResult<()> {
         return Ok(());
     }
     let res = Command::new("systemctl")
-        .args(&["--no-ask-password", "start", service])
+        .args(["--no-ask-password", "start", service])
         .status()?;
     if !res.success() {
         let _ = Command::new("systemctl")
-            .args(&["--no-pager", "status", service])
+            .args(["--no-pager", "status", service])
             .status();
         return Err(anyhow!("{}", res).into());
     }

--- a/rust/src/cliwrap.rs
+++ b/rust/src/cliwrap.rs
@@ -45,7 +45,7 @@ pub fn entrypoint(args: &[&str]) -> Result<()> {
     let args = &args[2..];
     // The outer code should always pass us at least one arg.
     let name = args
-        .get(0)
+        .first()
         .copied()
         .ok_or_else(|| anyhow!("Missing required argument"))?;
     // Handle this case early, it's not like the other cliwrap bits.
@@ -89,7 +89,7 @@ fn install_to_root(args: &[&str]) -> Result<()> {
         "cliwrap is deprecated; the replacement path is to get functionality into the relevant upstream projects.",
     );
     let root = args
-        .get(0)
+        .first()
         .map(Utf8Path::new)
         .ok_or_else(|| anyhow!("Missing required argument: ROOTDIR"))?;
     let rootdir = &Dir::open_ambient_dir(root, cap_std::ambient_authority())?;

--- a/rust/src/cliwrap/kernel_install.rs
+++ b/rust/src/cliwrap/kernel_install.rs
@@ -14,7 +14,7 @@ pub(crate) fn main(argv: &[&str]) -> Result<()> {
     if !ostree_ext::container_utils::is_ostree_container()? {
         return cliutil::exec_real_binary("kernel-install", argv);
     }
-    let is_install = matches!(argv.get(0), Some(&"add"));
+    let is_install = matches!(argv.first(), Some(&"add"));
 
     let modules_path = Utf8Dir::open_ambient_dir("lib/modules", cap_std::ambient_authority())?;
     //kernel-install is called by kernel-core and kernel-modules cleanup let's make sure we just call dracut once.

--- a/rust/src/cliwrap/yumdnf.rs
+++ b/rust/src/cliwrap/yumdnf.rs
@@ -157,7 +157,7 @@ impl RebaseCmd {
 }
 
 fn run_clean(argv: &Vec<String>) -> Result<RunDisposition> {
-    let arg = if let Some(subarg) = argv.get(0) {
+    let arg = if let Some(subarg) = argv.first() {
         subarg
     } else {
         anyhow::bail!("Missing required argument");

--- a/rust/src/console_progress.rs
+++ b/rust/src/console_progress.rs
@@ -197,7 +197,7 @@ pub(crate) fn console_progress_begin_task(msg: &str) {
 pub(crate) fn console_progress_begin_n_items(msg: &str, n: u64) {
     let mut lock = PROGRESS.lock().unwrap();
     assert_empty(&lock, msg);
-    *lock = Some(ProgressState::new(msg, ProgressType::NItems(n as u64)));
+    *lock = Some(ProgressState::new(msg, ProgressType::NItems(n)));
 }
 
 pub(crate) fn console_progress_begin_percent(msg: &str) {

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -177,7 +177,7 @@ impl FilesystemScriptPrep {
     pub(crate) fn new(rootfs: Dir) -> Result<Box<Self>> {
         for &path in Self::OPTIONAL_PATHS {
             if rootfs.try_exists(path)? {
-                rootfs.rename(path, &rootfs, &Self::saved_name(path))?;
+                rootfs.rename(path, &rootfs, Self::saved_name(path))?;
             }
         }
         for &(path, contents) in Self::REPLACE_OPTIONAL_PATHS {

--- a/rust/src/cxxrsutil.rs
+++ b/rust/src/cxxrsutil.rs
@@ -39,7 +39,7 @@ pub trait FFIGObjectReWrap<'a> {
     type ReWrapped;
 
     /// Convert a glib-rs wrapper object borrowed cxx-rs type.
-    fn reborrow_cxx(&'a self) -> &Self::ReWrapped;
+    fn reborrow_cxx(&'a self) -> &'a Self::ReWrapped;
 }
 
 /// Implement FFIGObjectWrapper given a pair of wrapper type
@@ -59,7 +59,7 @@ macro_rules! impl_wrap {
         impl<'a> FFIGObjectReWrap<'a> for $bound {
             type ReWrapped = $w;
 
-            fn reborrow_cxx(&'a self) -> &Self::ReWrapped {
+            fn reborrow_cxx(&'a self) -> &'a Self::ReWrapped {
                 let p: *const $sys = self.to_glib_none().0;
                 let p = p as *const Self::ReWrapped;
                 unsafe { &*p }

--- a/rust/src/deployment_utils.rs
+++ b/rust/src/deployment_utils.rs
@@ -115,5 +115,5 @@ pub fn deployment_add_manifest_diff(
     diffv.insert("n-added", diff.n_added);
     diffv.insert("added-size", diff.added_size);
     dict.insert("manifest-diff", diffv);
-    return true;
+    true
 }

--- a/rust/src/extensions.rs
+++ b/rust/src/extensions.rs
@@ -47,15 +47,11 @@ pub struct Extension {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
+#[derive(Default)]
 enum ExtensionKind {
+    #[default]
     OsExtension,
     Development,
-}
-
-impl Default for ExtensionKind {
-    fn default() -> Self {
-        ExtensionKind::OsExtension
-    }
 }
 
 fn extensions_load_stream(

--- a/rust/src/fedora_integration.rs
+++ b/rust/src/fedora_integration.rs
@@ -230,7 +230,7 @@ fn get_base_package_list() -> Result<HashSet<String>> {
         sysroot.load(gio::Cancellable::NONE)?;
         let deployments = sysroot.deployments();
         let default = deployments
-            .get(0)
+            .first()
             .ok_or_else(|| anyhow::anyhow!("No deployments found"))?;
         let checksum = default.csum();
         let repo = sysroot.repo();

--- a/rust/src/fsutil.rs
+++ b/rust/src/fsutil.rs
@@ -27,15 +27,15 @@ impl ResolvedOstreePaths {
 /// Returns a pair of the resolved path and in the case where
 /// the path points to a symlink, it also includes the resolved
 /// symlink target.
-pub fn resolve_ostree_paths<'a>(
+pub fn resolve_ostree_paths(
     path: &Utf8Path,
     fsroot: &ostree::RepoFile,
-    cache: &'a mut HashMap<Utf8PathBuf, ResolvedOstreePaths>,
+    cache: &mut HashMap<Utf8PathBuf, ResolvedOstreePaths>,
 ) -> Option<ResolvedOstreePaths> {
     assert!(path.is_absolute());
 
     // Recurse until root
-    if path.parent() == None {
+    if path.parent().is_none() {
         return Some(ResolvedOstreePaths {
             path: fsroot.clone(),
             symlink_target: None,
@@ -48,11 +48,7 @@ pub fn resolve_ostree_paths<'a>(
     }
 
     // Resolve our parent
-    let parent = if let Some(parent) = resolve_ostree_paths(path.parent().unwrap(), fsroot, cache) {
-        parent
-    } else {
-        return None;
-    };
+    let parent = resolve_ostree_paths(path.parent().unwrap(), fsroot, cache)?;
 
     // Resolve ourselves from our parent
     let child_file = parent
@@ -113,7 +109,7 @@ pub fn resolve_ostree_paths<'a>(
         cache.insert(path.to_owned(), result.clone());
     }
 
-    return Some(result);
+    Some(result)
 }
 
 pub trait FileHelpers {

--- a/rust/src/importer.rs
+++ b/rust/src/importer.rs
@@ -338,7 +338,7 @@ fn tweak_imported_file_info(file_info: &FileInfo, ro_executables: bool) {
             // https://github.com/fedora-sysv/chkconfig/pull/67 propagates everywhere
             // and/or https://github.com/ostreedev/ostree-rs-ext/pull/182 merges.
             if target.ends_with("//sbin/chkconfig") {
-                let canonicalized = &canonicalize_path(&target);
+                let canonicalized = &canonicalize_path(target);
                 file_info.set_symlink_target(canonicalized);
             }
         }

--- a/rust/src/initramfs.rs
+++ b/rust/src/initramfs.rs
@@ -100,7 +100,7 @@ fn generate_initramfs_overlay<P: glib::IsA<gio::Cancellable>>(
     // Yeah, we need an initramfs-making crate.  See also
     // https://github.com/dracutdevs/dracut/commit/a9c6704
     let mut cmd = std::process::Command::new("/bin/bash");
-    cmd.args(&[
+    cmd.args([
         "-c",
         "set -euo pipefail; cpio --create --format newc --quiet --reproducible --null | gzip -1",
     ]);
@@ -193,11 +193,11 @@ pub(crate) fn run_dracut(kernel_dir: &str) -> Result<()> {
     let cliwrap_dracut = Utf8Path::new(crate::cliwrap::CLIWRAP_DESTDIR).join("dracut");
     let dracut_path = cliwrap_dracut
         .exists()
-        .then(|| cliwrap_dracut)
+        .then_some(cliwrap_dracut)
         .unwrap_or_else(|| Utf8Path::new("dracut").to_owned());
     // If changing this, also look at changing rpmostree-kernel.cxx
     let res = Command::new(dracut_path)
-        .args(&[
+        .args([
             "--no-hostonly",
             "--kver",
             kernel_dir,
@@ -216,7 +216,6 @@ pub(crate) fn run_dracut(kernel_dir: &str) -> Result<()> {
         ));
     }
     let f = std::fs::OpenOptions::new()
-        .write(true)
         .append(true)
         .open(&tmp_initramfs_path)?;
     crate::initramfs::append_dracut_random_cpio(f.as_raw_fd())?;

--- a/rust/src/isolation.rs
+++ b/rust/src/isolation.rs
@@ -68,7 +68,7 @@ pub(crate) fn unprivileged_subprocess(binary: &str) -> Command {
         return Command::new(binary);
     }
     let mut cmd = Command::new("setpriv");
-    cmd.args(&[
+    cmd.args([
         "--no-new-privs",
         "--init-groups",
         "--reuid",

--- a/rust/src/journal.rs
+++ b/rust/src/journal.rs
@@ -81,7 +81,7 @@ fn impl_journal_print_staging_failure() -> Result<()> {
     j.match_add("_PID", ostree_pid.as_str())?;
     j.match_add("_BOOT_ID", previous_boot_id.as_str())?;
 
-    if j.next_entry()? != None {
+    if (j.next_entry()?).is_some() {
         return Ok(()); // finished successfully!
     }
 

--- a/rust/src/kickstart.rs
+++ b/rust/src/kickstart.rs
@@ -58,14 +58,14 @@ fn filtermap_line(line: &str) -> Option<&str> {
 impl Packages {
     fn parse<'a, 'b>(
         args: impl Iterator<Item = &'b str>,
-        mut lines: impl Iterator<Item = &'a str>,
+        lines: impl Iterator<Item = &'a str>,
     ) -> Result<Self> {
         // Ensure there's an argv0
         let args = [PACKAGES].into_iter().chain(args);
         let args = PackageArgs::try_parse_from(args)?;
         let mut install = Vec::new();
         let mut excludes = Vec::new();
-        while let Some(line) = lines.next() {
+        for line in lines {
             let line = line.trim();
             if line == END {
                 return Ok(Self {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -508,7 +508,7 @@ pub mod ffi {
         type TokioEnterGuard<'a>;
 
         fn tokio_handle_get() -> Box<TokioHandle>;
-        unsafe fn enter(self: &TokioHandle) -> Box<TokioEnterGuard>;
+        fn enter(self: &TokioHandle) -> Box<TokioEnterGuard>;
     }
 
     // scripts.rs

--- a/rust/src/live.rs
+++ b/rust/src/live.rs
@@ -61,7 +61,7 @@ pub(crate) fn get_live_state(
     deploy: &ostree::Deployment,
 ) -> Result<Option<LiveApplyState>> {
     let run = Dir::open_ambient_dir("/run", cap_std::ambient_authority())?;
-    if !run.try_exists(&get_runstate_dir(deploy).join(LIVE_STATE_NAME))? {
+    if !run.try_exists(get_runstate_dir(deploy).join(LIVE_STATE_NAME))? {
         return Ok(None);
     }
     let live_commit = repo.resolve_rev(LIVE_REF, true)?;
@@ -79,7 +79,7 @@ fn write_live_state(
     state: &LiveApplyState,
 ) -> Result<()> {
     let run = Dir::open_ambient_dir("/run", cap_std::ambient_authority())?;
-    let rundir = if let Some(d) = run.open_dir_optional(&get_runstate_dir(deploy))? {
+    let rundir = if let Some(d) = run.open_dir_optional(get_runstate_dir(deploy))? {
         d
     } else {
         return Ok(());

--- a/rust/src/passwd.rs
+++ b/rust/src/passwd.rs
@@ -353,17 +353,17 @@ enum PasswdKind {
 impl PasswdKind {
     // Get user/group passwd file
     fn passwd_file(&self) -> &'static str {
-        return match *self {
+        match *self {
             PasswdKind::User => "passwd",
             PasswdKind::Group => "group",
-        };
+        }
     }
     // Get user/group shadow file
     fn shadow_file(&self) -> &'static str {
-        return match *self {
+        match *self {
             PasswdKind::User => "shadow",
             PasswdKind::Group => "gshadow",
-        };
+        }
     }
 }
 

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -95,8 +95,8 @@ fn default_container_pull_config(imgref: &OstreeImageReference) -> Result<ImageP
         // Fetching from containers-storage, may require privileges to read files
         ostree_container::merge_default_container_proxy_opts_with_isolation(&mut cfg, None)?;
     } else {
-        let isolation_systemd = crate::utils::running_in_systemd().then(|| "rpm-ostree");
-        let isolation_default = rustix::process::getuid().is_root().then(|| "nobody");
+        let isolation_systemd = crate::utils::running_in_systemd().then_some("rpm-ostree");
+        let isolation_default = rustix::process::getuid().is_root().then_some("nobody");
         let isolation_user = isolation_systemd.or(isolation_default);
         ostree_container::merge_default_container_proxy_opts_with_isolation(
             &mut cfg,

--- a/rust/src/testutils.rs
+++ b/rust/src/testutils.rs
@@ -154,7 +154,7 @@ pub(crate) fn mutate_executables_to(
 fn update_os_tree(opts: &SyntheticUpgradeOpts) -> Result<()> {
     // A new mount namespace should have been created for us
     let r = Command::new("mount")
-        .args(&["-o", "remount,rw", "/sysroot"])
+        .args(["-o", "remount,rw", "/sysroot"])
         .status()?;
     if !r.success() {
         anyhow::bail!("Failed to remount /sysroot");
@@ -196,13 +196,13 @@ fn update_os_tree(opts: &SyntheticUpgradeOpts) -> Result<()> {
     let src_ref = opts.src_ref.as_deref().unwrap_or(opts.ostref.as_str());
     let mut cmd = Command::new("ostree");
     cmd.arg(format!("--repo={}", repo_path.to_str().unwrap()))
-        .args(&["commit", "--consume", "-b"])
+        .args(["commit", "--consume", "-b"])
         .arg(opts.ostref.as_str())
         .args(&[
             format!("--base={}", src_ref),
             format!("--tree=dir={}", tmp_rootfs.to_str().unwrap()),
         ])
-        .args(&[
+        .args([
             "--owner-uid=0",
             "--owner-gid=0",
             "--selinux-policy-from-base",

--- a/rust/src/tmpfiles.rs
+++ b/rust/src/tmpfiles.rs
@@ -67,7 +67,7 @@ pub fn deduplicate_tmpfiles_entries(tmprootfs_dfd: i32) -> CxxResult<()> {
         }
 
         let perms = Permissions::from_mode(0o644);
-        tmpfiles_dir.atomic_write_with_perms(&AUTOVAR_PATH, entries.as_bytes(), perms)?;
+        tmpfiles_dir.atomic_write_with_perms(AUTOVAR_PATH, entries.as_bytes(), perms)?;
     }
     Ok(())
 }

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -183,7 +183,7 @@ where
 /// a mapping.
 pub fn decompose_sha256_nevra(v: &str) -> Result<(&str, &str)> {
     let parts: Vec<&str> = v.splitn(2, ':').collect();
-    match (parts.get(0), parts.get(1)) {
+    match (parts.first(), parts.get(1)) {
         (Some(_), None) => bail!("Missing : in {}", v),
         (Some(sha256), Some(nevra)) => {
             ostree::validate_checksum_string(sha256)?;
@@ -557,7 +557,7 @@ pub(crate) fn impl_sealed_memfd(description: &str, content: &[u8]) -> Result<Own
 
     {
         let mfd_file = mfd.as_filelike_view::<std::fs::File>();
-        (&*mfd_file).set_len(content.len() as u64)?;
+        mfd_file.set_len(content.len() as u64)?;
         (&*mfd_file).write_all(content)?;
         (&*mfd_file).seek(std::io::SeekFrom::Start(0))?;
     }


### PR DESCRIPTION
Let's do a full run to silence the clippy lints.
