### PR TITLE
daemon/upgrader: Print OSTree signature verification text when pulling OCI

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1443,6 +1443,7 @@ struct ContainerImageState final
   ::rust::String image_digest;
   ::rust::String version;
   ::rpmostreecxx::ExportedManifestDiff cached_update_diff;
+  ::rust::String verify_text;
 
   using IsRelocatable = ::std::true_type;
 };

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1220,6 +1220,7 @@ struct ContainerImageState final
   ::rust::String image_digest;
   ::rust::String version;
   ::rpmostreecxx::ExportedManifestDiff cached_update_diff;
+  ::rust::String verify_text;
 
   using IsRelocatable = ::std::true_type;
 };

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -191,6 +191,7 @@ pub mod ffi {
         pub image_digest: String,
         pub version: String,
         pub cached_update_diff: ExportedManifestDiff,
+        pub verify_text: String,
     }
 
     #[derive(Debug, Default)]

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -37,6 +37,7 @@ impl From<Box<ostree_container::store::LayeredImageState>> for crate::ffi::Conta
             image_digest: s.manifest_digest.to_string(),
             version,
             cached_update_diff,
+            verify_text: s.verify_text.unwrap_or_default(),
         }
     }
 }

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -449,6 +449,8 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader *self, const char
                 rpmostreecxx::pull_container (*self->repo, *cancellable, r.refspec.c_str ()),
                 error);
 
+            if (!import->verify_text.empty ())
+              rpmostree_output_message ("%s", import->verify_text.c_str ());
             new_base_rev = g_strdup (import->merge_commit.c_str ());
           }
         break;


### PR DESCRIPTION
If using OSTree remote signature verification for an OCI pull, print the verification text we get from ostree-ext.

Requires: https://github.com/containers/bootc/pull/1028