### PR TITLE
compose: Simplify compose-image entrypoint

### DIFF
--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -783,7 +783,8 @@ async fn fetch_previous_metadata(
 pub(crate) fn compose_image(args: Vec<String>) -> CxxResult<()> {
     let cancellable = gio::Cancellable::NONE;
 
-    let opt = ComposeImageOpts::parse_from(args.iter().skip(1));
+    let args = args.iter().map(|v| v.as_str());
+    let opt = ComposeImageOpts::parse_from(["image"].into_iter().chain(args));
 
     let tempdir = tempfile::tempdir()?;
     let tempdir = Utf8Path::from_path(tempdir.path()).unwrap();

--- a/src/app/rpmostree-builtin-compose.cxx
+++ b/src/app/rpmostree-builtin-compose.cxx
@@ -70,9 +70,7 @@ rpmostree_compose_builtin_image (int argc, char **argv, RpmOstreeCommandInvocati
 {
   rust::Vec<rust::String> rustargv;
   g_assert_cmpint (argc, >, 0);
-  rustargv.push_back (std::string (argv[0]));
-  rustargv.push_back (std::string ("baseimage"));
-  for (int i = 1; i < argc; i++)
+  for (int i = 0; i < argc; i++)
     rustargv.push_back (std::string (argv[i]));
   CXX_TRY (rpmostreecxx::compose_image (rustargv), error);
   return TRUE;


### PR DESCRIPTION
The argv juggling is error prone and confusing. We were adding an argument on the C++ side that we then skipped on the rust side. Change things so we directly pass the C argv to Rust, re-adding the subcommand to the arguments on the Rust side so the Clap parser works.
