### PR TITLE
build-chunked-oci: Propagate creation timestamp with --from

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -270,12 +270,17 @@ jobs:
           sudo podman build -t localhost/base -f Containerfile.test
           sudo tar -xzvf ../../install.tar
           sudo podman build -v $(pwd)/usr/bin:/ci -t localhost/builder -f Containerfile.builder
+          orig_created=$(sudo skopeo inspect --raw --config containers-storage:localhost/base | jq -r .created)
           sudo podman run --rm --privileged --security-opt=label=disable \
             -v /var/lib/containers:/var/lib/containers \
             -v /var/tmp:/var/tmp \
             -v $(pwd):/output \
             localhost/builder rpm-ostree experimental compose build-chunked-oci --bootc --format-version=1 --from localhost/base --output oci:/output/base-chunked
           sudo skopeo inspect oci:base-chunked
+          new_created=$(sudo skopeo inspect --raw --config oci:base-chunked | jq -r .created)
+          # ostree only stores seconds, so canonialize the rfc3339 data to seconds
+          test "$(date --date="${orig_created}" --rfc-3339=seconds)" = "$(date --date="${new_created}" --rfc-3339=seconds)"
+
   build-c9s:
     name: "Build (c9s)"
     runs-on: ubuntu-latest

--- a/rust/src/containers_storage.rs
+++ b/rust/src/containers_storage.rs
@@ -13,10 +13,14 @@ use crate::cmdutils::CommandRunExt;
 /// will work reliably.
 /// https://github.com/containers/buildah/issues/5976
 pub(crate) fn reexec_if_needed() -> Result<()> {
-    crate::reexec::reexec_with_guardenv(
-        "_RPMOSTREE_REEXEC_USERNS",
-        &["unshare", "-U", "-m", "--map-root-user", "--keep-caps"],
-    )
+    if ostree_ext::container_utils::running_in_container() {
+        crate::reexec::reexec_with_guardenv(
+            "_RPMOSTREE_REEXEC_USERNS",
+            &["unshare", "-U", "-m", "--map-root-user", "--keep-caps"],
+        )
+    } else {
+        Ok(())
+    }
 }
 
 /// We need to handle containers that only have podman, not buildah (like the -bootc ones)


### PR DESCRIPTION
containers_storage: Only reexec if we're in a container

This fixes running this command directly as root outside
of a container.

---

build-chunked-oci: Propagate creation timestamp with --from

When we're building from an existing image, ensure that we
also inherit its creation timestamp. This is implemented
by ensuring the embedded ostree commit uses that timestamp,
which is then honored by the underling ostree-container
encapsulation logic.

Signed-off-by: Colin Walters <walters@verbum.org>

---