### PR TITLE
rpmostree-core: Emulate new %sysusers RPM scriplet

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,6 +184,10 @@ jobs:
     name: "compose-image tests"
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        RELEASE: ['40', '41', '42']
     container:
       image: registry.ci.openshift.org/coreos/coreos-assembler:latest
       options: "--user root --privileged -v /var/tmp:/var/tmp"
@@ -199,7 +203,9 @@ jobs:
       - name: Install
         run: tar -C / -xzvf install.tar
       - name: Integration tests
-        run: env TMPDIR=/var/tmp JOBS=3 ./tests/compose-image.sh
+        run: env TMPDIR=/var/tmp JOBS=3 RELEASE=${RELEASE} ./tests/compose-image.sh
+        env:
+          RELEASE: ${{ matrix.RELEASE }}
   compose-rootfs:
     name: "compose-rootfs tests"
     needs: build

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -2187,6 +2187,8 @@ extern "C"
                                                            ::rust::Str kver,
                                                            bool unified_core) noexcept;
 
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$run_sysusers (::std::int32_t rootfs_dfd) noexcept;
+
   void rpmostreecxx$cxxbridge1$log_treefile (::rpmostreecxx::Treefile const &tf) noexcept;
 
   bool rpmostreecxx$cxxbridge1$is_container_image_reference (::rust::Str refspec) noexcept;
@@ -3903,6 +3905,16 @@ void
 run_depmod (::std::int32_t rootfs_dfd, ::rust::Str kver, bool unified_core)
 {
   ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$run_depmod (rootfs_dfd, kver, unified_core);
+  if (error$.ptr)
+    {
+      throw ::rust::impl< ::rust::Error>::error (error$);
+    }
+}
+
+void
+run_sysusers (::std::int32_t rootfs_dfd)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$run_sysusers (rootfs_dfd);
   if (error$.ptr)
     {
       throw ::rust::impl< ::rust::Error>::error (error$);

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1862,6 +1862,8 @@ prepare_filesystem_script_prep (::std::int32_t rootfs);
 
 void run_depmod (::std::int32_t rootfs_dfd, ::rust::Str kver, bool unified_core);
 
+void run_sysusers (::std::int32_t rootfs_dfd);
+
 void log_treefile (::rpmostreecxx::Treefile const &tf) noexcept;
 
 bool is_container_image_reference (::rust::Str refspec) noexcept;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -263,6 +263,8 @@ pub mod ffi {
 
         fn run_depmod(rootfs_dfd: i32, kver: &str, unified_core: bool) -> Result<()>;
 
+        fn run_sysusers(rootfs_dfd: i32) -> Result<()>;
+
         fn log_treefile(tf: &Treefile);
 
         fn is_container_image_reference(refspec: &str) -> bool;

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -4435,6 +4435,17 @@ rpmostree_context_assemble (RpmOstreeContext *self, GCancellable *cancellable, G
 
   CXX_TRY_VAR (etc_guard, rpmostreecxx::prepare_tempetc_guard (tmprootfs_dfd), error);
 
+  /* if the %__systemd_sysusers macro is defined, that _very likely_ means that
+   * we're using an rpm with built-in sysusers support:
+   * https://fedoraproject.org/wiki/Changes/RPMSuportForSystemdSysusers
+   * Ideally, librpm would expose that part as a public API but it's currently
+   * just done during the transaction. So here we just do it ourselves, though
+   * a bit differently: librpm checks for the user/group provides before
+   * proceeding to call sysusers _just_ for that package. Here we do it for all
+   * of them. See also: https://github.com/coreos/rpm-ostree/issues/5333 */
+  if (!ROSCXX (run_sysusers (tmprootfs_dfd), error))
+    return glnx_prefix_error (error, "Running systemd-sysusers");
+
   /* NB: we're not running scripts right now for removals, so this is only for overlays and
    * replacements */
   if (overlays->len > 0 || overrides_replace->len > 0)


### PR DESCRIPTION
rpmostree-core: Emulate new %sysusers RPM scriplet

As part of the migration to direct sysusers support in RPMs, packages
are no longer creating their users/groups in %pre scripts as they rely
on RPM to do the work in a built in %sysusers scriplet.

The RPM library does not expose a direct interface to call those
scriplets so we instead emulate the process by directly calling out to
the binary pointed by `%__systemd_sysusers`, if it is set.

See: https://fedoraproject.org/wiki/Changes/RPMSuportForSystemdSysusers
See: https://github.com/rpm-software-management/rpm/commit/009d1397331a89413e2c5eead163cadb47ccdb4b

See: https://github.com/fedora-silverblue/issue-tracker/issues/636
See: https://gitlab.com/fedora/ostree/sig/-/issues/70
See: https://github.com/coreos/rpm-ostree/issues/5333

---

tests/compose-image: Test with Fedora 40, 41 & 42

- Add systemd-standalone-sysusers to container for F42+.
  Starting with Fedora 42, RPM will use sysusers to create users and we
  emulate that support by running sysusers in the rootfs before running
  other scriptlets.
  See: https://github.com/coreos/rpm-ostree/issues/5333

- Test with Fedora 41 by default

- Replace dnf with dnf5 for F41+
  See: https://fedoraproject.org/wiki/Changes/SwitchToDnf5

- tests/compose-image: Remove fedora-repos-modular
  Support for modularity has been removed from Fedora.
  See: https://fedoraproject.org/wiki/Changes/RetireModularity