### PR TITLE
ci: Use `cargo install --locked`

### DIFF
--- a/.github/workflows/autovendor.yml
+++ b/.github/workflows/autovendor.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - name: Install vendor tool
-        run: cargo install cargo-vendor-filterer
+        run: cargo install --locked cargo-vendor-filterer
       - name: Run
         run: mkdir -p target && cargo vendor-filterer --format=tar.zstd --prefix=vendor/ target/vendor.tar.zst
       - uses: actions/upload-artifact@v4

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -20,4 +20,4 @@ if [ -z "${SKIP_INSTALLDEPS:-}" ] && test $(id -u) -eq 0; then
 fi
 
 mkdir -p target
-time cargo install --root=target/cargo-vendor-filterer cargo-vendor-filterer --version ^0.5
+time cargo install --locked --root=target/cargo-vendor-filterer cargo-vendor-filterer --version ^0.5


### PR DESCRIPTION
To avoid issues like https://github.com/coreos/cargo-vendor-filterer/issues/110
