### PR TITLE
app: Hide `--os` and add `--stateroot` alias

### DIFF
--- a/src/app/rpmostree-builtin-cleanup.cxx
+++ b/src/app/rpmostree-builtin-cleanup.cxx
@@ -38,7 +38,10 @@ static gboolean opt_rollback;
 static gboolean opt_repomd;
 
 static GOptionEntry option_entries[] = {
-  { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+  { "os", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME",
+    "OSNAME" },
+  { "stateroot", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided STATEROOT",
+    "STATEROOT" },
   { "base", 'b', 0, G_OPTION_ARG_NONE, &opt_base,
     "Clear temporary files; will leave deployments unchanged", NULL },
   { "pending", 'p', 0, G_OPTION_ARG_NONE, &opt_pending, "Remove pending deployment", NULL },

--- a/src/app/rpmostree-builtin-deploy.cxx
+++ b/src/app/rpmostree-builtin-deploy.cxx
@@ -41,7 +41,10 @@ static gboolean opt_skip_branch_check;
 static char *opt_ex_cliwrap;
 
 static GOptionEntry option_entries[]
-    = { { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+    = { { "os", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_osname,
+          "Operate on provided OSNAME", "OSNAME" },
+        { "stateroot", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided STATEROOT",
+          "STATEROOT" },
         { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot,
           "Initiate a reboot after operation is complete", NULL },
         /* XXX As much as I dislike the inconsistency with "rpm-ostree upgrade",

--- a/src/app/rpmostree-builtin-finalize-deployment.cxx
+++ b/src/app/rpmostree-builtin-finalize-deployment.cxx
@@ -30,7 +30,10 @@ static gboolean opt_allow_missing;
 static GOptionEntry option_entries[] = {
   /* though there can only be one staged deployment at a time, this could still
    * be useful to assert a specific osname */
-  { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+  { "os", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME",
+    "OSNAME" },
+  { "stateroot", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided STATEROOT",
+    "STATEROOT" },
   { "allow-missing-checksum", 0, 0, G_OPTION_ARG_NONE, &opt_allow_missing,
     "Don't error out if no expected checksum is provided", NULL },
   { "allow-unlocked", 0, 0, G_OPTION_ARG_NONE, &opt_allow_unlocked,

--- a/src/app/rpmostree-builtin-initramfs-etc.cxx
+++ b/src/app/rpmostree-builtin-initramfs-etc.cxx
@@ -39,7 +39,10 @@ static gboolean opt_lock_finalization;
 static gboolean opt_unchanged_exit_77;
 
 static GOptionEntry option_entries[] = {
-  { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+  { "os", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME",
+    "OSNAME" },
+  { "stateroot", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided STATEROOT",
+    "STATEROOT" },
   { "force-sync", 0, 0, G_OPTION_ARG_NONE, &opt_force_sync,
     "Deploy a new tree with the latest tracked /etc files", NULL },
   { "track", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_track, "Track root /etc file", "FILE" },

--- a/src/app/rpmostree-builtin-initramfs.cxx
+++ b/src/app/rpmostree-builtin-initramfs.cxx
@@ -37,7 +37,10 @@ static gboolean opt_reboot;
 static gboolean opt_lock_finalization;
 
 static GOptionEntry option_entries[]
-    = { { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+    = { { "os", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_osname,
+          "Operate on provided OSNAME", "OSNAME" },
+        { "stateroot", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided STATEROOT",
+          "STATEROOT" },
         { "enable", 0, 0, G_OPTION_ARG_NONE, &opt_enable,
           "Enable regenerating initramfs locally using dracut", NULL },
         { "arg", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_add_arg,

--- a/src/app/rpmostree-builtin-kargs.cxx
+++ b/src/app/rpmostree-builtin-kargs.cxx
@@ -41,7 +41,10 @@ static gboolean opt_lock_finalization;
 static gboolean opt_unchanged_exit_77;
 
 static GOptionEntry option_entries[] = {
-  { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operation on provided OSNAME", "OSNAME" },
+  { "os", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME",
+    "OSNAME" },
+  { "stateroot", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided STATEROOT",
+    "STATEROOT" },
   { "deploy-index", 0, 0, G_OPTION_ARG_STRING, &opt_deploy_index,
     "Modify the kernel args from a specific deployment based on index. Index is in the form of a "
     "number (e.g. 0 means the first deployment in the list)",

--- a/src/app/rpmostree-builtin-rebase.cxx
+++ b/src/app/rpmostree-builtin-rebase.cxx
@@ -46,7 +46,10 @@ static gboolean opt_lock_finalization;
 static gboolean opt_bypass_driver;
 
 static GOptionEntry option_entries[]
-    = { { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+    = { { "os", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_osname,
+          "Operate on provided OSNAME", "OSNAME" },
+        { "stateroot", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided STATEROOT",
+          "STATEROOT" },
         { "branch", 'b', 0, G_OPTION_ARG_STRING, &opt_branch,
           "Rebase to branch BRANCH; use --remote to change remote as well", "BRANCH" },
         { "remote", 'm', 0, G_OPTION_ARG_STRING, &opt_remote,

--- a/src/app/rpmostree-builtin-refresh-md.cxx
+++ b/src/app/rpmostree-builtin-refresh-md.cxx
@@ -32,7 +32,10 @@ static char *opt_osname;
 static char *opt_force;
 
 static GOptionEntry option_entries[]
-    = { { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+    = { { "os", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_osname,
+          "Operate on provided OSNAME", "OSNAME" },
+        { "stateroot", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided STATEROOT",
+          "STATEROOT" },
         { "force", 'f', 0, G_OPTION_ARG_NONE, &opt_force, "Expire current cache", NULL },
         { NULL } };
 

--- a/src/app/rpmostree-builtin-reset.cxx
+++ b/src/app/rpmostree-builtin-reset.cxx
@@ -38,7 +38,10 @@ static gboolean opt_initramfs;
 static gboolean opt_lock_finalization;
 
 static GOptionEntry option_entries[]
-    = { { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+    = { { "os", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_osname,
+          "Operate on provided OSNAME", "OSNAME" },
+        { "stateroot", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided STATEROOT",
+          "STATEROOT" },
         { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot,
           "Initiate a reboot after transaction is complete", NULL },
         { "overlays", 'l', 0, G_OPTION_ARG_NONE, &opt_overlays, "Remove all overlayed packages",

--- a/src/app/rpmostree-builtin-upgrade.cxx
+++ b/src/app/rpmostree-builtin-upgrade.cxx
@@ -46,7 +46,10 @@ static gboolean opt_bypass_driver;
 
 /* "check-diff" is deprecated, replaced by "preview" */
 static GOptionEntry option_entries[]
-    = { { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+    = { { "os", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_osname,
+          "Operate on provided OSNAME", "OSNAME" },
+        { "stateroot", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided STATEROOT",
+          "STATEROOT" },
         { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot,
           "Initiate a reboot after operation is complete", NULL },
         { "allow-downgrade", 0, 0, G_OPTION_ARG_NONE, &opt_allow_downgrade,

--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -42,7 +42,10 @@ static gboolean opt_experimental;
 static gboolean opt_freeze;
 
 static GOptionEntry option_entries[]
-    = { { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+    = { { "os", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_osname,
+          "Operate on provided OSNAME", "OSNAME" },
+        { "stateroot", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided STATEROOT",
+          "STATEROOT" },
         { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot,
           "Initiate a reboot after operation is complete", NULL },
         { "dry-run", 'n', 0, G_OPTION_ARG_NONE, &opt_dry_run, "Exit after printing the transaction",

--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -53,7 +53,10 @@ static char **opt_disable_repo;
 static char **opt_release_ver;
 
 static GOptionEntry option_entries[]
-    = { { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+    = { { "os", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_osname,
+          "Operate on provided OSNAME", "OSNAME" },
+        { "stateroot", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided STATEROOT",
+          "STATEROOT" },
         { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot,
           "Initiate a reboot after operation is complete", NULL },
         { "dry-run", 'n', 0, G_OPTION_ARG_NONE, &opt_dry_run, "Exit after printing the transaction",


### PR DESCRIPTION
The `--stateroot` term is more often used now in libostree, so let's match that here too.

Noticed this while reviewing
https://github.com/openshift/assisted-installer/pull/1076.