### PR TITLE
libpriv/kernel: Pass through `DRACUT_NO_XATTR` when running dracut

### DIFF
--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -688,6 +688,10 @@ impl RootfsOpts {
                     .flat_map(|v| ["--source-root", v.as_str()]),
             )
             .args([manifest.as_str(), self.dest.as_str()])
+            // Otherwise, dracut might try to copy user.ostreemeta xattrs which
+            // it won't be able to. We should lower the xattr stripping into
+            // rpm-ostree ideally.
+            .env("DRACUT_NO_XATTR", "1")
             .run()
             .context("Executing compose install")?;
 


### PR DESCRIPTION
Since f4aecb9b ("rust/bwrap: don't swallow STDERR when running commands"), we now have the stderr from dracut, which reveals that it spews lots of warnings about being unable to copy xattrs when running from an `rpm-ostree compose rootfs`.

I think this comes from the `user.ostreemeta` xattr which hasn't been stripped yet.

It'd be better anyway to do this stripping within the rpm-ostree core I think, but for now it's actually trivial to work around this by setting `DRACUT_NO_XATTR`.

I'm pretty sure we could set this unconditionally, but out of an abundance of caution, we only do this for now from the `rpm-ostree compose rootfs` path where we know we want this.

Fixes: https://gitlab.com/fedora/bootc/tracker/-/issues/66