### PR TITLE
daemon,app: Support rebasing/deploying specific digests in OCI path

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -2126,7 +2126,8 @@ extern "C"
 
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$pull_container (
       ::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable,
-      ::rust::Str imgref, ::rust::Box< ::rpmostreecxx::ContainerImageState> *return$) noexcept;
+      ::rust::Str imgref, ::rust::Str digest_override,
+      ::rust::Box< ::rpmostreecxx::ContainerImageState> *return$) noexcept;
 
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$container_prune (::rpmostreecxx::OstreeSysroot const &sysroot,
@@ -3742,11 +3743,12 @@ PrunedContainerInfo::operator!= (PrunedContainerInfo const &rhs) const noexcept
 
 ::rust::Box< ::rpmostreecxx::ContainerImageState>
 pull_container (::rpmostreecxx::OstreeRepo const &repo,
-                ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref)
+                ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref,
+                ::rust::Str digest_override)
 {
   ::rust::MaybeUninit< ::rust::Box< ::rpmostreecxx::ContainerImageState> > return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$pull_container (repo, cancellable, imgref, &return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$pull_container (
+      repo, cancellable, imgref, digest_override, &return$.value);
   if (error$.ptr)
     {
       throw ::rust::impl< ::rust::Error>::error (error$);

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1821,7 +1821,8 @@ void deploy_from_self_entrypoint (::rust::Vec< ::rust::String> args);
 
 ::rust::Box< ::rpmostreecxx::ContainerImageState>
 pull_container (::rpmostreecxx::OstreeRepo const &repo,
-                ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref);
+                ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref,
+                ::rust::Str digest_override);
 
 ::rpmostreecxx::PrunedContainerInfo container_prune (::rpmostreecxx::OstreeSysroot const &sysroot);
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -227,6 +227,7 @@ pub mod ffi {
             repo: &OstreeRepo,
             cancellable: &GCancellable,
             imgref: &str,
+            digest_override: &str,
         ) -> Result<Box<ContainerImageState>>;
         fn container_prune(sysroot: &OstreeSysroot) -> Result<PrunedContainerInfo>;
         fn query_container_image_commit(

--- a/src/app/rpmostree-builtin-rebase.cxx
+++ b/src/app/rpmostree-builtin-rebase.cxx
@@ -142,14 +142,6 @@ rpmostree_builtin_rebase (int argc, char **argv, RpmOstreeCommandInvocation *inv
   if (strlen (new_provided_refspec) == 0)
     return glnx_throw (error, "Refspec is empty");
 
-  if (refspectype == rpmostreecxx::RefspecType::Container)
-    {
-      /* When using the container refspec type, if rebasing to a specific commit, we expect a
-       * specific digest tag in the refspec, not in a separate argument */
-      if (revision)
-        return glnx_throw (error, "Unexpected ostree revision alongside container refspec type");
-    }
-
   /* Check if remote refers to a local repo */
   g_autofree char *local_repo_remote = NULL;
   if (refspectype == rpmostreecxx::RefspecType::Ostree

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -430,9 +430,6 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader *self, const char
     {
     case rpmostreecxx::RefspecType::Container:
       {
-        if (override_commit)
-          return glnx_throw (error, "Specifying commit overrides for container-image-reference "
-                                    "type refspecs is not supported");
         if (check)
           {
             CXX_TRY_VAR (changed,
@@ -444,10 +441,10 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader *self, const char
           }
         else
           {
-            CXX_TRY_VAR (
-                import,
-                rpmostreecxx::pull_container (*self->repo, *cancellable, r.refspec.c_str ()),
-                error);
+            CXX_TRY_VAR (import,
+                         rpmostreecxx::pull_container (*self->repo, *cancellable,
+                                                       r.refspec.c_str (), override_commit_s),
+                         error);
 
             if (!import->verify_text.empty ())
               rpmostree_output_message ("%s", import->verify_text.c_str ());

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -183,9 +183,12 @@ apply_revision_override (RpmostreedTransaction *transaction, OstreeRepo *repo,
     return glnx_throw (error, "Cannot look up version while pinned to commit");
 
   if (r.kind == rpmostreecxx::RefspecType::Container)
-    /* NB: Not supported for now, but We can perhaps support this if we allow `revision` to
-     * possibly be a tag or digest */
-    return glnx_throw (error, "Cannot look up version while tracking a container image reference");
+    {
+      /* There's no "lookup" to do here; there's no concept of branch history in
+       * the OCI case. So just set the digest override and move on. */
+      rpmostree_origin_set_override_commit (origin, revision);
+      return TRUE;
+    }
 
   if (r.kind != rpmostreecxx::RefspecType::Ostree)
     return glnx_throw (error, "Invalid refspec type");

--- a/tests/kolainst/destructive/container-image
+++ b/tests/kolainst/destructive/container-image
@@ -72,12 +72,6 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   1)
     # Some tests of other things
 
-    if rpm-ostree deploy 42 2>err.txt; then
-        fatal "unexpectedly deployed version from container image reference"
-    fi
-    assert_file_has_content err.txt 'Cannot look up version while tracking a container image reference'
-    echo "ok cannot deploy when tracking container image"
-
     # Test layering
     if rpm -q foo 2>/dev/null; then
       fatal "found foo"

--- a/tests/kolainst/destructive/container-rebase-upgrade
+++ b/tests/kolainst/destructive/container-rebase-upgrade
@@ -29,10 +29,14 @@ set -x
 libtest_prepare_offline
 cd "$(mktemp -d)"
 
+curl -L https://builds.coreos.fedoraproject.org/prod/streams/testing/releases.json > testing.json
+latest_digest=$(jq -r '.releases[-1]["oci-images"][] | select(.architecture == "x86_64") | ."digest-ref"' testing.json | cut -f2 -d@)
+prev_digest=$(jq -r '.releases[-2]["oci-images"][] | select(.architecture == "x86_64") | ."digest-ref"' testing.json | cut -f2 -d@)
+
 image=quay.io/fedora/fedora-coreos
-image_tag=testing-devel
-digest=$(skopeo inspect -n docker://$image:$image_tag | jq -r .Digest)
-image_pull=ostree-remote-registry:fedora:$image@$digest
+image_tag=testing
+image_pull_digest=ostree-remote-registry:fedora:$image@$latest_digest
+image_pull_tag=ostree-remote-registry:fedora:$image:$image_tag
 
 systemctl mask --now zincati
 # Test for https://github.com/ostreedev/ostree/issues/3228
@@ -42,7 +46,20 @@ assert_file_has_content_literal kargs.txt "foo=\"a b c\""
 # also test custom origin stuff
 rpm-ostree rebase "${image_pull}" --custom-origin-description "Fedora CoreOS $image_tag stream" --custom-origin-url "$image:$image_tag"
 rpm-ostree status > status.txt
-assert_file_has_content_literal status.txt "$image:$image_tag" "Fedora CoreOS $image_tag stream"
+
+# test pinned rebase
+ostree admin undeploy 0
+rpm-ostree rebase "${image_pull_tag}" "${prev_digest}"
+rpm-ostree status --json > status.json
+assert_jq status.json \
+          ".deployments[0].\"container-image-reference\" == \"${image_pull_tag}\"" \
+          ".deployments[0].\"container-image-reference-digest\" == \"$prev_digest\""
+rpm-ostree deploy "${latest_digest}"
+rpm-ostree status --json > status.json
+assert_jq status.json \
+          ".deployments[0].\"container-image-reference\" == \"${image_pull_tag}\"" \
+          ".deployments[0].\"container-image-reference-digest\" == \"$latest_digest\""
+
 rpm-ostree upgrade
 # This provokes
 # https://github.com/coreos/rpm-ostree/issues/4107

--- a/tests/kolainst/destructive/container-rebase-upgrade
+++ b/tests/kolainst/destructive/container-rebase-upgrade
@@ -43,9 +43,15 @@ systemctl mask --now zincati
 rpm-ostree kargs --append "foo=\"a b c\""
 rpm-ostree kargs > kargs.txt
 assert_file_has_content_literal kargs.txt "foo=\"a b c\""
-# also test custom origin stuff
-rpm-ostree rebase "${image_pull}" --custom-origin-description "Fedora CoreOS $image_tag stream" --custom-origin-url "$image:$image_tag"
+# also test custom origin stuff and finalization locking
+rpm-ostree rebase "${image_pull_digest}" --custom-origin-description "Fedora CoreOS $image_tag stream" --custom-origin-url "$image:$image_tag" --lock-finalization
 rpm-ostree status > status.txt
+assert_file_has_content_literal status.txt "$image:$image_tag" "Fedora CoreOS $image_tag stream"
+if rpm-ostree finalize-deployment "${prev_digest}" &> out.txt; then
+  cat out.txt
+  assert_not_reached "finalize-deployment with the wrong checksum succeeded!"
+fi
+assert_file_has_content_literal out.txt "Expected staged base checksum $prev_digest, but found $latest_digest"
 
 # test pinned rebase
 ostree admin undeploy 0


### PR DESCRIPTION
In FCOS, we want to keep a tagged refspec in the origin, but still be
able to deploy a specific image.

Enable this.

(It's not quite the same as the OSTree case of course, because there's
no concept of branches there. But at least we can enforce that the
digest is located in the same repo as the canonical refspec.)

This is tracked on the bootc side in
containers/bootc#1165.