### PR TITLE
main: Silence SELinux log spam

### DIFF
--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -487,6 +487,8 @@ early_main (void)
    * `DnfSack` and Repo too. So just do this upfront. XXX: Clean up that API so it's always
    * attached to a context object. */
   dnf_context_set_config_file_path ("");
+
+  ostree_sepolicy_set_null_log ();
 }
 
 // The C++ `main()`, invoked from Rust only for most CLI commands currently.


### PR DESCRIPTION
We will never see the confusing "regex version mismatch" again. No one ever cared and it was never actionable.
