### PR TITLE
compose-rootfs: Fix perms for /

### DIFF
--- a/tests/compose-rootfs/Containerfile
+++ b/tests/compose-rootfs/Containerfile
@@ -26,6 +26,8 @@ RUN <<EORUN
 set -xeuo pipefail
 # Validate we aren't using ostree-container format
 test '!' -f /ostree/repo/config
+# Validate executable bit for others on /
+test $(($(stat -c '0%a' /) % 2)) = 1
 # Validate we have file caps
 getfattr -d -m security.capability /usr/bin/newuidmap
 bootc container lint


### PR DESCRIPTION
The trick we did here in working around `compose install` generating a `rootfs` subdirectory by moving its contents into the parent meant we lost the mode bits.

Somehow, only when targeting this for CentOS we hit on the mode being 0700 (I think this may relate to umask? We probably need to audit our whole codebase to avoid umask issues; but really in the longer term switch to trusting the `filesystem` rpm instead of manually extracting the root).
