### PR TITLE
treefile,compose: add advisories-metadata option

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -529,6 +529,13 @@ It supports the following parameters:
    it from affecting the commit checksum. Setting it to `disabled` will
    prevent the metadata from being added at all.
 
+ * `advisories-metadata`: String, optional: Can be one of `inline` (the default),
+   `detached` or  `disabled`. If set to `inline`, RPM advisories informations
+   are added to the OSTree commit metadata under the `rpmostree.advisories` key.
+   Setting this to `detached` also adds the information but puts it in the detached
+   metadata of the commit, preventing it from affecting the commit checksum.
+   Setting it to `disabled` will prevent the metadata from being added at all.
+
 ## Experimental options
 
 All options listed here are subject to change or removal in a future

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1352,6 +1352,7 @@ struct HistoryCtx;
 struct TokioHandle;
 struct TokioEnterGuard;
 enum class RepoMetadataTarget : ::std::uint8_t;
+enum class AdvisoriesMetadataTarget : ::std::uint8_t;
 struct Refspec;
 enum class OverrideReplacementType : ::std::uint8_t;
 struct OverrideReplacement;
@@ -1720,6 +1721,16 @@ enum class RepoMetadataTarget : ::std::uint8_t
 };
 #endif // CXXBRIDGE1_ENUM_rpmostreecxx$RepoMetadataTarget
 
+#ifndef CXXBRIDGE1_ENUM_rpmostreecxx$AdvisoriesMetadataTarget
+#define CXXBRIDGE1_ENUM_rpmostreecxx$AdvisoriesMetadataTarget
+enum class AdvisoriesMetadataTarget : ::std::uint8_t
+{
+  Inline = 0,
+  Detached = 1,
+  Disabled = 2,
+};
+#endif // CXXBRIDGE1_ENUM_rpmostreecxx$AdvisoriesMetadataTarget
+
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Refspec
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Refspec
 struct Refspec final
@@ -1825,6 +1836,7 @@ struct Treefile final : public ::rust::Opaque
   bool get_ima () const noexcept;
   ::rust::String get_releasever () const noexcept;
   ::rpmostreecxx::RepoMetadataTarget get_repo_metadata_target () const noexcept;
+  ::rpmostreecxx::AdvisoriesMetadataTarget get_advisories_metadata_target () const noexcept;
   bool rpmdb_backend_is_target () const noexcept;
   bool should_normalize_rpmdb () const noexcept;
   ::rpmostreecxx::OptUsrLocal get_opt_usrlocal () const noexcept;
@@ -2696,6 +2708,10 @@ extern "C"
                                                         ::rust::String *return$) noexcept;
 
   ::rpmostreecxx::RepoMetadataTarget rpmostreecxx$cxxbridge1$Treefile$get_repo_metadata_target (
+      ::rpmostreecxx::Treefile const &self) noexcept;
+
+  ::rpmostreecxx::AdvisoriesMetadataTarget
+  rpmostreecxx$cxxbridge1$Treefile$get_advisories_metadata_target (
       ::rpmostreecxx::Treefile const &self) noexcept;
 
   bool rpmostreecxx$cxxbridge1$Treefile$rpmdb_backend_is_target (
@@ -5322,6 +5338,12 @@ Treefile::get_releasever () const noexcept
 Treefile::get_repo_metadata_target () const noexcept
 {
   return rpmostreecxx$cxxbridge1$Treefile$get_repo_metadata_target (*this);
+}
+
+::rpmostreecxx::AdvisoriesMetadataTarget
+Treefile::get_advisories_metadata_target () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$Treefile$get_advisories_metadata_target (*this);
 }
 
 bool

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1129,6 +1129,7 @@ struct HistoryCtx;
 struct TokioHandle;
 struct TokioEnterGuard;
 enum class RepoMetadataTarget : ::std::uint8_t;
+enum class AdvisoriesMetadataTarget : ::std::uint8_t;
 struct Refspec;
 enum class OverrideReplacementType : ::std::uint8_t;
 struct OverrideReplacement;
@@ -1497,6 +1498,16 @@ enum class RepoMetadataTarget : ::std::uint8_t
 };
 #endif // CXXBRIDGE1_ENUM_rpmostreecxx$RepoMetadataTarget
 
+#ifndef CXXBRIDGE1_ENUM_rpmostreecxx$AdvisoriesMetadataTarget
+#define CXXBRIDGE1_ENUM_rpmostreecxx$AdvisoriesMetadataTarget
+enum class AdvisoriesMetadataTarget : ::std::uint8_t
+{
+  Inline = 0,
+  Detached = 1,
+  Disabled = 2,
+};
+#endif // CXXBRIDGE1_ENUM_rpmostreecxx$AdvisoriesMetadataTarget
+
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Refspec
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Refspec
 struct Refspec final
@@ -1602,6 +1613,7 @@ struct Treefile final : public ::rust::Opaque
   bool get_ima () const noexcept;
   ::rust::String get_releasever () const noexcept;
   ::rpmostreecxx::RepoMetadataTarget get_repo_metadata_target () const noexcept;
