### PR TITLE
container-encapsulate: Two patches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -274,7 +274,7 @@ jobs:
             -v /var/lib/containers:/var/lib/containers \
             -v /var/tmp:/var/tmp \
             -v $(pwd):/output \
-            localhost/builder rpm-ostree experimental compose build-chunked-oci --bootc --format-version=1 --from localhost/base --output oci:/output/base-chunked
+            localhost/builder rpm-ostree experimental compose build-chunked-oci --bootc --format-version=1 --max-layers 99 --from localhost/base --output oci:/output/base-chunked
           sudo skopeo inspect oci:base-chunked
   build-c9s:
     name: "Build (c9s)"

--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -182,6 +182,11 @@ pub(crate) struct BuildChunkedOCIOpts {
     #[clap(long, required = true)]
     format_version: u32,
 
+    #[clap(long)]
+    /// Maximum number of layers to use. The default is currently 64, although
+    /// this may change.
+    max_layers: Option<u32>,
+
     /// Tag to use for output image, or `latest` if unset.
     #[clap(long, default_value = "latest")]
     reference: String,
@@ -302,6 +307,7 @@ impl BuildChunkedOCIOpts {
                 repo_path.as_str(),
             ])
             .args(label_arg)
+            .args(self.max_layers.map(|l| format!("--max-layers={l}")))
             .args(
                 config_data
                     .iter()

--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -445,21 +445,8 @@ pub fn container_encapsulate(args: Vec<String>) -> CxxResult<()> {
         Utc.timestamp_opt(lowest_change_time.try_into().unwrap(), 0)
             .unwrap()
     );
-    println!("{} duplicates", state.duplicate_objects().count());
-    let multiple_owners = {
-        let mut mo: Vec<&Utf8Path> = state
-            .multiple_owners()
-            .map(|(path, _)| path.as_path())
-            .collect();
-        mo.sort_unstable();
-        mo
-    };
-    if !multiple_owners.is_empty() {
-        println!("Multiple owners:");
-        for path in multiple_owners {
-            println!("  {}", path);
-        }
-    }
+    println!("Duplicates: {}", state.duplicate_objects().count());
+    println!("Multiple owners: {}", state.multiple_owners().count());
 
     // Convert our build state into the state that ostree consumes, discarding
     // transient data such as the cases of files owned by multiple packages.


### PR DESCRIPTION
container-encapsulate: Quiet multiple owners

Right now this is all normal and expected basically. If someone
needs to debug a case around this later we can add some
sort of verbose debugging.

Signed-off-by: Colin Walters <walters@verbum.org>

---

container-encapsulate: Propagate --max-layers

The existing CLI has this, just propagate it.

Signed-off-by: Colin Walters <walters@verbum.org>

---