### PR TITLE
kargs: Add --source flag for tracking kargs ownership

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -35,6 +35,8 @@ librpmostreed_sources = \
 	src/daemon/rpmostree-sysroot-core.cxx \
 	src/daemon/rpmostree-sysroot-upgrader.h \
 	src/daemon/rpmostree-sysroot-upgrader.cxx \
+	src/daemon/rpmostree-bls-kargs.h \
+	src/daemon/rpmostree-bls-kargs.cxx \
 	src/daemon/rpmostreed-errors.h \
 	src/daemon/rpmostreed-errors.cxx \
 	src/daemon/rpmostreed-deployment-utils.h \

--- a/src/app/rpmostree-builtin-kargs.cxx
+++ b/src/app/rpmostree-builtin-kargs.cxx
@@ -39,6 +39,7 @@ static char *opt_osname;
 static char *opt_deploy_index;
 static gboolean opt_lock_finalization;
 static gboolean opt_unchanged_exit_77;
+static char *opt_source;
 
 static GOptionEntry option_entries[] = {
   { "os", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME",
@@ -77,6 +78,10 @@ static GOptionEntry option_entries[] = {
     NULL },
   { "lock-finalization", 0, 0, G_OPTION_ARG_NONE, &opt_lock_finalization,
     "Prevent automatic deployment finalization on shutdown", NULL },
+  { "source", 0, 0, G_OPTION_ARG_STRING, &opt_source,
+    "Track kernel arguments by source name (e.g. tuned). When used, replaces all previous kargs "
+    "from this source with the new set",
+    "NAME" },
   { NULL }
 };
 
@@ -205,6 +210,25 @@ rpmostree_builtin_kargs (int argc, char **argv, RpmOstreeCommandInvocation *invo
       return FALSE;
     }
 
+  if (opt_editor && opt_source)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                   "Cannot specify --editor with --source");
+      return FALSE;
+    }
+
+  if (opt_source && (opt_kernel_delete_strings || opt_kernel_replace_strings))
+    {
+      /* With --source, we replace all kargs from that source with the new set.
+       * Delete and replace don't make sense in this context - just use --append
+       * with the new complete set of kargs for this source.
+       */
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                   "Cannot specify --source with --delete or --replace. "
+                   "Use --append to specify the complete set of kargs for this source");
+      return FALSE;
+    }
+
   if (opt_kernel_delete_strings && opt_kernel_replace_strings)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
@@ -225,7 +249,7 @@ rpmostree_builtin_kargs (int argc, char **argv, RpmOstreeCommandInvocation *invo
     }
   if (!(opt_kernel_delete_strings) && !(opt_kernel_append_strings) && !(opt_kernel_replace_strings)
       && !(opt_editor) && !(opt_kernel_delete_if_present_strings)
-      && !(opt_kernel_append_if_missing_strings))
+      && !(opt_kernel_append_if_missing_strings) && !(opt_source))
     display_kernel_args = TRUE;
 
   if (opt_reboot && display_kernel_args)
