### PR TITLE
treefile: Add `sysusers:` knob

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -30,6 +30,7 @@ codestyle: {
 }
 
 def nhosts = 4
+// nb: the 1536 matches libvm.sh here
 def mem = (nhosts * 1536) + 512
 cosaPod(runAsUser: 0, memory: "${mem}Mi", cpu: "${nhosts}") {
   stage("Unit Tests") {

--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -543,6 +543,12 @@ version of `rpm-ostree`.
    names to use when substituting variables in yum repo files. The `releasever`
    variable name is invalid. Use the `releasever` key instead. The `basearch`
    name is invalid; it is filled in automatically.
+ * `sysusers`: enum, optional: Choices are:
+    - `compose-auto`: run systemd-sysusers at compose time if the
+      `%__systemd_sysusers` RPM macro is defined (this is the case in Fedora 42).
+    - `compose-forced`: run systemd-sysusers at compose time even if the
+      `%__systemd_sysusers` RPM macro is not defined (e.g. c9s and c10s).
+    The default is `compose-auto`.
  * `opt-usrlocal`: enum, optional: Defaults to `var`.  There are
    two possible behaviors:
    - `var`: `/opt` and `/usr/local` are symlinks to subdirectories in `/var`

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1813,6 +1813,7 @@ struct Treefile final : public ::rust::Opaque
   bool get_documentation () const noexcept;
   bool get_recommends () const noexcept;
   bool get_selinux () const noexcept;
+  bool get_sysusers_is_forced () const noexcept;
   ::std::uint32_t get_selinux_label_version () const noexcept;
   ::rust::String get_gpg_key () const noexcept;
   ::rust::String get_automatic_version_suffix () const noexcept;
@@ -2203,7 +2204,8 @@ extern "C"
                                                            ::rust::Str kver,
                                                            bool unified_core) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$run_sysusers (::std::int32_t rootfs_dfd) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$run_sysusers (::std::int32_t rootfs_dfd,
+                                                             bool force) noexcept;
 
   void rpmostreecxx$cxxbridge1$log_treefile (::rpmostreecxx::Treefile const &tf) noexcept;
 
@@ -2660,6 +2662,9 @@ extern "C"
   rpmostreecxx$cxxbridge1$Treefile$get_recommends (::rpmostreecxx::Treefile const &self) noexcept;
 
   bool rpmostreecxx$cxxbridge1$Treefile$get_selinux (::rpmostreecxx::Treefile const &self) noexcept;
+
+  bool rpmostreecxx$cxxbridge1$Treefile$get_sysusers_is_forced (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
   ::std::uint32_t rpmostreecxx$cxxbridge1$Treefile$get_selinux_label_version (
       ::rpmostreecxx::Treefile const &self) noexcept;
@@ -3926,9 +3931,9 @@ run_depmod (::std::int32_t rootfs_dfd, ::rust::Str kver, bool unified_core)
 }
 
 void
-run_sysusers (::std::int32_t rootfs_dfd)
+run_sysusers (::std::int32_t rootfs_dfd, bool force)
 {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$run_sysusers (rootfs_dfd);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$run_sysusers (rootfs_dfd, force);
   if (error$.ptr)
     {
       throw ::rust::impl<::rust::Error>::error (error$);
@@ -5237,6 +5242,12 @@ bool
 Treefile::get_selinux () const noexcept
 {
   return rpmostreecxx$cxxbridge1$Treefile$get_selinux (*this);
+}
+
+bool
+Treefile::get_sysusers_is_forced () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$Treefile$get_sysusers_is_forced (*this);
 }
 
 ::std::uint32_t

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1590,6 +1590,7 @@ struct Treefile final : public ::rust::Opaque
   bool get_documentation () const noexcept;
   bool get_recommends () const noexcept;
   bool get_selinux () const noexcept;
+  bool get_sysusers_is_forced () const noexcept;
   ::std::uint32_t get_selinux_label_version () const noexcept;
   ::rust::String get_gpg_key () const noexcept;
   ::rust::String get_automatic_version_suffix () const noexcept;
@@ -1877,7 +1878,7 @@ prepare_filesystem_script_prep (::std::int32_t rootfs);
 
 void run_depmod (::std::int32_t rootfs_dfd, ::rust::Str kver, bool unified_core);
 
-void run_sysusers (::std::int32_t rootfs_dfd);
+void run_sysusers (::std::int32_t rootfs_dfd, bool force);
 
 void log_treefile (::rpmostreecxx::Treefile const &tf) noexcept;
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -263,7 +263,7 @@ pub mod ffi {
 
         fn run_depmod(rootfs_dfd: i32, kver: &str, unified_core: bool) -> Result<()>;
 
-        fn run_sysusers(rootfs_dfd: i32) -> Result<()>;
+        fn run_sysusers(rootfs_dfd: i32, force: bool) -> Result<()>;
 
         fn log_treefile(tf: &Treefile);
 
@@ -628,6 +628,7 @@ pub mod ffi {
         fn get_documentation(&self) -> bool;
         fn get_recommends(&self) -> bool;
         fn get_selinux(&self) -> bool;
+        fn get_sysusers_is_forced(&self) -> bool;
         fn get_selinux_label_version(&self) -> u32;
         fn get_gpg_key(&self) -> String;
         fn get_automatic_version_suffix(&self) -> String;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -456,6 +456,7 @@ fn treefile_merge(dest: &mut TreeComposeConfig, src: &mut TreeComposeConfig) {
         basearch,
         rojig,
         selinux,
+        sysusers,
         selinux_label_version,
         ignore_devices,
         ima,
@@ -1335,6 +1336,10 @@ impl Treefile {
 
     pub(crate) fn get_selinux(&self) -> bool {
         self.parsed.base.selinux.unwrap_or(true)
+    }
+
+    pub(crate) fn get_sysusers_is_forced(&self) -> bool {
+        self.parsed.base.sysusers.unwrap_or_default() == SysUsers::ComposeForced
     }
 
     pub(crate) fn get_ignore_devices(&self) -> bool {
@@ -2536,6 +2541,8 @@ pub(crate) struct BaseComposeConfigFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) selinux_label_version: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) sysusers: Option<SysUsers>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) ima: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) gpg_key: Option<String>,
@@ -2662,6 +2669,14 @@ pub(crate) struct BaseComposeConfigFields {
 pub(crate) struct RepoPackage {
     pub(crate) repo: String,
     pub(crate) packages: BTreeSet<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone, Default)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum SysUsers {
+    #[default]
+    ComposeAuto,
+    ComposeForced,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default, PartialEq, Eq)]

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -4467,7 +4467,8 @@ rpmostree_context_assemble (RpmOstreeContext *self, GCancellable *cancellable, G
       CXX_TRY_VAR (have_passwd, rpmostreecxx::prepare_rpm_layering (tmprootfs_dfd, passwd_dirfd),
                    error);
 
-      if (!ROSCXX (run_sysusers (tmprootfs_dfd), error))
+      if (!ROSCXX (run_sysusers (tmprootfs_dfd, self->treefile_rs->get_sysusers_is_forced ()),
+                   error))
         return glnx_prefix_error (error, "Running systemd-sysusers");
 
       /* Necessary for unified core to work with semanage calls in %post, like container-selinux */

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -69,7 +69,7 @@ vm_kola_spawn() {
   fi
   setpriv --pdeathsig SIGKILL -- \
     env MANTLE_SSH_DIR="$PWD/kola-ssh" kola spawn -p qemu \
-    --qemu-image "$test_image" -v --idle \
+    --qemu-memory 1536 --qemu-image "$test_image" -v --idle \
     --json-info-fd 4 --output-dir "$outputdir" &
   # hack; need cleaner API for async kola spawn
   while [ ! -s info.json ]; do sleep 1; done


### PR DESCRIPTION
In the work to rebase FCOS/RHCOS to fedora-bootc/rhel-bootc, I want to make it possible to opt out of the passwd/group bits baked in the minimal manifests (the problem there of course goes back to UID/GID drift issues -- this has caused issues as well on the IoT/Edge side). The current passwd/group files in the minimal manifest are both outdated and incomplete (most of it can in fact trace its lineage all the way back to Fedora Atomic Host).

But more generally, in the FROM scratch flow, users _should_ have the ability to customize which user gets which UID. And one could imagine an option like `bootc-base-imagectl --passwd mypasswd --group mygroup` but (1) while the format is well-known, using it as an interface for building root filesystems is less so, and for example has no correspondence in the dnf world, and (2) such an interface implies taking ownership of all the entries.

A more universal config file for this of course is systemd-sysusers. And recently, rpm-ostree learned in #5334 to run systemd-sysusers prior to running any scriptlets for parity with similar functionality in RPM.

So it basically works today in Fedora to completely ditch the monolithic passwd/group stuff and instead fixate UIDs via sysusers dropins. And then, combining that with `bootc-base-imagectl --add-dir`, this becomes possible to feed into the FROM scratch flow.

We want to enable this flow in RHEL as well. All we need really is to force rpm-ostree to run systemd-sysusers even if the `%__systemd_sysusers` macro is undefined.

Add a new experimental `sysusers:` knob to the treefile. Currently, it takes one of two values:
- `compose-auto`: `systemd-sysusers` is run at compose time if the `%__systemd_sysusers` RPM macro is defined (status quo)
- `compose-forced`: `systemd-sysusers` is always run at compose time, even if the `%__systemd_sysusers` RPM macro is undefined

And the net result of this then is it moves the emphasis further to systemd-sysusers as a way of ensuring UID coherence across builds and e.g. all the flexibility it implies around configurability/composition/overrides etc...

(Worth noting that the systemd %post script actually always runs systemd-sysusers currently. But we can't rely on this because it's itself part of the RPM transaction and so has no effect on packages which have run before.)

Then, for the bootc-base-imagectl flow, we can add a new `--sysusers` switch which sets this new option and crucially disables all the `check-passwd`/`check-group` logic.

This is related to the nss-altfiles to sysusers migration though also somewhat independent. With `compose-forced`, the split back into `/usr/lib/{passwd,group}` still happens at the end of the compose.

However I still went with the `sysusers:` enum and left room for other strategies to be implemented, since any strategy around nss-altfiles migration must take into account what semantics are desired from the systemd-sysusers run at compose time.