### PR TITLE
wip: Add experimental build-from-manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
+dependencies = [
+ "memchr",
+ "regex-automata 0.4.6",
+ "serde",
+]
+
+[[package]]
 name = "build-env"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,6 +2385,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shlex",
+ "similar-asserts",
  "system-deps 7.0.3",
  "systemd",
  "tempfile",
@@ -2602,6 +2614,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+dependencies = [
+ "bstr",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe85670573cd6f0fa97940f26e7e6601213c3b0555246c24234131f88c5709e"
+dependencies = [
+ "console",
+ "similar",
 ]
 
 [[package]]
@@ -3106,6 +3138,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,9 @@ xmlrpc = "0.15.1"
 termcolor = "1.4.1"
 shlex = "1.3.0"
 
+[dev-dependencies]
+similar-asserts = "1.6.0"
+
 [build-dependencies]
 anyhow = "1.0"
 system-deps = "7.0"

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1780,6 +1780,7 @@ struct Treefile final : public ::rust::Opaque
   ::rust::String get_gpg_key () const noexcept;
   ::rust::String get_automatic_version_suffix () const noexcept;
   bool get_container () const noexcept;
+  void assert_no_repovars () const;
   bool get_machineid_compat () const noexcept;
   ::rust::Vec< ::rust::String> get_etc_group_members () const noexcept;
   bool get_boot_location_is_modules () const noexcept;
@@ -2625,6 +2626,9 @@ extern "C"
 
   bool
   rpmostreecxx$cxxbridge1$Treefile$get_container (::rpmostreecxx::Treefile const &self) noexcept;
+
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$Treefile$assert_no_repovars (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
   bool rpmostreecxx$cxxbridge1$Treefile$get_machineid_compat (
       ::rpmostreecxx::Treefile const &self) noexcept;
@@ -5186,6 +5190,16 @@ bool
 Treefile::get_container () const noexcept
 {
   return rpmostreecxx$cxxbridge1$Treefile$get_container (*this);
+}
+
+void
+Treefile::assert_no_repovars () const
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Treefile$assert_no_repovars (*this);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
 }
 
 bool

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1557,6 +1557,7 @@ struct Treefile final : public ::rust::Opaque
   ::rust::String get_gpg_key () const noexcept;
   ::rust::String get_automatic_version_suffix () const noexcept;
   bool get_container () const noexcept;
+  void assert_no_repovars () const;
   bool get_machineid_compat () const noexcept;
   ::rust::Vec< ::rust::String> get_etc_group_members () const noexcept;
   bool get_boot_location_is_modules () const noexcept;

--- a/rust/src/cli_experimental.rs
+++ b/rust/src/cli_experimental.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use anyhow::Result;
+use camino::Utf8PathBuf;
+use clap::{Parser, ValueEnum};
+use std::fmt::Display;
+
+#[derive(Debug, Parser)]
+#[clap(rename_all = "kebab-case")]
+/// Main options struct
+struct Experimental {
+    #[clap(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Debug, clap::Subcommand)]
+#[clap(rename_all = "kebab-case")]
+/// Subcommands
+enum Cmd {
+    /// Verbs for (container) build time operations.
+    Build {
+        #[clap(subcommand)]
+        cmd: BuildCmd,
+    },
+}
+
+/// Choice of build backend.
+#[derive(Debug, Clone, Default, clap::ValueEnum)]
+enum Mechanism {
+    /// Use rpm-ostree to construct the root.
+    #[default]
+    RpmOstree,
+    /// Use dnf to construct the root.
+    Dnf,
+}
+
+impl Display for Mechanism {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.to_possible_value().unwrap().get_name().fmt(f)
+    }
+}
+
+#[derive(Debug, clap::Subcommand)]
+#[clap(rename_all = "kebab-case")]
+/// Subcommands
+enum BuildCmd {
+    /// Initialize a root filesystem tree from a set of packages,
+    /// including setting up mounts for the API filesystems.
+    ///
+    /// All configuration for rpm/dnf will come from the source root.
+    InitRootFromManifest {
+        /// Path to source root used for base rpm/dnf configuration.
+        #[clap(long, required = true)]
+        source_root: Utf8PathBuf,
+
+        /// Path to rpm-ostree treefile.
+        #[clap(long, required = true)]
+        manifest: Utf8PathBuf,
+
+        /// Path to the target root, which should not exist. However, its parent
+        /// directory must exist.
+        target: Utf8PathBuf,
+    },
+}
+
+impl BuildCmd {
+    fn run(self) -> Result<()> {
+        match self {
+            BuildCmd::InitRootFromManifest {
+                source_root,
+                manifest,
+                target,
+            } => {
+                crate::compose::build_rootfs_from_manifest(&source_root, &manifest, &target)
+            }
+        }
+    }
+}
+
+/// Primary entrypoint to running our wrapped `yum`/`dnf` handling.
+pub fn main(argv: &[&str]) -> Result<i32> {
+    let opt = Experimental::parse_from(argv.into_iter().skip(1));
+    match opt.cmd {
+        Cmd::Build { cmd } => cmd.run()?,
+    }
+    Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse() -> Result<()> {
+        let opt = Experimental::try_parse_from([
+            "experimental",
+            "build",
+            "init-root",
+            "--source-root=/blah",
+            "/rootfs",
+        ])
+        .unwrap();
+        match opt.cmd {
+            Cmd::Build {
+                cmd: BuildCmd::InitRootFromManifest { target, .. },
+            } => {
+                assert_eq!(target, "/rootfs");
+            }
+        }
+        Ok(())
+    }
+}

--- a/rust/src/cmdutils.rs
+++ b/rust/src/cmdutils.rs
@@ -1,0 +1,207 @@
+//! Helpers intended for [`std::process::Command`] and related structures.
+//! This is copied from bootc, please edit there and re-sync!
+
+use std::{
+    io::{Read, Seek},
+    os::unix::process::CommandExt,
+    process::Command,
+};
+
+use anyhow::{Context, Result};
+
+#[allow(dead_code)]
+/// Helpers intended for [`std::process::Command`].
+pub trait CommandRunExt {
+    /// Log (at debug level) the full child commandline.
+    fn log_debug(&mut self) -> &mut Self;
+
+    /// Execute the child process.
+    fn run(&mut self) -> Result<()>;
+
+    /// Ensure the child does not outlive the parent.
+    fn lifecycle_bind(&mut self) -> &mut Self;
+
+    /// Execute the child process and capture its output. This uses `run` internally
+    /// and will return an error if the child process exits abnormally.
+    fn run_get_output(&mut self) -> Result<Box<dyn std::io::BufRead>>;
+
+    /// Execute the child process, parsing its stdout as JSON. This uses `run` internally
+    /// and will return an error if the child process exits abnormally.
+    fn run_and_parse_json<T: serde::de::DeserializeOwned>(&mut self) -> Result<T>;
+}
+
+/// Helpers intended for [`std::process::ExitStatus`].
+pub trait ExitStatusExt {
+    /// If the exit status signals it was not successful, return an error.
+    /// Note that we intentionally *don't* include the command string
+    /// in the output; we leave it to the caller to add that if they want,
+    /// as it may be verbose.
+    fn check_status(&mut self, stderr: std::fs::File) -> Result<()>;
+}
+
+/// Parse the last chunk (e.g. 1024 bytes) from the provided file,
+/// ensure it's UTF-8, and return that value. This function is infallible;
+/// if the file cannot be read for some reason, a copy of a static string
+/// is returned.
+fn last_utf8_content_from_file(mut f: std::fs::File) -> String {
+    // u16 since we truncate to just the trailing bytes here
+    // to avoid pathological error messages
+    const MAX_STDERR_BYTES: u16 = 1024;
+    let size = f
+        .metadata()
+        .map_err(|e| {
+            tracing::warn!("failed to fstat: {e}");
+        })
+        .map(|m| m.len().try_into().unwrap_or(u16::MAX))
+        .unwrap_or(0);
+    let size = size.min(MAX_STDERR_BYTES);
+    let seek_offset = -(size as i32);
+    let mut stderr_buf = Vec::with_capacity(size.into());
+    // We should never fail to seek()+read() really, but let's be conservative
+    let r = match f
+        .seek(std::io::SeekFrom::End(seek_offset.into()))
+        .and_then(|_| f.read_to_end(&mut stderr_buf))
+    {
+        Ok(_) => String::from_utf8_lossy(&stderr_buf),
+        Err(e) => {
+            tracing::warn!("failed seek+read: {e}");
+            "<failed to read stderr>".into()
+        }
+    };
+    (&*r).to_owned()
+}
+
+impl ExitStatusExt for std::process::ExitStatus {
+    fn check_status(&mut self, stderr: std::fs::File) -> Result<()> {
+        let stderr_buf = last_utf8_content_from_file(stderr);
+        if self.success() {
+            return Ok(());
+        }
+        anyhow::bail!(format!("Subprocess failed: {self:?}\n{stderr_buf}"))
+    }
+}
+
+impl CommandRunExt for Command {
+    /// Synchronously execute the child, and return an error if the child exited unsuccessfully.
+    fn run(&mut self) -> Result<()> {
+        let stderr = tempfile::tempfile()?;
+        self.stderr(stderr.try_clone()?);
+        tracing::trace!("exec: {self:?}");
+        self.status()?.check_status(stderr)
+    }
+
+    #[allow(unsafe_code)]
+    fn lifecycle_bind(&mut self) -> &mut Self {
+        // SAFETY: This API is safe to call in a forked child.
+        unsafe {
+            self.pre_exec(|| {
+                rustix::process::set_parent_process_death_signal(Some(
+                    rustix::process::Signal::Term,
+                ))
+                .map_err(Into::into)
+            })
+        }
+    }
+
+    /// Output a debug-level log message with this command.
+    fn log_debug(&mut self) -> &mut Self {
+        // We unconditionally log at trace level, so avoid double logging
+        if !tracing::enabled!(tracing::Level::TRACE) {
+            tracing::debug!("exec: {self:?}");
+        }
+        self
+    }
+
+    fn run_get_output(&mut self) -> Result<Box<dyn std::io::BufRead>> {
+        let mut stdout = tempfile::tempfile()?;
+        self.stdout(stdout.try_clone()?);
+        self.run()?;
+        stdout.seek(std::io::SeekFrom::Start(0)).context("seek")?;
+        Ok(Box::new(std::io::BufReader::new(stdout)))
+    }
+
+    /// Synchronously execute the child, and parse its stdout as JSON.
+    fn run_and_parse_json<T: serde::de::DeserializeOwned>(&mut self) -> Result<T> {
+        let output = self.run_get_output()?;
+        serde_json::from_reader(output).map_err(Into::into)
+    }
+}
+
+/// Helpers intended for [`tokio::process::Command`].
+#[allow(async_fn_in_trait)]
+#[allow(dead_code)]
+pub trait AsyncCommandRunExt {
+    /// Asynchronously execute the child, and return an error if the child exited unsuccessfully.
+    async fn run(&mut self) -> Result<()>;
+}
+
+impl AsyncCommandRunExt for tokio::process::Command {
+    async fn run(&mut self) -> Result<()> {
+        let stderr = tempfile::tempfile()?;
+        self.stderr(stderr.try_clone()?);
+        self.status().await?.check_status(stderr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_run_ext() {
+        // The basics
+        Command::new("true").run().unwrap();
+        assert!(Command::new("false").run().is_err());
+
+        // Verify we capture stderr
+        let e = Command::new("/bin/sh")
+            .args(["-c", "echo expected-this-oops-message 1>&2; exit 1"])
+            .run()
+            .err()
+            .unwrap();
+        similar_asserts::assert_eq!(
+            e.to_string(),
+            "Subprocess failed: ExitStatus(unix_wait_status(256))\nexpected-this-oops-message\n"
+        );
+
+        // Ignoring invalid UTF-8
+        let e = Command::new("/bin/sh")
+            .args([
+                "-c",
+                r"echo -e 'expected\xf5\x80\x80\x80\x80-foo\xc0bar\xc0\xc0' 1>&2; exit 1",
+            ])
+            .run()
+            .err()
+            .unwrap();
+        similar_asserts::assert_eq!(
+            e.to_string(),
+            "Subprocess failed: ExitStatus(unix_wait_status(256))\nexpected�����-foo�bar��\n"
+        );
+    }
+
+    #[test]
+    fn command_run_ext_json() {
+        #[derive(serde::Deserialize)]
+        struct Foo {
+            a: String,
+            b: u32,
+        }
+        let v: Foo = Command::new("echo")
+            .arg(r##"{"a": "somevalue", "b": 42}"##)
+            .run_and_parse_json()
+            .unwrap();
+        assert_eq!(v.a, "somevalue");
+        assert_eq!(v.b, 42);
+    }
+
+    #[tokio::test]
+    async fn async_command_run_ext() {
+        use tokio::process::Command as AsyncCommand;
+        let mut success = AsyncCommand::new("true");
+        let mut fail = AsyncCommand::new("false");
+        // Run these in parallel just because we can
+        let (success, fail) = tokio::join!(success.run(), fail.run(),);
+        success.unwrap();
+        assert!(fail.is_err());
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -16,6 +16,7 @@
 #![allow(clippy::ptr_arg)]
 
 // pub(crate) utilities
+mod cmdutils;
 mod cxxrsutil;
 mod ffiutil;
 pub(crate) mod ffiwrappers;
@@ -624,6 +625,7 @@ pub mod ffi {
         fn get_gpg_key(&self) -> String;
         fn get_automatic_version_suffix(&self) -> String;
         fn get_container(&self) -> bool;
+        fn assert_no_repovars(&self) -> Result<()>;
         fn get_machineid_compat(&self) -> bool;
         fn get_etc_group_members(&self) -> Vec<String>;
         fn get_boot_location_is_modules(&self) -> bool;
@@ -971,6 +973,7 @@ pub(crate) use composepost::*;
 mod core;
 use crate::core::*;
 mod capstdext;
+pub mod cli_experimental;
 mod daemon;
 pub(crate) use daemon::*;
 mod deployment_utils;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -41,6 +41,9 @@ async fn inner_async_main(args: Vec<String>) -> Result<i32> {
                     rpmostree_rust::container::container_encapsulate(args_orig).map(|_| 0)
                     .map_err(anyhow::Error::msg)
                 },
+                "experimental" => {
+                    rpmostree_rust::cli_experimental::main(args)
+                }
                 // C++ main
                 _ => Ok(rpmostree_rust::ffi::rpmostree_main(args)?),
             }

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1345,6 +1345,16 @@ impl Treefile {
         self.parsed.base.container.unwrap_or(false)
     }
 
+    // --source-root and repovars conflict
+    pub(crate) fn assert_no_repovars(&self) -> Result<()> {
+        if let Some(v) = self.parsed.repovars.as_ref() {
+            if !v.is_empty() {
+                anyhow::bail!("Cannot use repovars with source root")
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) fn get_machineid_compat(&self) -> bool {
         self.parsed.base.machineid_compat.unwrap_or(true)
     }

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -324,8 +324,11 @@ install_packages (RpmOstreeTreeComposeContext *self, gboolean *out_unmodified,
     rpmlogSetFile (NULL);
   }
 
-  if (!set_repos_dir (dnfctx, **self->treefile_rs, self->workdir_dfd, cancellable, error))
-    return FALSE;
+  if (!opt_source_root)
+    {
+      if (!set_repos_dir (dnfctx, **self->treefile_rs, self->workdir_dfd, cancellable, error))
+        return FALSE;
+    }
 
   /* By default, retain packages in addition to metadata with --cachedir, unless
    * we're doing unified core, in which case the pkgcache repo is the cache.

--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -324,7 +324,12 @@ install_packages (RpmOstreeTreeComposeContext *self, gboolean *out_unmodified,
     rpmlogSetFile (NULL);
   }
 
-  if (!opt_source_root)
+  if (opt_source_root)
+    {
+      CXX_TRY((*self->treefile_rs)->assert_no_repovars(), error);
+      g_debug ("source root set, validated no repovars");
+    }
+  else
     {
       if (!set_repos_dir (dnfctx, **self->treefile_rs, self->workdir_dfd, cancellable, error))
         return FALSE;

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -668,6 +668,11 @@ rpmostree_context_setup (RpmOstreeContext *self, const char *install_root, const
 
   dnf_context_set_install_root (self->dnfctx, install_root);
   dnf_context_set_source_root (self->dnfctx, source_root);
+  if (source_root)
+    {
+      g_autofree char *reposdir = g_build_filename (source_root, "etc/yum.repos.d", NULL);
+      dnf_context_set_repo_dir (self->dnfctx, reposdir);
+    }
 
   /* Hackaround libdnf logic, ensuring that `/etc/dnf/vars` gets sourced
    * from the host environment instead of the install_root:


### PR DESCRIPTION

Part of work on https://gitlab.com/fedora/bootc/tracker/-/issues/32

Basically here we're trying to make it more "first class"
to generate a base rootfs from the existing treefiles, which can
then be further mutated however (e.g. `RUN dnf --installroot=/rootfs`)
in a container build.