### PR TITLE
Remove /usr/local/man tempfile create

### DIFF
--- a/src/app/rpm-ostree-0-integration.conf
+++ b/src/app/rpm-ostree-0-integration.conf
@@ -12,7 +12,6 @@ d /usr/local/etc 0755 root root -
 d /usr/local/games 0755 root root -
 d /usr/local/include 0755 root root -
 d /usr/local/lib 0755 root root -
-d /usr/local/man 0755 root root -
 d /usr/local/sbin 0755 root root -
 d /usr/local/share 0755 root root -
 d /usr/local/src 0755 root root -


### PR DESCRIPTION
This PR resolved rpm-ostree part of issue https://issues.redhat.com/browse/RHEL-106203.

I only remove `/usr/local/man` tempfile create in `rpm-ostree`, but I can't fix `/home` and `/srv` which is created by systemd https://github.com/systemd/systemd/blob/main/tmpfiles.d/home.conf