### PR TITLE
tree-wide: Import and use cmdutils from bootc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
+dependencies = [
+ "memchr",
+ "regex-automata 0.4.6",
+ "serde",
+]
+
+[[package]]
 name = "build-env"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,6 +2385,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shlex",
+ "similar-asserts",
  "system-deps 7.0.3",
  "systemd",
  "tempfile",
@@ -2602,6 +2614,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+dependencies = [
+ "bstr",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe85670573cd6f0fa97940f26e7e6601213c3b0555246c24234131f88c5709e"
+dependencies = [
+ "console",
+ "similar",
 ]
 
 [[package]]
@@ -3106,6 +3138,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,9 @@ xmlrpc = "0.15.1"
 termcolor = "1.4.1"
 shlex = "1.3.0"
 
+[dev-dependencies]
+similar-asserts = "1.6.0"
+
 [build-dependencies]
 anyhow = "1.0"
 system-deps = "7.0"

--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -2,6 +2,7 @@
 
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use crate::cmdutils::CommandRunExt;
 use crate::cxxrsutil::*;
 use crate::ffi::BubblewrapMutability;
 use crate::normalization;
@@ -99,10 +100,7 @@ impl RoFilesMount {
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
             });
         }
-        let status = c.status()?;
-        if !status.success() {
-            return Err(anyhow::anyhow!("{}", status));
-        }
+        c.run()?;
         Ok(Self {
             tempdir: Some(tempdir),
         })

