### PR TITLE
core/cliwrap: Fix is_ostree_layout() in unit tests

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -192,7 +192,7 @@ impl FilesystemScriptPrep {
                 rootfs.atomic_write_with_perms(path, contents, mode)?;
             }
         }
-        if !is_ostree_layout()? {
+        if !is_ostree_layout(&rootfs)? {
             for &(path, contents) in Self::REPLACE_KERNEL_PATHS {
                 let mode = Permissions::from_mode(0o755);
                 let saved = &Self::saved_name(path);
@@ -217,6 +217,7 @@ impl FilesystemScriptPrep {
         for &path in Self::OPTIONAL_PATHS
             .iter()
             .chain(Self::REPLACE_OPTIONAL_PATHS.iter().map(|x| &x.0))
+            .chain(Self::REPLACE_KERNEL_PATHS.iter().map(|x| &x.0))
         {
             let saved = &Self::saved_name(path);
             if self.rootfs.try_exists(saved)? {
@@ -486,7 +487,7 @@ mod test {
         }
         // Replaced kernel-install.
         {
-            if !is_ostree_layout()? {
+            if !is_ostree_layout(&d)? {
                 let original_kernel_install = "original kernel_install";
                 d.atomic_write_with_perms(
                     super::KERNEL_INSTALL_PATH,


### PR DESCRIPTION
The `is_ostree_layout()` function parsed the real root filesystem. But we started using it in *unit tests* which creates unpredictable behavior.

The unit test for the core script wrapping was failing for me, and digging in I don't see how it could have ever passed. I don't think we're actually running the Rust tests in CI...need to dig into that.

- Change `is_ostree_layout` to take a cap-std root
- Add a unit test for it alone
- Change all users to pass the rootfs
- Fix the `undo()` method to undo the kernel-install wrapping correctly

With this the unit test passes again, and we shouldn't have any behavior which depends on the development root.
