### PR TITLE
rechunker: Use open_image when transport is oci-archive

### DIFF
--- a/tests/build-chunked-oci/test.sh
+++ b/tests/build-chunked-oci/test.sh
@@ -219,3 +219,13 @@ else
 fi
 
 echo "ok exclusive layers functionality"
+
+echo "Testing oci-archive output"
+podman run --rm --privileged --security-opt=label=disable \
+  -v /var/lib/containers:/var/lib/containers \
+  -v /var/tmp:/var/tmp \
+  -v "$(pwd)":/output \
+  localhost/builder rpm-ostree compose build-chunked-oci --bootc --from localhost/base --output=oci-archive:/output/test-archive
+
+test -f test-archive
+echo "ok oci-archive output"


### PR DESCRIPTION
This allows the use of oci-archive when the archive doesn't yet exist.

fixes #5442