### PR TITLE
ci/prow: Add a Dockerfile for build_root

### DIFF
--- a/ci/prow/Dockerfile.buildroot
+++ b/ci/prow/Dockerfile.buildroot
@@ -1,0 +1,3 @@
+# We don't preinstall anything additional yet, that
+# will be done by injected code.
+FROM quay.io/coreos-assembler/fcos-buildroot:testing-devel


### PR DESCRIPTION
Attempting to fix https://github.com/coreos/rpm-ostree/issues/5280
