### PR TITLE
kernel: Drop check for ostree-container

### DIFF
--- a/rust/src/kernel_install.rs
+++ b/rust/src/kernel_install.rs
@@ -92,12 +92,6 @@ pub fn main(argv: &[&str]) -> Result<u8> {
     if !matches!(layout.to_str(), Some(LAYOUT_OSTREE)) {
         return Ok(0);
     }
-    if !ostree_ext::container_utils::is_ostree_container()? {
-        eprintln!(
-            "warning: confused state: {LAYOUT_VAR}={LAYOUT_OSTREE} but not in an ostree container"
-        );
-        return Ok(0);
-    }
     let root = &Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
     tracing::debug!("argv={argv:?}");
     match argv {


### PR DESCRIPTION
Since we now support images without an embedded `/ostree`, the concept of an "ostree container" is much less extant. There's no need for us to double check things here - if the kernel layout is specified as ostree, that's all we need to know.

