### PR TITLE
compose: allow write-lockfile-to / lockfile / lockfile-strict together

### DIFF
--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -136,7 +136,7 @@ struct ComposeImageOpts {
     /// Operate only on cached data, do not access network repositories
     offline: bool,
 
-    #[clap(long, conflicts_with_all = ["lockfiles", "lockfile_strict"])]
+    #[clap(long)]
     /// Path to write a JSON-formatted lockfile
     write_lockfile_to: Option<Utf8PathBuf>,
 


### PR DESCRIPTION
You can read multiple (partial) lockfiles in input and write the resulting full lockfile in output, there is actually no restrictions and this is a use case in COSA.

Fixes d5338dc90988cc6be953b34d18e4ee2d6f5601cd