### PR TITLE
rust/bwrap: don't swallow STDERR when running commands

### DIFF
--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -446,6 +446,8 @@ impl Bubblewrap {
 
     /// Execute the container.  This method uses the normal gtk-rs `Option<T>` for the cancellable.
     fn run_inner(&mut self, cancellable: Option<&gio::Cancellable>) -> Result<()> {
+        // Merge STDERR/STDOUT so we don't swallow STDERR during execution
+        self.launcher.set_flags(gio::SubprocessFlags::STDERR_MERGE);
         let (child, argv0) = self.spawn()?;
         child_wait_check(child, cancellable).context(argv0)?;
         Ok(())

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -537,7 +537,7 @@ pub(crate) fn compose_postprocess_scripts(
             script,
             Permissions::from_mode(0o755),
         )?;
-        println!("Executing `postprocess` inline script '{}'", i);
+        println!("\n>>>> Executing `postprocess` inline script '{i}' <<<<\n");
         let child_argv = vec![binpath.to_string()];
         if let PostprocessBwrap::Wrap { unified_core } = bwrap {
             let _ = bwrap::bubblewrap_run_sync(
@@ -554,6 +554,7 @@ pub(crate) fn compose_postprocess_scripts(
         }
         rootfs_dfd.remove_file(target_binpath)?;
     }
+    println!("Completed running `postprocess` inline scripts");
 
     // And the single postprocess script.
     if let Some(postprocess_script) = treefile.get_postprocess_script() {

--- a/tests/compose.sh
+++ b/tests/compose.sh
@@ -39,6 +39,7 @@ if [ ! -d compose-cache ]; then
 
   pushd config
   git checkout "${FEDORA_COREOS_CONFIG_COMMIT}"
+  git submodule update
   # we flatten the treefile to make it easier to manipulate in tests (we have
   # lots of tests that check for include logic already)
   rpm-ostree compose tree --print-only manifest.yaml > manifest.json


### PR DESCRIPTION
Let's merge it with STDOUT so we still get the STDERR logs when
running commands.

The reason I came upon this is because when we run rpm-ostree compose
postprocess scripts we were clearly not getting all of the output. For
example a lot of our scripts are `set -x` but none of that output was
getting printed anywhere, and also things like `systemctl preset-all`
wouldn't show any output at all (which apparently that commands writes
its output to STDERR for some reason).