### PR TITLE
compose: Ensure tempdir is dropped after commit

### DIFF
--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -352,6 +352,8 @@ impl BuildChunkedOCIOpts {
             .context("Invoking compose container-encapsulate")?;
 
         drop(rootfs);
+        // Ensure our tempdir is only dropped now
+        drop(td);
         match rootfs_source {
             FileSource::Rootfs(_) => {}
             FileSource::Podman(mnt) => {


### PR DESCRIPTION
The tempdir holds the ostree repo.

I'm looking at an issue reported in a downstream build that failed like this:

```
+ rpm-ostree experimental compose build-chunked-oci --bootc --format-version=1 --rootfs /target-rootfs --output oci-archive:/buildcontext/out.ociarchive
Generating commit...
error: Generating commit from rootfs: syncfs: Not a directory
subprocess exited with status 1
subprocess exited with status 1
```

Which frankly has me just confused. The `syncfs` here is almost certainly coming from libostree's sync of the target repo.

And "Not a directory" is especially weird, implying that `repo/tmp` got swapped with something else?
