### PR TITLE
rust/bwrap: child_wait_check: let gio check status

### DIFF
--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -166,12 +166,8 @@ fn child_wait_check(
     child: gio::Subprocess,
     cancellable: Option<&gio::Cancellable>,
 ) -> std::result::Result<(), glib::Error> {
-    match child.wait(cancellable) {
-        Ok(_) => {
-            let estatus = child.exit_status();
-            glib::spawn_check_exit_status(estatus)?;
-            Ok(())
-        }
+    match child.wait_check(cancellable) {
+        Ok(_) => Ok(()),
         Err(e) => {
             child.force_exit();
             Err(e)


### PR DESCRIPTION
According to the docs [1] g_spawn_check_exit_status is deprecated and also that users should check their code to make sure they aren't conflating wait and exit statuses.

Let's just avoid it altogether by calling wait_check() [2] which will wait() and then call g_spawn_check_wait_status(), which is basically what our code was doing before, but without the conflation of wait and exit status.

[1] https://gnome.pages.gitlab.gnome.org/libsoup/glib/glib-Spawning-Processes.html#g-spawn-check-exit-status
[2] https://gnome.pages.gitlab.gnome.org/libsoup/gio/GSubprocess.html#g-subprocess-wait-check