### PR TITLE
compose: Add `--label` for build-chunked-oci

### DIFF
--- a/tests/build-chunked-oci/test.sh
+++ b/tests/build-chunked-oci/test.sh
@@ -9,11 +9,12 @@ podman run --rm --privileged --security-opt=label=disable \
   -v /var/lib/containers:/var/lib/containers \
   -v /var/tmp:/var/tmp \
   -v "$(pwd)":/output \
-  localhost/builder rpm-ostree compose build-chunked-oci --bootc --from ${testimg_base} --output containers-storage:${chunked_output}
+  localhost/builder rpm-ostree compose build-chunked-oci --bootc --from ${testimg_base} --output containers-storage:${chunked_output} --label foo=bar
 podman rmi ${testimg_base}
 podman inspect containers-storage:${chunked_output} | jq '.[0]' > config.json
 podman rmi ${chunked_output}
 test $(jq -r '.Architecture' < config.json) = "ppc64le"
+test $(jq -r '.Labels.foo' < config.json) = "bar"
 echo "ok cross arch rechunking"
 
 # Build a custom image, then rechunk it


### PR DESCRIPTION
This is trivial to do since the underlying `container-encapsulate` we do already supports this.

What becomes really interesting about this though is that in a container build flow where one is using `build-chunked-oci` with the `FROM: ./out.ociarchive` trick, it then becomes possible to _dynamically_ (i.e. from within the build process itself) choose whether to add a label, or determine what value a label should have, which is a common frustration in container image building.