### PR TITLE
Revert "src/libpriv: Add kernel-install-integration"

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -134,7 +134,6 @@ install-rpmostree-hook:
 	ln -Tsr -f $(DESTDIR)$(bindir)/rpm-ostree $(ostreeextdir)/ostree-ima-sign 
 	ln -Tsr -f $(DESTDIR)$(bindir)/rpm-ostree $(ostreeextdir)/ostree-provisional-repair 
 	ln -Tsr -f $(DESTDIR)$(bindir)/rpm-ostree $(ostreeextdir)/ostree-container
-	install -D -m 0755 -t $(DESTDIR)/usr/lib/kernel/install.d $(srcdir)/src/libpriv/05-rpmostree.install
 INSTALL_EXEC_HOOKS += install-rpmostree-hook
 
 # Wraps `cargo test`.  This is always a debug non-release build;

--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -253,7 +253,6 @@ $PYTHON autofiles.py > files \
   '%{_datadir}/dbus-1/system.d/*' \
   '%{_sysconfdir}/rpm-ostreed.conf' \
   '%{_prefix}/lib/systemd/system/*' \
-  '%{_prefix}/lib/kernel/install.d/*' \
   '%{_libexecdir}/rpm-ostree*' \
 %if %{with ostree_ext}
   '%{_libexecdir}/libostree/ext/*' \

--- a/src/libpriv/05-rpmostree.install
+++ b/src/libpriv/05-rpmostree.install
@@ -1,3 +1,0 @@
-#!/usr/bin/bash
-# This is the hook that has kernel-install call into rpm-ostree kernel-install
-exec /usr/bin/rpm-ostree kernel-install "$@"


### PR DESCRIPTION
This reverts commit 7ab70a9d8477b583a15715c8992c36e23f623f0a.

This caused https://bugzilla.redhat.com/show_bug.cgi?id=2342078 reverting until we got a better solution.