### PR TITLE
ci: Drop NEVRA override testing

### DIFF
--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -31,7 +31,6 @@ case $versionid in
     koji_kernel_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=2685011"
     kver=6.14.0
     krev=63
-    afterburn_version=5.9.0-1.fc42."$(arch)"
     ;;
   41)
     # 2.19.0-2 (this koji url must be different than above version)
@@ -39,7 +38,6 @@ case $versionid in
     koji_kernel_url="https://koji.fedoraproject.org/koji/buildinfo?buildID=2571615"
     kver=6.11.4
     krev=301
-    afterburn_version=5.7.0-4.fc41."$(arch)"
     ;;
   *) fatal "Unsupported Fedora version: $versionid";;
 esac
@@ -156,12 +154,6 @@ fi
 
 (cd /etc/yum.repos.d/ && curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-coreos-pool.repo)
 (cd /etc/yum.repos.d/ && curl -LO https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/ci/continuous/fcos-continuous.repo)
-
-# test repo override by NEVRA
-rpm-ostree override replace --experimental --from repo=fedora-coreos-pool \
-  afterburn-{,dracut-}"${afterburn_version}"
-
-rpm -q afterburn-{,dracut-}"${afterburn_version}"
 
 # test repo override by pkgname, and also test --install
 if rpm -q strace; then


### PR DESCRIPTION
The toil from maintaining these hardcoded older package versions is super high, let's drop it and accept the lower CI coverage for now.

(The end fix is to create synthetic RPMs automatically, but
 that's more work)
