### PR TITLE
Add new `treefile-apply` experimental command

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -144,4 +144,18 @@ if ! grep -qe "error: No such file or directory" err.txt; then
     fatal "did not find expected error when skipping CLI wraps."
 fi
 
+# test treefile-apply
+if rpm -q ltrace vim-enhanced; then
+  fatal "ltrace and/or vim-enhanced exist"
+fi
+vim_vr=$(rpm -q vim-minimal --qf '%{version}-%{release}')
+cat > /tmp/treefile.yaml << EOF
+packages:
+  - ltrace
+  # a split base/layered version-locked package
+  - vim-enhanced
+EOF
+rpm-ostree experimental compose treefile-apply /tmp/treefile.yaml
+rpm -q ltrace vim-enhanced-"$vim_vr"
+
 echo ok

--- a/rust/src/cli_experimental.rs
+++ b/rust/src/cli_experimental.rs
@@ -39,6 +39,10 @@ enum ComposeCmd {
         #[clap(flatten)]
         opts: crate::compose::CommitToContainerRootfsOpts,
     },
+    TreefileApply {
+        #[clap(flatten)]
+        opts: crate::treefile::TreefileApplyOpts,
+    },
 }
 
 impl ComposeCmd {
@@ -47,6 +51,7 @@ impl ComposeCmd {
             ComposeCmd::BuildChunkedOCI { opts } => opts.run(),
             ComposeCmd::Rootfs { opts } => opts.run(),
             ComposeCmd::CommitToContainerRootfs { opts } => opts.run(),
+            ComposeCmd::TreefileApply { opts } => opts.run(),
         }
     }
 }


### PR DESCRIPTION
We are working towards rebasing FCOS and RHCOS on top of fedora-bootc
and rhel-bootc. As one can imagine, we are quite heavily invested in
treefiles currently, so being able to keep using what we already have as
we transition into becoming a layered build is valuable.

Dockerfiles are great of course as the common language used to build
container images. But it's not great for implementing complex logic.

Add a new `rpm-ostree experimental compose treefile-apply` command
which takes a treefile, but applies its directives _live_ in the running
environment.

So in this model, the business logic in the Dockerfile is kept to a
minimum and all the heavy lifting happens via
`RUN rpm-ostree compose treefile-apply manifest.yaml`.

A very small subset of the treefile spec is actually supported. The goal
is _not_ to reimplement everything, but only what is needed and useful
in a derivation context.

This code actually started as a Python script in openshift/os, currently
used to build the OCP node image:

https://github.com/openshift/os/blob/master/scripts/apply-manifest

So in fact, the node image (which in turn is a layered build on top of
RHCOS) will also be using this code.