### PR TITLE
ci: fix copr build Unknown argument "builddep" for command "dnf5"

### DIFF
--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -31,6 +31,8 @@ pkg_install() {
 
 pkg_builddep_spec() {
     if test -x /usr/bin/dnf5; then
+        # copr build dnf5 environment deps
+        dnf install -y 'dnf5-command(builddep)'
         dnf builddep -y "$@"
     else
         dnf builddep -y --spec "$@"


### PR DESCRIPTION
The copr build environment does not have `dnf5-command(builddep)` installed. That caused dnf builddep command error.

```
dnf -y builddep ./contrib/packaging/bootc.spec
Unknown argument "builddep" for command "dnf5". Add "--help" for more information about the arguments.
It could be a command provided by a plugin, try: dnf5 install 'dnf5-command(builddep)'
make: *** [/mnt/workdir-c4js6f0t/bootc/.copr/Makefile:5: srpm] Error 2
```

dnf5 needs dnf5-command(builddep) installed to run "dnf builddep"

The copr build error log: https://log-detective.com/contribute/copr/8427985/srpm-builds

