### PR TITLE
Add `rpm-ostree experimental`

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -50,6 +50,10 @@ if ! grep -qe "error.*This system was not booted via libostree" err.txt; then
     fatal "did not find expected error"
 fi
 
+# This does nothing, just verifies the experimental CLI works.
+rpm-ostree experimental stub >out.txt
+grep 'Did nothing successfully' out.txt && rm out.txt
+
 rpm-ostree install testdaemon
 grep -qF 'u testdaemon-user' /usr/lib/sysusers.d/35-rpmostree-pkg-user-testdaemon-user.conf
 grep -qF 'g testdaemon-group' /usr/lib/sysusers.d/30-rpmostree-pkg-group-testdaemon-group.conf

--- a/rust/src/cli_experimental.rs
+++ b/rust/src/cli_experimental.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use anyhow::Result;
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[clap(rename_all = "kebab-case")]
+/// Main options struct
+struct Experimental {
+    #[clap(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Debug, clap::Subcommand)]
+#[clap(rename_all = "kebab-case")]
+/// Subcommands
+enum Cmd {
+    /// This command does nothing, it's a placeholder for future expansion.
+    #[clap(hide = true)]
+    Stub,
+}
+
+impl Cmd {
+    fn run(self) -> Result<()> {
+        match self {
+            Cmd::Stub => println!("Did nothing successfully."),
+        }
+        Ok(())
+    }
+}
+
+/// Primary entrypoint to running our wrapped `yum`/`dnf` handling.
+pub fn main(argv: &[&str]) -> Result<i32> {
+    let opt = Experimental::parse_from(argv.into_iter().skip(1));
+    opt.cmd.run()?;
+    Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse() -> Result<()> {
+        let opt = Experimental::try_parse_from(["experimental", "stub"]).unwrap();
+        match opt.cmd {
+            Cmd::Stub => {}
+        }
+        Ok(())
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -971,6 +971,7 @@ pub(crate) use composepost::*;
 mod core;
 use crate::core::*;
 mod capstdext;
+pub mod cli_experimental;
 mod daemon;
 pub(crate) use daemon::*;
 mod deployment_utils;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -41,6 +41,9 @@ async fn inner_async_main(args: Vec<String>) -> Result<i32> {
                     rpmostree_rust::container::container_encapsulate(args_orig).map(|_| 0)
                     .map_err(anyhow::Error::msg)
                 },
+                "experimental" => {
+                    rpmostree_rust::cli_experimental::main(args)
+                }
                 // C++ main
                 _ => Ok(rpmostree_rust::ffi::rpmostree_main(args)?),
             }


### PR DESCRIPTION
We already have `rpm-ostree ex` which is the same thing. However, adding things to that requires touching C code, which we often immediately turn back around and have invoke Rust, which is super annoying to juggle.

This CLI code is Rust from the start which makes adding commands more ergonomic.

For now this is just a placeholder.
