### PR TITLE
scripts: suppress error about glibc.posttrans scriptlet

### DIFF
--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -167,7 +167,12 @@ static const RpmOstreeLuaReplacement lua_replacements[] = {
    */
   { "glibc.post", "/usr/bin/bash", glibc_post_script },
   /* Code introduced in
-     https://src.fedoraproject.org/rpms/glibc/c/ca0613665ce6e1b4e92dadd3660ad39cf3dc5f3e?branch=main
+   * https://src.fedoraproject.org/rpms/glibc/c/d2ae0e3b919a3c9650cc604af23bb6e9ff97e598?branch=f42.
+   * We don't need to do anything for ostree systems.
+   */
+  { "glibc.posttrans", "/usr/bin/true", "" },
+  /* Code introduced in
+   * https://src.fedoraproject.org/rpms/glibc/c/ca0613665ce6e1b4e92dadd3660ad39cf3dc5f3e?branch=rawhide
    */
   { "glibc-gconv-extra.post", "/usr/bin/bash", glibc_post_script },
   /* See https://bugzilla.redhat.com/show_bug.cgi?id=1847454.


### PR DESCRIPTION
Fixes https://github.com/coreos/rpm-ostree/issues/5411. Follow-up for https://src.fedoraproject.org/rpms/glibc/pull-request/145 (rawhide) and https://src.fedoraproject.org/rpms/glibc/pull-request/144 (f42).

Thank you for contributing to rpm-ostree.

If you are adding functionality to tree composes, please add
a corresponding test to the compose-test suite. Similarly,
if adding a client-facing feature, consider the vmcheck
suite. Regressions fixes are also great candidates for new
tests.

If you're not sure where or how to add tests, don't hesitate
to ask for help from the maintainers.

Cheers!