@@ -358,6 +382,8 @@ rpmostree_builtin_kargs (int argc, char **argv, RpmOstreeCommandInvocation *invo
       if (opt_kernel_delete_if_present_strings && *opt_kernel_delete_if_present_strings)
         g_variant_dict_insert (&dict, "delete-if-present", "^as",
                                opt_kernel_delete_if_present_strings);
+      if (opt_source)
+        g_variant_dict_insert (&dict, "source", "s", opt_source);
       options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
       /* call the generated dbus-function */

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -294,6 +294,10 @@
         "initiating-command-line" (type 's')
         "lock-finalization" (type 'b')
         "reboot" (type 'b')
+        "source" (type 's') - Track kernel arguments by source name (e.g. "tuned").
+                              When set, all previous kargs from this source are removed
+                              and replaced with the new set. Source ownership is stored
+                              as a magic comment (# x-ostree-options-source-NAME) in the BLS config file.
     -->
     <method name="KernelArgs">
       <arg type="s" name="existing_kernel_arg_string" direction="in"/>

--- a/src/daemon/rpmostree-bls-kargs.cxx
+++ b/src/daemon/rpmostree-bls-kargs.cxx
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "config.h"
+
+#include "rpmostree-bls-kargs.h"
+#include <libglnx.h>
+#include <string.h>
+
+/**
+ * Compute the diff between old and new source kargs.
+ *
+ * Both @old_kargs and @new_kargs are space-separated kargs strings.
+ * The function computes the set difference in both directions:
+ *   - @out_to_add: kargs in @new_kargs but not in @old_kargs
+ *   - @out_to_remove: kargs in @old_kargs but not in @new_kargs
+ */
+gboolean
+rpmostree_bls_compute_source_diff (const char *old_kargs, const char *new_kargs, char ***out_to_add,
+                                   char ***out_to_remove)
+{
+  g_autoptr (GHashTable) old_set = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+  g_autoptr (GHashTable) new_set = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+
+  /* Parse old kargs into a set */
+  if (old_kargs != NULL && *old_kargs != '\0')
+    {
+      g_auto (GStrv) old_argv = g_strsplit (old_kargs, " ", -1);
+      for (char **iter = old_argv; iter && *iter; iter++)
+        {
+          if (**iter != '\0')
+            g_hash_table_add (old_set, g_strdup (*iter));
+        }
+    }
+
+  /* Parse new kargs into a set */
+  if (new_kargs != NULL && *new_kargs != '\0')
+    {
+      g_auto (GStrv) new_argv = g_strsplit (new_kargs, " ", -1);
+      for (char **iter = new_argv; iter && *iter; iter++)
+        {
+          if (**iter != '\0')
+            g_hash_table_add (new_set, g_strdup (*iter));
+        }
+    }
+
+  /* Compute to_add: in new but not in old */
+  g_autoptr (GPtrArray) to_add = g_ptr_array_new_with_free_func (g_free);
+  {
+    GHashTableIter iter;
+    gpointer key;
+    g_hash_table_iter_init (&iter, new_set);
+    while (g_hash_table_iter_next (&iter, &key, NULL))
+      {
+        if (!g_hash_table_contains (old_set, key))
+          g_ptr_array_add (to_add, g_strdup ((char *)key));
+      }
+  }
+
+  /* Compute to_remove: in old but not in new */
+  g_autoptr (GPtrArray) to_remove = g_ptr_array_new_with_free_func (g_free);
+  {
+    GHashTableIter iter;
+    gpointer key;
+    g_hash_table_iter_init (&iter, old_set);
+    while (g_hash_table_iter_next (&iter, &key, NULL))
+      {
+        if (!g_hash_table_contains (new_set, key))
+          g_ptr_array_add (to_remove, g_strdup ((char *)key));
+      }
+  }
+
+  gboolean changed = (to_add->len > 0 || to_remove->len > 0);
+
+  if (out_to_add)
+    {
+      g_ptr_array_add (to_add, NULL);
+      GPtrArray *arr = static_cast<GPtrArray *> (g_steal_pointer (&to_add));
+      *out_to_add = (char **)g_ptr_array_free (arr, FALSE);
+    }
+
+  if (out_to_remove)
+    {
+      g_ptr_array_add (to_remove, NULL);
+      GPtrArray *arr = static_cast<GPtrArray *> (g_steal_pointer (&to_remove));
+      *out_to_remove = (char **)g_ptr_array_free (arr, FALSE);
+    }
+
+  return changed;
+}

--- a/src/daemon/rpmostree-bls-kargs.h
+++ b/src/daemon/rpmostree-bls-kargs.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#pragma once
+
+#include <ostree.h>
+
+G_BEGIN_DECLS
+
+/**
+ * rpmostree_bls_compute_source_diff:
+ * @old_kargs: The current/old kargs string (can be NULL)
+ * @new_kargs: The new kargs string (can be NULL)
+ * @out_to_add: (out) (transfer full): Kargs to add
+ * @out_to_remove: (out) (transfer full): Kargs to remove
+ *
+ * Computes the diff between old and new source kargs.
+ * Both strings are space-separated lists of kernel arguments.
+ *
+ * Returns: TRUE if there are any changes, FALSE if identical
+ */
+gboolean rpmostree_bls_compute_source_diff (const char *old_kargs, const char *new_kargs,
+                                            char ***out_to_add, char ***out_to_remove);
+
+G_END_DECLS

--- a/src/daemon/rpmostree-sysroot-upgrader.cxx
+++ b/src/daemon/rpmostree-sysroot-upgrader.cxx
@@ -118,6 +118,10 @@ struct RpmOstreeSysrootUpgrader
   char *final_revision;             /* Computed by layering; if NULL, only using base_revision */
 
   char **kargs_strv; /* Kernel argument list to be written into deployment  */
+
+  /* Source-tagged kargs for tracking ownership (e.g., for tuned with transient /etc) */
+  char *kargs_source;      /* Source name (e.g., "tuned") */
+  char *kargs_source_args; /* Kargs string for this source */
 };
 
 enum
@@ -245,6 +249,8 @@ rpmostree_sysroot_upgrader_finalize (GObject *object)
   g_free (self->base_revision);
   g_free (self->final_revision);
   g_strfreev (self->kargs_strv);
+  g_free (self->kargs_source);
+  g_free (self->kargs_source_args);
 
   G_OBJECT_CLASS (rpmostree_sysroot_upgrader_parent_class)->finalize (object);
 }
