### PR TITLE
kernel-install: Support drop-in config directories for layout=ostree

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -61,7 +61,9 @@ It supports the following parameters:
       and above.
     * "kernel-install": The system is integrated with `/sbin/kernel-install`
       from systemd. You likely want to additionally pair this with configuring `layout=ostree`
-      in `/usr/lib/kernel/install.conf`, and adding a wrapper script to
+      in `/usr/lib/kernel/install.conf` or as a drop-in in
+      `/usr/lib/kernel/install.conf.d/` (recommended to avoid being overwritten
+      by systemd-udev updates), and adding a wrapper script to
       `/usr/lib/kernel/install.d/05-rpmostree.install`
 
  * `etc-group-members`: Array of strings, optional: Unix groups in this

--- a/src/libpriv/05-rpmostree.install
+++ b/src/libpriv/05-rpmostree.install
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
-# Check if install.conf is missing or does not include layout=ostree
-if [ ! -f /usr/lib/kernel/install.conf ] || ! grep -q layout=ostree /usr/lib/kernel/install.conf; then
+# kernel-install sets KERNEL_INSTALL_LAYOUT from install.conf and install.conf.d/
+if [[ "$KERNEL_INSTALL_LAYOUT" != "ostree" ]]; then
     exit 0
 fi
 # This is the hook that has kernel-install call into rpm-ostree kernel-install


### PR DESCRIPTION
kernel-install: Support drop-in config directories for layout=ostree
The 05-rpmostree.install hook and Rust kernel_install module previously
only checked /usr/lib/kernel/install.conf for the layout=ostree setting.
This breaks when the configuration is placed in a drop-in config file,
which per kernel-install(8) is the recommended way to preserve settings
that may be overwritten by package updates.

Update both the shell hook and Rust code to check all config sources
in priority order per kernel-install(8):

1. KERNEL_INSTALL_LAYOUT environment variable (already exported by
   kernel-install based on its config file parsing)
2. /etc/kernel/install.conf (user/distro config, takes precedence)
3. /etc/kernel/install.conf.d/*.conf (user/distro drop-ins)
4. /usr/lib/kernel/install.conf (vendor default)
5. /usr/lib/kernel/install.conf.d/*.conf (vendor drop-ins)

This allows bootc base images to place the configuration in a drop-in
file (e.g., /usr/lib/kernel/install.conf.d/00-kernel-layout.conf) where
it will not be overwritten when systemd-udev updates install.conf,
while maintaining backward compatibility with existing configurations.

Closes: RHEL-128312
Assisted-by: OpenCode (Opus 4.5)
Signed-off-by: Joseph Marrero Corchado <jmarrero@redhat.com>