### PR TITLE
Fix "ostree-container: symlinkat: File exists" on cs9 copr build

### DIFF
--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -34,7 +34,7 @@ BuildRequires: rust
 
 # Don't add the ostree-container binaries; this version
 # conditional needs to be kept in sync with the bootc one.
-%if 0%{?rhel} >= 10 || 0%{?fedora} > 41
+%if 0%{?rhel} >= 9 || 0%{?fedora} > 41
     %bcond_with ostree_ext
 %else
     %bcond_without ostree_ext


### PR DESCRIPTION
bootc already configured to `%if 0%{?rhel} >= 9 || 0%{?fedora} > 41` in https://github.com/bootc-dev/bootc/blob/main/contrib/packaging/bootc.spec#L3

This PR fixed rpm-ostree CS9 copr build failure:
```
error: Installing packages: Checkout rpm-ostree-2026.1.10.g21c1d59f-1.el9.x86_64: Copy checkout of 1845621591557754d090b27a2f6cecb57040ee3de67dae81db4c29a3c50f08fa to ostree-container: symlinkat: File exists
```