--- a/rust/src/cmdutils.rs
+++ b/rust/src/cmdutils.rs
@@ -1,0 +1,209 @@
+//! Helpers intended for [`std::process::Command`] and related structures.
+//! This is copied from bootc, please edit there and re-sync!
+
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::{
+    io::{Read, Seek},
+    os::unix::process::CommandExt,
+    process::Command,
+};
+
+use anyhow::{Context, Result};
+
+#[allow(dead_code)]
+/// Helpers intended for [`std::process::Command`].
+pub trait CommandRunExt {
+    /// Log (at debug level) the full child commandline.
+    fn log_debug(&mut self) -> &mut Self;
+
+    /// Execute the child process.
+    fn run(&mut self) -> Result<()>;
+
+    /// Ensure the child does not outlive the parent.
+    fn lifecycle_bind(&mut self) -> &mut Self;
+
+    /// Execute the child process and capture its output. This uses `run` internally
+    /// and will return an error if the child process exits abnormally.
+    fn run_get_output(&mut self) -> Result<Box<dyn std::io::BufRead>>;
+
+    /// Execute the child process, parsing its stdout as JSON. This uses `run` internally
+    /// and will return an error if the child process exits abnormally.
+    fn run_and_parse_json<T: serde::de::DeserializeOwned>(&mut self) -> Result<T>;
+}
+
+/// Helpers intended for [`std::process::ExitStatus`].
+pub trait ExitStatusExt {
+    /// If the exit status signals it was not successful, return an error.
+    /// Note that we intentionally *don't* include the command string
+    /// in the output; we leave it to the caller to add that if they want,
+    /// as it may be verbose.
+    fn check_status(&mut self, stderr: std::fs::File) -> Result<()>;
+}
+
+/// Parse the last chunk (e.g. 1024 bytes) from the provided file,
+/// ensure it's UTF-8, and return that value. This function is infallible;
+/// if the file cannot be read for some reason, a copy of a static string
+/// is returned.
+fn last_utf8_content_from_file(mut f: std::fs::File) -> String {
+    // u16 since we truncate to just the trailing bytes here
+    // to avoid pathological error messages
+    const MAX_STDERR_BYTES: u16 = 1024;
+    let size = f
+        .metadata()
+        .map_err(|e| {
+            tracing::warn!("failed to fstat: {e}");
+        })
+        .map(|m| m.len().try_into().unwrap_or(u16::MAX))
+        .unwrap_or(0);
+    let size = size.min(MAX_STDERR_BYTES);
+    let seek_offset = -(size as i32);
+    let mut stderr_buf = Vec::with_capacity(size.into());
+    // We should never fail to seek()+read() really, but let's be conservative
+    let r = match f
+        .seek(std::io::SeekFrom::End(seek_offset.into()))
+        .and_then(|_| f.read_to_end(&mut stderr_buf))
+    {
+        Ok(_) => String::from_utf8_lossy(&stderr_buf),
+        Err(e) => {
+            tracing::warn!("failed seek+read: {e}");
+            "<failed to read stderr>".into()
+        }
+    };
+    (&*r).to_owned()
+}
+
+impl ExitStatusExt for std::process::ExitStatus {
+    fn check_status(&mut self, stderr: std::fs::File) -> Result<()> {
+        let stderr_buf = last_utf8_content_from_file(stderr);
+        if self.success() {
+            return Ok(());
+        }
+        anyhow::bail!(format!("Subprocess failed: {self:?}\n{stderr_buf}"))
+    }
+}
+
+impl CommandRunExt for Command {
+    /// Synchronously execute the child, and return an error if the child exited unsuccessfully.
+    fn run(&mut self) -> Result<()> {
+        let stderr = tempfile::tempfile()?;
+        self.stderr(stderr.try_clone()?);
+        tracing::trace!("exec: {self:?}");
+        self.status()?.check_status(stderr)
+    }
+
+    #[allow(unsafe_code)]
+    fn lifecycle_bind(&mut self) -> &mut Self {
+        // SAFETY: This API is safe to call in a forked child.
+        unsafe {
+            self.pre_exec(|| {
+                rustix::process::set_parent_process_death_signal(Some(
+                    rustix::process::Signal::Term,
+                ))
+                .map_err(Into::into)
+            })
+        }
+    }
+
+    /// Output a debug-level log message with this command.
+    fn log_debug(&mut self) -> &mut Self {
+        // We unconditionally log at trace level, so avoid double logging
+        if !tracing::enabled!(tracing::Level::TRACE) {
+            tracing::debug!("exec: {self:?}");
+        }
+        self
+    }
+
+    fn run_get_output(&mut self) -> Result<Box<dyn std::io::BufRead>> {
+        let mut stdout = tempfile::tempfile()?;
+        self.stdout(stdout.try_clone()?);
+        self.run()?;
+        stdout.seek(std::io::SeekFrom::Start(0)).context("seek")?;
+        Ok(Box::new(std::io::BufReader::new(stdout)))
+    }
+
+    /// Synchronously execute the child, and parse its stdout as JSON.
+    fn run_and_parse_json<T: serde::de::DeserializeOwned>(&mut self) -> Result<T> {
+        let output = self.run_get_output()?;
+        serde_json::from_reader(output).map_err(Into::into)
+    }
+}
+
+/// Helpers intended for [`tokio::process::Command`].
+#[allow(async_fn_in_trait)]
+#[allow(dead_code)]
+pub trait AsyncCommandRunExt {
+    /// Asynchronously execute the child, and return an error if the child exited unsuccessfully.
+    async fn run(&mut self) -> Result<()>;
+}
+
+impl AsyncCommandRunExt for tokio::process::Command {
+    async fn run(&mut self) -> Result<()> {
+        let stderr = tempfile::tempfile()?;
+        self.stderr(stderr.try_clone()?);
+        self.status().await?.check_status(stderr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_run_ext() {
+        // The basics
+        Command::new("true").run().unwrap();
+        assert!(Command::new("false").run().is_err());
+
+        // Verify we capture stderr
+        let e = Command::new("/bin/sh")
+            .args(["-c", "echo expected-this-oops-message 1>&2; exit 1"])
+            .run()
+            .err()
+            .unwrap();
+        similar_asserts::assert_eq!(
+            e.to_string(),
+            "Subprocess failed: ExitStatus(unix_wait_status(256))\nexpected-this-oops-message\n"
+        );
+
+        // Ignoring invalid UTF-8
+        let e = Command::new("/bin/sh")
+            .args([
+                "-c",
+                r"echo -e 'expected\xf5\x80\x80\x80\x80-foo\xc0bar\xc0\xc0' 1>&2; exit 1",
+            ])
+            .run()
+            .err()
+            .unwrap();
+        similar_asserts::assert_eq!(
+            e.to_string(),
+            "Subprocess failed: ExitStatus(unix_wait_status(256))\nexpected�����-foo�bar��\n"
+        );
+    }
+
+    #[test]
+    fn command_run_ext_json() {
+        #[derive(serde::Deserialize)]
+        struct Foo {
+            a: String,
+            b: u32,
+        }
+        let v: Foo = Command::new("echo")
+            .arg(r##"{"a": "somevalue", "b": 42}"##)
+            .run_and_parse_json()
+            .unwrap();
+        assert_eq!(v.a, "somevalue");
+        assert_eq!(v.b, 42);
+    }
+
+    #[tokio::test]
+    async fn async_command_run_ext() {
+        use tokio::process::Command as AsyncCommand;
+        let mut success = AsyncCommand::new("true");
+        let mut fail = AsyncCommand::new("false");
+        // Run these in parallel just because we can
+        let (success, fail) = tokio::join!(success.run(), fail.run(),);
+        success.unwrap();
+        assert!(fail.is_err());
+    }
+}

--- a/rust/src/initramfs.rs
+++ b/rust/src/initramfs.rs
@@ -1,8 +1,9 @@
 //! Generate an "overlay" initramfs image
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use crate::cmdutils::CommandRunExt;
 use crate::cxxrsutil::*;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use camino::Utf8Path;
 use cap_std::fs::Dir;
 use cap_std::io_lifetimes::AsFilelike;
@@ -195,7 +196,7 @@ pub(crate) fn run_dracut(root_fs: &Dir, kernel_dir: &str) -> Result<()> {
         .then_some(cliwrap_dracut)
         .unwrap_or_else(|| Utf8Path::new("dracut").to_owned());
     // If changing this, also look at changing rpmostree-kernel.cxx
-    let res = Command::new(dracut_path)
+    Command::new(dracut_path)
         .args([
             "--no-hostonly",
             "--kver",
@@ -207,13 +208,7 @@ pub(crate) fn run_dracut(root_fs: &Dir, kernel_dir: &str) -> Result<()> {
             "-f",
         ])
         .arg(&tmp_initramfs_path)
-        .status()?;
-    if !res.success() {
-        return Err(anyhow!(
-            "Failed to generate initramfs (via dracut) for kernel: {kernel_dir}: {:?}",
-            res
-        ));
-    }
+        .run()?;
     let f = std::fs::OpenOptions::new()
         .append(true)
         .open(&tmp_initramfs_path)?;

--- a/rust/src/kernel_install.rs
+++ b/rust/src/kernel_install.rs
@@ -22,6 +22,8 @@ use cap_std_ext::cap_std;
 use cap_std_ext::dirext::CapStdExtDirExt;
 use fn_error_context::context;
 
+use crate::cmdutils::CommandRunExt;
+
 /// Parsed by kernel-install and set in the environment
 const LAYOUT_VAR: &str = "KERNEL_INSTALL_LAYOUT";
 /// The value we expect to find for layout
@@ -65,13 +67,10 @@ fn add(root: &Dir, argv: &[&str]) -> Result<()> {
     println!("Generating initramfs");
     crate::initramfs::run_dracut(root, &kver)?;
     println!("Running depmod");
-    let st = Command::new("depmod")
+    Command::new("depmod")
         .args(["-a", kver])
-        .status()
+        .run()
         .context("Invoking depmod")?;
-    if !st.success() {
-        anyhow::bail!("Failed to run depmod: {st:?}");
-    }
     Ok(())
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -16,6 +16,7 @@
 #![allow(clippy::ptr_arg)]
 
 // pub(crate) utilities
+mod cmdutils;
 mod cxxrsutil;
 mod ffiutil;
 pub(crate) mod ffiwrappers;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -19,6 +19,7 @@
  * - Add a test case in tests/compose
  */
 
+use crate::cmdutils::CommandRunExt;
 use crate::cxxrsutil::*;
 use anyhow::{anyhow, bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -831,13 +832,7 @@ impl Treefile {
     pub(crate) fn exec_finalize_d(&self, rootfs: &Dir) -> Result<()> {
         for (name, path) in self.externals.finalize_d.iter() {
             println!("Executing: {name}");
-            let st = Command::new(path)
-                .cwd_dir(rootfs.try_clone()?)
-                .status()
-                .with_context(|| format!("exec {path:?}"))?;
-            if !st.success() {
-                anyhow::bail!("finalize.d {name} failed: {st:?}");
-            }
+            Command::new(path).cwd_dir(rootfs.try_clone()?).run()?;
         }
         Ok(())
     }


### PR DESCRIPTION
The `.run()` helper here avoids a lot of duplicate/repetitive code, *and* we handle stderr in a much better way.

This is a general cleanup, but also prep specifically for adding more command invocations.
