### PR TITLE
Release 2025.11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2025])
-m4_define([release_version], [10])
+m4_define([release_version], [11])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2025.10
+Version: 2025.11
 Release: 1%{?dist}
 License: LGPL-2.0-or-later
 URL: https://github.com/coreos/rpm-ostree


### PR DESCRIPTION
Release 2025.11

```
Alexander Larsson (1):
      Fix SELinux aliases for /usr/etc/systemd/system (and similar)

Chris Kyrouac (1):
      Update version of afterburn

Colin Walters (3):
      ci: Bump afterburn version
      ci: Update for coreos-assembler API break
      ci: Drop NEVRA override testing

Etienne Champetier (4):
      compose: sort packages before rpmtsOrder()
      treefile: merge 'repo-metadata' config
      treefile,compose: add advisories-metadata option
      compose: allow write-lockfile-to / lockfile / lockfile-strict together

Jonathan Lebon (2):
      compose: Add `--lockfile` to `rpm-ostree compose rootfs`
      compose: Add `--label` for build-chunked-oci

Joseph Marrero Corchado (1):
      Release 2025.11

Marco Hünseler (1):
      fsutil.rs: Make `is_dir` return correct information

ckyrouac (3):
      rechunker: Recursively add directories with user.component xattr
      docs: Update docs with new rechunker features
      rechunker: Parse specific components into (path, checksum)

dependabot[bot] (1):
      build(deps): bump tracing-subscriber from 0.3.19 to 0.3.20

ningmingxiao (1):
      doc:update index.md
```