### PR TITLE
scripts: also hide /usr/lib/sysimage/rpm

### DIFF
--- a/rust/src/scripts.rs
+++ b/rust/src/scripts.rs
@@ -91,6 +91,8 @@ static IGNORED_PKG_SCRIPTS: phf::Set<&'static str> = phf_set! {
     "microcode_ctl.post",
     // https://bugzilla.redhat.com/show_bug.cgi?id=1199582
     "microcode_ctl.posttrans",
+    // /usr/lib/sysimage/rpm is read only when we run scripts
+    "rpm.posttrans",
 };
 
 /// Returns true if we should simply ignore (not execute) an RPM script.

--- a/src/libpriv/rpmostree-scripts.cxx
+++ b/src/libpriv/rpmostree-scripts.cxx
@@ -28,6 +28,7 @@
 #include <gio/gio.h>
 #include <systemd/sd-journal.h>
 
+#include "rpmostree-core.h"
 #include "rpmostree-rpm-util.h"
 #include "rpmostree-scripts.h"
 
@@ -354,7 +355,8 @@ rpmostree_run_script_in_bwrap_container (int rootfs_fd, GLnxTmpDir *var_lib_rpm_
     }
 
   /* Don't let scripts see the base rpm database by default */
-  bwrap->bind_read ("usr/share/empty", "usr/share/rpm");
+  bwrap->bind_read ("usr/share/empty", RPMOSTREE_RPMDB_LOCATION);
+  bwrap->bind_read ("usr/share/empty", RPMOSTREE_SYSIMAGE_RPMDB);
 
   /* Also a tmpfs for /run.
    * Add ostree-booted API; some scriptlets may work differently on OSTree systems; e.g.


### PR DESCRIPTION
We were already hiding `/usr/share/rpm`.
When `%_dbpath` points to `/usr/lib/sysimage/rpm` (`macros.rpm-ostree` not created yet), if a package calls `rpm -q ...` in one of his rpm scripts, when running postprocess-script we end up with an empty rpmdb at `/usr/lib/sysimage/rpm` and the real rpmdb at `/usr/share/rpm`. This breaks `bootupctl backend generate-update-metadata` as it looks first into `/usr/lib/sysimage/rpm`.