### PR TITLE
compose-rootfs: Don't output ostree-container format

### DIFF
--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -7,6 +7,7 @@ use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::os::fd::{AsFd, AsRawFd};
+use std::path::Path;
 use std::process::Command;
 
 use anyhow::{anyhow, Context, Result};
@@ -198,7 +199,7 @@ pub(crate) struct BuildChunkedOCIOpts {
     output: String,
 }
 
-/// Generate a filesystem tree in ostree-container format from an input manifest.
+/// Generate a filesystem tree from an input manifest.
 /// This can then be copied into e.g. a `FROM scratch` container image build.
 #[derive(Debug, Parser)]
 pub(crate) struct RootfsOpts {
@@ -473,6 +474,33 @@ fn mutate_source_root(exec_root: &Dir, source_root: &Utf8Path) -> Result<()> {
 }
 
 impl RootfsOpts {
+    // For bad legacy reasons "compose install" actually writes to a subdirectory named rootfs.
+    // Clean that up by deleting everything except rootfs/ and moving the contents of rootfs/
+    // to the toplevel.
+    //
+    // Further, we change usr/etc back to etc
+    fn fixup_installroot(d: &Dir) -> Result<()> {
+        let rootfs_name = "rootfs";
+        for ent in d.entries()? {
+            let ent = ent?;
+            let name = ent.file_name();
+            if let Some("rootfs") = name.to_str() {
+                continue;
+            }
+            d.remove_all_optional(&name)?;
+        }
+        for ent in d.read_dir(rootfs_name).context("Reading rootfs")? {
+            let ent = ent?;
+            let name = ent.file_name();
+            let origpath = Path::new(rootfs_name).join(&name);
+            d.rename(origpath, d, &name)
+                .with_context(|| format!("Renaming rootfs/{name:?}"))?;
+        }
+        // Clean up the now empty dir
+        d.remove_dir(rootfs_name).context("Removing rootfs")?;
+        Ok(())
+    }
+
     pub(crate) fn run(mut self) -> Result<()> {
         let manifest = self.manifest.as_path();
 
@@ -500,13 +528,8 @@ impl RootfsOpts {
         let td_path: Utf8PathBuf = td.path().to_owned().try_into()?;
 
         // If we're passed an ostree repo, open it.
-        let (repo_path, repo) = if let Some(ostree_repo) = self.ostree_repo {
-            let repo = ostree::Repo::open_at(
-                libc::AT_FDCWD,
-                ostree_repo.as_str(),
-                gio::Cancellable::NONE,
-            )?;
-            (ostree_repo, repo)
+        let repo_path = if let Some(ostree_repo) = self.ostree_repo {
+            ostree_repo
         } else {
             // Otherwise make a temporary ostree repo
             let repo_path = td_path.join("repo");
@@ -517,19 +540,18 @@ impl RootfsOpts {
                 None,
                 gio::Cancellable::NONE,
             )?;
-            (repo_path, repo)
+            drop(repo);
+            repo_path
         };
-        // Run a compose, generating an ostree commit.
-        let commitid_path = td_path.join("commitid.txt");
+
+        // Just build the root filesystem tree
         self_command()
             .args([
                 "compose",
-                "tree",
+                "install",
                 "--unified-core",
                 "--repo",
                 repo_path.as_str(),
-                "--write-commitid-to",
-                commitid_path.as_str(),
             ])
             .args(
                 self.cachedir
@@ -541,16 +563,36 @@ impl RootfsOpts {
                     .iter()
                     .flat_map(|v| ["--source-root", v.as_str()]),
             )
-            .arg(manifest.as_str())
-            .run()?;
-        // Read the ostree commit digest
-        let commit = std::fs::read_to_string(commitid_path)?;
-        let commit = commit.trim();
+            .args([manifest.as_str(), self.dest.as_str()])
+            .run()
+            .context("Executing compose install")?;
+        {
+            let target = Dir::open_ambient_dir(&self.dest, cap_std::ambient_authority())?;
+            Self::fixup_installroot(&target)?;
+        }
+        self_command()
+            .args([
+                "compose",
+                "postprocess",
+                self.dest.as_str(),
+                manifest.as_str(),
+            ])
+            .run()
+            .context("Executing compose postprocess")?;
 
-        // Finally, unpack that commit to the target root.
-        println!("Constructing rootfs from commit...");
-        unpack_commit_to_dir_as_bare_split_xattrs(&repo, commit, &self.dest)
-        // At this point we'll drop our temporary directory, including the ostree repo etc.
+        // After compose install/postprocess we still have usr/etc, not etc.
+        // Since we're generating a plain root and not an ostree commit, let's
+        // move it.
+        let target = Dir::open_ambient_dir(&self.dest, cap_std::ambient_authority())?;
+        let etc = "etc";
+        let usretc = "usr/etc";
+        if target.try_exists(usretc)? {
+            tracing::debug!("Renaming {usretc} to {etc}");
+            target
+                .rename(usretc, &target, etc)
+                .context("Renaming usr/etc to etc")?;
+        }
+        Ok(())
     }
 }
 

--- a/tests/compose-rootfs/Containerfile
+++ b/tests/compose-rootfs/Containerfile
@@ -2,14 +2,13 @@
 FROM quay.io/centos/centos:stream10 as repos
 
 # You must run this build with `-v /path/to/rpm-ostree:/run/build/rpm-ostree:ro`
-FROM quay.io/fedora/fedora:41 as builder
+FROM quay.io/fedora/fedora-bootc:41 as builder
 RUN <<EORUN
 set -xeuo pipefail
-# Install our dependencies
-dnf -y install rpm-ostree selinux-policy-targeted sqlite
 # Our goal here though is to test the updated rpm-ostree binary.
 # Right now there are a very few things that live outside the binary
 # like rpm-ostree-0-integration.conf, but we should probably move those in.
+# nocache 0228
 install /run/build/rpm-ostree /usr/bin
 EORUN
 # Copy in our source code.
@@ -17,12 +16,20 @@ COPY . /src
 WORKDIR /src
 RUN --mount=type=bind,from=repos,src=/,dst=/repos,rw <<EORUN
 set -xeuo pipefail
-exec rpm-ostree compose rootfs --source-root-rw=/repos manifest.yaml /target-rootfs
+exec env RUST_LOG=debug rpm-ostree compose rootfs --source-root-rw=/repos manifest.yaml /target-rootfs
 EORUN
 
 # This pulls in the rootfs generated in the previous step
 FROM scratch
 COPY --from=builder /target-rootfs/ /
+RUN <<EORUN
+set -xeuo pipefail
+# Validate we aren't using ostree-container format
+test '!' -f /ostree/repo/config
+# Validate we have file caps
+getfattr -d -m security.capability /usr/bin/newuidmap
+bootc container lint
+EORUN
 LABEL containers.bootc 1
 # https://pagure.io/fedora-kiwi-descriptions/pull-request/52
 ENV container=oci

--- a/tests/compose-rootfs/manifest.yaml
+++ b/tests/compose-rootfs/manifest.yaml
@@ -2,7 +2,16 @@ edition: "2024"
 packages:
   - bash
   - rpm
+  - attr
   - coreutils
   - selinux-policy-targeted
   - kernel
   - rpm-ostree
+
+postprocess:
+  - |
+    #!/bin/bash
+    cat >/usr/lib/ostree/prepare-root.conf <<'EOF'
+    [composefs]
+    enabled = yes
+    EOF


### PR DESCRIPTION
Just output a "plain" fsroot. We can't do ostree-container because (unlike compose image) we won't have the ostree.final-diffid indicator in the output image, so ostree/bootc won't honor all the ostree stuff.

Combined with a prior bug where we were missing setting the `security.capability` flag, this was causing the failures in trying to do the centos-bootc build.

Closes: https://github.com/coreos/rpm-ostree/issues/5314
