### PR TITLE
compose: Stabilize `compose build-chunked-oci`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,7 +244,7 @@ jobs:
       - name: Integration tests
         run: env TMPDIR=/var/tmp ./tests/encapsulate.sh
   test-build-chunked-oci:
-    name: "experimental build-chunked-oci tests"
+    name: "build-chunked-oci tests"
     needs: build-c9s
     runs-on: ubuntu-24.04
     steps:
@@ -275,7 +275,7 @@ jobs:
             -v /var/lib/containers:/var/lib/containers \
             -v /var/tmp:/var/tmp \
             -v $(pwd):/output \
-            localhost/builder rpm-ostree experimental compose build-chunked-oci --bootc --format-version=1 --max-layers 99 --from localhost/base --output containers-storage:localhost/chunked
+            localhost/builder rpm-ostree compose build-chunked-oci --bootc --format-version=1 --max-layers 99 --from localhost/base --output containers-storage:localhost/chunked
           sudo skopeo inspect containers-storage:localhost/chunked
           new_created=$(sudo skopeo inspect --raw --config containers-storage:localhost/chunked | jq -r .created)
           # ostree only stores seconds, so canonialize the rfc3339 data to seconds

--- a/docs/build-chunked-oci.md
+++ b/docs/build-chunked-oci.md
@@ -2,7 +2,7 @@
 nav_order: 5
 ---
 
-# experimental compose build-chunked-oci
+# compose build-chunked-oci
 
 Currently this project supports `rpm-ostree compose image` which is a highly
 opinionated tool which consumes treefiles and outputs an OCI archive.
@@ -10,7 +10,7 @@ opinionated tool which consumes treefiles and outputs an OCI archive.
 However, it does not support common container-native workflows such
 as copying content from a distinct container image.
 
-The `rpm-ostree experimental compose build-chunked-oci` command
+The `rpm-ostree compose build-chunked-oci` command
 accepts an arbitrary input container image, and synthesizes a
 bootc (ostree container) ready image from it.
 
@@ -28,7 +28,7 @@ instance, and can output to `containers-storage:` or `oci`.
 ```
 podman build -t quay.io/exampleos/exampleos:build ...
 ...
-rpm-ostree experimental compose build-chunked-oci --bootc --format-version=1 \
+rpm-ostree compose build-chunked-oci --bootc --format-version=1 \
            --from=quay.io/exampleos/exampleos:build --output containers-storage:quay.io/exampleos/exampleos:latest
 podman push quay.io/exampleos/exampleos:latest
 ```

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -24,6 +24,9 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+#if __cplusplus >= 202002L
+#include <ranges>
+#endif
 
 namespace rust
 {
@@ -61,6 +64,10 @@ public:
   String (const char *, std::size_t);
   String (const char16_t *);
   String (const char16_t *, std::size_t);
+#if __cplusplus >= 202002L
+  String (const char8_t *s);
+  String (const char8_t *s, std::size_t len);
+#endif
 
   static String lossy (const std::string &) noexcept;
   static String lossy (const char *) noexcept;
@@ -230,7 +237,11 @@ private:
 template <typename T> class Slice<T>::iterator final
 {
 public:
+#if __cplusplus >= 202002L
+  using iterator_category = std::contiguous_iterator_tag;
+#else
   using iterator_category = std::random_access_iterator_tag;
+#endif
   using value_type = T;
   using difference_type = std::ptrdiff_t;
   using pointer = typename std::add_pointer<T>::type;
@@ -248,6 +259,11 @@ public:
   iterator &operator+= (difference_type) noexcept;
   iterator &operator-= (difference_type) noexcept;
   iterator operator+ (difference_type) const noexcept;
+  friend inline iterator
+  operator+ (difference_type lhs, iterator rhs) noexcept
+  {
+    return rhs + lhs;
+  }
   iterator operator- (difference_type) const noexcept;
   difference_type operator- (const iterator &) const noexcept;
 
@@ -263,6 +279,11 @@ private:
   void *pos;
   std::size_t stride;
 };
+
+#if __cplusplus >= 202002L
+static_assert (std::ranges::contiguous_range<rust::Slice<const uint8_t> >);
+static_assert (std::contiguous_iterator<rust::Slice<const uint8_t>::iterator>);
+#endif
 
 template <typename T> Slice<T>::Slice () noexcept
 {
@@ -2193,6 +2214,9 @@ extern "C"
                                               ::rust::Str cachebranch,
                                               ::rpmostreecxx::GVariant **return$) noexcept;
 
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$compose_build_chunked_oci_entrypoint (
+      ::rust::Vec< ::rust::String> *args) noexcept;
+
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$compose_image (::rust::Vec< ::rust::String> *args) noexcept;
 
@@ -3970,6 +3994,18 @@ get_header_variant (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str cachebra
       throw ::rust::impl< ::rust::Error>::error (error$);
     }
   return ::std::move (return$.value);
+}
+
+void
+compose_build_chunked_oci_entrypoint (::rust::Vec< ::rust::String> args)
+{
+  ::rust::ManuallyDrop< ::rust::Vec< ::rust::String> > args$ (::std::move (args));
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$compose_build_chunked_oci_entrypoint (&args$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
 }
 
 void

--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -363,6 +363,11 @@ impl BuildChunkedOCIOpts {
     }
 }
 
