### PR TITLE
core: Process ostree layers before running sysusers

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -153,7 +153,7 @@ pub(crate) fn refspec_classify(refspec: &str) -> crate::ffi::RefspecType {
 /// call sysusers _just_ for that package. Here we do it for all of them. See
 /// also: https://github.com/coreos/rpm-ostree/issues/5333.
 pub(crate) fn run_sysusers(rootfs_dfd: i32) -> CxxResult<()> {
-    let args: Vec<_> = vec!["rpm", "--eval=%{?__systemd_sysusers}"]
+    let args: Vec<_> = ["rpm", "--eval=%{?__systemd_sysusers}"]
         .into_iter()
         .map(|s| s.to_string())
         .collect();

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -144,7 +144,14 @@ pub(crate) fn refspec_classify(refspec: &str) -> crate::ffi::RefspecType {
     }
 }
 
-/// Run systemd-sysusers in the rootfs if the %__systemd_sysusers RPM macro is set.
+/// If the %__systemd_sysusers macro is defined, that _very likely_
+/// means that we're using an rpm with built-in sysusers support:
+/// https://fedoraproject.org/wiki/Changes/RPMSuportForSystemdSysusers Ideally,
+/// librpm would expose that part as a public API but it's currently just
+/// done during the transaction. So here we just do it ourselves, though a bit
+/// differently: librpm checks for the user/group provides before proceeding to
+/// call sysusers _just_ for that package. Here we do it for all of them. See
+/// also: https://github.com/coreos/rpm-ostree/issues/5333.
 pub(crate) fn run_sysusers(rootfs_dfd: i32) -> CxxResult<()> {
     let args: Vec<_> = vec!["rpm", "--eval=%{?__systemd_sysusers}"]
         .into_iter()

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -4435,14 +4435,6 @@ rpmostree_context_assemble (RpmOstreeContext *self, GCancellable *cancellable, G
 
   CXX_TRY_VAR (etc_guard, rpmostreecxx::prepare_tempetc_guard (tmprootfs_dfd), error);
 
-  /* if the %__systemd_sysusers macro is defined, that _very likely_ means that
-   * we're using an rpm with built-in sysusers support:
-   * https://fedoraproject.org/wiki/Changes/RPMSuportForSystemdSysusers
-   * Ideally, librpm would expose that part as a public API but it's currently
-   * just done during the transaction. So here we just do it ourselves, though
-   * a bit differently: librpm checks for the user/group provides before
-   * proceeding to call sysusers _just_ for that package. Here we do it for all
-   * of them. See also: https://github.com/coreos/rpm-ostree/issues/5333 */
   if (!ROSCXX (run_sysusers (tmprootfs_dfd), error))
     return glnx_prefix_error (error, "Running systemd-sysusers");
 

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -4435,6 +4435,10 @@ rpmostree_context_assemble (RpmOstreeContext *self, GCancellable *cancellable, G
 
   CXX_TRY_VAR (etc_guard, rpmostreecxx::prepare_tempetc_guard (tmprootfs_dfd), error);
 
+  /* Any ostree refs to overlay */
+  if (!process_ostree_layers (self, tmprootfs_dfd, cancellable, error))
+    return FALSE;
+
   if (!ROSCXX (run_sysusers (tmprootfs_dfd), error))
     return glnx_prefix_error (error, "Running systemd-sysusers");
 
@@ -4442,10 +4446,6 @@ rpmostree_context_assemble (RpmOstreeContext *self, GCancellable *cancellable, G
    * replacements */
   if (overlays->len > 0 || overrides_replace->len > 0)
     {
-      /* Any ostree refs to overlay */
-      if (!process_ostree_layers (self, tmprootfs_dfd, cancellable, error))
-        return FALSE;
-
       CXX_TRY_VAR (fs_prep, rpmostreecxx::prepare_filesystem_script_prep (tmprootfs_dfd), error);
 
       auto passwd_entries = rpmostreecxx::new_passwd_entries ();


### PR DESCRIPTION
At least in FCOS, we add sysusers dropins via overlays and we need those
already present when running `systemd-sysusers`.

Looking at the history here, there's no reason it seems why we were
only processing ostree layers in the path where we had RPM packages
to overlay. It should be safe to move out of that gate. Anyway on the
client side nothing is hooked to that so it still remains a server-side
feature.

Closes: #5353