### PR TITLE
passwd: Prep work for fixing https://github.com/coreos/rpm-ostree/issues/5365

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -2850,9 +2850,8 @@ extern "C"
   rpmostreecxx$cxxbridge1$transaction_apply_live (::rpmostreecxx::OstreeSysroot const &sysroot,
                                                   ::rpmostreecxx::GVariant const &target) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$prepare_rpm_layering (::std::int32_t rootfs,
-                                                                     ::rust::Str merge_passwd_dir,
-                                                                     bool *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$prepare_rpm_layering (
+      ::std::int32_t rootfs, ::std::int32_t merge_passwd_dir, bool *return$) noexcept;
 
   ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$complete_rpm_layering (::std::int32_t rootfs) noexcept;
@@ -5735,7 +5734,7 @@ transaction_apply_live (::rpmostreecxx::OstreeSysroot const &sysroot,
 }
 
 bool
-prepare_rpm_layering (::std::int32_t rootfs, ::rust::Str merge_passwd_dir)
+prepare_rpm_layering (::std::int32_t rootfs, ::std::int32_t merge_passwd_dir)
 {
   ::rust::MaybeUninit<bool> return$;
   ::rust::repr::PtrLen error$

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -2055,7 +2055,7 @@ void applylive_sync_ref (::rpmostreecxx::OstreeSysroot const &sysroot);
 void transaction_apply_live (::rpmostreecxx::OstreeSysroot const &sysroot,
                              ::rpmostreecxx::GVariant const &target);
 
-bool prepare_rpm_layering (::std::int32_t rootfs, ::rust::Str merge_passwd_dir);
+bool prepare_rpm_layering (::std::int32_t rootfs, ::std::int32_t merge_passwd_dir);
 
 void complete_rpm_layering (::std::int32_t rootfs);
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -732,7 +732,7 @@ pub mod ffi {
 
     // passwd.rs
     extern "Rust" {
-        fn prepare_rpm_layering(rootfs: i32, merge_passwd_dir: &str) -> Result<bool>;
+        fn prepare_rpm_layering(rootfs: i32, merge_passwd_dir: i32) -> Result<bool>;
         fn complete_rpm_layering(rootfs: i32) -> Result<()>;
         fn deduplicate_tmpfiles_entries(rootfs: i32) -> Result<()>;
         fn passwd_cleanup(rootfs: i32) -> Result<()>;

--- a/src/libpriv/rpmostree-kernel.cxx
+++ b/src/libpriv/rpmostree-kernel.cxx
@@ -496,7 +496,7 @@ rpmostree_run_dracut (int rootfs_dfd, const char *const *argv, const char *kver,
    **/
   CXX_TRY_VAR (etc_guard, rpmostreecxx::prepare_tempetc_guard (rootfs_dfd), error);
 
-  CXX_TRY_VAR (have_passwd, rpmostreecxx::prepare_rpm_layering (rootfs_dfd, ""), error);
+  CXX_TRY_VAR (have_passwd, rpmostreecxx::prepare_rpm_layering (rootfs_dfd, -1), error);
 
   /* Note rebuild_from_initramfs now is only used as a fallback in the client-side regen
    * path when we can't fetch the canonical initramfs args to use. */

--- a/tests/kolainst/destructive/layering-useradd
+++ b/tests/kolainst/destructive/layering-useradd
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. ${KOLA_EXT_DATA}/libtest.sh
+
+set -x
+cd $(mktemp -d)
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+"")
+  libtest_prepare_fully_offline
+
+  rpm-ostree install ${KOLA_EXT_DATA}/rpm-repos/0/packages/x86_64/testdaemon*.rpm
+  if grep testdaemon /etc/passwd /usr/lib/passwd; then
+    fatal "found testdaemon in current passwd"
+  fi
+
+  /tmp/autopkgtest-reboot "1"
+;;
+"1")
+  rpmostree_assert_status '.deployments[0]["requested-local-packages"]|length == 1'
+
+  # Verify testdaemon altfiles
+  rpm -q testdaemon
+  grep testdaemon /usr/lib/passwd
+  grep testdaemon /usr/lib/group
+  if grep testdaemon /etc/passwd; then
+    fatal "found testdaemon in /etc/passwd"
+  fi
+
+  # Reset this
+  rpm-ostree uninstall testdaemon
+
+  /tmp/autopkgtest-reboot "2"
+;;
+"2")
+  if grep testdaemon /etc/passwd /usr/lib/passwd; then
+    fatal "found testdaemon in current passwd"
+  fi
+;;
+*) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac


### PR DESCRIPTION
I'm looking at https://github.com/coreos/rpm-ostree/issues/5365 - this is prep work just adding unit & integration test coverage for the existing code.

---

tests: Add a layering-useradd test

Verifies our behavior with useradd/groupadd in `%post`.

Signed-off-by: Colin Walters <walters@verbum.org>

---

passwd: Accept borrowed value

Prep cleanup.

Signed-off-by: Colin Walters <walters@verbum.org>

---

passwd: Some basic unit tests for prepare_rpm_layering

- Rename inner helper to complete_rpm_layering to match

Signed-off-by: Colin Walters <walters@verbum.org>

---

passwd: Make merge take a dfd

This allows it to be more sanely unit testable.

Signed-off-by: Colin Walters <walters@verbum.org>

---