### PR TITLE
daemon: allow rebasing to the same refspec if there is a digest override

### DIFF
--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -122,8 +122,9 @@ change_origin_refspec (GVariantDict *options, OstreeSysroot *sysroot, RpmOstreeO
   /* Classify to ensure we handle TYPE_CHECKSUM */
   auto new_refspectype = rpmostreecxx::refspec_classify (new_refspec);
 
-  if (new_refspectype == rpmostreecxx::RefspecType::Checksum)
-    {
+  if (new_refspectype == rpmostreecxx::RefspecType::Checksum
+      || rpmostree_origin_get_override_commit(origin) != NULL)
+     {
       rpmostree_origin_set_rebase_custom (origin, new_refspec, custom_origin_url,
                                           custom_origin_description);
     }

--- a/tests/kolainst/destructive/container-rebase-upgrade
+++ b/tests/kolainst/destructive/container-rebase-upgrade
@@ -66,6 +66,12 @@ assert_jq status.json \
           ".deployments[0].\"container-image-reference\" == \"${image_pull_tag}\"" \
           ".deployments[0].\"container-image-reference-digest\" == \"$latest_digest\""
 
+# test rebase to another pinned digest on the same refspec
+prev_prev_digest=$(jq -r '.releases[-3]["oci-images"][] | select(.architecture == "x86_64") | ."digest-ref"' testing.json | cut -f2 -d@)
+# Not sure how to test that since I'd have to reboot or undeploy which would break the test.
+# Basically we need `rebase  "${image_pull_tag}" "${prev_digest}"`
+# then `rebase  "${image_pull_tag}" "${latest_digest}"`
+
 rpm-ostree upgrade
 # This provokes
 # https://github.com/coreos/rpm-ostree/issues/4107


### PR DESCRIPTION
https://github.com/coreos/rpm-ostree/pull/5325
introduced the ability to rebase to a specific
digest while keeping the tagged refspec in the
origin.

In FCOS, we update from a pinned image to another
on the same stream (i.e. the same tagged refspec).

Allow this by checking if the digest override is
set.

See https://github.com/coreos/rpm-ostree/pull/5325#issuecomment-2706048328

-----

I haven't wrote C code in 10 years, and never Cpp, so I tried something ! I am not sure how I can add `origin_has_override_commit` in `libpriv/rpmostree-origin` ? So i used the getter for now.

Would that fix the issue ? 
Also I could not find a way to write a test so I wrote my thoughts in the test file. Thanks in advance for the guidance ! 