### PR TITLE
Many patches for stderr

### DIFF
--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -446,8 +446,6 @@ impl Bubblewrap {
 
     /// Execute the container.  This method uses the normal gtk-rs `Option<T>` for the cancellable.
     fn run_inner(&mut self, cancellable: Option<&gio::Cancellable>) -> Result<()> {
-        // Merge STDERR/STDOUT so we don't swallow STDERR during execution
-        self.launcher.set_flags(gio::SubprocessFlags::STDERR_MERGE);
         let (child, argv0) = self.spawn()?;
         child_wait_check(child, cancellable).context(argv0)?;
         Ok(())

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -548,9 +548,10 @@ pub(crate) fn compose_postprocess_scripts(
             )
             .context("Executing inline postprocessing script")?;
         } else {
-            Command::new(&binpath)
-                .run()
-                .context("Executing inline postprocessing script")?;
+            let st = Command::new(&binpath).status()?;
+            if !st.success() {
+                anyhow::bail!("Executing inline postprocessing script: {st:?}");
+            }
         }
         rootfs_dfd.remove_file(target_binpath)?;
     }
@@ -581,9 +582,10 @@ pub(crate) fn compose_postprocess_scripts(
             )
             .context("Executing postprocessing script")?;
         } else {
-            Command::new(&binpath)
-                .run()
-                .context("Executing postprocessing script")?;
+            let st = Command::new(&binpath).status()?;
+            if !st.success() {
+                anyhow::bail!("Executing postprocessing script: {st:?}");
+            }
         }
 
         rootfs_dfd.remove_file(target_binpath)?;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -19,7 +19,6 @@
  * - Add a test case in tests/compose
  */
 
-use crate::cmdutils::CommandRunExt;
 use crate::{compose_postprocess_scripts, cxxrsutil::*};
 use anyhow::{anyhow, bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -852,9 +851,10 @@ impl Treefile {
             if let Some(d) = self.directory.as_deref() {
                 cmd.env("RPMOSTREE_WORKDIR", d);
             }
-            cmd.cwd_dir(rootfs.try_clone()?)
-                .run()
-                .with_context(|| format!("Failed to execute {name}"))?;
+            let st = cmd.cwd_dir(rootfs.try_clone()?).status()?;
+            if !st.success() {
+                return Err(anyhow!("Failed to execute {name}: {st}"));
+            }
         }
         Ok(())
     }

--- a/tests/kolainst/destructive/layering-local
+++ b/tests/kolainst/destructive/layering-local
@@ -67,6 +67,11 @@ rpm-ostree install testpkg-lua-ignored
 rpm-ostree uninstall testpkg-lua-ignored
 echo "ok lua"
 
+rpm-ostree install testpkg-stdout-and-stderr
+assert_streq $(journalctl -u rpm-ostreed --grep='(some|more)-(stdout|stderr)-testing' | wc -l) 4
+rpm-ostree uninstall testpkg-stdout-and-stderr
+echo "ok stdout and stderr"
+
 # Disable repos, no Internet access should be required for the remaining tests
 rm -rf /etc/yum.repos.d/
 # Also disable zincati since we're rebasing

--- a/tests/kolainst/kolainst-build.sh
+++ b/tests/kolainst/kolainst-build.sh
@@ -85,6 +85,12 @@ build_rpm testpkg-lua-ignored \
              post_args "-p <lua>" \
              post '-- rpm-ostree-skip 
                    posix.stat("/")'
+build_rpm testpkg-stdout-and-stderr \
+             post "set -euo pipefail
+echo some-stdout-testing
+echo some-stderr-testing 1>&2
+echo more-stdout-testing
+echo more-stderr-testing 1>&2"
 
 # Will be useful in checking difference in package version while doing apply-live 
 build_rpm pkgsystemd \


### PR DESCRIPTION
This reverts commit https://github.com/coreos/rpm-ostree/commit/f4aecb9b62a97eee8368ca8058b33325891cd62d.
It causes ill-defined behavior with older glib, resulting in
file descriptor mis-assignments.

Also add tests that verify that we do get both stdout and stderr from both postprocess scripts and package scripts.

Closes: https://github.com/coreos/rpm-ostree/issues/5436