### PR TITLE
spec: Fix CentOS Stream 9 Copr build failure

### DIFF
--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -106,7 +106,13 @@ BuildRequires: jq
 
 %global libsolv_version 0.7.21
 %global libmodulemd_version 2.13.0
+# librepo version differs across distros
+# Fedora / CS10 / RHEL10: librepo ≥ 1.18 is available
+%if 0%{?fedora} || 0%{?rhel} >= 10
 %global librepo_version 1.18.0
+%else
+%global librepo_version 1.14.0
+%endif
 
 BuildRequires:  cmake >= 3.5.0
 BuildRequires:  gcc


### PR DESCRIPTION
Fix Copr build error on CentOS Stream 9:
```
No matching package to install: 'pkgconfig(librepo) >= 1.18.0'
Not all dependencies satisfied
Error: Some packages could not be found.

Copr build error: Build failed
```

Copr build failure log: https://copr.fedorainfracloud.org/coprs/g/CoreOS/continuous/build/9853977/

`librepo ≥ 1.18` is only available on Fedora, CentOS Stream 10 and RHEL 10.
