### PR TITLE
tests: Update remaining stream9 references to stream10

### DIFF
--- a/tests/build-chunked-oci/Containerfile.builder
+++ b/tests/build-chunked-oci/Containerfile.builder
@@ -1,5 +1,5 @@
-# Note that the GHA flow in ci.yml injects a binary from C9S.
-FROM quay.io/centos-bootc/centos-bootc:stream9
+# Note that the GHA flow in ci.yml injects a binary from C10S.
+FROM quay.io/centos-bootc/centos-bootc:stream10
 RUN <<EORUN
 set -xeuo pipefail
 # Pull in the binary we just built; if you're doing this locally you'll want

--- a/tests/build-chunked-oci/test-buildah.sh
+++ b/tests/build-chunked-oci/test-buildah.sh
@@ -2,11 +2,11 @@
 set -euxo pipefail
 
 cat > Containerfile <<EOF
-FROM quay.io/centos-bootc/centos-bootc:stream9
+FROM quay.io/centos-bootc/centos-bootc:stream10
 RUN dnf install -y vim-enhanced
 EOF
 
-buildah pull quay.io/centos-bootc/centos-bootc:stream9
+buildah pull quay.io/centos-bootc/centos-bootc:stream10
 buildah build -t localhost/my-image .
 /usr/bin/rpm-ostree experimental compose build-chunked-oci --bootc --from=localhost/my-image --output=containers-storage:localhost/my-image-chunked --format-version=2
 

--- a/tests/build-chunked-oci/test.sh
+++ b/tests/build-chunked-oci/test.sh
@@ -49,7 +49,7 @@ compare_image_contents() {
 }
 
 # First: a cross-arch rechunking
-testimg_base=quay.io/centos-bootc/centos-bootc:stream9
+testimg_base=quay.io/centos-bootc/centos-bootc:stream10
 chunked_output=localhost/chunked-ppc64le
 podman pull --arch=ppc64le ${testimg_base}
 podman run --rm --privileged --security-opt=label=disable \

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -549,7 +549,7 @@ vm_run_container() {
   # (use -n so this ssh invocation doesn't consume stdin)
   vm_cmd -n mkdir -p /var/cache/dnf
   vm_cmd podman run --rm -v /var/cache/dnf:/var/cache/dnf:z $podman_args \
-    quay.io/centos/centos:stream9 "$@"
+    quay.io/centos/centos:stream10 "$@"
 }
 
 # $1 - service name


### PR DESCRIPTION
Complete the migration from CentOS Stream 9 to Stream 10 that was started in commit a5f8d849. The build-chunked-oci tests were failing with "librpm.so.10: cannot open shared object file" because they were still using stream9 images with the stream10-built rpm-ostree binary.

Assisted-by: Claude Code