### PR TITLE
app, tests: Use the same PATH as on package based Fedora variants

### DIFF
--- a/src/app/rpm-ostree-0-integration.conf
+++ b/src/app/rpm-ostree-0-integration.conf
@@ -12,6 +12,6 @@ d /usr/local/etc 0755 root root -
 d /usr/local/games 0755 root root -
 d /usr/local/include 0755 root root -
 d /usr/local/lib 0755 root root -
-d /usr/local/sbin 0755 root root -
+L /usr/local/sbin - - - - bin
 d /usr/local/share 0755 root root -
 d /usr/local/src 0755 root root -

--- a/tests/compose/libbasic-test.sh
+++ b/tests/compose/libbasic-test.sh
@@ -133,6 +133,7 @@ echo "ok --parent"
 # Check symlinks injected into the rootfs.
 ostree --repo="${repo}" ls "${treeref}" /usr/local | grep '^l00777' > symlinks.txt
 assert_file_has_content_literal symlinks.txt '/usr/local -> ../var/usrlocal'
+assert_file_has_content_literal symlinks.txt '/usr/local/sbin -> bin'
 ostree --repo="${repo}" ls "${treeref}" /opt > symlinks.txt
 assert_file_has_content_literal symlinks.txt '/opt -> var/opt'
 echo "ok symlinks"


### PR DESCRIPTION
Some Linux distributions like Arch and Fedora are in different stages of unifying their `bin` and `sbin` directories [1,2].  This has been implemented by replacing the `/sbin` and `/usr/sbin` directories with relative symbolic links to their `bin` counterparts.  Since, both those distributions have also adopted the `/usr` merge [3], this means:
  * `/sbin` → `usr/bin` or `usr/sbin`
  * `/usr/sbin` → `bin`

One notable difference between Arch and Fedora is their handling of `/usr/local/sbin`.  It remains a separate directory on the former, and has been unified with `/usr/local/bin` in the package based variants of the latter but not those that use rpm-ostree.

Fedora variants that use rpm-ostree end up with different values for the `PATH` environment variable because systemd sets it based on the state of the `bin` and `sbin` directories [4].  Since, there are no Arch variants that use rpm-ostree and there are popular Fedora ones that do, and unifying `/usr/local/sbin` with its `bin` counterpart leads to a simpler `PATH`, it seems reasonable to replicate package based Fedora.

This will make new installations of rpm-ostree based operating systems use a unified `/usr/local/sbin`, and leave existing installations unchanged.

[1] https://archlinux.org/news/binaries-move-to-usrbin-requiring-update-intervention/
    https://lists.archlinux.org/pipermail/arch-dev-public/2012-March/022625.html

[2] https://fedoraproject.org/wiki/Changes/Unify_bin_and_sbin

[3] https://systemd.io/THE_CASE_FOR_THE_USR_MERGE/

[4] systemd commit 0f36a4c897ff53eb
    https://github.com/systemd/systemd/commit/0f36a4c897ff53eb
    https://github.com/systemd/systemd/pull/32389
    https://github.com/systemd/systemd/pull/32337

https://bugzilla.redhat.com/show_bug.cgi?id=2400220

----

I don't know how to test this change properly.  I copied the file to `/etc/tmpfiles.d/rpm-ostree-0-integration.conf` on a Fedora 42 Silverblue virtual machine, deleted `/var/usrlocal/sbin`, and rebooted.  That seemed to give the expected results.