### PR TITLE
Update links to use current docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rpm-ostree: A true hybrid image/package system
 
 rpm-ostree is a hybrid image/package system.  It combines
-[libostree](https://ostree.readthedocs.io/en/latest/) as a base image format,
+[libostree](https://ostreedev.github.io/ostree/) as a base image format,
 and accepts RPM on both the client and server side, sharing code with the
 [dnf](https://en.wikipedia.org/wiki/DNF_(software)) project; specifically
 [libdnf](https://github.com/rpm-software-management/libdnf). and thus bringing

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ nav_order: 1
 {:toc}
 
 rpm-ostree is a hybrid image/package system.  It combines
-[libostree](https://ostree.readthedocs.io/en/latest/) as a base image format,
+[libostree](https://ostreedev.github.io/ostree/) as a base image format,
 and accepts RPM on both the client and server side, sharing code with the
 [dnf](https://en.wikipedia.org/wiki/DNF_(software)) project; specifically
 [libdnf](https://github.com/rpm-software-management/libdnf). and thus bringing

--- a/experiments-and-demos/skopeo2ostree/Dockerfile
+++ b/experiments-and-demos/skopeo2ostree/Dockerfile
@@ -24,7 +24,7 @@ RUN echo 'Storage=persistent' >> /etc/systemd/journald.conf
 RUN systemctl unmask systemd-remount-fs.service dev-hugepages.mount sys-fs-fuse-connections.mount systemd-logind.service getty.target console-getty.service
 # FIXME - not starting for some reason
 RUN systemctl mask firewalld
-# https://ostree.readthedocs.io/en/latest/manual/adapting-existing/
+# https://ostreedev.github.io/ostree/adapting-existing/
 RUN for x in srv home media mnt opt; do mv /${x} /var/${x} && ln -sr /var/${x} /${x}; done \
     && rm /root -rf && ln -sr /var/roothome /root \
     && rm /usr/local -rf && ln -sr /var/usrlocal /usr/local \


### PR DESCRIPTION
Update docs links. The old docs links point to a site that appears to be RTD style boilerplate.