@@ -1268,6 +1274,33 @@ rpmostree_sysroot_upgrader_set_kargs (RpmOstreeSysrootUpgrader *self, char **ker
   self->kargs_strv = g_strdupv (kernel_args);
 }
 
+/**
+ * rpmostree_sysroot_upgrader_set_kargs_source:
+ * @self: Self
+ * @source: The source name (e.g., "tuned")
+ * @kargs: The kargs string for this source (or NULL to clear)
+ *
+ * Set source-specific kernel arguments that will be tracked in the
+ * BLS config file. This enables tools like tuned to manage their kargs
+ * even when /etc is transient (bootc use case).
+ *
+ * The source ownership is stored as a magic comment in the BLS config:
+ *   # x-ostree-options-source-<name> <kargs>
+ */
+void
+rpmostree_sysroot_upgrader_set_kargs_source (RpmOstreeSysrootUpgrader *self, const char *source,
+                                             const char *kargs)
+{
+  g_clear_pointer (&self->kargs_source, g_free);
+  g_clear_pointer (&self->kargs_source_args, g_free);
+
+  if (source != NULL)
+    {
+      self->kargs_source = g_strdup (source);
+      self->kargs_source_args = g_strdup (kargs);
+    }
+}
+
 static gboolean
 write_history (RpmOstreeSysrootUpgrader *self, OstreeDeployment *new_deployment,
                GCancellable *cancellable, GError **error)
@@ -1436,6 +1469,94 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
 
   if (!write_history (self, new_deployment, cancellable, error))
     return FALSE;
