### PR TITLE
dependabot: Group minor+patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 6
+  groups:
+    minor:
+      update-types:
+        - minor
+        - patch
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:


### PR DESCRIPTION
Dependabot is hopelessly behind now, and the chance that a minor or patch update *individually* breaks something has been in practice near zero.
