### PR TITLE
Bump to latest bootc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,15 +225,17 @@ dependencies = [
 [[package]]
 name = "bootc-utils"
 version = "0.0.0"
-source = "git+https://github.com/containers/bootc?rev=6663e6fe5e4615e99a8e95028f1cb975474ce8ec#6663e6fe5e4615e99a8e95028f1cb975474ce8ec"
+source = "git+https://github.com/containers/bootc?rev=73de2a8ef0a312243b686c6bd2c91413ee725c05#73de2a8ef0a312243b686c6bd2c91413ee725c05"
 dependencies = [
  "anyhow",
  "rustix",
  "serde",
  "serde_json",
+ "shlex",
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2179,7 +2181,7 @@ dependencies = [
 [[package]]
 name = "ostree-ext"
 version = "0.15.3"
-source = "git+https://github.com/containers/bootc?rev=6663e6fe5e4615e99a8e95028f1cb975474ce8ec#6663e6fe5e4615e99a8e95028f1cb975474ce8ec"
+source = "git+https://github.com/containers/bootc?rev=73de2a8ef0a312243b686c6bd2c91413ee725c05#73de2a8ef0a312243b686c6bd2c91413ee725c05"
 dependencies = [
  "anyhow",
  "bootc-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ openssl = "0.10.70"
 once_cell = "1.20.2"
 os-release = "0.1.0"
 # We pull this one from git, as the project is no longer published as an external crate.
-ostree-ext = { git = "https://github.com/containers/bootc", rev = "6663e6fe5e4615e99a8e95028f1cb975474ce8ec" }
+ostree-ext = { git = "https://github.com/containers/bootc", rev = "73de2a8ef0a312243b686c6bd2c91413ee725c05" }
 paste = "1.0"
 phf = { version = "0.11", features = ["macros"] }
 rand = "0.8.5"


### PR DESCRIPTION
To pull in
https://github.com/containers/bootc/pull/1096/commits/57bd0dc9835669274696998386a547afb6709ff5 specifically so that it gets used by Anaconda.
