### PR TITLE
Un-hide finalization APIs

### DIFF
--- a/src/app/libmain.cxx
+++ b/src/app/libmain.cxx
@@ -140,8 +140,9 @@ static RpmOstreeCommand commands[] = {
                                         | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT
                                         | RPM_OSTREE_BUILTIN_FLAG_HIDDEN),
     NULL, rpmostree_builtin_start_daemon },
-  { "finalize-deployment", static_cast<RpmOstreeBuiltinFlags> (RPM_OSTREE_BUILTIN_FLAG_HIDDEN),
-    NULL, rpmostree_builtin_finalize_deployment },
+  { "finalize-deployment", static_cast<RpmOstreeBuiltinFlags> (0),
+    "Unset the finalization locking state of the staged deployment and reboot",
+    rpmostree_builtin_finalize_deployment },
   { NULL }
 };
 

--- a/src/app/rpmostree-builtin-deploy.cxx
+++ b/src/app/rpmostree-builtin-deploy.cxx
@@ -59,7 +59,7 @@ static GOptionEntry option_entries[]
           "Just download latest ostree and RPM data, don't deploy", NULL },
         { "skip-branch-check", 0, 0, G_OPTION_ARG_NONE, &opt_skip_branch_check,
           "Do not check if commit belongs on the same branch", NULL },
-        { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization,
+        { "lock-finalization", 0, 0, G_OPTION_ARG_NONE, &opt_lock_finalization,
           "Prevent automatic deployment finalization on shutdown", NULL },
         { "disallow-downgrade", 0, 0, G_OPTION_ARG_NONE, &opt_disallow_downgrade,
           "Forbid deployment of chronologically older trees", NULL },

--- a/src/app/rpmostree-builtin-initramfs-etc.cxx
+++ b/src/app/rpmostree-builtin-initramfs-etc.cxx
@@ -50,7 +50,7 @@ static GOptionEntry option_entries[] = {
   { "untrack-all", 0, 0, G_OPTION_ARG_NONE, &opt_untrack_all, "Untrack all root /etc files", NULL },
   { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot,
     "Initiate a reboot after operation is complete", NULL },
-  { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization,
+  { "lock-finalization", 0, 0, G_OPTION_ARG_NONE, &opt_lock_finalization,
     "Prevent automatic deployment finalization on shutdown", NULL },
   { "unchanged-exit-77", 0, 0, G_OPTION_ARG_NONE, &opt_unchanged_exit_77,
     "If no new deployment made, exit 77", NULL },

--- a/src/app/rpmostree-builtin-initramfs.cxx
+++ b/src/app/rpmostree-builtin-initramfs.cxx
@@ -49,7 +49,7 @@ static GOptionEntry option_entries[]
           "Disable regenerating initramfs locally", NULL },
         { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot,
           "Initiate a reboot after operation is complete", NULL },
-        { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization,
+        { "lock-finalization", 0, 0, G_OPTION_ARG_NONE, &opt_lock_finalization,
           "Prevent automatic deployment finalization on shutdown", NULL },
         { NULL } };
 

--- a/src/app/rpmostree-builtin-kargs.cxx
+++ b/src/app/rpmostree-builtin-kargs.cxx
@@ -75,7 +75,7 @@ static GOptionEntry option_entries[] = {
     NULL },
   { "editor", 0, 0, G_OPTION_ARG_NONE, &opt_editor, "Use an editor to modify the kernel arguments",
     NULL },
-  { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization,
+  { "lock-finalization", 0, 0, G_OPTION_ARG_NONE, &opt_lock_finalization,
     "Prevent automatic deployment finalization on shutdown", NULL },
   { NULL }
 };

--- a/src/app/rpmostree-builtin-rebase.cxx
+++ b/src/app/rpmostree-builtin-rebase.cxx
@@ -71,7 +71,7 @@ static GOptionEntry option_entries[]
           "Enable experimental features", NULL },
         { "disallow-downgrade", 0, 0, G_OPTION_ARG_NONE, &opt_disallow_downgrade,
           "Forbid deployment of chronologically older trees", NULL },
-        { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization,
+        { "lock-finalization", 0, 0, G_OPTION_ARG_NONE, &opt_lock_finalization,
           "Prevent automatic deployment finalization on shutdown", NULL },
         { "bypass-driver", 0, 0, G_OPTION_ARG_NONE, &opt_bypass_driver,
           "Force a rebase even if an updates driver is registered", NULL },

--- a/src/app/rpmostree-builtin-upgrade.cxx
+++ b/src/app/rpmostree-builtin-upgrade.cxx
@@ -71,7 +71,7 @@ static GOptionEntry option_entries[]
           "If no new deployment made, exit 77", NULL },
         { "trigger-automatic-update-policy", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE,
           &opt_automatic, "For automated use only; triggered by automatic timer", NULL },
-        { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization,
+        { "lock-finalization", 0, 0, G_OPTION_ARG_NONE, &opt_lock_finalization,
           "Prevent automatic deployment finalization on shutdown", NULL },
         { "bypass-driver", 0, 0, G_OPTION_ARG_NONE, &opt_bypass_driver,
           "Force an upgrade even if an updates driver is registered", NULL },

--- a/src/app/rpmostree-override-builtins.cxx
+++ b/src/app/rpmostree-override-builtins.cxx
@@ -50,7 +50,7 @@ static GOptionEntry option_entries[]
           "Initiate a reboot after operation is complete", NULL },
         { "dry-run", 'n', 0, G_OPTION_ARG_NONE, &opt_dry_run, "Exit after printing the transaction",
           NULL },
-        { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization,
+        { "lock-finalization", 0, 0, G_OPTION_ARG_NONE, &opt_lock_finalization,
           "Prevent automatic deployment finalization on shutdown", NULL },
         { "cache-only", 'C', 0, G_OPTION_ARG_NONE, &opt_cache_only, "Only operate on cached data",
           NULL },

--- a/src/app/rpmostree-pkg-builtins.cxx
+++ b/src/app/rpmostree-pkg-builtins.cxx
@@ -69,7 +69,7 @@ static GOptionEntry option_entries[]
           "Do nothing if package already (un)installed", NULL },
         { "unchanged-exit-77", 0, 0, G_OPTION_ARG_NONE, &opt_unchanged_exit_77,
           "If no overlays were changed, exit 77", NULL },
-        { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization,
+        { "lock-finalization", 0, 0, G_OPTION_ARG_NONE, &opt_lock_finalization,
           "Prevent automatic deployment finalization on shutdown", NULL },
         { "enablerepo", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_enable_repo,
           "Enable the repository based on the repo id. Is only supported in a container build.",


### PR DESCRIPTION
This was classified as experimental originally, but is clearly stable and in use by zincati etc.

Motivated by potential use in OpenShift and other places.
