### PR TITLE
Release 2026.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,8 +2,8 @@ AC_PREREQ([2.63])
 dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
-m4_define([year_version], [2025])
-m4_define([release_version], [12])
+m4_define([year_version], [2026])
+m4_define([release_version], [1])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2025.12
+Version: 2026.1
 Release: 1%{?dist}
 License: LGPL-2.0-or-later
 URL: https://github.com/coreos/rpm-ostree
@@ -133,6 +133,9 @@ BuildRequires:  gettext
 Requires:       libmodulemd%{?_isa} >= %{libmodulemd_version}
 Requires:       libsolv%{?_isa} >= %{libsolv_version}
 Requires:       librepo%{?_isa} >= %{librepo_version}
+%if 0%{?fedora} >= 43 || 0%{?rhel} >= 11
+Requires:       rpm-libs%{?_isa} >= 5.99.90
+%endif
 
 #########################################################################
 #                     end of libdnf build deps                          #


### PR DESCRIPTION
# v2026.1
## Overview
This is a maintenance release focused on **kernel-install integration improvements**, **package layering bug fixes**, and a new **`no-initramfs` compose option**.
## Key Changes
### New Features
- **`no-initramfs:` treefile knob** ([#5529](https://github.com/coreos/rpm-ostree/pull/5529)) - Allows composing images without generating an initramfs, useful for specific deployment scenarios
### Bug Fixes
- **kernel-install drop-in config support** ([#5551](https://github.com/coreos/rpm-ostree/pull/5551)) - Adds support for drop-in configuration directories when using `layout=ostree`, improving kernel update handling
- **Package layering fix** ([#5510](https://github.com/coreos/rpm-ostree/pull/5510)) - Fixes an issue where the base database was incorrectly used during idempotent transactions, improving reliability of package layering operations
### Infrastructure & Maintenance
- Build/test infrastructure updated to mirror bootc patterns ([#5525](https://github.com/coreos/rpm-ostree/pull/5525))
- Replaced unmaintained `paste` crate with maintained `pastey` fork ([#5528](https://github.com/coreos/rpm-ostree/pull/5528))
- Memory optimization: avoid allocation in `pre_exec` closure ([#5533](https://github.com/coreos/rpm-ostree/pull/5533))
- Updated ostree-ext dependency ([#5553](https://github.com/coreos/rpm-ostree/pull/5553))
- Documentation links updated to current docs site ([#5534](https://github.com/coreos/rpm-ostree/pull/5534))

## New Contributors
* @RoyalOughtness made their first contribution in https://github.com/coreos/rpm-ostree/pull/5528
* @purplesyringa made their first contribution in https://github.com/coreos/rpm-ostree/pull/5533
* @danielhoherd made their first contribution in https://github.com/coreos/rpm-ostree/pull/5534

**Full Changelog**: https://github.com/coreos/rpm-ostree/compare/v2025.12...v2026.1