### PR TITLE
Release 2025.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2025])
-m4_define([release_version], [3])
+m4_define([release_version], [4])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2025.3
+Version: 2025.4
 Release: 1%{?dist}
 License: LGPL-2.0-or-later
 URL: https://github.com/coreos/rpm-ostree


### PR DESCRIPTION
v2025.4

This is a bugfix release with fixes for kernel-install integration and rpmdb cleanup. 

When running on package mode systems now we will avoid calling into rpm-ostree kernel-install #5259 and when rpm-ostree kernel-install is called we will check if we are cli wrapping systemctl and unwrap it to allow the initramfs to be created correctly.

When running rpmdb cleanup now we make sure to close any open connection to the rpmdb.  #5247 

```
Colin Walters (2):
      container: Do rpmdb cleanup in outer scope
      build-sys: Bump version to 2025.3

Joseph Marrero Corchado (3):
      05-rpmostree.install: check for layout=ostree and install.conf presence
      kernel_install: unwrap systemd if it's wrapped
      packaging/spec: remove kernel_install conditional
```

**Full Changelog**: https://github.com/coreos/rpm-ostree/compare/v2025.3...v2025.4