+
+  /* Write source kargs metadata if set.
+   * For staged deployments, we update the staged GVariant file with
+   * a "bootconfig-comments" key so the magic comments survive finalization
+   * at shutdown. For direct deployments, we write the BLS file directly.
+   */
+  if (self->kargs_source != NULL)
+    {
+      g_autofree char *comment_key
+          = g_strdup_printf ("x-ostree-options-source-%s", self->kargs_source);
+      const char *source_val
+          = (self->kargs_source_args != NULL && self->kargs_source_args[0] != '\0')
+                ? self->kargs_source_args
+                : "";
+
+      if (use_staging)
+        {
+          /* Update the staged deployment GVariant with the source comment.
+           * During finalization at shutdown, ostree reads "bootconfig-comments"
+           * from the staged data and restores these comments on the deployment's
+           * bootconfig before writing the final BLS entry.
+           */
+          static const char staged_path[] = "/run/ostree/staged-deployment";
+
+          g_autoptr (GMappedFile) mfile = g_mapped_file_new (staged_path, FALSE, error);
+          if (!mfile)
+            return glnx_prefix_error (error, "Reading staged deployment data");
+
+          g_autoptr (GBytes) contents = g_mapped_file_get_bytes (mfile);
+
+          g_autoptr (GVariant) staged_data
+              = g_variant_new_from_bytes ((GVariantType *)"a{sv}", contents, TRUE);
+          g_autoptr (GVariantDict) dict = g_variant_dict_new (staged_data);
+
+          /* Build the bootconfig-comments a{ss} variant with our source comment */
+          g_autoptr (GVariantBuilder) comments_builder
+              = g_variant_builder_new ((GVariantType *)"a{ss}");
+
+          /* Preserve any existing comments from the staged data */
+          g_autoptr (GVariant) existing_comments = NULL;
+          if (g_variant_dict_lookup (dict, "bootconfig-comments", "@a{ss}", &existing_comments))
+            {
+              GVariantIter iter;
+              const char *k, *v;
+              g_variant_iter_init (&iter, existing_comments);
+              while (g_variant_iter_next (&iter, "{&s&s}", &k, &v))
+                {
+                  /* Skip our own comment key — we'll add the updated value below */
+                  if (!g_str_equal (k, comment_key))
+                    g_variant_builder_add (comments_builder, "{ss}", k, v);
+                }
+            }
+
+          /* Add our source comment */
+          g_variant_builder_add (comments_builder, "{ss}", comment_key, source_val);
+
+          g_variant_dict_insert_value (dict, "bootconfig-comments",
+                                       g_variant_builder_end (comments_builder));
+          g_autoptr (GVariant) new_data = g_variant_ref_sink (g_variant_dict_end (dict));
+
+          if (!glnx_file_replace_contents_at (
+                  AT_FDCWD, staged_path,
+                  static_cast<const guint8 *> (g_variant_get_data (new_data)),
+                  g_variant_get_size (new_data), GLNX_FILE_REPLACE_NODATASYNC, cancellable, error))
+            return glnx_prefix_error (error, "Writing updated staged deployment data");
+        }
+      else
+        {
+          /* Direct deploy: write the BLS file on disk directly. No finalization
+           * will happen, so this is the final BLS entry.
+           */
+          OstreeBootconfigParser *new_bootconfig
+              = ostree_deployment_get_bootconfig (new_deployment);
+          if (new_bootconfig != NULL)
+            {
+              ostree_bootconfig_parser_set_comment (new_bootconfig, comment_key, source_val);
+
+              g_autofree char *bootconfig_path
+                  = g_strdup_printf ("boot/loader/entries/ostree-%s-%d.conf", self->osname,
+                                     ostree_deployment_get_bootserial (new_deployment));
+
+              int sysroot_fd = ostree_sysroot_get_fd (self->sysroot);
+              if (!ostree_bootconfig_parser_write_at (new_bootconfig, sysroot_fd, bootconfig_path,
+                                                      cancellable, error))
+                return glnx_prefix_error (error, "Writing source kargs to bootconfig");
+            }
+        }
+    }
 
   /* Also do a sanitycheck even if there's no local mutation; it's basically free
    * and might save someone in the future.  The RPMOSTREE_SKIP_SANITYCHECK

--- a/src/daemon/rpmostree-sysroot-upgrader.h
+++ b/src/daemon/rpmostree-sysroot-upgrader.h
@@ -124,4 +124,18 @@ gboolean rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
                                             GCancellable *cancellable, GError **error);
 
 void rpmostree_sysroot_upgrader_set_kargs (RpmOstreeSysrootUpgrader *self, char **kernel_args);
+
+/**
+ * rpmostree_sysroot_upgrader_set_kargs_source:
+ * @self: Upgrader
+ * @source: The source name (e.g., "tuned")
+ * @kargs: The kargs string for this source (or NULL to clear)
+ *
+ * Sets source-specific kernel arguments that will be tracked in the
+ * BLS config. This enables tools like tuned to manage their kargs
+ * even when /etc is transient.
+ */
+void rpmostree_sysroot_upgrader_set_kargs_source (RpmOstreeSysrootUpgrader *self,
+                                                  const char *source, const char *kargs);
+
 G_END_DECLS

