### PR TITLE
Avoid allocating in `pre_exec` closure

### DIFF
--- a/rust/src/bwrap.rs
+++ b/rust/src/bwrap.rs
@@ -94,10 +94,9 @@ impl RoFilesMount {
             .cwd_dir(rootfs.try_clone()?);
         unsafe {
             c.pre_exec(|| {
-                rustix::process::set_parent_process_death_signal(Some(
+                Ok(rustix::process::set_parent_process_death_signal(Some(
                     rustix::process::Signal::TERM,
-                ))
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+                ))?)
             });
         }
         c.run()?;


### PR DESCRIPTION
`Error::new` allocates memory (see https://github.com/rust-lang/rust/pull/148971). This is bad in multi-threaded programs, which rpm-ostree AFAIK is. If the fork occurs while the allocator lock is held by another thread, deadlocks can occur, since there's no one left in the new process to unlock the mutex. I do not believe this is UB, and modern libc offer protections against this issue, but this isn't POSIX-compliant and should preferably be avoided.

`rustix` provides a non-allocating `impl From<Errno> for std::io::Error`, use it instead. This also ensures the correct error code is forwarded to the parent process, instead of the default `-EINVAL`.