+  ::rpmostreecxx::AdvisoriesMetadataTarget get_advisories_metadata_target () const noexcept;
   bool rpmdb_backend_is_target () const noexcept;
   bool should_normalize_rpmdb () const noexcept;
   ::rpmostreecxx::OptUsrLocal get_opt_usrlocal () const noexcept;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -538,6 +538,13 @@ pub mod ffi {
         Disabled,
     }
 
+    #[derive(Debug)]
+    enum AdvisoriesMetadataTarget {
+        Inline,
+        Detached,
+        Disabled,
+    }
+
     #[derive(Debug, PartialEq, Eq)]
     struct Refspec {
         kind: RefspecType,
@@ -640,6 +647,7 @@ pub mod ffi {
         fn get_ima(&self) -> bool;
         fn get_releasever(&self) -> String;
         fn get_repo_metadata_target(&self) -> RepoMetadataTarget;
+        fn get_advisories_metadata_target(&self) -> AdvisoriesMetadataTarget;
         fn rpmdb_backend_is_target(&self) -> bool;
         fn should_normalize_rpmdb(&self) -> bool;
         fn get_opt_usrlocal(&self) -> OptUsrLocal;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -475,6 +475,7 @@ fn treefile_merge(dest: &mut TreeComposeConfig, src: &mut TreeComposeConfig) {
         automatic_version_prefix,
         automatic_version_suffix,
         repo_metadata,
+        advisories_metadata,
         rpmdb,
         mutate_os_release,
         preserve_passwd,
@@ -1422,6 +1423,14 @@ impl Treefile {
 
     pub(crate) fn get_repo_metadata_target(&self) -> crate::ffi::RepoMetadataTarget {
         self.parsed.base.repo_metadata.unwrap_or_default().into()
+    }
+
+    pub(crate) fn get_advisories_metadata_target(&self) -> crate::ffi::AdvisoriesMetadataTarget {
+        self.parsed
+            .base
+            .advisories_metadata
+            .unwrap_or_default()
+            .into()
     }
 
     /// Returns true if the database backend must be regenerated using the target system.
@@ -2415,6 +2424,30 @@ impl From<RepoMetadataTarget> for crate::ffi::RepoMetadataTarget {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "kebab-case")]
+pub(crate) enum AdvisoriesMetadataTarget {
+    Inline,
+    Detached,
+    Disabled,
+}
+
+impl Default for AdvisoriesMetadataTarget {
+    fn default() -> Self {
+        Self::Inline
+    }
+}
+
+impl From<AdvisoriesMetadataTarget> for crate::ffi::AdvisoriesMetadataTarget {
+    fn from(target: AdvisoriesMetadataTarget) -> Self {
+        match target {
+            AdvisoriesMetadataTarget::Inline => Self::Inline,
+            AdvisoriesMetadataTarget::Detached => Self::Detached,
+            AdvisoriesMetadataTarget::Disabled => Self::Disabled,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
+#[serde(rename_all = "kebab-case")]
 pub(crate) enum OptUsrLocal {
     Var,
     Root,
@@ -2639,6 +2672,8 @@ pub(crate) struct BaseComposeConfigFields {
     pub(crate) add_commit_metadata: Option<BTreeMap<String, serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) repo_metadata: Option<RepoMetadataTarget>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) advisories_metadata: Option<AdvisoriesMetadataTarget>,
     // The database backend
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) rpmdb: Option<RpmdbBackend>,

--- a/tests/compose/test-advisories-metadata.sh
+++ b/tests/compose/test-advisories-metadata.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -xeuo pipefail
+
+dn=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=libcomposetest.sh
+. "${dn}/libcomposetest.sh"
+
+treefile_set advisories-metadata '"detached"'
+runcompose
+echo "ok compose detached"
+
+
+ostree --repo=${repo} show --print-metadata-key rpmostree.advisories ${treeref} && \
+    fatal "rpmostree.advisories present in inline metadata when should be detached"
+ostree --repo=${repo} show --print-detached-metadata-key rpmostree.advisories ${treeref} && \
+    echo "ok metadata detached" || echo "rpmostree.advisories missing (no advisories in repo ?)"
+
+treefile_set advisories-metadata '"disabled"'
+runcompose
+echo "ok compose disabled"
+
+ostree --repo=${repo} show --print-metadata-key rpmostree.advisories ${treeref} && \
+    fatal "rpmostree.advisories present in inline metadata when should be disabled"
+ostree --repo=${repo} show --print-detached-metadata-key rpmostree.advisories ${treeref} && \
+    fatal "rpmostree.advisories present in detached metadata when should be disabled"
+echo "ok metadata disabled"


### PR DESCRIPTION
Similar to repo-metadata, advisories-metadata option allow to set
if you should store advisories information in the commit metadata,
in the detached metadata, or not at all.