--- a/src/daemon/rpmostreed-transaction-types.cxx
+++ b/src/daemon/rpmostreed-transaction-types.cxx
@@ -24,6 +24,7 @@
 #include <libglnx.h>
 #include <systemd/sd-journal.h>
 
+#include "rpmostree-bls-kargs.h"
 #include "rpmostree-core.h"
 #include "rpmostree-cxxrs.h"
 #include "rpmostree-importer.h"
@@ -2751,6 +2752,113 @@ kernel_arg_apply_final_str (KernelArgTransaction *self, RpmOstreeSysrootUpgrader
   return TRUE;
 }
 
+/**
+ * kernel_arg_apply_source:
+ *
+ * Apply source-aware kernel argument changes. When a source is specified,
+ * we track the kargs associated with that source and handle replacement
+ * semantics: all previous kargs from this source are removed and the new
+ * set is applied.
+ *
+ * The source ownership is tracked using a magic comment in the BLS config:
+ *   # x-ostree-options-source-<name> <kargs>
+ *
+ * This enables tools like tuned to manage their kargs even when /etc is
+ * transient (bootc use case), since the BLS config persists on /boot.
+ */
+static gboolean
+kernel_arg_apply_source (KernelArgTransaction *self, RpmOstreeSysrootUpgrader *upgrader,
+                         const char *source, OstreeKernelArgs *kargs, GCancellable *cancellable,
+                         GError **error)
+{
+  g_return_val_if_fail (self != NULL, FALSE);
+  g_return_val_if_fail (upgrader != NULL, FALSE);
+  g_return_val_if_fail (source != NULL, FALSE);
+  g_return_val_if_fail (kargs != NULL, FALSE);
+
+  /* Validate source name: must be non-empty and contain only alphanumeric,
+   * dash, and underscore characters. This prevents malformed BLS comment entries.
+   */
+  if (*source == '\0')
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT, "Source name must not be empty");
+      return FALSE;
+    }
+  for (const char *p = source; *p != '\0'; p++)
+    {
+      if (!g_ascii_isalnum (*p) && *p != '-' && *p != '_')
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                       "Invalid source name '%s': only alphanumeric characters, "
+                       "dashes, and underscores are allowed",
+                       source);
+          return FALSE;
+        }
+    }
+
+  /* Get the merge deployment to read current BLS config */
+  OstreeDeployment *merge_deployment = rpmostree_sysroot_upgrader_get_merge_deployment (upgrader);
+  if (merge_deployment == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "No merge deployment found");
+      return FALSE;
+    }
+
+  OstreeBootconfigParser *bootconfig = ostree_deployment_get_bootconfig (merge_deployment);
+  if (bootconfig == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "No bootconfig found for deployment");
+      return FALSE;
+    }
+
+  /* Read existing source kargs from the magic comment */
+  g_autofree char *comment_key = g_strdup_printf ("x-ostree-options-source-%s", source);
+  const char *old_source_kargs = ostree_bootconfig_parser_get_comment (bootconfig, comment_key);
+
+  /* Build new source kargs string from the added args */
+  g_autofree char *new_source_kargs = NULL;
+  if (self->kernel_args_added && self->kernel_args_added[0])
+    new_source_kargs = g_strjoinv (" ", self->kernel_args_added);
+
+  /* Compute what needs to change */
+  g_auto (GStrv) to_add = NULL;
+  g_auto (GStrv) to_remove = NULL;
+  gboolean has_changes
+      = rpmostree_bls_compute_source_diff (old_source_kargs, new_source_kargs, &to_add, &to_remove);
+
+  if (!has_changes)
+    {
+      rpmostree_output_message ("No changes to kernel arguments from source '%s'.", source);
+      return TRUE;
+    }
+
+  /* Remove old source kargs from the current kargs */
+  for (char **iter = to_remove; iter && *iter; iter++)
+    {
+      /* Use the delete API - ignore errors for missing args */
+      GError *local_error = NULL;
+      if (!ostree_kernel_args_delete (kargs, *iter, &local_error))
+        {
+          /* It's OK if the arg doesn't exist - it might have been manually removed */
+          g_clear_error (&local_error);
+        }
+    }
+
+  /* Add new source kargs */
+  for (char **iter = to_add; iter && *iter; iter++)
+    {
+      ostree_kernel_args_append (kargs, *iter);
+    }
+
+  /* Store the source metadata so the upgrader writes it to the new
+   * deployment's BLS config after deploy.
+   */
+  rpmostree_sysroot_upgrader_set_kargs_source (upgrader, source, new_source_kargs);
+
+  /* Use the shared apply path for deploy + reboot handling */
+  return kernel_arg_apply (self, upgrader, kargs, TRUE, cancellable, error);
+}
+
 static gboolean
 kernel_arg_apply_patching (KernelArgTransaction *self, RpmOstreeSysrootUpgrader *upgrader,
                            OstreeKernelArgs *kargs, GCancellable *cancellable, GError **error)
