### PR TITLE
rust: Rename `BuildChunkedOCI` struct to `BuildChunkedOCIOpts`

### DIFF
--- a/rust/src/cli_experimental.rs
+++ b/rust/src/cli_experimental.rs
@@ -29,7 +29,7 @@ enum Cmd {
 enum ComposeCmd {
     BuildChunkedOCI {
         #[clap(flatten)]
-        opts: crate::compose::BuildChunkedOCI,
+        opts: crate::compose::BuildChunkedOCIOpts,
     },
 }
 

--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -84,7 +84,7 @@ impl Default for InitializeMode {
 }
 
 #[derive(Debug, Parser)]
-struct Opt {
+struct ComposeImageOpts {
     #[clap(long)]
     #[clap(value_parser)]
     /// Directory to use for caching downloaded packages and other data
@@ -546,7 +546,7 @@ pub(crate) fn compose_image(args: Vec<String>) -> CxxResult<()> {
     use crate::isolation::self_command;
     let cancellable = gio::Cancellable::NONE;
 
-    let opt = Opt::parse_from(args.iter().skip(1));
+    let opt = ComposeImageOpts::parse_from(args.iter().skip(1));
 
     let tempdir = tempfile::tempdir()?;
     let tempdir = Utf8Path::from_path(tempdir.path()).unwrap();

--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -156,7 +156,7 @@ struct ComposeImageOpts {
 
 /// Generate a "chunked" OCI archive from an input rootfs.
 #[derive(Debug, Parser)]
-pub(crate) struct BuildChunkedOCI {
+pub(crate) struct BuildChunkedOCIOpts {
     /// Path to the source root filesystem tree.
     #[clap(long, required_unless_present = "from")]
     rootfs: Option<Utf8PathBuf>,
@@ -269,7 +269,7 @@ impl Drop for PodmanMount {
     }
 }
 
-impl BuildChunkedOCI {
+impl BuildChunkedOCIOpts {
     pub(crate) fn run(self) -> Result<()> {
         enum FileSource {
             Rootfs(Utf8PathBuf),


### PR DESCRIPTION
For consistency, but also because it can be confusing to have the enum variant be named the same as the underlying struct.

This caused a runtime issue for me that I can't reproduce anymore, but for posterity:

```
$ rpm-ostree experimental compose build-chunked-oci
thread 'tokio-runtime-worker' panicked at /var/home/jlebon/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.27/src/builder/debug_asserts.rs:281:9:
Command build-chunked-oci: Argument group name must be unique

        'BuildChunkedOCI' is already in use
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: task 1 panicked with message "Command build-chunked-oci: Argument group name must be unique\n\n\t'BuildChunkedOCI' is already in use"
```

