### PR TITLE
Add support for skipping lua scripts via a magic comment

### DIFF
--- a/docs/architecture-core.md
+++ b/docs/architecture-core.md
@@ -141,6 +141,22 @@ not writable.  This helps ensure offline updates are possible; a
 package script running client side cannot affect persistent system
 state.
 
+#### Lua scripts
+
+At the moment, because lua scripts aren't sandboxed they are not supported.
+For more information, see <https://github.com/coreos/rpm-ostree/issues/749>.
+
+However, in most cases these scripts are "upgrade hacks" or would mutate
+live system state, and should generally just be skipped. If you want
+these scripts to only apply to librpm systems (e.g. `dnf` but not `rpm-ostree`)
+then you can add a magic comment in the first 10 lines:
+
+```
+-- rpm-ostree-skip
+```
+
+This will cause rpm-ostree to ignore the script.
+
 ### Content in /var
 
 rpm-ostree automatically synthesizes [systemd tmpfiles.d](https://www.freedesktop.org/software/systemd/man/tmpfiles.d.html)

--- a/tests/kolainst/destructive/layering-local
+++ b/tests/kolainst/destructive/layering-local
@@ -60,6 +60,13 @@ assert_not_file_has_content_literal out.txt foo-1.2-3
 mv /etc/rpm-ostreed.conf{.bak,} && rpm-ostree reload
 echo "ok Recommends"
 
+if rpm-ostree install testpkg-lua-should-fail 2>err.txt; then
+  fatal "Installed testpkg-lua-should-fail"
+fi
+rpm-ostree install testpkg-lua-ignored
+rpm-ostree uninstall testpkg-lua-ignored
+echo "ok lua"
+
 # Disable repos, no Internet access should be required for the remaining tests
 rm -rf /etc/yum.repos.d/
 # Also disable zincati since we're rebasing

--- a/tests/kolainst/kolainst-build.sh
+++ b/tests/kolainst/kolainst-build.sh
@@ -78,6 +78,13 @@ build_rpm testpkg-post-infinite-loop \
              post "echo entering testpkg-post-infinite-loop 1>&2; while true; do sleep 1h; done"
 build_rpm testpkg-touch-run \
              post "touch /{run,tmp,var/tmp}/should-not-persist"
+build_rpm testpkg-lua-should-fail \
+             post_args "-p <lua>" \
+             post 'posix.stat("/")'
+build_rpm testpkg-lua-ignored \
+             post_args "-p <lua>" \
+             post '-- rpm-ostree-skip 
+                   posix.stat("/")'
 
 # Will be useful in checking difference in package version while doing apply-live 
 build_rpm pkgsystemd \


### PR DESCRIPTION
As the doc updates say, in many use cases for lua scripts we have never needed them and just wanted to ignore them.

This gives people a way to denote that in the script itself, without us having to change the client.

This doesn't fix https://github.com/coreos/rpm-ostree/issues/749 but should greatly lessen the pain from it.
