### PR TITLE
tree: Fix Rust 1.89 lifetime lint

### DIFF
--- a/rust/src/fedora_integration.rs
+++ b/rust/src/fedora_integration.rs
@@ -36,7 +36,7 @@ mod bodhi {
         update: BodhiUpdate,
     }
 
-    pub(crate) fn canonicalize_update_id(id: &str) -> Cow<str> {
+    pub(crate) fn canonicalize_update_id(id: &str) -> Cow<'_, str> {
         let id = match id.strip_prefix(BODHI_URL_PREFIX) {
             Some(s) => return Cow::Borrowed(s),
             None => id,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -515,7 +515,7 @@ pub mod ffi {
         type TokioEnterGuard<'a>;
 
         fn tokio_handle_get() -> Box<TokioHandle>;
-        fn enter(self: &TokioHandle) -> Box<TokioEnterGuard>;
+        fn enter(self: &TokioHandle) -> Box<TokioEnterGuard<'_>>;
     }
 
     // scripts.rs

--- a/rust/src/tokio_ffi.rs
+++ b/rust/src/tokio_ffi.rs
@@ -11,7 +11,7 @@ pub(crate) fn tokio_handle_get() -> Box<TokioHandle> {
 }
 
 impl TokioHandle {
-    pub(crate) fn enter(&self) -> Box<TokioEnterGuard> {
+    pub(crate) fn enter(&self) -> Box<TokioEnterGuard<'_>> {
         Box::new(TokioEnterGuard(self.0.enter()))
     }
 }

--- a/rust/src/variant_utils.rs
+++ b/rust/src/variant_utils.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use glib::translate::*;
 use ostree_ext::glib;
 
-pub(crate) fn byteswap_be_to_native(v: &glib::Variant) -> Cow<glib::Variant> {
+pub(crate) fn byteswap_be_to_native(v: &glib::Variant) -> Cow<'_, glib::Variant> {
     if cfg!(target_endian = "big") {
         Cow::Borrowed(v)
     } else {


### PR DESCRIPTION
Add the omitted lifetimes.