### PR TITLE
compose: Drop rpmdb sqlite journaling files if rpmdb-normalize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +866,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,12 +1272,24 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1774,6 +1810,16 @@ dependencies = [
  "bitflags 2.8.0",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2677,6 +2723,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.12",
  "rpmostree-client",
+ "rusqlite",
  "rust-ini",
  "rustix",
  "serde",
@@ -2693,6 +2740,20 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "xmlrpc",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.8.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ phf = { version = "0.11", features = ["macros"] }
 rand = "0.8.5"
 rayon = "1.10.0"
 regex = "1.10"
+rusqlite = "0.32.1"
 reqwest = { version = "0.12", features = ["native-tls", "blocking", "gzip"] }
 rpmostree-client = { path = "rust/rpmostree-client", version = "0.1.0" }
 rust-ini = "0.21.1"

--- a/tests/compose/libbasic-test.sh
+++ b/tests/compose/libbasic-test.sh
@@ -43,6 +43,8 @@ echo "ok etc/default/useradd"
 for path in /usr/share/rpm /usr/lib/sysimage/rpm-ostree-base-db; do
     ostree --repo=${repo} ls -R ${treeref} ${path} > db.txt
     assert_file_has_content_literal db.txt rpmdb.sqlite
+    # Verify we *aren't* normalizing yet
+    assert_file_has_content_literal db.txt rpmdb.sqlite-shm
 done
 ostree --repo=${repo} ls ${treeref} /usr/lib/sysimage/rpm >/dev/null
 echo "ok db"

--- a/tests/compose/test-misc-tweaks.sh
+++ b/tests/compose/test-misc-tweaks.sh
@@ -50,6 +50,7 @@ cat > config/other.yaml <<'EOF'
 recommends: true
 selinux-label-version: 1
 readonly-executables: true
+rpmdb-normalize: true
 container-cmd:
   - /usr/bin/bash
 opt-usrlocal: "root"
@@ -187,6 +188,12 @@ assert_not_file_has_content out.txt 'bin/barbarextra'
 ostree --repo=${repo} ls ${treeref} /usr/etc > out.txt
 assert_file_has_content out.txt 'etc/sharedfile'
 echo "ok remove-from-packages"
+
+# Verify rpmdb-normalize
+ostree --repo=${repo} ls -R ${treeref} /usr/share/rpm > db.txt
+assert_file_has_content_literal db.txt rpmdb.sqlite
+assert_not_file_has_content_literal db.txt rpmdb.sqlite-shm
+echo "ok db"
 
 ostree --repo=${repo} ls ${treeref} /opt > ls.txt
 assert_file_has_content ls.txt '^d0'


### PR DESCRIPTION


See https://github.com/rpm-software-management/rpm/issues/2219
This is one of the things that makes builds unreproducible in
general, which is worth fixing alone.

But the thing immediately driving this now for me is that I
think we're getting some ill-defined behavior because we
may have these files hardlinked (via ostree) and depending
on the container build environment, we may or may not see
modifications "through" the hardlink:
https://docs.kernel.org/filesystems/overlayfs.html#index

If we happen to mutate the `rpmdb.sqlite-shm` file in
one path but not the other confusion could easily result.

(Actually what we want to do really is drop our other
 hardlinked copies of the rpmdb entirely, but that's
 a bigger change)

Out of conservatism for now, we only do this if
`rpmdb-normalize` is set (which none of the Fedora derivatives
set today AFAICS). I do think we should likely
do this in client side layering too, but this
reduces the blast radius for now.
I plan to enable this in fedora-bootc.

Signed-off-by: Colin Walters <walters@verbum.org>

---