### PR TITLE
tmpfiles: Misc cleanup patches

### DIFF
--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -665,7 +665,7 @@ pub(crate) fn configure_build_repo_from_target(
 #[cfg(test)]
 mod tests {
     use cap_std::fs::PermissionsExt;
-    use cap_std_ext::{cap_tempfile, cmdext::CapStdExtCommandExt};
+    use cap_std_ext::cap_tempfile;
     use gio::prelude::FileExt;
 
     use super::*;

--- a/rust/src/tmpfiles.rs
+++ b/rust/src/tmpfiles.rs
@@ -3,30 +3,28 @@
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
-use crate::cxxrsutil::*;
-use crate::ffiutil;
+
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write;
+use std::io::Write as StdWrite;
+use std::path::{Path, PathBuf};
 
 use anyhow::bail;
 use anyhow::{Context, Result};
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
-use cap_std::fs::DirBuilderExt;
-use cap_std::fs::MetadataExt;
 use cap_std::fs::{Dir, Permissions, PermissionsExt};
+use cap_std::fs::{DirBuilderExt, MetadataExt};
 use cap_std::io_lifetimes::AsFilelike;
 use cap_std_ext::dirext::CapStdExtDirExt;
 use fn_error_context::context;
 use ostree_ext::gio;
-use ostree_ext::gio::FileInfo;
-use ostree_ext::gio::FileType;
+use ostree_ext::gio::{FileInfo, FileType};
 use ostree_ext::prelude::CancellableExtManual;
-use std::borrow::Cow;
-use std::collections::BTreeMap;
-use std::collections::BTreeSet;
-use std::fmt::Write;
-use std::io::Write as StdWrite;
-use std::path::Path;
-use std::path::PathBuf;
+
+use crate::cxxrsutil::*;
+use crate::ffiutil;
 
 const TMPFILESD: &str = "usr/lib/tmpfiles.d";
 /// A "staging" tmpfiles.d location generated when importing packages

--- a/rust/src/tmpfiles.rs
+++ b/rust/src/tmpfiles.rs
@@ -29,7 +29,11 @@ use std::path::Path;
 use std::path::PathBuf;
 
 const TMPFILESD: &str = "usr/lib/tmpfiles.d";
+/// A "staging" tmpfiles.d location generated when importing packages
+/// in rpmostree-importer.cxx.
 const RPMOSTREE_TMPFILESD: &str = "usr/lib/rpm-ostree/tmpfiles.d";
+/// The final merged tmpfiles.d entry we generate from the per-package
+/// "staged" versions stored above.
 const AUTOVAR_PATH: &str = "rpm-ostree-autovar.conf";
 
 fn fix_tmpfiles_path(abs_path: std::borrow::Cow<str>) -> Cow<str> {

--- a/rust/src/tmpfiles.rs
+++ b/rust/src/tmpfiles.rs
@@ -509,7 +509,7 @@ q /var/tmp 1777 root root 30d
             "d /var/lib/test/nested 0777 test-user test-group - -",
             "f /var/lib/nfs/etab 0770 test-user test-group - -",
         ];
-        assert_eq!(entries, expected, "{:#?}", entries);
+        similar_asserts::assert_eq!(entries, expected);
     }
 
     #[test]
@@ -517,7 +517,7 @@ q /var/tmp 1777 root root 30d
         let intact_cases = vec!["/", "/var", "/var/foo", "/run/foo"];
         for entry in intact_cases {
             let output = canonicalize_escape_path(Cow::Borrowed(entry));
-            assert_eq!(output, entry);
+            similar_asserts::assert_eq!(output, entry);
         }
 
         let quoting_cases = maplit::btreemap! {
@@ -527,7 +527,7 @@ q /var/tmp 1777 root root 30d
         };
         for (input, expected) in quoting_cases {
             let output = canonicalize_escape_path(Cow::Borrowed(input));
-            assert_eq!(output, expected);
+            similar_asserts::assert_eq!(output, expected);
         }
     }
 
@@ -543,7 +543,7 @@ q /var/tmp 1777 root root 30d
             file_info.set_attribute_uint32("unix::mode", 0o721);
             let out = translate_to_tmpfiles_d(path, &file_info, username, groupname).unwrap();
             let expected = r#"d '/var/foo bar' 0721 testuser testgroup - -"#;
-            assert_eq!(out, expected);
+            similar_asserts::assert_eq!(out, expected);
         }
         {
             // Symlink
@@ -552,7 +552,7 @@ q /var/tmp 1777 root root 30d
             file_info.set_symlink_target("/mytarget");
             let out = translate_to_tmpfiles_d(path, &file_info, username, groupname).unwrap();
             let expected = r#"L '/var/foo bar' - - - - /mytarget"#;
-            assert_eq!(out, expected);
+            similar_asserts::assert_eq!(out, expected);
         }
         {
             // File
@@ -561,7 +561,7 @@ q /var/tmp 1777 root root 30d
             file_info.set_attribute_uint32("unix::mode", 0o123);
             let out = translate_to_tmpfiles_d(path, &file_info, username, groupname).unwrap();
             let expected = r#"f '/var/foo bar' 0123 testuser testgroup - -"#;
-            assert_eq!(out, expected);
+            similar_asserts::assert_eq!(out, expected);
         }
         {
             // Other unsupported

--- a/src/libpriv/rpmostree-importer.cxx
+++ b/src/libpriv/rpmostree-importer.cxx
@@ -631,6 +631,7 @@ import_rpm_to_repo (RpmOstreeImporter *self, char **out_csum, char **out_metadat
 
       if (!glnx_mkdtemp ("rpm-ostree-import.XXXXXX", 0700, &tmpdir, error))
         return FALSE;
+      // See the corresponding read side of this in tmpfiles.rs.
       if (!glnx_shutil_mkdir_p_at (tmpdir.fd, "usr/lib/rpm-ostree/tmpfiles.d", 0755, cancellable,
                                    error))
         return FALSE;


### PR DESCRIPTION
Just prep for more work.

---

Move more tmpfiles code into tmpfiles module

Before we kind of viewed the "translate tmpfiles in package import"
as the core flow, but I think that needs to be a peer of
"postprocess tmpfiles".

Move all the tmpfiles code from importer.rs into tmpfiles.rs.

No functional changes.

Signed-off-by: Colin Walters <walters@verbum.org>

---

importer: Add a comment linking to the consumer side

Signed-off-by: Colin Walters <walters@verbum.org>

---

tmpfiles: Canonicalize import order

- std
- external crates
- local crates

Signed-off-by: Colin Walters <walters@verbum.org>

---

tmpfiles: Rename escape function

I think this is clearer.

---