### PR TITLE
compose: Support buildah too

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -275,8 +275,8 @@ jobs:
           sudo podman run --rm --privileged --security-opt=label=disable \
             -v /var/lib/containers:/var/lib/containers \
             -v /var/tmp:/var/tmp \
-            localhost/builder rpm-ostree experimental compose build-chunked-oci --bootc --format-version=1 --from localhost/base --output containers-storage:localhost/base-chunked
-          sudo podman inspect localhost/base-chunked
+            localhost/builder rpm-ostree experimental compose build-chunked-oci --bootc --format-version=1 --from localhost/base --output oci:base-chunked
+          sudo skopeo inspect oci:base-chunked
   build-c9s:
     name: "Build (c9s)"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -212,18 +212,19 @@ jobs:
           echo 'deb [trusted=yes] https://ftp.debian.org/debian/ testing main' | sudo tee /etc/apt/sources.list.d/testing.list
           sudo apt update
           sudo apt install -y crun/testing podman/testing skopeo/testing
+          # Something is confused in latest GHA here
+          sudo rm /var/lib/containers -rf
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Download build
         uses: actions/download-artifact@v4.1.7
         with:
           name: install.tar
-      - name: Install
-        run: tar -C / -xzvf install.tar
       - name: Test compose-rootfs
         run: |
-          cd tests/compose
-          sudo podman build -v ./usr/bin/rpm-ostree:/run/build/rpm-ostree:ro --security-opt=label=disable --cap-add=all --device /dev/fuse -t localhost/test -f Containerfile .
+          cd tests/compose-rootfs
+          tar -xzvf ../../install.tar
+          sudo podman build -v $(pwd)/usr/bin/rpm-ostree:/run/build/rpm-ostree:ro --security-opt=label=disable --cap-add=all --device /dev/fuse -t localhost/test -f Containerfile .
   container-encapsulate:
     name: "Encapsulate tests"
     needs: build
@@ -254,9 +255,8 @@ jobs:
           echo 'deb [trusted=yes] https://ftp.debian.org/debian/ testing main' | sudo tee /etc/apt/sources.list.d/testing.list
           sudo apt update
           sudo apt install -y crun/testing podman/testing skopeo/testing
-          crun --version
-          podman --version
-          skopeo --version
+          # Something is confused in latest GHA here
+          sudo rm /var/lib/containers -rf
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Download build
@@ -267,15 +267,14 @@ jobs:
         run: |
           set -xeuo pipefail
           cd tests/build-chunked-oci
-          # Something is confused in latest GHA here, I was getting: Error: database graph driver "" does not match our graph driver "overlay": database configuration mismatch
-          sudo rm /var/lib/containers -rf
           sudo podman build -t localhost/base -f Containerfile.test
           sudo tar -xzvf ../../install.tar
           sudo podman build -v $(pwd)/usr/bin:/ci -t localhost/builder -f Containerfile.builder
           sudo podman run --rm --privileged --security-opt=label=disable \
             -v /var/lib/containers:/var/lib/containers \
             -v /var/tmp:/var/tmp \
-            localhost/builder rpm-ostree experimental compose build-chunked-oci --bootc --format-version=1 --from localhost/base --output oci:base-chunked
+            -v $(pwd):/output \
+            localhost/builder rpm-ostree experimental compose build-chunked-oci --bootc --format-version=1 --from localhost/base --output oci:/output/base-chunked
           sudo skopeo inspect oci:base-chunked
   build-c9s:
     name: "Build (c9s)"

