### PR TITLE
Release 2025.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,8 +2,8 @@ AC_PREREQ([2.63])
 dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
-m4_define([year_version], [2024])
-m4_define([release_version], [9])
+m4_define([year_version], [2025])
+m4_define([release_version], [1])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2024.9
+Version: 2025.1
 Release: 1%{?dist}
 License: LGPL-2.0-or-later
 URL: https://github.com/coreos/rpm-ostree


### PR DESCRIPTION
```
Alex Haydock (1):
      Update timer to be more in-line with dnf-automatic

Colin Walters (13):
      packaging: Add a bcond without ostree_ext
      tree-wide: `cargo clippy --fix` + a few manual warning fixes
      core: stop wrapping kernel-install when layout=ostree is set
      packaging/Dockerfile: This is long since dead
      cliwrap: use `const` over `static`
      ci: Use `cargo install --locked`
      Add `rpm-ostree experimental`
      tree-wide: Import and use cmdutils from bootc
      core: Create usr/sbin -> bin if we detect merged sbin filesystem
      Cargo.lock: Update(*)
      Fix use of deprecated GString::to_str()
      Cargo.lock: Downgrade cxx to avoid missing cxxbridge-cmd during vendoring
      deny.toml: Update allowed licenses

Joseph Marrero Corchado (3):
      docs: Add debug.md
      src/libpriv: Add kernel-install-integration
      Release 2025.1

Xiaofeng Wang (1):
      ci: fix copr build Unknown argument "builddep" for command "dnf5"
```

## New Contributors

* @alexhaydock made their first contribution in https://github.com/coreos/rpm-ostree/pull/5183
* @henrywang made their first contribution in https://github.com/coreos/rpm-ostree/pull/5202

**Full Changelog**: https://github.com/coreos/rpm-ostree/compare/v2024.9...v2025.1
