### PR TITLE
Release 2025.7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2025])
-m4_define([release_version], [6])
+m4_define([release_version], [7])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2025.5
+Version: 2025.7
 Release: 1%{?dist}
 License: LGPL-2.0-or-later
 URL: https://github.com/coreos/rpm-ostree


### PR DESCRIPTION
This is mostly a bugfix and stabilization Release.

```
Colin Walters (4):
      compose-rootfs: Fix perms for /
      compose: Ensure tempdir is dropped after commit
      README.md: Revert deprecation notice, update arch diagram
      compose-rootfs: Ensure we don't emit user.ostreemeta

John Eckersberg (2):
      compose: Stabilize `compose build-chunked-oci`
      docs: expand on chunked images

Jonathan Lebon (2):
      daemon,app: Support rebasing/deploying specific digests in OCI path
      daemon: Support deployment finalization by OCI digest

Joseph Marrero Corchado (1):
      Release 2025.7

Timothée Ravier (2):
      rpmostree-core: Emulate new %sysusers RPM scriplet
      tests/compose-image: Test with Fedora 40, 41 & 42
```

## New Contributors

* @jeckersb made their first contribution in https://github.com/coreos/rpm-ostree/pull/5326

**Full Changelog**: https://github.com/coreos/rpm-ostree/compare/v2025.6...v2025.7