### PR TITLE
cci: Install built rpm on top of cosa

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -45,7 +45,9 @@ cosaPod(runAsUser: 0, memory: "${mem}Mi", cpu: "${nhosts}") {
     """)
   }
   stage("Build FCOS") {
+    unstash 'rpms'
     shwrap("""
+      dnf install -y *.rpm
       chown -R -h builder: .
       runuser -u builder -- coreos-assembler init --force https://github.com/coreos/fedora-coreos-config
       # include our built rpm-ostree in the image


### PR DESCRIPTION
I would have sworn we were doing this before, but if so I can't find it in git logs.

We want to test the new rpm-ostree at build time too of course.

xref https://github.com/coreos/rpm-ostree/issues/5251#issuecomment-2613541437