--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -6,7 +6,7 @@ use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::os::fd::{AsFd, AsRawFd};
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use anyhow::{anyhow, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -23,6 +23,7 @@ use ostree_ext::{container as ostree_container, glib};
 use ostree_ext::{oci_spec, ostree};
 
 use crate::cmdutils::CommandRunExt;
+use crate::containers_storage::PodmanMount;
 use crate::cxxrsutil::{CxxResult, FFIGObjectWrapper};
 use crate::isolation::self_command;
 
@@ -187,89 +188,6 @@ pub(crate) struct BuildChunkedOCIOpts {
     output: String,
 }
 
-struct PodmanMount {
-    path: Utf8PathBuf,
-    temp_cid: Option<String>,
-    mounted: bool,
-}
-
-impl PodmanMount {
-    #[context("Unmounting container")]
-    fn _impl_unmount(&mut self) -> Result<()> {
-        if self.mounted {
-            tracing::debug!("unmounting {}", self.path.as_str());
-            self.mounted = false;
-            Command::new("umount")
-                .args(["-l", self.path.as_str()])
-                .stdout(Stdio::null())
-                .run()
-                .context("umount")?;
-            tracing::trace!("umount ok");
-        }
-        if let Some(cid) = self.temp_cid.take() {
-            tracing::debug!("rm container {cid}");
-            Command::new("podman")
-                .args(["rm", cid.as_str()])
-                .stdout(Stdio::null())
-                .run()
-                .context("podman rm")?;
-            tracing::trace!("rm ok");
-        }
-        Ok(())
-    }
-
-    #[context("Mounting continer {container}")]
-    fn _impl_mount(container: &str) -> Result<Utf8PathBuf> {
-        let mut o = Command::new("podman")
-            .args(["mount", container])
-            .run_get_output()?;
-        let mut s = String::new();
-        o.read_to_string(&mut s)?;
-        while s.ends_with('\n') {
-            s.pop();
-        }
-        tracing::debug!("mounted container {container} at {s}");
-        Ok(s.into())
-    }
-
-    #[allow(dead_code)]
-    fn new_for_container(container: &str) -> Result<Self> {
-        let path = Self::_impl_mount(container)?;
-        Ok(Self {
-            path,
-            temp_cid: None,
-            mounted: true,
-        })
-    }
-
-    fn new_for_image(image: &str) -> Result<Self> {
-        let mut o = Command::new("podman")
-            .args(["create", image])
-            .run_get_output()?;
-        let mut s = String::new();
-        o.read_to_string(&mut s)?;
-        let cid = s.trim();
-        let path = Self::_impl_mount(cid)?;
-        tracing::debug!("created container {cid} from {image}");
-        Ok(Self {
-            path,
-            temp_cid: Some(cid.to_owned()),
-            mounted: true,
-        })
-    }
-
-    fn unmount(mut self) -> Result<()> {
-        self._impl_unmount()
-    }
-}
-
-impl Drop for PodmanMount {
-    fn drop(&mut self) {
-        tracing::trace!("In drop, mounted={}", self.mounted);
-        let _ = self._impl_unmount();
-    }
-}
-
 /// Generate a filesystem tree in ostree-container format from an input manifest.
 /// This can then be copied into e.g. a `FROM scratch` container image build.
 #[derive(Debug, Parser)]
@@ -322,7 +240,7 @@ impl BuildChunkedOCIOpts {
         };
         let rootfs = match &rootfs_source {
             FileSource::Rootfs(p) => p.as_path(),
-            FileSource::Podman(mnt) => mnt.path.as_path(),
+            FileSource::Podman(mnt) => mnt.path(),
         };
         let rootfs = Dir::open_ambient_dir(rootfs, cap_std::ambient_authority())
             .with_context(|| format!("Opening {}", rootfs))?;

--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -23,7 +23,7 @@ use ostree_ext::{container as ostree_container, glib};
 use ostree_ext::{oci_spec, ostree};
 
 use crate::cmdutils::CommandRunExt;
-use crate::containers_storage::PodmanMount;
+use crate::containers_storage::Mount;
 use crate::cxxrsutil::{CxxResult, FFIGObjectWrapper};
 use crate::isolation::self_command;
 
@@ -230,13 +230,14 @@ impl BuildChunkedOCIOpts {
     pub(crate) fn run(self) -> Result<()> {
         enum FileSource {
             Rootfs(Utf8PathBuf),
-            Podman(PodmanMount),
+            Podman(Mount),
         }
         let rootfs_source = if let Some(rootfs) = self.rootfs {
             FileSource::Rootfs(rootfs)
         } else {
             let image = self.from.as_deref().unwrap();
-            FileSource::Podman(PodmanMount::new_for_image(image)?)
+            crate::containers_storage::reexec_if_needed()?;
+            FileSource::Podman(Mount::new_for_image(image)?)
         };
         let rootfs = match &rootfs_source {
             FileSource::Rootfs(p) => p.as_path(),

--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -277,7 +277,8 @@ impl BuildChunkedOCIOpts {
             Command::new("skopeo")
                 .args(["inspect", "--config", img_transport.as_str()])
                 .stdout(tmpf.as_file().try_clone()?)
-                .run()?;
+                .run()
+                .context("Invoking skopeo to inspect config")?;
             Some(tmpf.into_temp_path())
         } else {
             None
@@ -535,6 +536,7 @@ fn postprocess_mtree(repo: &ostree::Repo, rootfs: &ostree::MutableTree) -> Resul
     Ok(())
 }
 
+#[context("Generating commit from rootfs")]
 fn generate_commit_from_rootfs(
     repo: &ostree::Repo,
     rootfs: &Dir,

--- a/rust/src/containers_storage.rs
+++ b/rust/src/containers_storage.rs
@@ -1,0 +1,98 @@
+//! Helpers for interacting with containers-storage via forking podman.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use fn_error_context::context;
+
+use crate::cmdutils::CommandRunExt;
+
+pub(crate) struct PodmanMount {
+    path: Utf8PathBuf,
+    temp_cid: Option<String>,
+    mounted: bool,
+}
+
+impl PodmanMount {
+    /// Access the mount path.
+    pub(crate) fn path(&self) -> &Utf8Path {
+        &self.path
+    }
+
+    #[context("Unmounting container")]
+    fn _impl_unmount(&mut self) -> Result<()> {
+        if self.mounted {
+            tracing::debug!("unmounting {}", self.path.as_str());
+            self.mounted = false;
+            Command::new("umount")
+                .args(["-l", self.path.as_str()])
+                .stdout(Stdio::null())
+                .run()
+                .context("umount")?;
+            tracing::trace!("umount ok");
+        }
+        if let Some(cid) = self.temp_cid.take() {
+            tracing::debug!("rm container {cid}");
+            Command::new("podman")
+                .args(["rm", cid.as_str()])
+                .stdout(Stdio::null())
+                .run()
+                .context("podman rm")?;
+            tracing::trace!("rm ok");
+        }
+        Ok(())
+    }
+
+    #[context("Mounting continer {container}")]
+    fn _impl_mount(container: &str) -> Result<Utf8PathBuf> {
+        let mut o = Command::new("podman")
+            .args(["mount", container])
+            .run_get_output()?;
+        let mut s = String::new();
+        o.read_to_string(&mut s)?;
+        while s.ends_with('\n') {
+            s.pop();
+        }
+        tracing::debug!("mounted container {container} at {s}");
+        Ok(s.into())
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn new_for_container(container: &str) -> Result<Self> {
+        let path = Self::_impl_mount(container)?;
+        Ok(Self {
+            path,
+            temp_cid: None,
+            mounted: true,
+        })
+    }
+
+    pub(crate) fn new_for_image(image: &str) -> Result<Self> {
+        let mut o = Command::new("podman")
+            .args(["create", image])
+            .run_get_output()?;
+        let mut s = String::new();
+        o.read_to_string(&mut s)?;
+        let cid = s.trim();
+        let path = Self::_impl_mount(cid)?;
+        tracing::debug!("created container {cid} from {image}");
+        Ok(Self {
+            path,
+            temp_cid: Some(cid.to_owned()),
+            mounted: true,
+        })
+    }
+
+    pub(crate) fn unmount(mut self) -> Result<()> {
+        self._impl_unmount()
+    }
+}
+
+impl Drop for PodmanMount {
+    fn drop(&mut self) {
+        tracing::trace!("In drop, mounted={}", self.mounted);
+        let _ = self._impl_unmount();
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -20,6 +20,7 @@ mod cmdutils;
 mod cxxrsutil;
 mod ffiutil;
 pub(crate) mod ffiwrappers;
+mod reexec;
 pub(crate) use cxxrsutil::*;
 use ffi::BubblewrapMutability;
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -963,6 +963,7 @@ pub mod client;
 pub(crate) use client::*;
 pub mod cliwrap;
 pub mod container;
+mod containers_storage;
 pub use cliwrap::*;
 pub(crate) use container::*;
 mod compose;

--- a/rust/src/reexec.rs
+++ b/rust/src/reexec.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+
+use anyhow::Result;
+use fn_error_context::context;
+
+/// Re-execute the current process if the provided environment variable is not set.
+#[context("Reexec self")]
+pub(crate) fn reexec_with_guardenv(k: &str, prefix_args: &[&str]) -> Result<()> {
+    if std::env::var_os(k).is_some() {
+        tracing::trace!("Skipping re-exec due to env var {k}");
+        return Ok(());
+    }
+    let self_exe = std::fs::read_link("/proc/self/exe")?;
+    let mut prefix_args = prefix_args.iter();
+    let mut cmd = if let Some(p) = prefix_args.next() {
+        let mut c = Command::new(p);
+        c.args(prefix_args);
+        c.arg(self_exe);
+        c
+    } else {
+        Command::new(self_exe)
+    };
+    cmd.env(k, "1");
+    cmd.args(std::env::args_os().skip(1));
+    tracing::debug!("Re-executing current process for {k}");
+    Err(cmd.exec().into())
+}


### PR DESCRIPTION
compose: Split off a containers_storage module

Prep for further work.

Signed-off-by: Colin Walters <walters@verbum.org>

---

compose: Support buildah too

It's helpful for us to support build environments that only have podman,
as well as those that only have buildah. They're mostly doing the same
things; an abstraction over them is trivial. From this code, the only
difference really is `podman create` vs `buildah from`.

Signed-off-by: Colin Walters <walters@verbum.org>

---

compose: Add some error prefixing

Turned out I was missing skopeo.

Signed-off-by: Colin Walters <walters@verbum.org>

---