### PR TITLE
Release 2025.8

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2025])
-m4_define([release_version], [7])
+m4_define([release_version], [8])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2025.5
+Version: 2025.8
 Release: 1%{?dist}
 License: LGPL-2.0-or-later
 URL: https://github.com/coreos/rpm-ostree


### PR DESCRIPTION
```
Colin Walters (7):
      tree-wide: Run clang-format with clang 20.1.3
      test-container: Update for F42
      tests: Drop testing of ostree-container
      tests/container-image: Rework to handle container base
      tests/cached-sigs: Fix to handle container refspec by default
      tests: Drop override-kernel
      tests/override-replace-2: Update to support f42

Iain Collins (1):
      daemon/transaction-types: pass an empty dictionary instead of NULL to change_origin_refspec

Jonathan Lebon (19):
      treefile: Support inlined conditional includes
      treefile-apply: Add `--var` option
      treefile-apply: Handle `repos` key
      treefile-apply: Enable versionlock plugin when running dnf
      treefile-apply: Tweak `versionlock` hack
      core: Move sysusers docstring to the Rust side
      rust/core: Drop unnecessary Vec
      core: Process ostree layers before running sysusers
      core: Ignore replaced files in rpmdb write transaction
      core: Drop unused variable
      tests/compose: Bump f-c-c commit to f42
      tests/compose: Disable basic test
      tests/compose: Adapt for latest alternatives changes
      tests/compose: Temporarily disable ima test
      tests/compose: Better override opt-usrlocal
      rust/treefile: Fix edition defaulting
      testutils: Stop trying to mutate binaries in /usr/sbin
      libvm: Handle container case when changing refspec to vmcheck
      tests/kolainst: update client-layering-upgrade for f42

Joseph Marrero Corchado (3):
      ci: update cargo-deny-action
      deny.toml: allow LGPL-2.1-or-later WITH GCC-exception-2.0
      Release 2025.8

Timothée Ravier (2):
      rust/src/compose: Show full comment in command line help
      rust/src/compose: Add max-layers opt to compose image
```

## New Contributors
* @IainCollins262 made their first contribution in https://github.com/coreos/rpm-ostree/commit/5c789dc8cc7b3c72d945c36061243c6f560e3824

**Full Changelog**: https://github.com/coreos/rpm-ostree/compare/v2025.7...v2025.8