### PR TITLE
compose: Stabilize `compose rootfs`

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -2196,6 +2196,9 @@ extern "C"
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$compose_image (::rust::Vec< ::rust::String> *args) noexcept;
 
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$compose_rootfs_entrypoint (::rust::Vec< ::rust::String> *args) noexcept;
+
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$configure_build_repo_from_target (
       ::rpmostreecxx::OstreeRepo const &build_repo,
       ::rpmostreecxx::OstreeRepo const &target_repo) noexcept;
@@ -3974,6 +3977,17 @@ compose_image (::rust::Vec< ::rust::String> args)
 {
   ::rust::ManuallyDrop< ::rust::Vec< ::rust::String> > args$ (::std::move (args));
   ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$compose_image (&args$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
+}
+
+void
+compose_rootfs_entrypoint (::rust::Vec< ::rust::String> args)
+{
+  ::rust::ManuallyDrop< ::rust::Vec< ::rust::String> > args$ (::std::move (args));
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$compose_rootfs_entrypoint (&args$.value);
   if (error$.ptr)
     {
       throw ::rust::impl< ::rust::Error>::error (error$);

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1862,6 +1862,8 @@ bool commit_has_matching_sepolicy (::rpmostreecxx::GVariant const &commit,
 
 void compose_image (::rust::Vec< ::rust::String> args);
 
+void compose_rootfs_entrypoint (::rust::Vec< ::rust::String> args);
+
 void configure_build_repo_from_target (::rpmostreecxx::OstreeRepo const &build_repo,
                                        ::rpmostreecxx::OstreeRepo const &target_repo);
 

--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -518,6 +518,11 @@ impl RootfsOpts {
     }
 }
 
+pub(crate) fn compose_rootfs_entrypoint(args: Vec<String>) -> CxxResult<()> {
+    RootfsOpts::parse_from(args).run()?;
+    Ok(())
+}
+
 impl CommitToContainerRootfsOpts {
     /// Execute `compose commit-to-container-rootfs`. This just:
     /// - Opens up the target ostree repo

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -282,6 +282,7 @@ pub mod ffi {
     // compose.rs
     extern "Rust" {
         fn compose_image(args: Vec<String>) -> Result<()>;
+        fn compose_rootfs_entrypoint(args: Vec<String>) -> Result<()>;
 
         fn configure_build_repo_from_target(
             build_repo: &OstreeRepo,

--- a/src/app/rpmostree-builtin-compose.cxx
+++ b/src/app/rpmostree-builtin-compose.cxx
@@ -53,6 +53,8 @@ static RpmOstreeCommand compose_subcommands[] = {
   { "image", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
     "Generate a reproducible \"chunked\" container image (using RPM data) from a treefile",
     rpmostree_compose_builtin_image },
+  { "rootfs", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD, "Generate a root filesystem tree from a treefile",
+    rpmostree_compose_builtin_rootfs },
   { NULL, (RpmOstreeBuiltinFlags)0, NULL, NULL }
 };
 
@@ -75,5 +77,17 @@ rpmostree_compose_builtin_image (int argc, char **argv, RpmOstreeCommandInvocati
   for (int i = 1; i < argc; i++)
     rustargv.push_back (std::string (argv[i]));
   CXX_TRY (rpmostreecxx::compose_image (rustargv), error);
+  return TRUE;
+}
+
+gboolean
+rpmostree_compose_builtin_rootfs (int argc, char **argv, RpmOstreeCommandInvocation *invocation,
+                                  GCancellable *cancellable, GError **error)
+{
+  rust::Vec<rust::String> rustargv;
+  g_assert_cmpint (argc, >, 0);
+  for (int i = 0; i < argc; i++)
+    rustargv.push_back (std::string (argv[i]));
+  CXX_TRY (rpmostreecxx::compose_rootfs_entrypoint (rustargv), error);
   return TRUE;
 }

--- a/src/app/rpmostree-compose-builtins.h
+++ b/src/app/rpmostree-compose-builtins.h
@@ -48,5 +48,8 @@ gboolean rpmostree_compose_builtin_container_encapsulate (int argc, char **argv,
 gboolean rpmostree_compose_builtin_image (int argc, char **argv,
                                           RpmOstreeCommandInvocation *invocation,
                                           GCancellable *cancellable, GError **error);
+gboolean rpmostree_compose_builtin_rootfs (int argc, char **argv,
+                                           RpmOstreeCommandInvocation *invocation,
+                                           GCancellable *cancellable, GError **error);
 
 G_END_DECLS

--- a/tests/compose-rootfs/Containerfile
+++ b/tests/compose-rootfs/Containerfile
@@ -17,7 +17,7 @@ COPY . /src
 WORKDIR /src
 RUN --mount=type=bind,from=repos,src=/,dst=/repos,rw <<EORUN
 set -xeuo pipefail
-exec rpm-ostree experimental compose rootfs --source-root-rw=/repos manifest.yaml /target-rootfs
+exec rpm-ostree compose rootfs --source-root-rw=/repos manifest.yaml /target-rootfs
 EORUN
 
 # This pulls in the rootfs generated in the previous step


### PR DESCRIPTION
Expose this as `rpm-ostree compose rootfs`.