+pub(crate) fn compose_build_chunked_oci_entrypoint(args: Vec<String>) -> CxxResult<()> {
+    BuildChunkedOCIOpts::parse_from(args).run()?;
+    Ok(())
+}
+
 /// Given a .repo file, rewrite all references to gpgkey=file:// inside
 /// it to point into the source_root (if the key can be found there).
 /// This is a workaround for https://github.com/coreos/rpm-ostree/issues/5285

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -281,6 +281,7 @@ pub mod ffi {
 
     // compose.rs
     extern "Rust" {
+        fn compose_build_chunked_oci_entrypoint(args: Vec<String>) -> Result<()>;
         fn compose_image(args: Vec<String>) -> Result<()>;
         fn compose_rootfs_entrypoint(args: Vec<String>) -> Result<()>;
 

--- a/src/app/rpmostree-builtin-compose.cxx
+++ b/src/app/rpmostree-builtin-compose.cxx
@@ -55,6 +55,9 @@ static RpmOstreeCommand compose_subcommands[] = {
     rpmostree_compose_builtin_image },
   { "rootfs", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD, "Generate a root filesystem tree from a treefile",
     rpmostree_compose_builtin_rootfs },
+  { "build-chunked-oci", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+    "Generate a \"chunked\" OCI archive from an input rootfs",
+    rpmostree_compose_builtin_build_chunked_oci },
   { NULL, (RpmOstreeBuiltinFlags)0, NULL, NULL }
 };
 
@@ -89,5 +92,18 @@ rpmostree_compose_builtin_rootfs (int argc, char **argv, RpmOstreeCommandInvocat
   for (int i = 0; i < argc; i++)
     rustargv.push_back (std::string (argv[i]));
   CXX_TRY (rpmostreecxx::compose_rootfs_entrypoint (rustargv), error);
+  return TRUE;
+}
+
+gboolean
+rpmostree_compose_builtin_build_chunked_oci (int argc, char **argv,
+                                             RpmOstreeCommandInvocation *invocation,
+                                             GCancellable *cancellable, GError **error)
+{
+  rust::Vec<rust::String> rustargv;
+  g_assert_cmpint (argc, >, 0);
+  for (int i = 0; i < argc; i++)
+    rustargv.push_back (std::string (argv[i]));
+  CXX_TRY (rpmostreecxx::compose_build_chunked_oci_entrypoint (rustargv), error);
   return TRUE;
 }

--- a/src/app/rpmostree-compose-builtins.h
+++ b/src/app/rpmostree-compose-builtins.h
@@ -51,5 +51,8 @@ gboolean rpmostree_compose_builtin_image (int argc, char **argv,
 gboolean rpmostree_compose_builtin_rootfs (int argc, char **argv,
                                            RpmOstreeCommandInvocation *invocation,
                                            GCancellable *cancellable, GError **error);
+gboolean rpmostree_compose_builtin_build_chunked_oci (int argc, char **argv,
+                                                      RpmOstreeCommandInvocation *invocation,
+                                                      GCancellable *cancellable, GError **error);
 
 G_END_DECLS


### PR DESCRIPTION
Expose this as `rpm-ostree compose build-chunked-oci`

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
