### PR TITLE
rechunker: Use podman unshare when rootless

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -265,6 +265,16 @@ jobs:
           sudo rm /var/lib/containers -rf
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Unprivileged tests
+        run: |
+          set -xeuo pipefail
+          sudo apt-get update
+          sudo apt-get install -y fuse-overlayfs
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          podman build -v $(pwd):/src -t localhost/buildah -f tests/build-chunked-oci/Containerfile.buildah .
+          podman run --rm --device=/dev/fuse localhost/buildah /test-buildah.sh
       - name: Download build
         uses: actions/download-artifact@v4.1.7
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ cap-std-ext = "4"
 cap-primitives = "3"
 cap-std = { version = "3", features = ["fs_utf8"] }
 # Explicitly force on libc
-rustix = { version = "1.0", features = ["use-libc", "process", "fs"] }
+rustix = { version = "1.0", features = ["use-libc", "process", "fs", "thread"] }
 chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 cxx = "1.0.158"

--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -286,6 +286,9 @@ impl BuildChunkedOCIOpts {
             Podman(Mount),
         }
 
+        // Ensure we're in the proper namespace for container operations
+        crate::containers_storage::reexec_if_needed()?;
+
         let existing_manifest = self.check_existing_image(&self.output)?;
 
         let rootfs_source = if let Some(rootfs) = self.rootfs {

--- a/tests/build-chunked-oci/Containerfile.buildah
+++ b/tests/build-chunked-oci/Containerfile.buildah
@@ -1,0 +1,15 @@
+FROM quay.io/containers/buildah:latest as builder
+
+RUN <<ENDF
+set -xeuo pipefail
+dnf -y builddep rpm-ostree
+cd /src
+./autogen.sh --prefix=/usr --libdir=/usr/lib64 --sysconfdir=/etc --disable-gtk-doc
+make
+cp target/release/rpm-ostree /rpm-ostree
+ENDF
+
+FROM quay.io/containers/buildah:latest
+RUN dnf -y install rpm-ostree && rpm -e rpm-ostree
+COPY --from=builder /rpm-ostree /usr/bin/rpm-ostree
+COPY tests/build-chunked-oci/test-buildah.sh /test-buildah.sh

--- a/tests/build-chunked-oci/test-buildah.sh
+++ b/tests/build-chunked-oci/test-buildah.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euxo pipefail
+
+cat > Containerfile <<EOF
+FROM quay.io/centos-bootc/centos-bootc:stream9
+RUN dnf install -y vim-enhanced
+EOF
+
+buildah pull quay.io/centos-bootc/centos-bootc:stream9
+buildah build -t localhost/my-image .
+/usr/bin/rpm-ostree experimental compose build-chunked-oci --bootc --from=localhost/my-image --output=containers-storage:localhost/my-image-chunked --format-version=2
+
+# Sanity check: verify ostree labels are present
+echo "Checking for ostree labels..."
+if ! skopeo inspect containers-storage:localhost/my-image-chunked | grep -q '"ostree\.'; then
+    echo "ERROR: No ostree labels found in output image"
+    exit 1
+fi
+
+echo "SUCCESS: Output image exists and contains ostree labels"


### PR DESCRIPTION
When running the rechunker as non-root, we need to use podman unshare to
be able to run the skopeo commands to mount/copy the image. Similarly
when running within a container (e.g. inside a buildah container), we
need to manually run unshare. We can't use podman unshare inside the
buildah container because it will fail due to already running as user 0.