### PR TITLE
Release 2025.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2025])
-m4_define([release_version], [4])
+m4_define([release_version], [5])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2025.4
+Version: 2025.5
 Release: 1%{?dist}
 License: LGPL-2.0-or-later
 URL: https://github.com/coreos/rpm-ostree


### PR DESCRIPTION
v2025.5

```
Colin Walters (15):
      compose: More error context for container-encapsulate
      chunked-oci: Rework to support --from too
      treefile: Add error context for finalize.d
      core: Ignore xattrs in copyup for rpmfi overrides
      Update bootc
      postprocess: Remove boot/loader
      ci/prow: Add a Dockerfile for build_root
      postprocess: Add an error prefix
      Add `experimental compose rootfs`
      compose: Split off a containers_storage module
      compose: Support buildah too
      compose: Add some error prefixing
      ci: Various fixes
      core: Use source root for repos and dnf vars
      compose-rootfs: Add --source-root-rw

Jonathan Lebon (5):
      rust: Rename `Opt` struct to `ComposeImage`
      rust: Rename `BuildChunkedOCI` struct to `BuildChunkedOCIOpts`
      Add new `treefile-apply` experimental command
      ci/test-container.sh: Make it easier to execute locally
      ci/test-container.sh: Run `treefile-apply` test earlier

Joseph Marrero Corchado (1):
      Release 2025.5
```