### PR TITLE
build-chunked-oci: Handle multi-arch, perserve labels

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -273,20 +273,9 @@ jobs:
         run: |
           set -xeuo pipefail
           cd tests/build-chunked-oci
-          sudo podman build -t localhost/base -f Containerfile.test
-          sudo tar -xzvf ../../install.tar
+          tar -xzvf ../../install.tar
           sudo podman build -v $(pwd)/usr/bin:/ci -t localhost/builder -f Containerfile.builder
-          orig_created=$(sudo skopeo inspect --raw --config containers-storage:localhost/base | jq -r .created)
-          sudo podman run --rm --privileged --security-opt=label=disable \
-            -v /var/lib/containers:/var/lib/containers \
-            -v /var/tmp:/var/tmp \
-            -v $(pwd):/output \
-            localhost/builder rpm-ostree compose build-chunked-oci --bootc --format-version=1 --max-layers 99 --from localhost/base --output containers-storage:localhost/chunked
-          sudo skopeo inspect containers-storage:localhost/chunked
-          new_created=$(sudo skopeo inspect --raw --config containers-storage:localhost/chunked | jq -r .created)
-          # ostree only stores seconds, so canonialize the rfc3339 data to seconds
-          test "$(date --date="${orig_created}" --rfc-3339=seconds)" = "$(date --date="${new_created}" --rfc-3339=seconds)"
-
+          sudo ./test.sh
   build-c9s:
     name: "Build (c9s)"
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -225,7 +225,7 @@ dependencies = [
 [[package]]
 name = "bootc-utils"
 version = "0.0.0"
-source = "git+https://github.com/containers/bootc?rev=73de2a8ef0a312243b686c6bd2c91413ee725c05#73de2a8ef0a312243b686c6bd2c91413ee725c05"
+source = "git+https://github.com/containers/bootc?rev=d9b18c8883ad24e7b0faf596758e3c12b26656e5#d9b18c8883ad24e7b0faf596758e3c12b26656e5"
 dependencies = [
  "anyhow",
  "rustix",
@@ -460,6 +460,29 @@ dependencies = [
  "strum",
  "strum_macros",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "composefs"
+version = "0.2.0"
+source = "git+https://github.com/containers/composefs-rs?rev=55ae2e9ba72f6afda4887d746e6b98f0a1875ac4#55ae2e9ba72f6afda4887d746e6b98f0a1875ac4"
+dependencies = [
+ "anyhow",
+ "async-compression",
+ "clap",
+ "containers-image-proxy",
+ "hex",
+ "indicatif",
+ "oci-spec",
+ "regex-automata 0.4.9",
+ "rustix",
+ "sha2",
+ "tar",
+ "tempfile",
+ "thiserror 2.0.11",
+ "tokio",
+ "zerocopy 0.8.24",
+ "zstd",
 ]
 
 [[package]]
@@ -1688,6 +1711,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
+ "tokio",
  "unicode-width 0.2.0",
  "web-time",
 ]
@@ -2181,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "ostree-ext"
 version = "0.15.3"
-source = "git+https://github.com/containers/bootc?rev=73de2a8ef0a312243b686c6bd2c91413ee725c05#73de2a8ef0a312243b686c6bd2c91413ee725c05"
+source = "git+https://github.com/containers/bootc?rev=d9b18c8883ad24e7b0faf596758e3c12b26656e5#d9b18c8883ad24e7b0faf596758e3c12b26656e5"
 dependencies = [
  "anyhow",
  "bootc-utils",
@@ -2190,6 +2214,7 @@ dependencies = [
  "chrono",
  "clap",
  "comfy-table",
+ "composefs",
  "containers-image-proxy",
  "flate2",
  "fn-error-context",
@@ -2366,7 +2391,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -4094,7 +4119,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -4102,6 +4136,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ openssl = "0.10.70"
 once_cell = "1.20.2"
 os-release = "0.1.0"
 # We pull this one from git, as the project is no longer published as an external crate.
-ostree-ext = { git = "https://github.com/containers/bootc", rev = "73de2a8ef0a312243b686c6bd2c91413ee725c05" }
+ostree-ext = { git = "https://github.com/containers/bootc", rev = "d9b18c8883ad24e7b0faf596758e3c12b26656e5" }
 paste = "1.0"
 phf = { version = "0.11", features = ["macros"] }
 rand = "0.8.5"

--- a/deny.toml
+++ b/deny.toml
@@ -12,4 +12,4 @@ name = "ring"
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-git = ["https://github.com/containers/bootc"]
+allow-git = ["https://github.com/containers/bootc", "https://github.com/containers/composefs-rs"]

--- a/tests/build-chunked-oci/Containerfile.test
+++ b/tests/build-chunked-oci/Containerfile.test
@@ -10,3 +10,4 @@ dnf clean all
 rm /var/lib/rpm -rf
 bootc container lint
 EORUN
+LABEL testlabel=1

--- a/tests/build-chunked-oci/test.sh
+++ b/tests/build-chunked-oci/test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# First: a cross-arch rechunking
+testimg_base=quay.io/centos-bootc/centos-bootc:stream9
+chunked_output=localhost/chunked-ppc64le
+podman pull --arch=ppc64le ${testimg_base}
+podman run --rm --privileged --security-opt=label=disable \
+  -v /var/lib/containers:/var/lib/containers \
+  -v /var/tmp:/var/tmp \
+  -v $(pwd):/output \
+  localhost/builder rpm-ostree compose build-chunked-oci --bootc --from ${testimg_base} --output containers-storage:${chunked_output}
+podman rmi ${testimg_base}
+podman inspect containers-storage:${chunked_output} | jq '.[0]' > config.json
+podman rmi ${chunked_output}
+test $(jq -r '.Architecture' < config.json) = "ppc64le"
+echo "ok cross arch rechunking"
+
+# Build a custom image, then rechunk it
+podman build -t localhost/base -f Containerfile.test
+orig_created=$(podman inspect containers-storage:localhost/base | jq -r '.[0].Created')
+podman run --rm --privileged --security-opt=label=disable \
+  -v /var/lib/containers:/var/lib/containers \
+  -v /var/tmp:/var/tmp \
+  -v $(pwd):/output \
+  localhost/builder rpm-ostree compose build-chunked-oci --bootc --format-version=1 --max-layers 99 --from localhost/base --output containers-storage:localhost/chunked
+podman inspect containers-storage:localhost/chunked | jq '.[0]' > new-config.json
+# Verify we propagated the creation date
+new_created=$(jq -r .Created < new-config.json)
+# ostree only stores seconds, so canonialize the rfc3339 data to seconds
+test "$(date --date="${orig_created}" --rfc-3339=seconds)" = "$(date --date="${new_created}" --rfc-3339=seconds)"
+# Verify we propagated labels
+test $(jq -r .Labels.testlabel < new-config.json) = "1"
+echo "ok rechunking with labels"


### PR DESCRIPTION

- Move build-chunked-oci test into its own script; motivated
  by extending this and making it easier to run outside GHA.
  Less bash-in-YAML
- Ensure we pass the correct container metadata down to
  build-chunked-oci to preserve labels
- Because all we do is rearrange files in tarballs basically
  (i.e. we don't execute any code in the target) we should handle
  cross-architecture rechunking OK. Ensure that we also
  propagate the architecture from the original manifest.

Closes: #5340 

Signed-off-by: Colin Walters <walters@verbum.org>

---