### PR TITLE
treefile: Set RPMOSTREE_WORKDIR for finalize.d

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -558,4 +558,6 @@ in the same directory as the manifest, they will be automatically used:
   host/ambient environment (*not* from the target); the current working directory will be
   the target root filesystem. There is no additional sandboxing or containerization
   applied to the execution of the binary. The builtin "change detection"
-  is not applied to the content of the scripts.
+  is not applied to the content of the scripts. The environment variable
+  `RPMOSTREE_WORKDIR` will be set to the path of the associated treefile,
+  which can be used to copy in additional content from that directory.

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -835,8 +835,11 @@ impl Treefile {
     pub(crate) fn exec_finalize_d(&self, rootfs: &Dir) -> Result<()> {
         for (name, path) in self.externals.finalize_d.iter() {
             println!("Executing: {name}");
-            Command::new(path)
-                .cwd_dir(rootfs.try_clone()?)
+            let mut cmd = Command::new(path);
+            if let Some(d) = self.directory.as_deref() {
+                cmd.env("RPMOSTREE_WORKDIR", d);
+            }
+            cmd.cwd_dir(rootfs.try_clone()?)
                 .run()
                 .with_context(|| format!("Failed to execute {name}"))?;
         }

--- a/tests/compose/test-misc-tweaks.sh
+++ b/tests/compose/test-misc-tweaks.sh
@@ -115,6 +115,17 @@ postprocess:
    test -f /usr/share/included-postprocess-test
 EOF
 
+# Also test finalize.d
+mkdir config/finalize.d
+cat >config/finalize.d/01-test.sh <<'EOF'
+#!/bin/bash
+set -xeuo pipefail
+[[ "${RPMOSTREE_WORKDIR}" =~ config ]]
+# Verify we can read our sourcedir
+test -f "${RPMOSTREE_WORKDIR}/manifest.json"
+touch usr/share/finalize-dot-d-test
+EOF
+
 mkdir -p tmp/rootfs
 for x in $(seq 3); do
   rm tmp/rootfs/usr -rf


### PR DESCRIPTION
It's useful to have the source directory too to be able to copy things from it for example. I plan to use this for bootc-base-imagectl in fedora-bootc.
