### PR TITLE
ci: Run Rust unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,8 @@ jobs:
         run: ./ci/codestyle.sh
       - name: Build
         run: ./ci/build.sh && make install DESTDIR=$(pwd)/install && tar -C install -czf install.tar .
+      - name: Unit tests
+        run: cargo test
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
@@ -259,6 +261,8 @@ jobs:
         run: ./ci/installdeps.sh
       - name: Build
         run: ./ci/build.sh && make install DESTDIR=$(pwd)/install && tar -C install -czf install.tar .
+      - name: Unit tests
+        run: cargo test
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This dropped out in
https://github.com/coreos/rpm-ostree/pull/5153/files and we missed that that run was also doing unit tests.
