### PR TITLE
copr: fix "No matching package to install: 'rust-packaging'" in

### DIFF
--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -19,9 +19,13 @@ ExcludeArch:    %{ix86}
 %endif
 
 BuildRequires: make
+%if 0%{?rhel}
+BuildRequires: rust-toolset
+%else
 BuildRequires: rust-packaging
 BuildRequires: cargo
 BuildRequires: rust
+%endif
 
 # Enable ASAN + UBSAN
 %bcond_with sanitizers


### PR DESCRIPTION
`rpm-ostree` copr build failed on RHEL and CentOS Stream with error `No matching package to install: 'rust-packaging'`. This PR is to fix this issue.
