### PR TITLE
Cargo: update ostree-ext to b76d75d6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,8 +214,8 @@ dependencies = [
 
 [[package]]
 name = "bootc-internal-utils"
-version = "0.0.0"
-source = "git+https://github.com/containers/bootc?rev=40ebdd5829a151cadb5dbadcb1b047f8f4d038cb#40ebdd5829a151cadb5dbadcb1b047f8f4d038cb"
+version = "0.1.0"
+source = "git+https://github.com/containers/bootc?rev=b76d75d6024bd0aa0f270ff181807aff4209f9c9#b76d75d6024bd0aa0f270ff181807aff4209f9c9"
 dependencies = [
  "anstream",
  "anyhow",
@@ -467,7 +467,7 @@ dependencies = [
 [[package]]
 name = "composefs"
 version = "0.3.0"
-source = "git+https://github.com/containers/composefs-rs?rev=82e211ee3e5c8e2b7b3bc00b40b828133633c41b#82e211ee3e5c8e2b7b3bc00b40b828133633c41b"
+source = "git+https://github.com/containers/composefs-rs?rev=e9008489375044022e90d26656960725a76f4620#e9008489375044022e90d26656960725a76f4620"
 dependencies = [
  "anyhow",
  "hex",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "composefs-boot"
 version = "0.3.0"
-source = "git+https://github.com/containers/composefs-rs?rev=82e211ee3e5c8e2b7b3bc00b40b828133633c41b#82e211ee3e5c8e2b7b3bc00b40b828133633c41b"
+source = "git+https://github.com/containers/composefs-rs?rev=e9008489375044022e90d26656960725a76f4620#e9008489375044022e90d26656960725a76f4620"
 dependencies = [
  "anyhow",
  "composefs",
@@ -500,7 +500,7 @@ dependencies = [
 [[package]]
 name = "composefs-oci"
 version = "0.3.0"
-source = "git+https://github.com/containers/composefs-rs?rev=82e211ee3e5c8e2b7b3bc00b40b828133633c41b#82e211ee3e5c8e2b7b3bc00b40b828133633c41b"
+source = "git+https://github.com/containers/composefs-rs?rev=e9008489375044022e90d26656960725a76f4620#e9008489375044022e90d26656960725a76f4620"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "ostree-ext"
 version = "0.15.3"
-source = "git+https://github.com/containers/bootc?rev=40ebdd5829a151cadb5dbadcb1b047f8f4d038cb#40ebdd5829a151cadb5dbadcb1b047f8f4d038cb"
+source = "git+https://github.com/containers/bootc?rev=b76d75d6024bd0aa0f270ff181807aff4209f9c9#b76d75d6024bd0aa0f270ff181807aff4209f9c9"
 dependencies = [
  "anyhow",
  "bootc-internal-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ openssl = "0.10.73"
 once_cell = "1.21.3"
 os-release = "0.1.0"
 # We pull this one from git, as the project is no longer published as an external crate.
-ostree-ext = { git = "https://github.com/containers/bootc", rev = "40ebdd5829a151cadb5dbadcb1b047f8f4d038cb" }
+ostree-ext = { git = "https://github.com/containers/bootc", rev = "b76d75d6024bd0aa0f270ff181807aff4209f9c9" }
 pastey = "0.1.1"
 phf = { version = "0.12", features = ["macros"] }
 rand = "0.9.1"


### PR DESCRIPTION
This updates ostree-ext and related dependencies (composefs-rs, bootc-internal-utils) to address an issue where G_MESSAGES_DEBUG=all causes packages to be incorrectly shown as "Removed" during rebase operations.

The root cause was that GLib debug output was being written to stdout instead of stderr, corrupting the ostree commit hash parsing in ostree-ext's container layer import. When the subprocess output is polluted with debug messages, the merge commit ends up missing content from derived layers.

Fixes: OCPBUGS-64692
Fixes: RHEL-130454
See: https://github.com/bootc-dev/bootc/pull/1917
