### PR TITLE
Various enhancements and tweaks for OCP node image build

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -98,9 +98,29 @@ packages:
   - ltrace
   # a split base/layered version-locked package
   - vim-enhanced
+# also test repo enablement but using variables so we don't have to rewrite a
+# new treefile each time
+conditional-include:
+  - if: addrepos == "disable"
+    include:
+      repos: []
+  - if: addrepos == "enable"
+    include:
+      repos: [fedora-cisco-openh264]
+      packages: [openh264-devel]
 EOF
-rpm-ostree experimental compose treefile-apply /tmp/treefile.yaml
+# setting `repos` to empty list; should fail
+if rpm-ostree experimental compose treefile-apply /tmp/treefile.yaml --var addrepos=disable; then
+  fatal "installed packages without enabled repos?"
+fi
+if rpm -q ltrace; then fatal "ltrace installed"; fi
+if rpm -q vim-enhanced-"$vim_vr"; then fatal "vim-enhanced installed"; fi
+# not setting repos; default enablement
+rpm-ostree experimental compose treefile-apply /tmp/treefile.yaml --var addrepos=
 rpm -q ltrace vim-enhanced-"$vim_vr"
+# setting repos; only those repos enabled
+rpm-ostree experimental compose treefile-apply /tmp/treefile.yaml --var addrepos=enable
+rpm -q openh264-devel
 
 rpm-ostree cliwrap install-to-root /
 

--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -437,6 +437,19 @@ It supports the following parameters:
        include: f35-selinux-workaround.yaml
     ```
 
+    Specifying a treefile spec inlined is also supported:
+
+    ```yaml
+    conditional-include:
+      - if: releasever >= 35
+        include:
+          packages:
+            - foobar
+    ```
+
+    Inlined treefiles do not support any options referring to external files
+    (e.g. `postprocess-script`, `add-files`, and `passwd`/`group`).
+
  * `container`: boolean, optional: Defaults to `false`.  If `true`, then
    rpm-ostree will not do any special handling of kernel, initrd or the
    /boot directory. This is useful if the target for the tree is some kind

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -4833,7 +4833,8 @@ impl TreefileApplyOpts {
 fn run_dnf(command: &str, args: &[&str]) -> Result<()> {
     let mut cmd = Command::new("dnf");
     cmd.arg(command).args(args);
-    cmd.arg("--noplugins");
+    cmd.arg("--disableplugin=*");
+    cmd.arg("--enableplugin=versionlock");
     cmd.arg("-y");
 
     let status = cmd.status().context("collecting dnf status")?;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -4804,6 +4804,14 @@ impl TreefileApplyOpts {
                 None => {} // implicitly leave environment default if unset
             }
 
+            if let Some(repos) = &tf.parsed.repos {
+                install_args.push("--disablerepo=*");
+                for repo in repos {
+                    install_args.push("--enablerepo");
+                    install_args.push(repo);
+                }
+            }
+
             // lock all base packages during installation
             // https://gitlab.com/fedora/bootc/tracker/-/issues/59
             run_dnf("versionlock", &["add", "*", "--disablerepo", "*"])

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -4817,7 +4817,8 @@ impl TreefileApplyOpts {
             run_dnf("versionlock", &["add", "*", "--disablerepo", "*"])
                 .context("locking base packages with dnf")?;
             run_dnf("install", &install_args).context("installing packages with dnf")?;
-            run_dnf("versionlock", &["clear"]).context("clearing base packages lock with dnf")?;
+            run_dnf("versionlock", &["clear", "--disablerepo", "*"])
+                .context("clearing base packages lock with dnf")?;
         };
 
         // handle postprocess scripts


### PR DESCRIPTION
Working on moving openshift/os over to `treefile-apply` and identified a few more things we need. See individual commit messages.