### PR TITLE
core: Ignore xattrs in copyup for rpmfi overrides

### DIFF
--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -3677,7 +3677,11 @@ apply_rpmfi_overrides (RpmOstreeContext *self, int tmprootfs_dfd, DnfPackage *pk
 
       if (!S_ISDIR (stbuf.st_mode))
         {
-          if (!ostree_break_hardlink (tmprootfs_dfd, fn, FALSE, cancellable, error))
+          // Break the hardlink into the object store, making a copy.
+          // Ignore any underlying xattrs here; we'll always relabel security.selinux
+          // at the end, and otherwise the RPM is canonical for things like
+          // security.capability.
+          if (!ostree_break_hardlink (tmprootfs_dfd, fn, TRUE, cancellable, error))
             return glnx_prefix_error (error, "Copyup %s", fn);
         }
 


### PR DESCRIPTION
Ignore xattrs when doing a copyup from the repo.
As far as I can tell and think of, this should always be safe. Basically we care about xattrs like
`security.selinux` and `security.capabilty`. For SELinux, we always relabel at the end when generating the commit. For `security.capability`, it's defined by the RPM. Other xattrs we shouldn't default to inheriting
from the "base" object - the RPM should set them
in general.

This enables using `rpm-ostree compose` in a podman/docker container which applies e.g. `container_t` to all files.