@@ -2852,10 +2960,17 @@ kernel_arg_transaction_execute (RpmostreedTransaction *transaction, GCancellable
 
   auto final_kernel_args
       = static_cast<const char *> (vardict_lookup_ptr (self->options, "final-kernel-args", "&s"));
+  auto source = static_cast<const char *> (vardict_lookup_ptr (self->options, "source", "&s"));
+
   if (final_kernel_args != NULL)
     {
       /* Pre-assembled kargs string (e.g. coming from --editor) */
       return kernel_arg_apply_final_str (self, upgrader, final_kernel_args, cancellable, error);
+    }
+  else if (source != NULL)
+    {
+      /* Source-aware kargs management (e.g. for tuned with transient /etc) */
+      return kernel_arg_apply_source (self, upgrader, source, kargs, cancellable, error);
     }
   else
     {

--- a/tests/kolainst/destructive/kargs-source
+++ b/tests/kolainst/destructive/kargs-source
@@ -1,0 +1,158 @@
+#!/bin/bash
+# Test for rpm-ostree kargs --source functionality
+# This enables tools like tuned to manage kargs on systems with transient /etc
+set -euo pipefail
+
+. ${KOLA_EXT_DATA}/libtest.sh
+cd "$(mktemp -d)"
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+    # Test 1: Verify --source cannot be combined with --editor
+    if rpm-ostree kargs --source=test --editor 2>err.txt; then
+      fatal "--source with --editor should have failed"
+    fi
+    assert_file_has_content err.txt "Cannot specify --editor with --source"
+    echo "ok --source rejects --editor"
+
+    # Test 2: Verify --source cannot be combined with --delete
+    if rpm-ostree kargs --source=test --delete=foo 2>err.txt; then
+      fatal "--source with --delete should have failed"
+    fi
+    assert_file_has_content err.txt "Cannot specify --source with --delete"
+    echo "ok --source rejects --delete"
+
+    # Test 3: Verify --source cannot be combined with --replace
+    if rpm-ostree kargs --source=test --replace=foo=bar 2>err.txt; then
+      fatal "--source with --replace should have failed"
+    fi
+    assert_file_has_content err.txt "Cannot specify --source with"
+    echo "ok --source rejects --replace"
+
+    # Test 4: Verify invalid source name with spaces is rejected
+    if rpm-ostree kargs --source='bad name' --append=foo=bar 2>err.txt; then
+      fatal "--source with spaces should have failed"
+    fi
+    assert_file_has_content err.txt "Invalid source name"
+    echo "ok --source rejects invalid name (spaces)"
+
+    # Test 5: Verify invalid source name with special chars is rejected
+    if rpm-ostree kargs --source='foo@bar' --append=foo=bar 2>err.txt; then
+      fatal "--source with special chars should have failed"
+    fi
+    assert_file_has_content err.txt "Invalid source name"
+    echo "ok --source rejects invalid name (special chars)"
+
+    # Test 6: Verify empty source name is rejected
+    if rpm-ostree kargs --source='' --append=foo=bar 2>err.txt; then
+      fatal "--source with empty name should have failed"
+    fi
+    assert_file_has_content err.txt "Source name must not be empty"
+    echo "ok --source rejects empty name"
+
+    # Test 7: Verify valid source name with underscores and dashes is accepted
+    rpm-ostree kargs --source=my_custom-src --append=test_valid=1
+    rpm-ostree kargs > kargs.txt
+    assert_file_has_content_literal kargs.txt 'test_valid=1'
+    # Clean up: clear the test source
+    rpm-ostree kargs --source=my_custom-src
+    rpm-ostree kargs > kargs.txt
+    assert_not_file_has_content kargs.txt 'test_valid'
+    echo "ok --source accepts valid name (underscores/dashes)"
+
+    # Test 8: Basic source kargs - add kargs with source tracking
+    rpm-ostree kargs --source=tuned --append=nohz=full --append=isolcpus=1-3
+    rpm-ostree kargs > kargs.txt
+    assert_file_has_content_literal kargs.txt 'nohz=full'
+    assert_file_has_content_literal kargs.txt 'isolcpus=1-3'
+    echo "ok basic --source append"
+
+    # Verify the source key is in the pending deployment's BLS config
+    rpm-ostree status --json > status.json
+    # The deployment should be staged
+    assert_jq status.json '.deployments[0]["staged"] == true'
+
+    /tmp/autopkgtest-reboot 1
+    ;;
+  1)
+    # After reboot, verify kargs persisted
+    rpm-ostree kargs > kargs.txt
+    assert_file_has_content_literal kargs.txt 'nohz=full'
+    assert_file_has_content_literal kargs.txt 'isolcpus=1-3'
+
+    # Verify the source comment survived the staging roundtrip and is in the BLS config.
+    # This requires ostree with the "bootconfig-comments" staged serialization support.
+    grep -h '# x-ostree-options-source-tuned' /boot/loader/entries/ostree-*.conf | head -1 > source.txt
+    assert_file_has_content_literal source.txt 'nohz=full isolcpus=1-3'
+    echo "ok source comment persisted in BLS config after reboot"
+
+    # Test 9: Source replacement semantics - new source kargs replace old ones
+    rpm-ostree kargs --source=tuned --append=nohz=on --append=rcu_nocbs=2-7
+    rpm-ostree kargs > kargs.txt
+    # Old kargs should be gone (in pending deployment)
+    assert_not_file_has_content kargs.txt 'nohz=full'
+    assert_not_file_has_content kargs.txt 'isolcpus=1-3'
+    # New kargs should be present
+    assert_file_has_content_literal kargs.txt 'nohz=on'
+    assert_file_has_content_literal kargs.txt 'rcu_nocbs=2-7'
+    echo "ok --source replacement semantics"
+
+    /tmp/autopkgtest-reboot 2
+    ;;
+  2)
+    # Verify replacement persisted after reboot
+    rpm-ostree kargs > kargs.txt
+    assert_not_file_has_content kargs.txt 'nohz=full'
+    assert_not_file_has_content kargs.txt 'isolcpus=1-3'
+    assert_file_has_content_literal kargs.txt 'nohz=on'
+    assert_file_has_content_literal kargs.txt 'rcu_nocbs=2-7'
+    echo "ok replacement persisted after reboot"
+
+    # Test 10: Multiple sources can coexist
+    rpm-ostree kargs --source=dracut --append=rd.driver.pre=vfio-pci
+    rpm-ostree kargs > kargs.txt
+    # tuned kargs should still be present
+    assert_file_has_content_literal kargs.txt 'nohz=on'
+    assert_file_has_content_literal kargs.txt 'rcu_nocbs=2-7'
+    # dracut kargs should be added
+    assert_file_has_content_literal kargs.txt 'rd.driver.pre=vfio-pci'
+    echo "ok multiple sources coexist"
+
+    /tmp/autopkgtest-reboot 3
+    ;;
+  3)
+    # Verify multiple sources persisted
+    rpm-ostree kargs > kargs.txt
+    assert_file_has_content_literal kargs.txt 'nohz=on'
+    assert_file_has_content_literal kargs.txt 'rcu_nocbs=2-7'
+    assert_file_has_content_literal kargs.txt 'rd.driver.pre=vfio-pci'
+    echo "ok multiple sources persisted"
+
+    # Test 11: Clear source kargs (no --append = clear all owned kargs)
+    rpm-ostree kargs --source=dracut
+    rpm-ostree kargs > kargs.txt
+    # dracut kargs should be removed
+    assert_not_file_has_content kargs.txt 'rd.driver.pre=vfio-pci'
+    # tuned kargs should still be present
+    assert_file_has_content_literal kargs.txt 'nohz=on'
+    assert_file_has_content_literal kargs.txt 'rcu_nocbs=2-7'
+    echo "ok --source clear (empty append)"
+
+    /tmp/autopkgtest-reboot 4
+    ;;
+  4)
+    # Verify clear persisted
+    rpm-ostree kargs > kargs.txt
+    assert_not_file_has_content kargs.txt 'rd.driver.pre=vfio-pci'
+    assert_file_has_content_literal kargs.txt 'nohz=on'
+    echo "ok source clear persisted"
+
+    # Test 12: Idempotent operation - running same source kargs again should be no-op
+    rpm-ostree kargs --source=tuned --append=nohz=on --append=rcu_nocbs=2-7 > out.txt
+    assert_file_has_content_literal out.txt "No changes"
+    echo "ok idempotent source operation"
+
+    echo "All kargs --source tests passed!"
+    ;;
+  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac


