### PR TITLE
libpriv/rpm: Always copy rpmdb even in user mode checkouts

### DIFF
--- a/src/libpriv/rpmostree-rpm-util.cxx
+++ b/src/libpriv/rpmostree-rpm-util.cxx
@@ -814,6 +814,11 @@ checkout_only_rpmdb (OstreeRepo *repo, const char *ref, const char *rpmdb, GLnxT
     (OstreeRepoCheckoutMode)0,
   };
   checkout_options.mode = OSTREE_REPO_CHECKOUT_MODE_USER;
+  /* If the input repo is bare-user, then we'll just get hardlinks, which means
+   * that rpm interacting with it may end up *writing* to it (e.g. the sqlite shm files).
+   * Force a copy so that even if we're operating on bare-user we won't corrupt the repo.
+   */
+  checkout_options.force_copy = TRUE;
   const char *subpath = glnx_strjoina ("/", rpmdb);
   checkout_options.subpath = subpath;
   if (!ostree_repo_checkout_at (repo, &checkout_options, tmpdir->fd, RPMOSTREE_RPMDB_LOCATION,


### PR DESCRIPTION
I'm working on doing container reencapsulation and using a user-mode repo and got burned by the hardlinking here and rpm always *writing* to the repo even when reading it.

Most systems we care about have reflinks so it's cheap. And in practice most usage of this before was actually checking out from bare (not bare-user) repos, so we were copying anyways.
