### PR TITLE
rechunker: Parse specific components into (path, checksum)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "bootc-internal-utils"
 version = "0.0.0"
-source = "git+https://github.com/containers/bootc?rev=d35d2359d54cc14aae19db6a73291773d4fb3bbe#d35d2359d54cc14aae19db6a73291773d4fb3bbe"
+source = "git+https://github.com/containers/bootc?rev=05030a3d9a069d381a0048fca537fce1b8fc8e49#05030a3d9a069d381a0048fca537fce1b8fc8e49"
 dependencies = [
  "anyhow",
  "chrono",
@@ -288,7 +288,7 @@ dependencies = [
  "ambient-authority",
  "fs-set-times",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 2.0.4",
  "ipnet",
  "maybe-owned",
  "rustix 1.0.8",
@@ -306,7 +306,7 @@ dependencies = [
  "camino",
  "cap-primitives",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 2.0.4",
  "rustix 1.0.8",
 ]
 
@@ -464,7 +464,7 @@ dependencies = [
 [[package]]
 name = "composefs"
 version = "0.3.0"
-source = "git+https://github.com/containers/composefs-rs?rev=28d4721f77f973f0e394d60d6a69d9b39cb38d7f#28d4721f77f973f0e394d60d6a69d9b39cb38d7f"
+source = "git+https://github.com/containers/composefs-rs?rev=8d1e570275621531d39b8f01681584bcc85ce01c#8d1e570275621531d39b8f01681584bcc85ce01c"
 dependencies = [
  "anyhow",
  "hex",
@@ -484,7 +484,7 @@ dependencies = [
 [[package]]
 name = "composefs-boot"
 version = "0.3.0"
-source = "git+https://github.com/containers/composefs-rs?rev=28d4721f77f973f0e394d60d6a69d9b39cb38d7f#28d4721f77f973f0e394d60d6a69d9b39cb38d7f"
+source = "git+https://github.com/containers/composefs-rs?rev=8d1e570275621531d39b8f01681584bcc85ce01c#8d1e570275621531d39b8f01681584bcc85ce01c"
 dependencies = [
  "anyhow",
  "composefs",
@@ -497,14 +497,14 @@ dependencies = [
 [[package]]
 name = "composefs-oci"
 version = "0.3.0"
-source = "git+https://github.com/containers/composefs-rs?rev=28d4721f77f973f0e394d60d6a69d9b39cb38d7f#28d4721f77f973f0e394d60d6a69d9b39cb38d7f"
+source = "git+https://github.com/containers/composefs-rs?rev=8d1e570275621531d39b8f01681584bcc85ce01c#8d1e570275621531d39b8f01681584bcc85ce01c"
 dependencies = [
  "anyhow",
  "async-compression",
  "composefs",
  "containers-image-proxy",
  "hex",
- "indicatif",
+ "indicatif 0.17.11",
  "oci-spec",
  "rustix 1.0.8",
  "sha2",
@@ -523,6 +523,19 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1051,7 +1064,7 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
- "io-lifetimes",
+ "io-lifetimes 2.0.4",
  "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
@@ -1727,11 +1740,24 @@ version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
- "console",
+ "console 0.15.11",
  "number_prefix",
  "portable-atomic",
  "tokio",
  "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
+dependencies = [
+ "console 0.16.0",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -1747,7 +1773,7 @@ version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
- "io-lifetimes",
+ "io-lifetimes 2.0.4",
  "windows-sys 0.59.0",
 ]
 
@@ -1756,6 +1782,12 @@ name = "io-lifetimes"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
 
 [[package]]
 name = "io-uring"
@@ -1894,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -2292,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "ostree-ext"
 version = "0.15.3"
-source = "git+https://github.com/containers/bootc?rev=d35d2359d54cc14aae19db6a73291773d4fb3bbe#d35d2359d54cc14aae19db6a73291773d4fb3bbe"
+source = "git+https://github.com/containers/bootc?rev=05030a3d9a069d381a0048fca537fce1b8fc8e49#05030a3d9a069d381a0048fca537fce1b8fc8e49"
 dependencies = [
  "anyhow",
  "bootc-internal-utils",
@@ -2312,8 +2344,8 @@ dependencies = [
  "gvariant",
  "hex",
  "indexmap",
- "indicatif",
- "io-lifetimes",
+ "indicatif 0.18.0",
+ "io-lifetimes 3.0.1",
  "libc",
  "libsystemd",
  "ocidir",
@@ -2836,7 +2868,7 @@ dependencies = [
  "fail",
  "fn-error-context",
  "futures",
- "indicatif",
+ "indicatif 0.17.11",
  "indoc",
  "is-terminal",
  "libc",
@@ -3160,7 +3192,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
 dependencies = [
- "console",
+ "console 0.15.11",
  "similar",
 ]
 
@@ -3713,6 +3745,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ openssl = "0.10.73"
 once_cell = "1.21.3"
 os-release = "0.1.0"
 # We pull this one from git, as the project is no longer published as an external crate.
-ostree-ext = { git = "https://github.com/containers/bootc", rev = "d35d2359d54cc14aae19db6a73291773d4fb3bbe" }
+ostree-ext = { git = "https://github.com/containers/bootc", rev = "05030a3d9a069d381a0048fca537fce1b8fc8e49" }
 paste = "1.0"
 phf = { version = "0.12", features = ["macros"] }
 rand = "0.9.1"

--- a/tests/build-chunked-oci/Containerfile.recursive
+++ b/tests/build-chunked-oci/Containerfile.recursive
@@ -13,43 +13,43 @@ RUN <<END
 
     # the root layers directory
     setfattr -n user.component -v "root" /usr/share/layers
-    echo "This is a file 1" > /usr/share/layers/fileA
-    echo "This is a file 2" > /usr/share/layers/targetA
+    echo "foo" > /usr/share/layers/fileA
+    echo "foo" > /usr/share/layers/targetA
     ln -s /usr/share/layers/targetA /usr/share/layers/linkA
-    echo "This is a file 3" > /usr/share/layers/targetB
+    echo "foo" > /usr/share/layers/targetB
     ln -s /usr/share/layers/targetB /usr/share/layers/broken-linkB
     rm /usr/share/layers/targetB
     ln -s /usr/share/layers/dir1/targetB /usr/share/layers/linkB
 
     # dir1 has user.component set
     setfattr -n user.component -v "dir1" /usr/share/layers/dir1
-    echo "This is a file 4" > /usr/share/layers/dir1/targetA
+    echo "foo" > /usr/share/layers/dir1/targetA
     ln -s /usr/share/layers/dir1/targetA /usr/share/layers/dir1/linkA
     # link to a file in dir2
-    echo "This is a file 5" > /usr/share/layers/dir2/targetB
+    echo "foo" > /usr/share/layers/dir2/targetB
     ln -s /usr/share/layers/dir2/targetB /usr/share/layers/dir1/linkB
     # linked to from root
-    echo "This is a file 6" > /usr/share/layers/dir1/targetB
+    echo "foo" > /usr/share/layers/dir1/targetB
     mkdir -p /usr/share/layers/dir1/dirA
-    echo "This is a file 7" > /usr/share/layers/dir1/dirA/fileA
+    echo "foo" > /usr/share/layers/dir1/dirA/fileA
 
     # dir2 has no user.component set so it will be included in the root layer
-    echo "This is a file A" > /usr/share/layers/dir2/fileA
-    echo "This is a file B" > /usr/share/layers/dir2/targetA
+    echo "foo" > /usr/share/layers/dir2/fileA
+    echo "foo" > /usr/share/layers/dir2/targetA
     ln -s /usr/share/layers/dir2/targetA /usr/share/layers/dir2/linkA
     mkdir -p /usr/share/layers/dir2/dirA
-    echo "This is a file C" > /usr/share/layers/dir2/dirA/fileA
+    echo "foo" > /usr/share/layers/dir2/dirA/fileA
 
     # dir3 has no user.component set but some files in dir3 have a user.component
-    echo "This is a file D" > /usr/share/layers/dir3/fileA
+    echo "foo" > /usr/share/layers/dir3/fileA
     # fileB has a user.component
-    echo "This is a file E" > /usr/share/layers/dir3/fileB
+    echo "foo" > /usr/share/layers/dir3/fileB
     setfattr -n user.component -v "dir3fileB" /usr/share/layers/dir3/fileB
 
     # dir4 has a user.component set but some files have a user.component
     setfattr -n user.component -v "dir4" /usr/share/layers/dir4
-    echo "This is a file F" > /usr/share/layers/dir4/fileA
-    echo "This is a file G" > /usr/share/layers/dir4/fileB
+    echo "foo" > /usr/share/layers/dir4/fileA
+    echo "foo" > /usr/share/layers/dir4/fileB
     setfattr -n user.component -v "dir4fileB" /usr/share/layers/dir4/fileB
 
 END


### PR DESCRIPTION
This allows files with duplicate contents (and checksums) to be stored in different layers.

fixes #5458 