### PR DESCRIPTION
On bootc systems with transient /etc, TuneD loses track of which kernel arguments it previously added because its state file (/etc/tuned/bootcmdline) is wiped on each reboot. This causes kargs to stack indefinitely - each time TuneD runs, it adds the same kargs again without knowing they already exist.

This implements Colin's suggestion from the tuned PR discussion: add a --source flag that tracks kargs ownership in the BLS config file itself. When used, the source's previous kargs are removed and replaced with the new set.

The implementation:

1. Adds --source=NAME option to 'rpm-ostree kargs'. When specified, all kargs from that source are replaced with the new set provided via --append.

2. Stores source ownership using a custom key in the BLS config: ostree-source-<name>=<kargs> Since BLS lives on /boot (not /etc), it persists across reboots even with transient /etc.

3. On subsequent runs with the same --source, computes a diff between old and new source kargs, removes the old ones, and adds the new ones.

4. Multiple sources can coexist independently (tuned, dracut, user, etc.)

5. For staged deployments, the source metadata is written to the staged deployment GVariant ("bootconfig-extra" key) so custom BLS keys survive the finalization roundtrip at shutdown. For direct deployments, the BLS file is written directly.

6. Source names are validated to contain only alphanumeric characters, dashes, and underscores to prevent malformed BLS keys.

Example workflow for TuneD:
  # First run sets tuned's kargs
  rpm-ostree kargs --source=tuned --append=nohz=full --append=isolcpus=1-3

  # After reboot (with transient /etc), running again replaces, not stacks
  rpm-ostree kargs --source=tuned --append=nohz=on --append=rcu_nocbs=2-7

  # Old kargs (nohz=full, isolcpus=1-3) are removed
  # New kargs (nohz=on, rcu_nocbs=2-7) are added

Restrictions:
- --source cannot be combined with --editor (use append-based workflow)
- --source cannot be combined with --delete or --replace (replacement semantics are automatic)

Requires: ostree with "bootconfig-extra" staged serialization support
Resolves: RHEL-135363
See: https://github.com/bootc-dev/bootc/issues/899
See: https://github.com/redhat-performance/tuned/pull/821

Assisted-by: OpenCode (Claude Opus 4.6)

Thank you for contributing to rpm-ostree.

If you are adding functionality to tree composes, please add
a corresponding test to the compose-test suite. Similarly,
if adding a client-facing feature, consider the vmcheck
suite. Regressions fixes are also great candidates for new
tests.

If you're not sure where or how to add tests, don't hesitate
to ask for help from the maintainers.

Cheers!
