### PR TITLE
spec: Add version conditionals

### DIFF
--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -27,8 +27,14 @@ BuildRequires: rust
 %bcond_with sanitizers
 # Embedded unit tests
 %bcond_with bin_unit_tests
-# Don't add the ostree-container binaries
-%bcond_without ostree_ext
+
+# Don't add the ostree-container binaries; this version
+# conditional needs to be kept in sync with the bootc one.
+%if 0%{?rhel} >= 10 || 0%{?fedora} > 41
+    %bcond_with ostree_ext
+%else
+    %bcond_without ostree_ext
+%endif
 
 # This is copied from the libdnf spec
 %if 0%{?rhel} && ! 0%{?centos}


### PR DESCRIPTION
This should fix https://github.com/containers/bootc/issues/1033 by ensuring the copr builds use the same logic.

(It's so annoying that we have default branching on packages,
 but keeping them in sync is so annoying in general that
 we end up merging, which defeats the reason for having branches
 at all, and so we end up with these version conditionals anyways)
