### PR TITLE
postprocess: create rpmdb symlink / macro earlier

### DIFF
--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -2290,9 +2290,6 @@ extern "C"
       ::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable &cancellable) noexcept;
 
   ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$compose_postprocess_rpm_macro (::std::int32_t rootfs_dfd) noexcept;
-
-  ::rust::repr::PtrLen
   rpmostreecxx$cxxbridge1$postprocess_cleanup_rpmdb (::std::int32_t rootfs_dfd) noexcept;
 
   ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$rewrite_rpmdb_for_target (::std::int32_t rootfs_dfd,
@@ -4177,16 +4174,6 @@ workaround_selinux_cross_labeling (::std::int32_t rootfs_dfd,
 {
   ::rust::repr::PtrLen error$
       = rpmostreecxx$cxxbridge1$workaround_selinux_cross_labeling (rootfs_dfd, cancellable);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-}
-
-void
-compose_postprocess_rpm_macro (::std::int32_t rootfs_dfd)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$compose_postprocess_rpm_macro (rootfs_dfd);
   if (error$.ptr)
     {
       throw ::rust::impl<::rust::Error>::error (error$);

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1944,8 +1944,6 @@ void rootfs_prepare_links (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile c
 void workaround_selinux_cross_labeling (::std::int32_t rootfs_dfd,
                                         ::rpmostreecxx::GCancellable &cancellable);
 
-void compose_postprocess_rpm_macro (::std::int32_t rootfs_dfd);
-
 void postprocess_cleanup_rpmdb (::std::int32_t rootfs_dfd);
 
 void rewrite_rpmdb_for_target (::std::int32_t rootfs_dfd, bool normalize);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -320,7 +320,6 @@ pub mod ffi {
             rootfs_dfd: i32,
             cancellable: Pin<&mut GCancellable>,
         ) -> Result<()>;
-        fn compose_postprocess_rpm_macro(rootfs_dfd: i32) -> Result<()>;
         fn postprocess_cleanup_rpmdb(rootfs_dfd: i32) -> Result<()>;
         fn rewrite_rpmdb_for_target(rootfs_dfd: i32, normalize: bool) -> Result<()>;
         fn directory_size(dfd: i32, cancellable: &GCancellable) -> Result<u64>;

--- a/src/libpriv/rpmostree-postprocess.cxx
+++ b/src/libpriv/rpmostree-postprocess.cxx
@@ -626,9 +626,6 @@ rpmostree_rootfs_postprocess_common (int rootfs_fd, GCancellable *cancellable, G
         }
     }
 
-  /* Make sure there is an RPM macro in place pointing to the rpmdb in /usr */
-  ROSCXX_TRY (compose_postprocess_rpm_macro (rootfs_fd), error);
-
   CXX_TRY (rpmostreecxx::postprocess_cleanup_rpmdb (rootfs_fd), error);
 
   if (!cleanup_selinux_lockfiles (rootfs_fd, cancellable, error))

--- a/tests/compose/test-basic-unified.sh
+++ b/tests/compose/test-basic-unified.sh
@@ -35,6 +35,11 @@ tf['repo-packages'] = [{
 
 treefile_set "postprocess" '["""#!/bin/bash
 set -euo pipefail
+[[ $(readlink /var/lib/rpm) == "../../usr/share/rpm" ]] && echo test-rpmdb-symlink-ok
+[[ $(readlink /usr/lib/sysimage/rpm) == "../../share/rpm" ]] && echo test-rpmdb-symlink-ok
+[[ $(cat /usr/lib/rpm/macros.d/macros.rpm-ostree) == "%_dbpath /usr/share/rpm" ]] && echo test-rpm-dbpath-ok
+[[ $(rpm -E '%_dbpath') == "/usr/share/rpm" ]] && echo test-rpm-dbpath-ok
+rpm -q rpm && echo test-rpm-q-ok
 echo postprocess-some-stdout-testing
 echo postprocess-some-stderr-testing 1>&2
 echo postprocess-more-stdout-testing
@@ -92,6 +97,7 @@ runcompose --add-metadata-from-json $(pwd)/metadata.json \
 cat compose.log
 assert_streq $(grep -cEe 'testpkg-(some|more)-(stdout|stderr)-testing' compose.log) 4
 assert_streq $(grep -cEe 'postprocess-(some|more)-(stdout|stderr)-testing' compose.log) 4
+assert_streq $(grep -cEe 'test-(rpmdb-symlink|rpm-dbpath|rpm-q)-ok' compose.log) 5
 
 # Run it again, but without RPMOSTREE_PRESERVE_TMPDIR. Should be a no-op. This
 # exercises fd handling in the tree context.


### PR DESCRIPTION
When `%_dbpath` points to `/usr/lib/sysimage/rpm` (`macros.rpm-ostree` not created yet), if a package calls `rpm -q ...` in one of his rpm scripts, then we end up with an empty rpmdb at `/usr/lib/sysimage/rpm`, breaking `bootupctl backend generate-update-metadata` in postprocess-script.

To make sure `rpm -q` is usable in postprocess-scripts, move the creation of
- `/usr/lib/sysimage/rpm` -> `/usr/share/rpm` symlink
- `macros.rpm-ostree` file
 
before the postprocess-script calls.