### PR TITLE
compose: Support operating unprivileged on `registry` and `oci`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -276,6 +276,7 @@ jobs:
           tar -xzvf ../../install.tar
           sudo podman build -v $(pwd)/usr/bin:/ci -t localhost/builder -f Containerfile.builder
           sudo ./test.sh
+          sudo ./test-oci.sh
   build-c9s:
     name: "Build (c9s)"
     runs-on: ubuntu-latest

--- a/rust/src/container.rs
+++ b/rust/src/container.rs
@@ -35,6 +35,11 @@ use crate::fsutil::{self, FileHelpers, ResolvedOstreePaths};
 use crate::progress::progress_task;
 use crate::CxxResult;
 
+/// Parse a transport from a CLI argument.
+pub(crate) fn parse_transport(s: &str) -> Result<ostree_ext::container::Transport> {
+    ostree_ext::container::Transport::try_from(s)
+}
+
 #[derive(Debug, Parser)]
 struct ContainerEncapsulateOpts {
     #[clap(long)]


### PR DESCRIPTION
Closes: https://github.com/coreos/rpm-ostree/issues/5324
