### PR TITLE
Use ostree-ext from bootc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "bootc-utils"
+version = "0.0.0"
+source = "git+https://github.com/containers/bootc?rev=dc7d4cf320ec6d8b2470d1d5f76da66ec60b6810#dc7d4cf320ec6d8b2470d1d5f76da66ec60b6810"
+dependencies = [
+ "anyhow",
+ "rustix",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "bstr"
 version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +264,9 @@ name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cap-primitives"
@@ -299,6 +316,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffa1c0edc4958d742bab2e903e52f93ccee482072680e08d6ce0784873e65b1"
 dependencies = [
+ "camino",
  "cap-std",
  "rand",
  "rustix",
@@ -429,6 +447,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "comfy-table"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
+dependencies = [
+ "crossterm",
+ "strum",
+ "strum_macros",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "console"
 version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +568,28 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.8.0",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -1772,6 +1824,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,14 +2128,15 @@ dependencies = [
 [[package]]
 name = "ostree-ext"
 version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3749ad9f089cd49975c43d4e510888f7063a7b2339265f15f165a0b8b2268a5c"
+source = "git+https://github.com/containers/bootc?rev=dc7d4cf320ec6d8b2470d1d5f76da66ec60b6810#dc7d4cf320ec6d8b2470d1d5f76da66ec60b6810"
 dependencies = [
  "anyhow",
+ "bootc-utils",
  "camino",
  "cap-std-ext",
  "chrono",
  "clap",
+ "comfy-table",
  "containers-image-proxy",
  "flate2",
  "fn-error-context",
@@ -2097,7 +2160,6 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
- "terminal_size",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2123,6 +2185,29 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "paste"
@@ -2698,6 +2783,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "scratch"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3096,16 +3187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
-dependencies = [
- "rustix",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,8 @@ nix = { version = "0.29.0", features = ["fs", "mount", "signal", "user"] }
 openssl = "0.10.68"
 once_cell = "1.20.2"
 os-release = "0.1.0"
-ostree-ext = "0.15"
+# We pull this one from git, as the project is no longer published as an external crate.
+ostree-ext = { git = "https://github.com/containers/bootc", rev = "dc7d4cf320ec6d8b2470d1d5f76da66ec60b6810" }
 paste = "1.0"
 phf = { version = "0.11", features = ["macros"] }
 rand = "0.8.5"

--- a/deny.toml
+++ b/deny.toml
@@ -12,4 +12,4 @@ name = "ring"
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-git = []
+allow-git = ["https://github.com/containers/bootc"]

--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -199,6 +199,8 @@ export RUSTFLAGS="%{build_rustflags}"
 %cargo_license_summary
 %{cargo_license} > LICENSE.dependencies
 %cargo_vendor_manifest
+# https://pagure.io/fedora-rust/rust-packaging/issue/33
+sed -i -e '/https:\/\//d' cargo-vendor.txt
 %endif
 
 %install

--- a/rust/src/sysroot_upgrade.rs
+++ b/rust/src/sysroot_upgrade.rs
@@ -127,10 +127,7 @@ async fn pull_container_async(
     };
     let digest = prep.manifest_digest.clone();
     output_message(&format!("Importing: {} (digest: {})", &imgref, &digest));
-    let ostree_layers = prep
-        .ostree_layers
-        .iter()
-        .chain(std::iter::once(&prep.ostree_commit_layer));
+    let ostree_layers = prep.ostree_layers.iter().chain(&prep.ostree_commit_layer);
     let mut total_to_fetch = 0;
     let (stored, (n_to_fetch, size_to_fetch)) = layer_counts(ostree_layers);
     if stored > 0 {


### PR DESCRIPTION
Depends: https://github.com/coreos/rpm-ostree/pull/5226

The idea is ostree-ext is deprecated in favor of bootc; however
we still directly use it here, and fixing that is going to take
a while longer than I thought.

Switch to pulling a pinned version from bootc's git, so
at least we don't need to maintain a formal crate for it
and think about API stability.