### PR TITLE
ci: Import bootc setup action, use in a few jobs

### DIFF
--- a/.github/actions/bootc-ubuntu-setup/action.yml
+++ b/.github/actions/bootc-ubuntu-setup/action.yml
@@ -1,0 +1,49 @@
+# Keep this in sync with the copy in bootc-dev/bootc
+name: 'Bootc Ubuntu Setup'
+description: 'Default host setup'
+runs:
+  using: 'composite'
+  steps:
+    # We really want support for heredocs
+    - name: Update podman and install just
+      shell: bash
+      run: |
+        set -eux
+        # Require the runner is ubuntu-24.04
+        IDV=$(. /usr/lib/os-release && echo ${ID}-${VERSION_ID})
+        test "${IDV}" = "ubuntu-24.04"
+        # plucky is the next release
+        echo 'deb http://azure.archive.ubuntu.com/ubuntu plucky universe main' | sudo tee /etc/apt/sources.list.d/plucky.list
+        sudo apt update
+        # skopeo is currently older in plucky for some reason hence --allow-downgrades
+        sudo apt install -y --allow-downgrades crun/plucky podman/plucky skopeo/plucky just
+    # The default runners have TONS of crud on them...
+    - name: Free up disk space on runner
+      shell: bash
+      run: |
+        sudo df -h
+        unwanted=('^aspnetcore-.*' '^dotnet-.*' '^llvm-.*' 'php.*' '^mongodb-.*' '^mysql-.*'
+                  azure-cli google-chrome-stable firefox mono-devel)
+        for x in ${unwanted[@]}; do
+          sudo apt-get remove -y $x > /dev/null
+        done
+        # Start other removal operations in parallel
+        sudo docker image prune --all --force > /dev/null &
+        sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android &
+        # Wait for all background processes to complete
+        wait
+        sudo df -h
+    # This is the default on e.g. Fedora derivatives, but not Debian
+    - name: Enable unprivileged /dev/kvm access
+      shell: bash
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+        ls -l /dev/kvm
+    # Used by a few workflows, but generally useful
+    - name: Set architecture variable
+      id: set_arch
+      shell: bash
+      run: echo "ARCH=$(arch)" >> $GITHUB_ENV
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,10 +137,12 @@ jobs:
   container-build:
     name: "Container build"
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Bootc Ubuntu Setup
+        uses: ./.github/actions/bootc-ubuntu-setup
       - name: Checkout coreos-layering-examples
         uses: actions/checkout@v3
         with:
@@ -209,17 +211,14 @@ jobs:
   compose-rootfs:
     name: "compose-rootfs tests"
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      # https://github.com/containers/podman/discussions/17362
-      - name: Get a newer podman for heredoc support (from debian testing)
-        run: |
-          set -eux
-          echo 'deb [trusted=yes] https://ftp.debian.org/debian/ testing main' | sudo tee /etc/apt/sources.list.d/testing.list
-          sudo apt update
-          sudo apt install -y crun/testing podman/testing skopeo/testing
-          # Something is confused in latest GHA here
-          sudo rm /var/lib/containers -rf
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Bootc Ubuntu Setup
+        uses: ./.github/actions/bootc-ubuntu-setup
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Download build
@@ -254,19 +253,12 @@ jobs:
     needs: build-c9s
     runs-on: ubuntu-24.04
     steps:
-      # https://github.com/containers/podman/discussions/17362
-      - name: Get a newer podman for heredoc support (from debian testing)
-        run: |
-          set -eux
-          echo 'deb [trusted=yes] https://ftp.debian.org/debian/ testing main' | sudo tee /etc/apt/sources.list.d/testing.list
-          sudo apt update
-          sudo apt install -y crun/testing podman/testing skopeo/testing
-          # Something is confused in latest GHA here
-          sudo rm /var/lib/containers -rf
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Bootc Ubuntu Setup
+        uses: ./.github/actions/bootc-ubuntu-setup
       - name: Unprivileged tests
         run: |
           set -xeuo pipefail


### PR DESCRIPTION
This cleans up disk space, which we're now hitting.

However to really be consistent we need to stop using `container:` in all jobs and switch to having this action run first step, and then spawn podman (or docker) inside jobs.
