### PR TITLE
compose: Cache RPMs if cache dir on separate filesystem

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.cxx
+++ b/src/app/rpmostree-compose-builtin-tree.cxx
@@ -1369,9 +1369,11 @@ rpmostree_compose_builtin_install (int argc, char **argv, RpmOstreeCommandInvoca
       return FALSE;
     }
 
-  /* Destination is turned into workdir */
   const char *destdir = argv[2];
-  opt_workdir = g_strdup (destdir);
+
+  /* Destination is turned into workdir in non-unified core mode. */
+  if (!opt_unified_core)
+    opt_workdir = g_strdup (destdir);
 
   g_autoptr (RpmOstreeTreeComposeContext) self = NULL;
   if (!rpm_ostree_compose_context_new (treefile_path, basearch.c_str (), FALSE, &self, cancellable,

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -33,6 +33,7 @@
 #include <systemd/sd-journal.h>
 #include <utility>
 
+#include "libdnf/dnf-context.h"
 #include "rpmostree-core-private.h"
 #include "rpmostree-cxxrs.h"
 #include "rpmostree-importer.h"
@@ -2625,8 +2626,11 @@ rpmostree_context_consume_package (RpmOstreeContext *self, DnfPackage *pkg, int 
    * deleted and hence more annoying to debug, but in practice people
    * should be able to redownload, and if the error was something like
    * ENOSPC, deleting it was the right move I'd say.
+   *
+   * But respect dnf's keepcache setting, which might've been set by a higher
+   * level.
    */
-  if (!rpmostree_pkg_is_local (pkg))
+  if (!rpmostree_pkg_is_local (pkg) && !dnf_context_get_keep_cache (self->dnfctx))
     {
       if (!glnx_unlinkat (AT_FDCWD, pkg_path, 0, error))
         return FALSE;

--- a/tests/compose-rootfs/Containerfile
+++ b/tests/compose-rootfs/Containerfile
@@ -14,9 +14,16 @@ EORUN
 # Copy in our source code.
 COPY . /src
 WORKDIR /src
-RUN --mount=type=bind,from=repos,src=/,dst=/repos,rw <<EORUN
+# also test using a cache in this flow
+RUN --mount=type=bind,from=repos,src=/,dst=/repos,rw --mount=type=cache,rw,target=/cache <<EORUN
 set -xeuo pipefail
-exec env RUST_LOG=debug rpm-ostree compose rootfs --source-root-rw=/repos manifest.yaml /target-rootfs
+env RUST_LOG=debug rpm-ostree compose rootfs --cachedir=/cache --source-root-rw=/repos manifest.yaml /target-rootfs
+# just the fact that we got here means we didn't hit EXDEV
+# but also sanity-check that there are actual RPMs in the cache
+nrpms=$(find /cache -name '*.rpm' | wc -l)
+if [ $nrpms = 0 ]; then
+  echo "No RPMs found in cache!"; exit 1
+fi
 EORUN
 
 # This pulls in the rootfs generated in the previous step


### PR DESCRIPTION
When using `rpm-ostree compose rootfs` as done by the bootc custom base
image flow within a container build, the output rootfs directory needs
to be on the build container's overlay rootfs so it's usable to the
next stage.

This then conflicts with trying to use a separate mounted cache
directory since the rootfs contains hardlinks from the pkgcache repo.

Let's handle this case gracefully by detecting it and storing only
libdnf bits in the cache directory, but crucially also preserving RPMs.
The pkgcache then is created elsewhere.

This also meshes well with the fact that in postprocessing we also
mutate the hardlinked files (e.g. nuking `user.ostreemeta` xattrs) which
basically means the pkgcache repo is not actually usable as a cache.