### PR TITLE
05-rpmostree.install: check for layout=ostree and install.conf presence

### DIFF
--- a/src/libpriv/05-rpmostree.install
+++ b/src/libpriv/05-rpmostree.install
@@ -1,4 +1,8 @@
 #!/usr/bin/bash
+# Check if install.conf is missing or does not include layout=ostree
+if [ ! -f /usr/lib/kernel/install.conf ] || ! grep -q layout=ostree /usr/lib/kernel/install.conf; then
+    exit 0
+fi
 # This is the hook that has kernel-install call into rpm-ostree kernel-install
 if test -x /usr/bin/rpm-ostree; then
     exec /usr/bin/rpm-ostree kernel-install "$@"


### PR DESCRIPTION
This is in response to https://bugzilla.redhat.com/show_bug.cgi?id=2342078
