### PR TITLE
More updates before the release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,7 +167,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     container:
-      image: registry.ci.openshift.org/coreos/coreos-assembler:latest
+      image: quay.io/coreos-assembler/fcos-buildroot:testing-devel
       options: "--user root --privileged -v /var/tmp:/var/tmp"
     steps:
       - name: Checkout repository
@@ -189,9 +189,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        RELEASE: ['40', '41', '42']
+        RELEASE: ['43', '44']
     container:
-      image: registry.ci.openshift.org/coreos/coreos-assembler:latest
+      image: quay.io/coreos-assembler/fcos-buildroot:testing-devel
       options: "--user root --privileged -v /var/tmp:/var/tmp"
     steps:
       - name: Checkout repository
@@ -235,7 +235,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     container:
-      image: registry.ci.openshift.org/coreos/coreos-assembler:latest
+      image: quay.io/coreos-assembler/fcos-buildroot:testing-devel
       options: "--user root --privileged -v /var/tmp:/var/tmp"
     steps:
       - name: Checkout repository
@@ -244,6 +244,8 @@ jobs:
         uses: actions/download-artifact@v4.1.7
         with:
           name: install.tar
+      - name: Install test deps
+        run: dnf -y install skopeo
       - name: Install
         run: tar -C / -xzvf install.tar
       - name: Integration tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -31,12 +22,6 @@ name = "ambient-authority"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -49,12 +34,27 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -78,44 +78,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstyle-query"
-version = "1.1.3"
+name = "anstyle-parse"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
- "windows-sys 0.59.0",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "async-compression"
-version = "0.4.27"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
- "flate2",
- "futures-core",
- "memchr",
+ "compression-codecs",
+ "compression-core",
  "pin-project-lite",
  "tokio",
- "zstd",
- "zstd-safe",
 ]
 
 [[package]]
@@ -126,24 +132,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -199,9 +190,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "block-buffer"
@@ -217,14 +208,14 @@ name = "bootc-internal-utils"
 version = "0.1.0"
 source = "git+https://github.com/containers/bootc?rev=b76d75d6024bd0aa0f270ff181807aff4209f9c9#b76d75d6024bd0aa0f270ff181807aff4209f9c9"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anyhow",
  "chrono",
  "owo-colors",
- "rustix 1.0.8",
+ "rustix",
  "serde",
  "serde_json",
- "shlex",
+ "shlex 1.3.0",
  "tempfile",
  "tokio",
  "tracing",
@@ -234,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -251,23 +242,23 @@ checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "camino"
-version = "1.1.10"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -279,14 +270,14 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cap-primitives"
-version = "3.4.4"
+version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1e394ed14f39f8bc26f59d4c0c010dbe7f0a1b9bafff451b1f98b67c8af62a"
+checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -294,67 +285,68 @@ dependencies = [
  "io-lifetimes 2.0.4",
  "ipnet",
  "maybe-owned",
- "rustix 1.0.8",
+ "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
 [[package]]
 name = "cap-std"
-version = "3.4.4"
+version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c0355ca583dd58f176c3c12489d684163861ede3c9efa6fd8bba314c984189"
+checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
 dependencies = [
  "camino",
  "cap-primitives",
  "io-extras",
  "io-lifetimes 2.0.4",
- "rustix 1.0.8",
+ "rustix",
 ]
 
 [[package]]
 name = "cap-std-ext"
-version = "4.0.6"
+version = "4.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7770022cf9ca0e804cdc7725fa6be84a3721e5733ba889b3300689dcdb407fa1"
+checksum = "6fe962d42e07c22aec2618191c3683412735b7e6dcd7bab2eec811ab4697c58e"
 dependencies = [
  "cap-primitives",
  "cap-tempfile",
  "libc",
- "rustix 1.0.8",
+ "rustix",
 ]
 
 [[package]]
 name = "cap-tempfile"
-version = "3.4.4"
+version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bdc50d18ee6c3551b30eb7ad5c4628d7c73ed9e1696b63c432a55602d634d7d"
+checksum = "68d8ad5cfac469e58e632590f033d45c66415ef7a8aa801409884818036706f5"
 dependencies = [
  "camino",
  "cap-std",
- "rand 0.8.5",
- "rustix 1.0.8",
+ "rand 0.8.6",
+ "rustix",
  "rustix-linux-procfs",
  "uuid",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.1"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0390889d58f934f01cd49736275b4c2da15bcfc328c78ff2349907e6cabf22"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -362,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -374,11 +366,10 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
@@ -389,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -399,11 +390,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -411,36 +402,36 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "codespan-reporting"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
@@ -449,15 +440,15 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comfy-table"
-version = "7.1.4"
+version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "crossterm",
  "unicode-segmentation",
@@ -473,11 +464,11 @@ dependencies = [
  "hex",
  "log",
  "once_cell",
- "rand 0.9.2",
- "rustix 1.0.8",
+ "rand 0.9.4",
+ "rustix",
  "sha2",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "xxhash-rust",
  "zerocopy",
@@ -493,7 +484,7 @@ dependencies = [
  "composefs",
  "hex",
  "regex-automata",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "zerocopy",
 ]
 
@@ -509,11 +500,30 @@ dependencies = [
  "hex",
  "indicatif 0.17.11",
  "oci-spec",
- "rustix 1.0.8",
+ "rustix",
  "sha2",
  "tar",
  "tokio",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "console"
@@ -530,15 +540,14 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.0"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -556,18 +565,19 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "const_format"
-version = "0.2.34"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -583,19 +593,19 @@ dependencies = [
 
 [[package]]
 name = "containers-image-proxy"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ca6531917f9b250bf6a1af43603b2e083c192565774451411f9bf4f8bf8f2b"
+checksum = "f4efbec7ca93c60462005402029839fcc8958eb5239bab1dd09f6d3e5165911a"
 dependencies = [
  "cap-std-ext",
  "futures-util",
  "itertools",
  "oci-spec",
- "rustix 1.0.8",
+ "rustix",
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -605,6 +615,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -661,14 +681,15 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "crossterm_winapi",
+ "document-features",
  "parking_lot",
- "rustix 0.38.44",
+ "rustix",
  "winapi",
 ]
 
@@ -689,9 +710,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -709,23 +730,24 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.161"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3523cc02ad831111491dd64b27ad999f1ae189986728e477604e61b81f828df"
+checksum = "747d8437319e3a2f43d93b341c137927ca70c0f5dabeea7a005a73665e247c7e"
 dependencies = [
  "cc",
+ "cxx-build",
  "cxxbridge-cmd",
  "cxxbridge-flags",
  "cxxbridge-macro",
- "foldhash",
+ "foldhash 0.2.0",
  "link-cplusplus",
 ]
 
 [[package]]
 name = "cxx-build"
-version = "1.0.161"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212b754247a6f07b10fa626628c157593f0abf640a3dd04cce2760eca970f909"
+checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -733,40 +755,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.161"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f426a20413ec2e742520ba6837c9324b55ffac24ead47491a6e29f933c5b135a"
+checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
 dependencies = [
  "clap",
  "codespan-reporting",
  "indexmap",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.161"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258b6069020b4e5da6415df94a50ee4f586a6c38b037a180e940a43d06a070d"
+checksum = "23384a836ab4f0ad98ace7e3955ad2de39de42378ab487dc28d3990392cb283a"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.161"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dec184b52be5008d6eaf7e62fc1802caf1ad1227d11b3b7df2c409c7ffc3f4"
+checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
 dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -790,7 +811,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -801,7 +822,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -822,7 +843,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -832,7 +853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -848,13 +869,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -867,10 +888,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.15.0"
+name = "document-features"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -889,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -899,11 +929,11 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "env_filter",
  "jiff",
@@ -927,12 +957,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -943,7 +973,7 @@ checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
 dependencies = [
  "log",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -960,27 +990,31 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
-version = "0.2.25"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "flate2"
-version = "1.1.2"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "libz-sys",
@@ -995,7 +1029,7 @@ checksum = "2cd66269887534af4b0c3e3337404591daa8dc8b9b2b3db71f9523beb4bafb41"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1009,6 +1043,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1037,7 +1077,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1054,9 +1094,9 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -1068,15 +1108,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
- "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1089,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1099,15 +1139,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1116,38 +1156,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1157,7 +1197,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1173,25 +1212,38 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1203,14 +1255,8 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gio"
@@ -1239,7 +1285,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1248,7 +1294,7 @@ version = "0.20.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc4b6e352d4716d84d7dde562dd9aee2a7d48beb872dd9ece7f2d1515b2d683"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1273,7 +1319,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1338,16 +1384,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
+ "http 1.4.1",
  "indexmap",
  "slab",
  "tokio",
@@ -1363,12 +1409,18 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1376,7 +1428,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1419,12 +1471,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1446,7 +1497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -1457,7 +1508,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1500,15 +1551,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
- "h2 0.4.11",
- "http 1.3.1",
+ "futures-core",
+ "h2 0.4.14",
+ "http 1.4.1",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -1520,15 +1572,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.3.1",
- "hyper 1.6.0",
+ "http 1.4.1",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1555,7 +1606,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.10.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1565,24 +1616,23 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.1",
  "http-body 1.0.1",
- "hyper 1.6.0",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
- "system-configuration 0.6.1",
+ "socket2 0.6.4",
+ "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -1591,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1615,12 +1665,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1628,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1641,11 +1692,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -1656,48 +1706,50 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -1707,9 +1759,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1718,9 +1770,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1728,13 +1780,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.17.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1753,11 +1806,11 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.0"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console 0.16.0",
+ "console 0.16.3",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
@@ -1766,9 +1819,12 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "io-extras"
@@ -1777,7 +1833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes 2.0.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1793,48 +1849,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
 
 [[package]]
-name = "io-uring"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
-dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "iso8601"
@@ -1856,53 +1891,70 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -1911,10 +1963,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.174"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdnf-sys"
@@ -1926,17 +1984,6 @@ dependencies = [
  "cxx-build",
  "pkg-config",
  "system-deps",
-]
-
-[[package]]
-name = "libredox"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
-dependencies = [
- "bitflags 2.9.1",
- "libc",
- "redox_syscall",
 ]
 
 [[package]]
@@ -1963,7 +2010,7 @@ dependencies = [
  "once_cell",
  "serde",
  "sha2",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -1981,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.22"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1992,46 +2039,45 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6f6da007f968f9def0d65a05b187e2960183de70c160204ecfccf0ee330212"
+checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "maplit"
@@ -2056,9 +2102,9 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"
@@ -2088,24 +2134,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
@@ -2124,7 +2171,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2137,7 +2184,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2164,11 +2211,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.1"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2187,19 +2234,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "oci-spec"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2078e2f6be932a4de9aca90a375a45590809dfb5a08d93ab1ee217107aceeb67"
+checksum = "fc3da52b83ce3258fbf29f66ac784b279453c2ac3c22c5805371b921ede0d308"
 dependencies = [
  "const_format",
  "derive_builder",
@@ -2209,7 +2247,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2229,20 +2267,20 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
@@ -2250,7 +2288,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -2266,14 +2304,14 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -2346,7 +2384,7 @@ dependencies = [
  "gvariant",
  "hex",
  "indexmap",
- "indicatif 0.18.0",
+ "indicatif 0.18.4",
  "io-lifetimes 3.0.1",
  "libc",
  "libsystemd",
@@ -2355,7 +2393,7 @@ dependencies = [
  "ostree",
  "pin-project",
  "regex",
- "rustix 1.0.8",
+ "rustix",
  "serde",
  "serde_json",
  "tar",
@@ -2382,15 +2420,15 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2398,15 +2436,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -2417,9 +2455,9 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
@@ -2452,7 +2490,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2466,62 +2504,56 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2536,10 +2568,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.3.0"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -2563,23 +2605,23 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2591,10 +2633,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2603,12 +2651,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2628,7 +2676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2637,23 +2685,23 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2661,9 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -2671,38 +2719,38 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2712,9 +2760,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2723,9 +2771,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -2769,22 +2817,21 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.22"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "async-compression",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.11",
- "http 1.3.1",
+ "h2 0.4.14",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.10.1",
  "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -2801,7 +2848,6 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
@@ -2819,7 +2865,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2841,7 +2887,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "binread",
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "camino",
  "cap-primitives",
  "cap-std",
@@ -2868,19 +2914,19 @@ dependencies = [
  "ostree-ext",
  "pastey",
  "phf",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rayon",
  "regex",
- "reqwest 0.12.22",
+ "reqwest 0.12.28",
  "rpmostree-client",
  "rusqlite",
  "rust-ini",
- "rustix 1.0.8",
+ "rustix",
  "serde",
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "shlex",
+ "shlex 1.3.0",
  "similar-asserts",
  "system-deps",
  "systemd",
@@ -2898,7 +2944,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2908,44 +2954,25 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7295b7ce3bf4806b419dc3420745998b447178b7005e2011947b38fc5aa6791"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
-
-[[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.12.1",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
-dependencies = [
- "bitflags 2.9.1",
- "errno",
- "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2955,14 +2982,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
 dependencies = [
  "once_cell",
- "rustix 1.0.8",
+ "rustix",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -2982,9 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -3002,23 +3029,23 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3029,18 +3056,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scratch"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f6280af86e5f559536da57a45ebc84948833b3bee313a7dd25232e09c878a52"
+checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.9.1",
- "core-foundation",
+ "bitflags 2.12.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3048,9 +3075,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3058,49 +3085,60 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3155,13 +3193,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.5"
+name = "shlex"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"
@@ -3185,15 +3236,15 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -3213,19 +3264,19 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -3248,7 +3299,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3270,9 +3321,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3302,7 +3353,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3312,18 +3363,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.5.0",
 ]
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.9.1",
- "core-foundation",
+ "bitflags 2.12.1",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
 
@@ -3349,9 +3400,9 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "7.0.5"
+version = "7.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4be53aa0cba896d2dc615bd42bbc130acdcffa239e0a2d965ea5b3b2a86ffdb"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
 dependencies = [
  "cfg-expr",
  "heck",
@@ -3388,21 +3439,21 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3425,11 +3476,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3440,18 +3491,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3474,9 +3525,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3484,32 +3535,29 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
- "socket2 0.6.0",
+ "socket2 0.6.4",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3524,9 +3572,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -3534,9 +3582,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3546,9 +3594,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3559,43 +3607,60 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "tower"
-version = "0.5.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -3608,20 +3673,25 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.9.1",
+ "async-compression",
+ "bitflags 2.12.1",
  "bytes",
+ "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.1",
  "http-body 1.0.1",
- "iri-string",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3638,9 +3708,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -3649,20 +3719,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3670,9 +3740,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-journald"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0b4143302cf1022dac868d521e36e8b27691f72c84b3311750d5188ebba657"
+checksum = "2d3a81ed245bfb62592b1e2bc153e77656d94ee6a0497683a65a12ccaf2438d0"
 dependencies = [
  "libc",
  "tracing-core",
@@ -3692,9 +3762,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3716,27 +3786,27 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -3746,9 +3816,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-prefix"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -3764,13 +3834,14 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -3793,13 +3864,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "js-sys",
- "serde",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -3817,9 +3888,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -3843,58 +3914,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3902,31 +3966,65 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
- "wasm-bindgen-backend",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.12.1",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3960,11 +4058,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3975,9 +4073,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -3988,37 +4086,37 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
  "windows-result",
@@ -4027,18 +4125,18 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -4072,11 +4170,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -4103,28 +4201,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -4140,12 +4221,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4156,12 +4231,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4176,22 +4245,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4206,12 +4263,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4222,12 +4273,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4242,12 +4287,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4260,16 +4299,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
 name = "winnow"
-version = "0.7.12"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -4290,40 +4323,125 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags 2.9.1",
- "windows-sys 0.52.0",
+ "bitflags 2.12.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "bitflags 2.9.1",
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.12.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xattr"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.0.8",
+ "rustix",
 ]
 
 [[package]]
 name = "xml-rs"
-version = "0.8.27"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xmlrpc"
@@ -4346,11 +4464,10 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -4358,68 +4475,68 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4428,9 +4545,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4439,14 +4556,20 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"
@@ -4468,9 +4591,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,25 +44,25 @@ polkitgobject = { name = "polkit-gobject-1", version = "0" }
 rpm = "4"
 
 [dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.102"
 binread = "2.2.0"
-bitflags = "2.9"
-camino = "1.1.10"
+bitflags = "2.12"
+camino = "1.2.2"
 cap-std-ext = "4"
 cap-primitives = "3"
 cap-std = { version = "3", features = ["fs_utf8"] }
 # Explicitly force on libc
-rustix = { version = "1.0", features = ["use-libc", "process", "fs", "thread"] }
-chrono = { version = "0.4.41", features = ["serde"] }
+rustix = { version = "1.1", features = ["use-libc", "process", "fs", "thread"] }
+chrono = { version = "0.4.44", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
-cxx = "1.0.158"
+cxx = "1.0.180"
 envsubst = "0.2.1"
-either = "1.15.0"
-env_logger = "0.11.5"
+either = "1.16.0"
+env_logger = "0.11.10"
 fail = { version = "0.5", features = ["failpoints"] }
 fn-error-context = "0.2.0"
-futures = "0.3.31"
-indoc = "2.0.6"
+futures = "0.3.32"
+indoc = "2.0.7"
 indicatif = "0.17.11"
 is-terminal = "0.4"
 libc = "0.2.174"
@@ -70,28 +70,28 @@ libdnf-sys = { path = "rust/libdnf-sys", version = "0.1.0" }
 maplit = "1.0"
 nix = { version = "0.30.1", features = ["fs", "mount", "signal", "user"] }
 openssl = "0.10.80"
-once_cell = "1.21.3"
+once_cell = "1.21.4"
 os-release = "0.1.0"
 # We pull this one from git, as the project is no longer published as an external crate.
 ostree-ext = { git = "https://github.com/containers/bootc", rev = "b76d75d6024bd0aa0f270ff181807aff4209f9c9" }
 pastey = "0.1.1"
 phf = { version = "0.12", features = ["macros"] }
-rand = "0.9.1"
-rayon = "1.10.0"
+rand = "0.9.3"
+rayon = "1.12.0"
 regex = "1.10"
 rusqlite = "0.37.0"
 reqwest = { version = "0.12", features = ["native-tls", "blocking", "gzip"] }
 rpmostree-client = { path = "rust/rpmostree-client", version = "0.1.0" }
-rust-ini = "0.21.2"
+rust-ini = "0.21.3"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_derive = "1.0.118"
-serde_json = "1.0.140"
+serde_json = "1.0.150"
 serde_yaml = "0.9.34"
 systemd = "0.10.0"
-tempfile = "3.20.0"
+tempfile = "3.27.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tokio = { version = "1.46.1", features = ["time", "process", "rt", "net"] }
+tokio = { version = "1.52.3", features = ["time", "process", "rt", "net"] }
 xmlrpc = "0.15.1"
 termcolor = "1.4.1"
 shlex = "1.3.0"

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ AM_CPPFLAGS += -DDATADIR='"$(datadir)"' \
 	-DLOCALEDIR=\"$(datadir)/locale\" \
 	-DSYSCONFDIR='"$(sysconfdir)"' \
 	-DRPM_OSTREE_GITREV='"$(RPM_OSTREE_GITREV)"' \
-	-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_56 -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_70
+	-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_56 -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_76
 # Compiler warnings
 warnings_skipped = sign-compare
 warnings_error = empty-body format=2 format-security format-nonliteral \

--- a/ci/test-container.sh
+++ b/ci/test-container.sh
@@ -79,9 +79,40 @@ rpm-ostree override replace $koji_kernel_url
 # test that the new initramfs was generated
 test -f /usr/lib/modules/${kver}-${krev}.fc${versionid}.x86_64/initramfs.img
 
-# TODO: treefile-apply tests are disabled on f44+ due to versionlock
-# plugin incompatibilities with dnf5. Re-enable when fixed.
-# See also: https://github.com/coreos/rpm-ostree/issues/5365
+# test treefile-apply
+# do it before cliwrap because we want real dnf
+if rpm -q ltrace vim-enhanced; then
+  fatal "ltrace and/or vim-enhanced exist"
+fi
+vim_vr=$(rpm -q vim-minimal --qf '%{version}-%{release}')
+cat > /tmp/treefile.yaml << EOF
+packages:
+  - ltrace
+  # a split base/layered version-locked package
+  - vim-enhanced
+# also test repo enablement but using variables so we don't have to rewrite a
+# new treefile each time
+conditional-include:
+  - if: addrepos == "disable"
+    include:
+      repos: []
+  - if: addrepos == "enable"
+    include:
+      repos: [fedora-cisco-openh264]
+      packages: [openh264-devel]
+EOF
+# setting `repos` to empty list; should fail
+if rpm-ostree experimental compose treefile-apply /tmp/treefile.yaml --var addrepos=disable; then
+  fatal "installed packages without enabled repos?"
+fi
+if rpm -q ltrace; then fatal "ltrace installed"; fi
+if rpm -q vim-enhanced-"$vim_vr"; then fatal "vim-enhanced installed"; fi
+# not setting repos; default enablement
+rpm-ostree experimental compose treefile-apply /tmp/treefile.yaml --var addrepos=
+rpm -q ltrace vim-enhanced-"$vim_vr"
+# setting repos; only those repos enabled
+rpm-ostree experimental compose treefile-apply /tmp/treefile.yaml --var addrepos=enable
+rpm -q openh264-devel
 
 rpm-ostree cliwrap install-to-root /
 

--- a/ci/testdeps.txt
+++ b/ci/testdeps.txt
@@ -5,3 +5,4 @@ python3-pyyaml
 libubsan libasan libtsan elfutils fuse sudo python3-gobject-base
 selinux-policy-devel selinux-policy-targeted python3-createrepo_c
 rsync python3-rpm parallel distribution-gpg-keys cpio
+skopeo

--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,13 @@ AC_PATH_PROG([XSLTPROC], [xsltproc])
 
 GLIB_TESTS
 LIBGLNX_CONFIGURE
+dnl Additional checks needed by newer libglnx (not yet in libglnx.m4)
+AC_CHECK_DECLS([name_to_handle_at], [], [], [[
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+]])
+AC_CHECK_FUNCS([open_tree openat2])
 
 m4_ifdef([GOBJECT_INTROSPECTION_CHECK], [
   GOBJECT_INTROSPECTION_CHECK([1.34.0])

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1,15 +1,16 @@
-#include "rpmostree-cxxrs.h"
-#include "rpmostree-clientlib.h"
+#include "src/libpriv/rpmostree-cxxrs-prelude.h"
 #include "rpmostree-container.hpp"
 #include "rpmostree-cxxrsutil.hpp"
-#include "rpmostree-diff.hpp"
-#include "rpmostree-libbuiltin.h"
-#include "rpmostree-output.h"
-#include "rpmostree-package-variants.h"
-#include "rpmostree-rpm-util.h"
 #include "rpmostree-util.h"
 #include "rpmostreemain.h"
-#include "src/libpriv/rpmostree-cxxrs-prelude.h"
+#include "rpmostree-clientlib.h"
+#include "rpmostree-diff.hpp"
+#include "rpmostree-libbuiltin.h"
+#include "rpmostree-util.h"
+#include "rpmostree-output.h"
+#include "rpmostree-rpm-util.h"
+#include "rpmostree-package-variants.h"
+#include "rpmostree-cxxrs.h"
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -31,98 +32,102 @@
 #include <ranges>
 #endif
 
-namespace rust
-{
-inline namespace cxxbridge1
-{
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
+#pragma GCC diagnostic ignored "-Wshadow"
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wdollar-in-identifier-extension"
+#endif // __clang__
+#endif // __GNUC__
+
+namespace rust {
+inline namespace cxxbridge1 {
 // #include "rust/cxx.h"
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception> void panic [[noreturn]] (const char *msg);
+template <typename Exception>
+void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 struct unsafe_bitcopy_t;
 
-namespace
-{
-template <typename T> class impl;
+namespace {
+template <typename T>
+class impl;
 } // namespace
 
-template <typename T>::std::size_t size_of ();
-template <typename T>::std::size_t align_of ();
+template <typename T>
+::std::size_t size_of();
+template <typename T>
+::std::size_t align_of();
 
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
-class String final
-{
+class String final {
 public:
-  String () noexcept;
-  String (const String &) noexcept;
-  String (String &&) noexcept;
-  ~String () noexcept;
+  String() noexcept;
+  String(const String &) noexcept;
+  String(String &&) noexcept;
+  ~String() noexcept;
 
-  String (const std::string &);
-  String (const char *);
-  String (const char *, std::size_t);
-  String (const char16_t *);
-  String (const char16_t *, std::size_t);
+  String(const std::string &);
+  String(const char *);
+  String(const char *, std::size_t);
+  String(const char16_t *);
+  String(const char16_t *, std::size_t);
 #ifdef __cpp_char8_t
-  String (const char8_t *s);
-  String (const char8_t *s, std::size_t len);
+  String(const char8_t *s);
+  String(const char8_t *s, std::size_t len);
 #endif
 
-  static String lossy (const std::string &) noexcept;
-  static String lossy (const char *) noexcept;
-  static String lossy (const char *, std::size_t) noexcept;
-  static String lossy (const char16_t *) noexcept;
-  static String lossy (const char16_t *, std::size_t) noexcept;
+  static String lossy(const std::string &) noexcept;
+  static String lossy(const char *) noexcept;
+  static String lossy(const char *, std::size_t) noexcept;
+  static String lossy(const char16_t *) noexcept;
+  static String lossy(const char16_t *, std::size_t) noexcept;
 
-  String &operator= (const String &) & noexcept;
-  String &operator= (String &&) & noexcept;
+  String &operator=(const String &) & noexcept;
+  String &operator=(String &&) & noexcept;
 
-  explicit operator std::string () const;
+  explicit operator std::string() const;
 
-  const char *data () const noexcept;
-  std::size_t size () const noexcept;
-  std::size_t length () const noexcept;
-  bool empty () const noexcept;
+  const char *data() const noexcept;
+  std::size_t size() const noexcept;
+  std::size_t length() const noexcept;
+  bool empty() const noexcept;
 
-  const char *c_str () noexcept;
+  const char *c_str() noexcept;
 
-  std::size_t capacity () const noexcept;
-  void reserve (size_t new_cap) noexcept;
+  std::size_t capacity() const noexcept;
+  void reserve(size_t new_cap) noexcept;
 
   using iterator = char *;
-  iterator begin () noexcept;
-  iterator end () noexcept;
+  iterator begin() noexcept;
+  iterator end() noexcept;
 
   using const_iterator = const char *;
-  const_iterator begin () const noexcept;
-  const_iterator end () const noexcept;
-  const_iterator cbegin () const noexcept;
-  const_iterator cend () const noexcept;
+  const_iterator begin() const noexcept;
+  const_iterator end() const noexcept;
+  const_iterator cbegin() const noexcept;
+  const_iterator cend() const noexcept;
 
-  bool operator== (const String &) const noexcept;
-  bool operator!= (const String &) const noexcept;
-  bool operator< (const String &) const noexcept;
-  bool operator<= (const String &) const noexcept;
-  bool operator> (const String &) const noexcept;
-  bool operator>= (const String &) const noexcept;
+  bool operator==(const String &) const noexcept;
+  bool operator!=(const String &) const noexcept;
+  bool operator<(const String &) const noexcept;
+  bool operator<=(const String &) const noexcept;
+  bool operator>(const String &) const noexcept;
+  bool operator>=(const String &) const noexcept;
 
-  void swap (String &) noexcept;
+  void swap(String &) noexcept;
 
-  String (unsafe_bitcopy_t, const String &) noexcept;
+  String(unsafe_bitcopy_t, const String &) noexcept;
 
 private:
   struct lossy_t;
-  String (lossy_t, const char *, std::size_t) noexcept;
-  String (lossy_t, const char16_t *, std::size_t) noexcept;
-  friend void
-  swap (String &lhs, String &rhs) noexcept
-  {
-    lhs.swap (rhs);
-  }
+  String(lossy_t, const char *, std::size_t) noexcept;
+  String(lossy_t, const char16_t *, std::size_t) noexcept;
+  friend void swap(String &lhs, String &rhs) noexcept { lhs.swap(rhs); }
 
   std::array<std::uintptr_t, 3> repr;
 };
@@ -130,49 +135,48 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_STR
 #define CXXBRIDGE1_RUST_STR
-class Str final
-{
+class Str final {
 public:
-  Str () noexcept;
-  Str (const String &) noexcept;
-  Str (const std::string &);
-  Str (const char *);
-  Str (const char *, std::size_t);
+  Str() noexcept;
+  Str(const String &) noexcept;
+  Str(const std::string &);
+  Str(const char *);
+  Str(const char *, std::size_t);
 
-  Str &operator= (const Str &) & noexcept = default;
+  Str &operator=(const Str &) & noexcept = default;
 
-  explicit operator std::string () const;
+  explicit operator std::string() const;
 #if __cplusplus >= 201703L
-  explicit operator std::string_view () const;
+  explicit operator std::string_view() const;
 #endif
 
-  const char *data () const noexcept;
-  std::size_t size () const noexcept;
-  std::size_t length () const noexcept;
-  bool empty () const noexcept;
+  const char *data() const noexcept;
+  std::size_t size() const noexcept;
+  std::size_t length() const noexcept;
+  bool empty() const noexcept;
 
-  Str (const Str &) noexcept = default;
-  ~Str () noexcept = default;
+  Str(const Str &) noexcept = default;
+  ~Str() noexcept = default;
 
   using iterator = const char *;
   using const_iterator = const char *;
-  const_iterator begin () const noexcept;
-  const_iterator end () const noexcept;
-  const_iterator cbegin () const noexcept;
-  const_iterator cend () const noexcept;
+  const_iterator begin() const noexcept;
+  const_iterator end() const noexcept;
+  const_iterator cbegin() const noexcept;
+  const_iterator cend() const noexcept;
 
-  bool operator== (const Str &) const noexcept;
-  bool operator!= (const Str &) const noexcept;
-  bool operator< (const Str &) const noexcept;
-  bool operator<= (const Str &) const noexcept;
-  bool operator> (const Str &) const noexcept;
-  bool operator>= (const Str &) const noexcept;
+  bool operator==(const Str &) const noexcept;
+  bool operator!=(const Str &) const noexcept;
+  bool operator<(const Str &) const noexcept;
+  bool operator<=(const Str &) const noexcept;
+  bool operator>(const Str &) const noexcept;
+  bool operator>=(const Str &) const noexcept;
 
-  void swap (Str &) noexcept;
+  void swap(Str &) noexcept;
 
 private:
   class uninit;
-  Str (uninit) noexcept;
+  Str(uninit) noexcept;
   friend impl<Str>;
 
   std::array<std::uintptr_t, 2> repr;
@@ -181,72 +185,72 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
-namespace detail
-{
-template <bool> struct copy_assignable_if
-{
-};
+namespace detail {
+template <bool>
+struct copy_assignable_if {};
 
-template <> struct copy_assignable_if<false>
-{
-  copy_assignable_if () noexcept = default;
-  copy_assignable_if (const copy_assignable_if &) noexcept = default;
-  copy_assignable_if &operator= (const copy_assignable_if &) & noexcept = delete;
-  copy_assignable_if &operator= (copy_assignable_if &&) & noexcept = default;
+template <>
+struct copy_assignable_if<false> {
+  copy_assignable_if() noexcept = default;
+  copy_assignable_if(const copy_assignable_if &) noexcept = default;
+  copy_assignable_if &operator=(const copy_assignable_if &) & noexcept = delete;
+  copy_assignable_if &operator=(copy_assignable_if &&) & noexcept = default;
 };
 } // namespace detail
 
 template <typename T>
-class Slice final : private detail::copy_assignable_if<std::is_const<T>::value>
-{
+class Slice final
+    : private detail::copy_assignable_if<std::is_const<T>::value> {
 public:
   using value_type = T;
 
-  Slice () noexcept;
-  Slice (T *, std::size_t count) noexcept;
+  Slice() noexcept;
+  Slice(T *, std::size_t count) noexcept;
 
-  template <typename C> explicit Slice (C &c) : Slice (c.data (), c.size ()) {}
+  template <typename C>
+  explicit Slice(C &c) : Slice(c.data(), c.size()) {}
 
-  Slice &operator= (const Slice<T> &) & noexcept = default;
-  Slice &operator= (Slice<T> &&) & noexcept = default;
+  Slice &operator=(const Slice<T> &) & noexcept = default;
+  Slice &operator=(Slice<T> &&) & noexcept = default;
 
-  T *data () const noexcept;
-  std::size_t size () const noexcept;
-  std::size_t length () const noexcept;
-  bool empty () const noexcept;
+  T *data() const noexcept;
+  std::size_t size() const noexcept;
+  std::size_t length() const noexcept;
+  bool empty() const noexcept;
 
-  T &operator[] (std::size_t n) const noexcept;
-  T &at (std::size_t n) const;
-  T &front () const noexcept;
-  T &back () const noexcept;
+  T &operator[](std::size_t n) const noexcept;
+  T &at(std::size_t n) const;
+  T &front() const noexcept;
+  T &back() const noexcept;
 
-  Slice (const Slice<T> &) noexcept = default;
-  ~Slice () noexcept = default;
+  Slice(const Slice<T> &) noexcept = default;
+  ~Slice() noexcept = default;
 
   class iterator;
-  iterator begin () const noexcept;
-  iterator end () const noexcept;
+  iterator begin() const noexcept;
+  iterator end() const noexcept;
 
-  void swap (Slice &) noexcept;
+  void swap(Slice &) noexcept;
 
 private:
   class uninit;
-  Slice (uninit) noexcept;
+  Slice(uninit) noexcept;
   friend impl<Slice>;
-  friend void sliceInit (void *, const void *, std::size_t) noexcept;
-  friend void *slicePtr (const void *) noexcept;
-  friend std::size_t sliceLen (const void *) noexcept;
+  friend void sliceInit(void *, const void *, std::size_t) noexcept;
+  friend void *slicePtr(const void *) noexcept;
+  friend std::size_t sliceLen(const void *) noexcept;
 
   std::array<std::uintptr_t, 2> repr;
 };
 
 #ifdef __cpp_deduction_guides
 template <typename C>
-explicit Slice (C &c) -> Slice<std::remove_reference_t<decltype (*std::declval<C> ().data ())>>;
+explicit Slice(C &c)
+    -> Slice<std::remove_reference_t<decltype(*std::declval<C>().data())>>;
 #endif // __cpp_deduction_guides
 
-template <typename T> class Slice<T>::iterator final
-{
+template <typename T>
+class Slice<T>::iterator final {
 public:
 #if __cplusplus >= 202002L
   using iterator_category = std::contiguous_iterator_tag;
@@ -258,32 +262,30 @@ public:
   using pointer = typename std::add_pointer<T>::type;
   using reference = typename std::add_lvalue_reference<T>::type;
 
-  reference operator* () const noexcept;
+  reference operator*() const noexcept;
   pointer operator->() const noexcept;
-  reference operator[] (difference_type) const noexcept;
+  reference operator[](difference_type) const noexcept;
 
-  iterator &operator++ () noexcept;
-  iterator operator++ (int) noexcept;
-  iterator &operator-- () noexcept;
-  iterator operator-- (int) noexcept;
+  iterator &operator++() noexcept;
+  iterator operator++(int) noexcept;
+  iterator &operator--() noexcept;
+  iterator operator--(int) noexcept;
 
-  iterator &operator+= (difference_type) noexcept;
-  iterator &operator-= (difference_type) noexcept;
-  iterator operator+ (difference_type) const noexcept;
-  friend inline iterator
-  operator+ (difference_type lhs, iterator rhs) noexcept
-  {
+  iterator &operator+=(difference_type) noexcept;
+  iterator &operator-=(difference_type) noexcept;
+  iterator operator+(difference_type) const noexcept;
+  friend inline iterator operator+(difference_type lhs, iterator rhs) noexcept {
     return rhs + lhs;
   }
-  iterator operator- (difference_type) const noexcept;
-  difference_type operator- (const iterator &) const noexcept;
+  iterator operator-(difference_type) const noexcept;
+  difference_type operator-(const iterator &) const noexcept;
 
-  bool operator== (const iterator &) const noexcept;
-  bool operator!= (const iterator &) const noexcept;
-  bool operator< (const iterator &) const noexcept;
-  bool operator<= (const iterator &) const noexcept;
-  bool operator> (const iterator &) const noexcept;
-  bool operator>= (const iterator &) const noexcept;
+  bool operator==(const iterator &) const noexcept;
+  bool operator!=(const iterator &) const noexcept;
+  bool operator<(const iterator &) const noexcept;
+  bool operator<=(const iterator &) const noexcept;
+  bool operator>(const iterator &) const noexcept;
+  bool operator>=(const iterator &) const noexcept;
 
 private:
   friend class Slice;
@@ -292,437 +294,367 @@ private:
 };
 
 #if __cplusplus >= 202002L
-static_assert (std::ranges::contiguous_range<rust::Slice<const uint8_t>>);
-static_assert (std::contiguous_iterator<rust::Slice<const uint8_t>::iterator>);
+static_assert(std::ranges::contiguous_range<rust::Slice<const uint8_t>>);
+static_assert(std::contiguous_iterator<rust::Slice<const uint8_t>::iterator>);
 #endif
 
-template <typename T> Slice<T>::Slice () noexcept
-{
-  sliceInit (this, reinterpret_cast<void *> (align_of<T> ()), 0);
-}
-
-template <typename T> Slice<T>::Slice (T *s, std::size_t count) noexcept
-{
-  assert (s != nullptr || count == 0);
-  sliceInit (this,
-             s == nullptr && count == 0 ? reinterpret_cast<void *> (align_of<T> ())
-                                        : const_cast<typename std::remove_const<T>::type *> (s),
-             count);
+template <typename T>
+Slice<T>::Slice() noexcept {
+  sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
 }
 
 template <typename T>
-T *
-Slice<T>::data () const noexcept
-{
-  return reinterpret_cast<T *> (slicePtr (this));
+Slice<T>::Slice(T *s, std::size_t count) noexcept {
+  assert(s != nullptr || count == 0);
+  sliceInit(this,
+            s == nullptr && count == 0
+                ? reinterpret_cast<void *>(align_of<T>())
+                : const_cast<typename std::remove_const<T>::type *>(s),
+            count);
 }
 
 template <typename T>
-std::size_t
-Slice<T>::size () const noexcept
-{
-  return sliceLen (this);
+T *Slice<T>::data() const noexcept {
+  return reinterpret_cast<T *>(slicePtr(this));
 }
 
 template <typename T>
-std::size_t
-Slice<T>::length () const noexcept
-{
-  return this->size ();
+std::size_t Slice<T>::size() const noexcept {
+  return sliceLen(this);
 }
 
 template <typename T>
-bool
-Slice<T>::empty () const noexcept
-{
-  return this->size () == 0;
+std::size_t Slice<T>::length() const noexcept {
+  return this->size();
 }
 
 template <typename T>
-T &
-Slice<T>::operator[] (std::size_t n) const noexcept
-{
-  assert (n < this->size ());
-  auto ptr = static_cast<char *> (slicePtr (this)) + size_of<T> () * n;
-  return *reinterpret_cast<T *> (ptr);
+bool Slice<T>::empty() const noexcept {
+  return this->size() == 0;
 }
 
 template <typename T>
-T &
-Slice<T>::at (std::size_t n) const
-{
-  if (n >= this->size ())
-    {
-      panic<std::out_of_range> ("rust::Slice index out of range");
-    }
+T &Slice<T>::operator[](std::size_t n) const noexcept {
+  assert(n < this->size());
+  auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
+  return *reinterpret_cast<T *>(ptr);
+}
+
+template <typename T>
+T &Slice<T>::at(std::size_t n) const {
+  if (n >= this->size()) {
+    panic<std::out_of_range>("rust::Slice index out of range");
+  }
   return (*this)[n];
 }
 
 template <typename T>
-T &
-Slice<T>::front () const noexcept
-{
-  assert (!this->empty ());
+T &Slice<T>::front() const noexcept {
+  assert(!this->empty());
   return (*this)[0];
 }
 
 template <typename T>
-T &
-Slice<T>::back () const noexcept
-{
-  assert (!this->empty ());
-  return (*this)[this->size () - 1];
+T &Slice<T>::back() const noexcept {
+  assert(!this->empty());
+  return (*this)[this->size() - 1];
 }
 
 template <typename T>
 typename Slice<T>::iterator::reference
-Slice<T>::iterator::operator* () const noexcept
-{
-  return *static_cast<T *> (this->pos);
+Slice<T>::iterator::operator*() const noexcept {
+  return *static_cast<T *>(this->pos);
 }
 
 template <typename T>
 typename Slice<T>::iterator::pointer
-Slice<T>::iterator::operator->() const noexcept
-{
-  return static_cast<T *> (this->pos);
+Slice<T>::iterator::operator->() const noexcept {
+  return static_cast<T *>(this->pos);
 }
 
 template <typename T>
-typename Slice<T>::iterator::reference
-Slice<T>::iterator::operator[] (typename Slice<T>::iterator::difference_type n) const noexcept
-{
-  auto ptr = static_cast<char *> (this->pos) + this->stride * n;
-  return *reinterpret_cast<T *> (ptr);
+typename Slice<T>::iterator::reference Slice<T>::iterator::operator[](
+    typename Slice<T>::iterator::difference_type n) const noexcept {
+  auto ptr = static_cast<char *>(this->pos) + this->stride * n;
+  return *reinterpret_cast<T *>(ptr);
 }
 
 template <typename T>
-typename Slice<T>::iterator &
-Slice<T>::iterator::operator++ () noexcept
-{
-  this->pos = static_cast<char *> (this->pos) + this->stride;
+typename Slice<T>::iterator &Slice<T>::iterator::operator++() noexcept {
+  this->pos = static_cast<char *>(this->pos) + this->stride;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::iterator::operator++ (int) noexcept
-{
-  auto ret = iterator (*this);
-  this->pos = static_cast<char *> (this->pos) + this->stride;
+typename Slice<T>::iterator Slice<T>::iterator::operator++(int) noexcept {
+  auto ret = iterator(*this);
+  this->pos = static_cast<char *>(this->pos) + this->stride;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator &
-Slice<T>::iterator::operator-- () noexcept
-{
-  this->pos = static_cast<char *> (this->pos) - this->stride;
+typename Slice<T>::iterator &Slice<T>::iterator::operator--() noexcept {
+  this->pos = static_cast<char *>(this->pos) - this->stride;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::iterator::operator-- (int) noexcept
-{
-  auto ret = iterator (*this);
-  this->pos = static_cast<char *> (this->pos) - this->stride;
+typename Slice<T>::iterator Slice<T>::iterator::operator--(int) noexcept {
+  auto ret = iterator(*this);
+  this->pos = static_cast<char *>(this->pos) - this->stride;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator &
-Slice<T>::iterator::operator+= (typename Slice<T>::iterator::difference_type n) noexcept
-{
-  this->pos = static_cast<char *> (this->pos) + this->stride * n;
+typename Slice<T>::iterator &Slice<T>::iterator::operator+=(
+    typename Slice<T>::iterator::difference_type n) noexcept {
+  this->pos = static_cast<char *>(this->pos) + this->stride * n;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator &
-Slice<T>::iterator::operator-= (typename Slice<T>::iterator::difference_type n) noexcept
-{
-  this->pos = static_cast<char *> (this->pos) - this->stride * n;
+typename Slice<T>::iterator &Slice<T>::iterator::operator-=(
+    typename Slice<T>::iterator::difference_type n) noexcept {
+  this->pos = static_cast<char *>(this->pos) - this->stride * n;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::iterator::operator+ (typename Slice<T>::iterator::difference_type n) const noexcept
-{
-  auto ret = iterator (*this);
-  ret.pos = static_cast<char *> (this->pos) + this->stride * n;
+typename Slice<T>::iterator Slice<T>::iterator::operator+(
+    typename Slice<T>::iterator::difference_type n) const noexcept {
+  auto ret = iterator(*this);
+  ret.pos = static_cast<char *>(this->pos) + this->stride * n;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::iterator::operator- (typename Slice<T>::iterator::difference_type n) const noexcept
-{
-  auto ret = iterator (*this);
-  ret.pos = static_cast<char *> (this->pos) - this->stride * n;
+typename Slice<T>::iterator Slice<T>::iterator::operator-(
+    typename Slice<T>::iterator::difference_type n) const noexcept {
+  auto ret = iterator(*this);
+  ret.pos = static_cast<char *>(this->pos) - this->stride * n;
   return ret;
 }
 
 template <typename T>
 typename Slice<T>::iterator::difference_type
-Slice<T>::iterator::operator- (const iterator &other) const noexcept
-{
-  auto diff = std::distance (static_cast<char *> (other.pos), static_cast<char *> (this->pos));
-  return diff / static_cast<typename Slice<T>::iterator::difference_type> (this->stride);
+Slice<T>::iterator::operator-(const iterator &other) const noexcept {
+  auto diff = std::distance(static_cast<char *>(other.pos),
+                            static_cast<char *>(this->pos));
+  return diff / static_cast<typename Slice<T>::iterator::difference_type>(
+                    this->stride);
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator== (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator==(const iterator &other) const noexcept {
   return this->pos == other.pos;
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator!= (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator!=(const iterator &other) const noexcept {
   return this->pos != other.pos;
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator< (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator<(const iterator &other) const noexcept {
   return this->pos < other.pos;
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator<= (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator<=(const iterator &other) const noexcept {
   return this->pos <= other.pos;
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator> (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator>(const iterator &other) const noexcept {
   return this->pos > other.pos;
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator>= (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator>=(const iterator &other) const noexcept {
   return this->pos >= other.pos;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::begin () const noexcept
-{
+typename Slice<T>::iterator Slice<T>::begin() const noexcept {
   iterator it;
-  it.pos = slicePtr (this);
-  it.stride = size_of<T> ();
+  it.pos = slicePtr(this);
+  it.stride = size_of<T>();
   return it;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::end () const noexcept
-{
-  iterator it = this->begin ();
-  it.pos = static_cast<char *> (it.pos) + it.stride * this->size ();
+typename Slice<T>::iterator Slice<T>::end() const noexcept {
+  iterator it = this->begin();
+  it.pos = static_cast<char *>(it.pos) + it.stride * this->size();
   return it;
 }
 
 template <typename T>
-void
-Slice<T>::swap (Slice &rhs) noexcept
-{
-  std::swap (*this, rhs);
+void Slice<T>::swap(Slice &rhs) noexcept {
+  std::swap(*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
 
 #ifndef CXXBRIDGE1_RUST_BOX
 #define CXXBRIDGE1_RUST_BOX
-template <typename T> class Box final
-{
+template <typename T>
+class Box final {
 public:
   using element_type = T;
-  using const_pointer = typename std::add_pointer<typename std::add_const<T>::type>::type;
+  using const_pointer =
+      typename std::add_pointer<typename std::add_const<T>::type>::type;
   using pointer = typename std::add_pointer<T>::type;
 
-  Box () = delete;
-  Box (Box &&) noexcept;
-  ~Box () noexcept;
+  Box() = delete;
+  Box(Box &&) noexcept;
+  ~Box() noexcept;
 
-  explicit Box (const T &);
-  explicit Box (T &&);
+  explicit Box(const T &);
+  explicit Box(T &&);
 
-  Box &operator= (Box &&) & noexcept;
+  Box &operator=(Box &&) & noexcept;
 
   const T *operator->() const noexcept;
-  const T &operator* () const noexcept;
+  const T &operator*() const noexcept;
   T *operator->() noexcept;
-  T &operator* () noexcept;
+  T &operator*() noexcept;
 
-  template <typename... Fields> static Box in_place (Fields &&...);
+  template <typename... Fields>
+  static Box in_place(Fields &&...);
 
-  void swap (Box &) noexcept;
+  void swap(Box &) noexcept;
 
-  static Box from_raw (T *) noexcept;
+  static Box from_raw(T *) noexcept;
 
-  T *into_raw () noexcept;
+  T *into_raw() noexcept;
 
   /* Deprecated */ using value_type = element_type;
 
 private:
   class uninit;
   class allocation;
-  Box (uninit) noexcept;
-  void drop () noexcept;
+  Box(uninit) noexcept;
+  void drop() noexcept;
 
-  friend void
-  swap (Box &lhs, Box &rhs) noexcept
-  {
-    lhs.swap (rhs);
-  }
+  friend void swap(Box &lhs, Box &rhs) noexcept { lhs.swap(rhs); }
 
   T *ptr;
 };
 
-template <typename T> class Box<T>::uninit
-{
-};
+template <typename T>
+class Box<T>::uninit {};
 
-template <typename T> class Box<T>::allocation
-{
-  static T *alloc () noexcept;
-  static void dealloc (T *) noexcept;
+template <typename T>
+class Box<T>::allocation {
+  static T *alloc() noexcept;
+  static void dealloc(T *) noexcept;
 
 public:
-  allocation () noexcept : ptr (alloc ()) {}
-  ~allocation () noexcept
-  {
-    if (this->ptr)
-      {
-        dealloc (this->ptr);
-      }
+  allocation() noexcept : ptr(alloc()) {}
+  ~allocation() noexcept {
+    if (this->ptr) {
+      dealloc(this->ptr);
+    }
   }
   T *ptr;
 };
 
-template <typename T> Box<T>::Box (Box &&other) noexcept : ptr (other.ptr) { other.ptr = nullptr; }
-
-template <typename T> Box<T>::Box (const T &val)
-{
-  allocation alloc;
-  ::new (alloc.ptr) T (val);
-  this->ptr = alloc.ptr;
-  alloc.ptr = nullptr;
-}
-
-template <typename T> Box<T>::Box (T &&val)
-{
-  allocation alloc;
-  ::new (alloc.ptr) T (std::move (val));
-  this->ptr = alloc.ptr;
-  alloc.ptr = nullptr;
-}
-
-template <typename T> Box<T>::~Box () noexcept
-{
-  if (this->ptr)
-    {
-      this->drop ();
-    }
+template <typename T>
+Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
+  other.ptr = nullptr;
 }
 
 template <typename T>
-Box<T> &
-Box<T>::operator= (Box &&other) & noexcept
-{
-  if (this->ptr)
-    {
-      this->drop ();
-    }
+Box<T>::Box(const T &val) {
+  allocation alloc;
+  ::new (alloc.ptr) T(val);
+  this->ptr = alloc.ptr;
+  alloc.ptr = nullptr;
+}
+
+template <typename T>
+Box<T>::Box(T &&val) {
+  allocation alloc;
+  ::new (alloc.ptr) T(std::move(val));
+  this->ptr = alloc.ptr;
+  alloc.ptr = nullptr;
+}
+
+template <typename T>
+Box<T>::~Box() noexcept {
+  if (this->ptr) {
+    this->drop();
+  }
+}
+
+template <typename T>
+Box<T> &Box<T>::operator=(Box &&other) & noexcept {
+  if (this->ptr) {
+    this->drop();
+  }
   this->ptr = other.ptr;
   other.ptr = nullptr;
   return *this;
 }
 
 template <typename T>
-const T *
-Box<T>::operator->() const noexcept
-{
+const T *Box<T>::operator->() const noexcept {
   return this->ptr;
 }
 
 template <typename T>
-const T &
-Box<T>::operator* () const noexcept
-{
+const T &Box<T>::operator*() const noexcept {
   return *this->ptr;
 }
 
 template <typename T>
-T *
-Box<T>::operator->() noexcept
-{
+T *Box<T>::operator->() noexcept {
   return this->ptr;
 }
 
 template <typename T>
-T &
-Box<T>::operator* () noexcept
-{
+T &Box<T>::operator*() noexcept {
   return *this->ptr;
 }
 
 template <typename T>
 template <typename... Fields>
-Box<T>
-Box<T>::in_place (Fields &&...fields)
-{
+Box<T> Box<T>::in_place(Fields &&...fields) {
   allocation alloc;
   auto ptr = alloc.ptr;
-  ::new (ptr) T{ std::forward<Fields> (fields)... };
+  ::new (ptr) T{std::forward<Fields>(fields)...};
   alloc.ptr = nullptr;
-  return from_raw (ptr);
+  return from_raw(ptr);
 }
 
 template <typename T>
-void
-Box<T>::swap (Box &rhs) noexcept
-{
+void Box<T>::swap(Box &rhs) noexcept {
   using std::swap;
-  swap (this->ptr, rhs.ptr);
+  swap(this->ptr, rhs.ptr);
 }
 
 template <typename T>
-Box<T>
-Box<T>::from_raw (T *raw) noexcept
-{
+Box<T> Box<T>::from_raw(T *raw) noexcept {
   Box box = uninit{};
   box.ptr = raw;
   return box;
 }
 
 template <typename T>
-T *
-Box<T>::into_raw () noexcept
-{
+T *Box<T>::into_raw() noexcept {
   T *raw = this->ptr;
   this->ptr = nullptr;
   return raw;
 }
 
-template <typename T> Box<T>::Box (uninit) noexcept {}
+template <typename T>
+Box<T>::Box(uninit) noexcept {}
 #endif // CXXBRIDGE1_RUST_BOX
 
 #ifndef CXXBRIDGE1_RUST_BITCOPY_T
 #define CXXBRIDGE1_RUST_BITCOPY_T
-struct unsafe_bitcopy_t final
-{
-  explicit unsafe_bitcopy_t () = default;
+struct unsafe_bitcopy_t final {
+  explicit unsafe_bitcopy_t() = default;
 };
 #endif // CXXBRIDGE1_RUST_BITCOPY_T
 
@@ -733,307 +665,257 @@ constexpr unsafe_bitcopy_t unsafe_bitcopy{};
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T> class Vec final
-{
+template <typename T>
+class Vec final {
 public:
   using value_type = T;
 
-  Vec () noexcept;
-  Vec (std::initializer_list<T>);
-  Vec (const Vec &);
-  Vec (Vec &&) noexcept;
-  ~Vec () noexcept;
+  Vec() noexcept;
+  Vec(std::initializer_list<T>);
+  Vec(const Vec &);
+  Vec(Vec &&) noexcept;
+  ~Vec() noexcept;
 
-  Vec &operator= (Vec &&) & noexcept;
-  Vec &operator= (const Vec &) &;
+  Vec &operator=(Vec &&) & noexcept;
+  Vec &operator=(const Vec &) &;
 
-  std::size_t size () const noexcept;
-  bool empty () const noexcept;
-  const T *data () const noexcept;
-  T *data () noexcept;
-  std::size_t capacity () const noexcept;
+  std::size_t size() const noexcept;
+  bool empty() const noexcept;
+  const T *data() const noexcept;
+  T *data() noexcept;
+  std::size_t capacity() const noexcept;
 
-  const T &operator[] (std::size_t n) const noexcept;
-  const T &at (std::size_t n) const;
-  const T &front () const noexcept;
-  const T &back () const noexcept;
+  const T &operator[](std::size_t n) const noexcept;
+  const T &at(std::size_t n) const;
+  const T &front() const noexcept;
+  const T &back() const noexcept;
 
-  T &operator[] (std::size_t n) noexcept;
-  T &at (std::size_t n);
-  T &front () noexcept;
-  T &back () noexcept;
+  T &operator[](std::size_t n) noexcept;
+  T &at(std::size_t n);
+  T &front() noexcept;
+  T &back() noexcept;
 
-  void reserve (std::size_t new_cap);
-  void push_back (const T &value);
-  void push_back (T &&value);
-  template <typename... Args> void emplace_back (Args &&...args);
-  void truncate (std::size_t len);
-  void clear ();
+  void reserve(std::size_t new_cap);
+  void push_back(const T &value);
+  void push_back(T &&value);
+  template <typename... Args>
+  void emplace_back(Args &&...args);
+  void truncate(std::size_t len);
+  void clear();
 
   using iterator = typename Slice<T>::iterator;
-  iterator begin () noexcept;
-  iterator end () noexcept;
+  iterator begin() noexcept;
+  iterator end() noexcept;
 
   using const_iterator = typename Slice<const T>::iterator;
-  const_iterator begin () const noexcept;
-  const_iterator end () const noexcept;
-  const_iterator cbegin () const noexcept;
-  const_iterator cend () const noexcept;
+  const_iterator begin() const noexcept;
+  const_iterator end() const noexcept;
+  const_iterator cbegin() const noexcept;
+  const_iterator cend() const noexcept;
 
-  void swap (Vec &) noexcept;
+  void swap(Vec &) noexcept;
 
-  Vec (unsafe_bitcopy_t, const Vec &) noexcept;
+  Vec(unsafe_bitcopy_t, const Vec &) noexcept;
 
 private:
-  void reserve_total (std::size_t new_cap) noexcept;
-  void set_len (std::size_t len) noexcept;
-  void drop () noexcept;
+  void reserve_total(std::size_t new_cap) noexcept;
+  void set_len(std::size_t len) noexcept;
+  void drop() noexcept;
 
-  friend void
-  swap (Vec &lhs, Vec &rhs) noexcept
-  {
-    lhs.swap (rhs);
-  }
+  friend void swap(Vec &lhs, Vec &rhs) noexcept { lhs.swap(rhs); }
 
   std::array<std::uintptr_t, 3> repr;
 };
 
-template <typename T> Vec<T>::Vec (std::initializer_list<T> init) : Vec{}
-{
-  this->reserve_total (init.size ());
-  std::move (init.begin (), init.end (), std::back_inserter (*this));
+template <typename T>
+Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
+  this->reserve_total(init.size());
+  std::move(init.begin(), init.end(), std::back_inserter(*this));
 }
-
-template <typename T> Vec<T>::Vec (const Vec &other) : Vec ()
-{
-  this->reserve_total (other.size ());
-  std::copy (other.begin (), other.end (), std::back_inserter (*this));
-}
-
-template <typename T> Vec<T>::Vec (Vec &&other) noexcept : repr (other.repr)
-{
-  new (&other) Vec ();
-}
-
-template <typename T> Vec<T>::~Vec () noexcept { this->drop (); }
 
 template <typename T>
-Vec<T> &
-Vec<T>::operator= (Vec &&other) & noexcept
-{
-  this->drop ();
+Vec<T>::Vec(const Vec &other) : Vec() {
+  this->reserve_total(other.size());
+  std::copy(other.begin(), other.end(), std::back_inserter(*this));
+}
+
+template <typename T>
+Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
+  new (&other) Vec();
+}
+
+template <typename T>
+Vec<T>::~Vec() noexcept {
+  this->drop();
+}
+
+template <typename T>
+Vec<T> &Vec<T>::operator=(Vec &&other) & noexcept {
+  this->drop();
   this->repr = other.repr;
-  new (&other) Vec ();
+  new (&other) Vec();
   return *this;
 }
 
 template <typename T>
-Vec<T> &
-Vec<T>::operator= (const Vec &other) &
-{
-  if (this != &other)
-    {
-      this->drop ();
-      new (this) Vec (other);
-    }
+Vec<T> &Vec<T>::operator=(const Vec &other) & {
+  if (this != &other) {
+    this->drop();
+    new (this) Vec(other);
+  }
   return *this;
 }
 
 template <typename T>
-bool
-Vec<T>::empty () const noexcept
-{
-  return this->size () == 0;
+bool Vec<T>::empty() const noexcept {
+  return this->size() == 0;
 }
 
 template <typename T>
-T *
-Vec<T>::data () noexcept
-{
-  return const_cast<T *> (const_cast<const Vec<T> *> (this)->data ());
+T *Vec<T>::data() noexcept {
+  return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
 }
 
 template <typename T>
-const T &
-Vec<T>::operator[] (std::size_t n) const noexcept
-{
-  assert (n < this->size ());
-  auto data = reinterpret_cast<const char *> (this->data ());
-  return *reinterpret_cast<const T *> (data + n * size_of<T> ());
+const T &Vec<T>::operator[](std::size_t n) const noexcept {
+  assert(n < this->size());
+  auto data = reinterpret_cast<const char *>(this->data());
+  return *reinterpret_cast<const T *>(data + n * size_of<T>());
 }
 
 template <typename T>
-const T &
-Vec<T>::at (std::size_t n) const
-{
-  if (n >= this->size ())
-    {
-      panic<std::out_of_range> ("rust::Vec index out of range");
-    }
+const T &Vec<T>::at(std::size_t n) const {
+  if (n >= this->size()) {
+    panic<std::out_of_range>("rust::Vec index out of range");
+  }
   return (*this)[n];
 }
 
 template <typename T>
-const T &
-Vec<T>::front () const noexcept
-{
-  assert (!this->empty ());
+const T &Vec<T>::front() const noexcept {
+  assert(!this->empty());
   return (*this)[0];
 }
 
 template <typename T>
-const T &
-Vec<T>::back () const noexcept
-{
-  assert (!this->empty ());
-  return (*this)[this->size () - 1];
+const T &Vec<T>::back() const noexcept {
+  assert(!this->empty());
+  return (*this)[this->size() - 1];
 }
 
 template <typename T>
-T &
-Vec<T>::operator[] (std::size_t n) noexcept
-{
-  assert (n < this->size ());
-  auto data = reinterpret_cast<char *> (this->data ());
-  return *reinterpret_cast<T *> (data + n * size_of<T> ());
+T &Vec<T>::operator[](std::size_t n) noexcept {
+  assert(n < this->size());
+  auto data = reinterpret_cast<char *>(this->data());
+  return *reinterpret_cast<T *>(data + n * size_of<T>());
 }
 
 template <typename T>
-T &
-Vec<T>::at (std::size_t n)
-{
-  if (n >= this->size ())
-    {
-      panic<std::out_of_range> ("rust::Vec index out of range");
-    }
+T &Vec<T>::at(std::size_t n) {
+  if (n >= this->size()) {
+    panic<std::out_of_range>("rust::Vec index out of range");
+  }
   return (*this)[n];
 }
 
 template <typename T>
-T &
-Vec<T>::front () noexcept
-{
-  assert (!this->empty ());
+T &Vec<T>::front() noexcept {
+  assert(!this->empty());
   return (*this)[0];
 }
 
 template <typename T>
-T &
-Vec<T>::back () noexcept
-{
-  assert (!this->empty ());
-  return (*this)[this->size () - 1];
+T &Vec<T>::back() noexcept {
+  assert(!this->empty());
+  return (*this)[this->size() - 1];
 }
 
 template <typename T>
-void
-Vec<T>::reserve (std::size_t new_cap)
-{
-  this->reserve_total (new_cap);
+void Vec<T>::reserve(std::size_t new_cap) {
+  this->reserve_total(new_cap);
 }
 
 template <typename T>
-void
-Vec<T>::push_back (const T &value)
-{
-  this->emplace_back (value);
+void Vec<T>::push_back(const T &value) {
+  this->emplace_back(value);
 }
 
 template <typename T>
-void
-Vec<T>::push_back (T &&value)
-{
-  this->emplace_back (std::move (value));
+void Vec<T>::push_back(T &&value) {
+  this->emplace_back(std::move(value));
 }
 
 template <typename T>
 template <typename... Args>
-void
-Vec<T>::emplace_back (Args &&...args)
-{
-  auto size = this->size ();
-  this->reserve_total (size + 1);
-  ::new (reinterpret_cast<T *> (reinterpret_cast<char *> (this->data ()) + size * size_of<T> ()))
-      T (std::forward<Args> (args)...);
-  this->set_len (size + 1);
+void Vec<T>::emplace_back(Args &&...args) {
+  auto size = this->size();
+  this->reserve_total(size + 1);
+  ::new (reinterpret_cast<T *>(reinterpret_cast<char *>(this->data()) +
+                               size * size_of<T>()))
+      T(std::forward<Args>(args)...);
+  this->set_len(size + 1);
 }
 
 template <typename T>
-void
-Vec<T>::clear ()
-{
-  this->truncate (0);
+void Vec<T>::clear() {
+  this->truncate(0);
 }
 
 template <typename T>
-typename Vec<T>::iterator
-Vec<T>::begin () noexcept
-{
-  return Slice<T> (this->data (), this->size ()).begin ();
+typename Vec<T>::iterator Vec<T>::begin() noexcept {
+  return Slice<T>(this->data(), this->size()).begin();
 }
 
 template <typename T>
-typename Vec<T>::iterator
-Vec<T>::end () noexcept
-{
-  return Slice<T> (this->data (), this->size ()).end ();
+typename Vec<T>::iterator Vec<T>::end() noexcept {
+  return Slice<T>(this->data(), this->size()).end();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator
-Vec<T>::begin () const noexcept
-{
-  return this->cbegin ();
+typename Vec<T>::const_iterator Vec<T>::begin() const noexcept {
+  return this->cbegin();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator
-Vec<T>::end () const noexcept
-{
-  return this->cend ();
+typename Vec<T>::const_iterator Vec<T>::end() const noexcept {
+  return this->cend();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator
-Vec<T>::cbegin () const noexcept
-{
-  return Slice<const T> (this->data (), this->size ()).begin ();
+typename Vec<T>::const_iterator Vec<T>::cbegin() const noexcept {
+  return Slice<const T>(this->data(), this->size()).begin();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator
-Vec<T>::cend () const noexcept
-{
-  return Slice<const T> (this->data (), this->size ()).end ();
+typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
+  return Slice<const T>(this->data(), this->size()).end();
 }
 
 template <typename T>
-void
-Vec<T>::swap (Vec &rhs) noexcept
-{
+void Vec<T>::swap(Vec &rhs) noexcept {
   using std::swap;
-  swap (this->repr, rhs.repr);
+  swap(this->repr, rhs.repr);
 }
 
-template <typename T> Vec<T>::Vec (unsafe_bitcopy_t, const Vec &bits) noexcept : repr (bits.repr) {}
+template <typename T>
+Vec<T>::Vec(unsafe_bitcopy_t, const Vec &bits) noexcept : repr(bits.repr) {}
 #endif // CXXBRIDGE1_RUST_VEC
 
 #ifndef CXXBRIDGE1_RUST_ERROR
 #define CXXBRIDGE1_RUST_ERROR
-class Error final : public std::exception
-{
+class Error final : public std::exception {
 public:
-  Error (const Error &);
-  Error (Error &&) noexcept;
-  ~Error () noexcept override;
+  Error(const Error &);
+  Error(Error &&) noexcept;
+  ~Error() noexcept override;
 
-  Error &operator= (const Error &) &;
-  Error &operator= (Error &&) & noexcept;
+  Error &operator=(const Error &) &;
+  Error &operator=(Error &&) & noexcept;
 
-  const char *what () const noexcept override;
+  const char *what() const noexcept override;
 
 private:
-  Error () noexcept = default;
+  Error() noexcept = default;
   friend impl<Error>;
   const char *msg;
   std::size_t len;
@@ -1042,284 +924,188 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_OPAQUE
 #define CXXBRIDGE1_RUST_OPAQUE
-class Opaque
-{
+class Opaque {
 public:
-  Opaque () = delete;
-  Opaque (const Opaque &) = delete;
-  ~Opaque () = delete;
+  Opaque() = delete;
+  Opaque(const Opaque &) = delete;
+  ~Opaque() = delete;
 };
 #endif // CXXBRIDGE1_RUST_OPAQUE
 
 #ifndef CXXBRIDGE1_IS_COMPLETE
 #define CXXBRIDGE1_IS_COMPLETE
-namespace detail
-{
-namespace
-{
-template <typename T, typename = std::size_t> struct is_complete : std::false_type
-{
-};
-template <typename T> struct is_complete<T, decltype (sizeof (T))> : std::true_type
-{
-};
+namespace detail {
+namespace {
+template <typename T, typename = std::size_t>
+struct is_complete : std::false_type {};
+template <typename T>
+struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
 } // namespace
 } // namespace detail
 #endif // CXXBRIDGE1_IS_COMPLETE
 
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
-class layout
-{
-  template <typename T> friend std::size_t size_of ();
-  template <typename T> friend std::size_t align_of ();
+class layout {
   template <typename T>
-  static typename std::enable_if<std::is_base_of<Opaque, T>::value, std::size_t>::type
-  do_size_of ()
-  {
-    return T::layout::size ();
+  friend std::size_t size_of();
+  template <typename T>
+  friend std::size_t align_of();
+  template <typename T>
+  static typename std::enable_if<std::is_base_of<Opaque, T>::value,
+                                 std::size_t>::type
+  do_size_of() {
+    return T::layout::size();
   }
   template <typename T>
-  static typename std::enable_if<!std::is_base_of<Opaque, T>::value, std::size_t>::type
-  do_size_of ()
-  {
-    return sizeof (T);
+  static typename std::enable_if<!std::is_base_of<Opaque, T>::value,
+                                 std::size_t>::type
+  do_size_of() {
+    return sizeof(T);
   }
   template <typename T>
-  static typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
-  size_of ()
-  {
-    return do_size_of<T> ();
+  static
+      typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
+      size_of() {
+    return do_size_of<T>();
   }
   template <typename T>
-  static typename std::enable_if<std::is_base_of<Opaque, T>::value, std::size_t>::type
-  do_align_of ()
-  {
-    return T::layout::align ();
+  static typename std::enable_if<std::is_base_of<Opaque, T>::value,
+                                 std::size_t>::type
+  do_align_of() {
+    return T::layout::align();
   }
   template <typename T>
-  static typename std::enable_if<!std::is_base_of<Opaque, T>::value, std::size_t>::type
-  do_align_of ()
-  {
-    return alignof (T);
+  static typename std::enable_if<!std::is_base_of<Opaque, T>::value,
+                                 std::size_t>::type
+  do_align_of() {
+    return alignof(T);
   }
   template <typename T>
-  static typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
-  align_of ()
-  {
-    return do_align_of<T> ();
+  static
+      typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
+      align_of() {
+    return do_align_of<T>();
   }
 };
 
 template <typename T>
-std::size_t
-size_of ()
-{
-  return layout::size_of<T> ();
+std::size_t size_of() {
+  return layout::size_of<T>();
 }
 
 template <typename T>
-std::size_t
-align_of ()
-{
-  return layout::align_of<T> ();
+std::size_t align_of() {
+  return layout::align_of<T>();
 }
 #endif // CXXBRIDGE1_LAYOUT
 
-#ifndef CXXBRIDGE1_RELOCATABLE
-#define CXXBRIDGE1_RELOCATABLE
-namespace detail
-{
-template <typename... Ts> struct make_void
-{
-  using type = void;
-};
-
-template <typename... Ts> using void_t = typename make_void<Ts...>::type;
-
-template <typename Void, template <typename...> class, typename...> struct detect : std::false_type
-{
-};
-template <template <typename...> class T, typename... A>
-struct detect<void_t<T<A...>>, T, A...> : std::true_type
-{
-};
-
-template <template <typename...> class T, typename... A> using is_detected = detect<void, T, A...>;
-
-template <typename T> using detect_IsRelocatable = typename T::IsRelocatable;
+class Str::uninit {};
+inline Str::Str(uninit) noexcept {}
 
 template <typename T>
-struct get_IsRelocatable : std::is_same<typename T::IsRelocatable, std::true_type>
-{
-};
-} // namespace detail
-
+class Slice<T>::uninit {};
 template <typename T>
-struct IsRelocatable
-    : std::conditional<
-          detail::is_detected<detail::detect_IsRelocatable, T>::value, detail::get_IsRelocatable<T>,
-          std::integral_constant<bool, std::is_trivially_move_constructible<T>::value
-                                           && std::is_trivially_destructible<T>::value>>::type
-{
-};
-#endif // CXXBRIDGE1_RELOCATABLE
+inline Slice<T>::Slice(uninit) noexcept {}
 
-class Str::uninit
-{
-};
-inline Str::Str (uninit) noexcept {}
-
-template <typename T> class Slice<T>::uninit
-{
-};
-template <typename T> inline Slice<T>::Slice (uninit) noexcept {}
-
-namespace repr
-{
+namespace repr {
 using Fat = ::std::array<::std::uintptr_t, 2>;
 
-struct PtrLen final
-{
+struct PtrLen final {
   void *ptr;
   ::std::size_t len;
 };
 } // namespace repr
 
-namespace detail
-{
-template <typename T, typename = void *> struct operator_new
-{
-  void *
-  operator() (::std::size_t sz)
-  {
-    return ::operator new (sz);
-  }
+namespace detail {
+template <typename T, typename = void *>
+struct operator_new {
+  void *operator()(::std::size_t sz) { return ::operator new(sz); }
 };
 
-template <typename T> struct operator_new<T, decltype (T::operator new (sizeof (T)))>
-{
-  void *
-  operator() (::std::size_t sz)
-  {
-    return T::operator new (sz);
-  }
+template <typename T>
+struct operator_new<T, decltype(T::operator new(sizeof(T)))> {
+  void *operator()(::std::size_t sz) { return T::operator new(sz); }
 };
 
-class Fail final
-{
+class Fail final {
   ::rust::repr::PtrLen &throw$;
-
 public:
-  Fail (::rust::repr::PtrLen &throw$) noexcept : throw$ (throw$) {}
-  void operator() (char const *) noexcept;
-  void operator() (std::string const &) noexcept;
+  Fail(::rust::repr::PtrLen &throw$) noexcept : throw$(throw$) {}
+  void operator()(char const *) noexcept;
+  void operator()(std::string const &) noexcept;
 };
 } // namespace detail
 
-template <typename T> union ManuallyDrop
-{
+template <typename T>
+union ManuallyDrop {
   T value;
-  ManuallyDrop (T &&value) : value (::std::move (value)) {}
-  ~ManuallyDrop () {}
+  ManuallyDrop(T &&value) : value(::std::move(value)) {}
+  ~ManuallyDrop() {}
 };
 
-template <typename T> union MaybeUninit
-{
+template <typename T>
+union MaybeUninit {
   T value;
-  void *
-  operator new (::std::size_t sz)
-  {
-    return detail::operator_new<T>{}(sz);
-  }
-  MaybeUninit () {}
-  ~MaybeUninit () {}
+  void *operator new(::std::size_t sz) { return detail::operator_new<T>{}(sz); }
+  MaybeUninit() {}
+  ~MaybeUninit() {}
 };
 
-namespace
-{
-template <> class impl<Str> final
-{
+namespace {
+template <>
+class impl<Str> final {
 public:
-  static Str
-  new_unchecked (repr::Fat repr) noexcept
-  {
+  static Str new_unchecked(repr::Fat repr) noexcept {
     Str str = Str::uninit{};
     str.repr = repr;
     return str;
   }
-  static repr::Fat
-  repr (Str str) noexcept
-  {
-    return str.repr;
-  }
 };
 
-template <typename T> class impl<Slice<T>> final
-{
+template <typename T>
+class impl<Slice<T>> final {
 public:
-  static Slice<T>
-  slice (repr::Fat repr) noexcept
-  {
+  static Slice<T> slice(repr::Fat repr) noexcept {
     Slice<T> slice = typename Slice<T>::uninit{};
     slice.repr = repr;
     return slice;
   }
 };
 
-template <> class impl<Error> final
-{
+template <>
+class impl<Error> final {
 public:
-  static Error
-  error (repr::PtrLen repr) noexcept
-  {
+  static Error error(repr::PtrLen repr) noexcept {
     Error error;
-    error.msg = static_cast<char const *> (repr.ptr);
+    error.msg = static_cast<char const *>(repr.ptr);
     error.len = repr.len;
     return error;
   }
 };
 
-template <bool> struct deleter_if
-{
-  template <typename T>
-  void
-  operator() (T *)
-  {
-  }
+template <bool> struct deleter_if {
+  template <typename T> void operator()(T *) {}
 };
-
-template <> struct deleter_if<true>
-{
-  template <typename T>
-  void
-  operator() (T *ptr)
-  {
-    ptr->~T ();
-  }
+template <> struct deleter_if<true> {
+  template <typename T> void operator()(T *ptr) { ptr->~T(); }
 };
 } // namespace
 } // namespace cxxbridge1
 
-namespace behavior
-{
-class missing
-{
-};
-missing trycatch (...);
+namespace behavior {
+class missing {};
+missing trycatch(...);
 
 template <typename Try, typename Fail>
 static typename ::std::enable_if<::std::is_same<
-    decltype (trycatch (::std::declval<Try> (), ::std::declval<Fail> ())), missing>::value>::type
-trycatch (Try &&func, Fail &&fail) noexcept
-try
-  {
-    func ();
-  }
-catch (::std::exception const &e)
-  {
-    fail (e.what ());
-  }
+    decltype(trycatch(::std::declval<Try>(), ::std::declval<Fail>())),
+    missing>::value>::type
+trycatch(Try &&func, Fail &&fail) noexcept try {
+  func();
+} catch (::std::exception const &e) {
+  fail(e.what());
+}
 } // namespace behavior
 } // namespace rust
 
@@ -1329,53 +1115,51 @@ catch (::std::exception const &e)
 #define CXX_DEFAULT_VALUE(value)
 #endif
 
-namespace rpmostreecxx
-{
-struct StringMapping;
-enum class SystemHostType : ::std::uint8_t;
-enum class BubblewrapMutability : ::std::uint8_t;
-struct Bubblewrap;
-struct ContainerImageState;
-struct ExportedManifestDiff;
-struct PrunedContainerInfo;
-enum class RefspecType : ::std::uint8_t;
-struct TempEtcGuard;
-struct FilesystemScriptPrep;
-struct DeploymentLayeredMeta;
-struct OverrideReplacementSource;
-enum class ParsedRevisionKind : ::std::uint8_t;
-struct ParsedRevision;
-struct RpmImporterFlags;
-struct RpmImporter;
-struct HistoryEntry;
-struct HistoryCtx;
-struct TokioHandle;
-struct TokioEnterGuard;
-enum class RepoMetadataTarget : ::std::uint8_t;
-enum class AdvisoriesMetadataTarget : ::std::uint8_t;
-struct Refspec;
-enum class OverrideReplacementType : ::std::uint8_t;
-struct OverrideReplacement;
-enum class OptUsrLocal : ::std::uint8_t;
-struct Treefile;
-struct RepoPackage;
-struct LiveApplyState;
-struct PasswdDB;
-struct PasswdEntries;
-struct Extensions;
-struct LockedPackage;
-struct LockfileConfig;
-using CxxGObjectArray = ::rpmostreecxx::CxxGObjectArray;
-using ClientConnection = ::rpmostreecxx::ClientConnection;
-using RPMDiff = ::rpmostreecxx::RPMDiff;
-using RpmOstreeDiffPrintFormat = ::rpmostreecxx::RpmOstreeDiffPrintFormat;
-using Progress = ::rpmostreecxx::Progress;
-using RpmTs = ::rpmostreecxx::RpmTs;
-using PackageMeta = ::rpmostreecxx::PackageMeta;
+namespace rpmostreecxx {
+  struct StringMapping;
+  enum class SystemHostType : ::std::uint8_t;
+  enum class BubblewrapMutability : ::std::uint8_t;
+  struct Bubblewrap;
+  struct ContainerImageState;
+  struct ExportedManifestDiff;
+  struct PrunedContainerInfo;
+  enum class RefspecType : ::std::uint8_t;
+  struct TempEtcGuard;
+  struct FilesystemScriptPrep;
+  struct DeploymentLayeredMeta;
+  struct OverrideReplacementSource;
+  enum class ParsedRevisionKind : ::std::uint8_t;
+  struct ParsedRevision;
+  struct RpmImporterFlags;
+  struct RpmImporter;
+  struct HistoryEntry;
+  struct HistoryCtx;
+  struct TokioHandle;
+  struct TokioEnterGuard;
+  enum class RepoMetadataTarget : ::std::uint8_t;
+  enum class AdvisoriesMetadataTarget : ::std::uint8_t;
+  struct Refspec;
+  enum class OverrideReplacementType : ::std::uint8_t;
+  struct OverrideReplacement;
+  enum class OptUsrLocal : ::std::uint8_t;
+  struct Treefile;
+  struct RepoPackage;
+  struct LiveApplyState;
+  struct PasswdDB;
+  struct PasswdEntries;
+  struct Extensions;
+  struct LockedPackage;
+  struct LockfileConfig;
+  using CxxGObjectArray = ::rpmostreecxx::CxxGObjectArray;
+  using ClientConnection = ::rpmostreecxx::ClientConnection;
+  using RPMDiff = ::rpmostreecxx::RPMDiff;
+  using RpmOstreeDiffPrintFormat = ::rpmostreecxx::RpmOstreeDiffPrintFormat;
+  using Progress = ::rpmostreecxx::Progress;
+  using RpmTs = ::rpmostreecxx::RpmTs;
+  using PackageMeta = ::rpmostreecxx::PackageMeta;
 }
 
-namespace rpmostreecxx
-{
+namespace rpmostreecxx {
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$StringMapping
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$StringMapping
 // Currently cxx-rs doesn't support mappings; like probably most projects,
@@ -1383,8 +1167,7 @@ namespace rpmostreecxx
 // our data sizes aren't large, we serialize this as a vector of strings pairs.
 // In the future it's also likely that cxx-rs will support a C++ string_view
 // so we could avoid duplicating in that direction.
-struct StringMapping final
-{
+struct StringMapping final {
   ::rust::String k;
   ::rust::String v;
 
@@ -1395,8 +1178,7 @@ struct StringMapping final
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$SystemHostType
 #define CXXBRIDGE1_ENUM_rpmostreecxx$SystemHostType
 // Classify the running system.
-enum class SystemHostType : ::std::uint8_t
-{
+enum class SystemHostType : ::std::uint8_t {
   OstreeContainer = 0,
   OstreeHost = 1,
   Unknown = 2,
@@ -1405,8 +1187,7 @@ enum class SystemHostType : ::std::uint8_t
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$BubblewrapMutability
 #define CXXBRIDGE1_ENUM_rpmostreecxx$BubblewrapMutability
-enum class BubblewrapMutability : ::std::uint8_t
-{
+enum class BubblewrapMutability : ::std::uint8_t {
   Immutable = 0,
   RoFiles = 1,
   MutateFreely = 2,
@@ -1415,52 +1196,49 @@ enum class BubblewrapMutability : ::std::uint8_t
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Bubblewrap
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Bubblewrap
-struct Bubblewrap final : public ::rust::Opaque
-{
-  ::std::int32_t get_rootfs_fd () const noexcept;
-  void append_bwrap_arg (::rust::Str arg) noexcept;
-  void append_child_arg (::rust::Str arg) noexcept;
-  void setenv (::rust::Str k, ::rust::Str v) noexcept;
-  void take_fd (::std::int32_t source_fd, ::std::int32_t target_fd) noexcept;
-  void set_inherit_stdin () noexcept;
-  void take_stdin_fd (::std::int32_t source_fd) noexcept;
-  void take_stdout_fd (::std::int32_t source_fd) noexcept;
-  void take_stderr_fd (::std::int32_t source_fd) noexcept;
-  void take_stdout_and_stderr_fd (::std::int32_t source_fd) noexcept;
-  void bind_read (::rust::Str src, ::rust::Str dest) noexcept;
-  void bind_readwrite (::rust::Str src, ::rust::Str dest) noexcept;
-  void setup_compat_var ();
-  void run (::rpmostreecxx::GCancellable const &cancellable);
-  ~Bubblewrap () = delete;
+struct Bubblewrap final : public ::rust::Opaque {
+  ::std::int32_t get_rootfs_fd() const noexcept;
+  void append_bwrap_arg(::rust::Str arg) noexcept;
+  void append_child_arg(::rust::Str arg) noexcept;
+  void setenv(::rust::Str k, ::rust::Str v) noexcept;
+  void take_fd(::std::int32_t source_fd, ::std::int32_t target_fd) noexcept;
+  void set_inherit_stdin() noexcept;
+  void take_stdin_fd(::std::int32_t source_fd) noexcept;
+  void take_stdout_fd(::std::int32_t source_fd) noexcept;
+  void take_stderr_fd(::std::int32_t source_fd) noexcept;
+  void take_stdout_and_stderr_fd(::std::int32_t source_fd) noexcept;
+  void bind_read(::rust::Str src, ::rust::Str dest) noexcept;
+  void bind_readwrite(::rust::Str src, ::rust::Str dest) noexcept;
+  void setup_compat_var();
+  void run(::rpmostreecxx::GCancellable const &cancellable);
+  ~Bubblewrap() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$Bubblewrap
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$ExportedManifestDiff
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$ExportedManifestDiff
-struct ExportedManifestDiff final
-{
+struct ExportedManifestDiff final {
   // Check if the struct is initialized
-  bool initialized CXX_DEFAULT_VALUE (false);
+  bool initialized CXX_DEFAULT_VALUE(false);
   // The total number of packages in the next upgrade
-  ::std::uint64_t total CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t total CXX_DEFAULT_VALUE(0);
   // The size of the total number of packages in the next upgrade
-  ::std::uint64_t total_size CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t total_size CXX_DEFAULT_VALUE(0);
   // The total number of removed packages in the next upgrade
-  ::std::uint64_t n_removed CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t n_removed CXX_DEFAULT_VALUE(0);
   // The size of total number of removed packages in the next upgrade
-  ::std::uint64_t removed_size CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t removed_size CXX_DEFAULT_VALUE(0);
   // The total number of added packages in the next upgrade
-  ::std::uint64_t n_added CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t n_added CXX_DEFAULT_VALUE(0);
   // The size of total number of added packages in the next upgrade
-  ::std::uint64_t added_size CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t added_size CXX_DEFAULT_VALUE(0);
   // The version of the next upgrade
   ::rust::String version;
 
@@ -1470,11 +1248,10 @@ struct ExportedManifestDiff final
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$ContainerImageState
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$ContainerImageState
-// `ContainerImageState` is currently identical to ostree-rs-ext's `LayeredImageState` struct,
-// because cxx.rs currently requires types used as extern Rust types to be defined by the same crate
+// `ContainerImageState` is currently identical to ostree-rs-ext's `LayeredImageState` struct, because
+// cxx.rs currently requires types used as extern Rust types to be defined by the same crate
 // that contains the bridge using them, so we redefine an `ContainerImport` struct here.
-struct ContainerImageState final
-{
+struct ContainerImageState final {
   ::rust::String base_commit;
   ::rust::String merge_commit;
   ::rust::String image_digest;
@@ -1488,21 +1265,19 @@ struct ContainerImageState final
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$PrunedContainerInfo
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$PrunedContainerInfo
-struct PrunedContainerInfo final
-{
-  ::std::uint32_t images CXX_DEFAULT_VALUE (0);
-  ::std::uint32_t layers CXX_DEFAULT_VALUE (0);
+struct PrunedContainerInfo final {
+  ::std::uint32_t images CXX_DEFAULT_VALUE(0);
+  ::std::uint32_t layers CXX_DEFAULT_VALUE(0);
 
-  bool operator== (PrunedContainerInfo const &) const noexcept;
-  bool operator!= (PrunedContainerInfo const &) const noexcept;
+  bool operator==(PrunedContainerInfo const &) const noexcept;
+  bool operator!=(PrunedContainerInfo const &) const noexcept;
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$PrunedContainerInfo
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$RefspecType
 #define CXXBRIDGE1_ENUM_rpmostreecxx$RefspecType
-enum class RefspecType : ::std::uint8_t
-{
+enum class RefspecType : ::std::uint8_t {
   Ostree = 0,
   Checksum = 1,
   Container = 2,
@@ -1511,45 +1286,40 @@ enum class RefspecType : ::std::uint8_t
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$TempEtcGuard
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$TempEtcGuard
-struct TempEtcGuard final : public ::rust::Opaque
-{
-  void undo () const;
-  ~TempEtcGuard () = delete;
+struct TempEtcGuard final : public ::rust::Opaque {
+  void undo() const;
+  ~TempEtcGuard() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$TempEtcGuard
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$FilesystemScriptPrep
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$FilesystemScriptPrep
-struct FilesystemScriptPrep final : public ::rust::Opaque
-{
-  void undo ();
-  ~FilesystemScriptPrep () = delete;
+struct FilesystemScriptPrep final : public ::rust::Opaque {
+  void undo();
+  ~FilesystemScriptPrep() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$FilesystemScriptPrep
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$DeploymentLayeredMeta
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$DeploymentLayeredMeta
-struct DeploymentLayeredMeta final
-{
-  bool is_layered CXX_DEFAULT_VALUE (false);
+struct DeploymentLayeredMeta final {
+  bool is_layered CXX_DEFAULT_VALUE(false);
   ::rust::String base_commit;
-  ::std::uint32_t clientlayer_version CXX_DEFAULT_VALUE (0);
+  ::std::uint32_t clientlayer_version CXX_DEFAULT_VALUE(0);
 
   using IsRelocatable = ::std::true_type;
 };
@@ -1557,8 +1327,7 @@ struct DeploymentLayeredMeta final
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacementSource
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacementSource
-struct OverrideReplacementSource final
-{
+struct OverrideReplacementSource final {
   ::rpmostreecxx::OverrideReplacementType kind;
   ::rust::String name;
 
@@ -1568,8 +1337,7 @@ struct OverrideReplacementSource final
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$ParsedRevisionKind
 #define CXXBRIDGE1_ENUM_rpmostreecxx$ParsedRevisionKind
-enum class ParsedRevisionKind : ::std::uint8_t
-{
+enum class ParsedRevisionKind : ::std::uint8_t {
   Version = 0,
   Checksum = 1,
 };
@@ -1577,8 +1345,7 @@ enum class ParsedRevisionKind : ::std::uint8_t
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$ParsedRevision
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$ParsedRevision
-struct ParsedRevision final
-{
+struct ParsedRevision final {
   ::rpmostreecxx::ParsedRevisionKind kind;
   ::rust::String value;
 
@@ -1588,50 +1355,44 @@ struct ParsedRevision final
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporterFlags
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporterFlags
-struct RpmImporterFlags final : public ::rust::Opaque
-{
-  bool is_ima_enabled () const noexcept;
-  ~RpmImporterFlags () = delete;
+struct RpmImporterFlags final : public ::rust::Opaque {
+  bool is_ima_enabled() const noexcept;
+  ~RpmImporterFlags() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporterFlags
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporter
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporter
-struct RpmImporter final : public ::rust::Opaque
-{
-  ::rust::String handle_translate_pathname (::rust::Str path) noexcept;
-  ::rust::String ostree_branch () const noexcept;
-  ::rust::String pkg_name () const noexcept;
-  bool doc_files_are_filtered () const noexcept;
-  void doc_files_insert (::rust::Str path) noexcept;
-  bool doc_files_contains (::rust::Str path) const noexcept;
-  void rpmfi_overrides_insert (::rust::Str path, ::std::uint64_t index) noexcept;
-  bool rpmfi_overrides_contains (::rust::Str path) const noexcept;
-  ::std::uint64_t rpmfi_overrides_get (::rust::Str path) const noexcept;
-  bool is_ima_enabled () const noexcept;
-  void tweak_imported_file_info (::rpmostreecxx::GFileInfo const &file_info) const noexcept;
-  bool is_file_filtered (::rust::Str path, ::rpmostreecxx::GFileInfo const &file_info) const;
-  void translate_to_tmpfiles_entry (::rust::Str abs_path,
-                                    ::rpmostreecxx::GFileInfo const &file_info,
-                                    ::rust::Str username, ::rust::Str groupname);
-  bool has_tmpfiles_entries () const noexcept;
-  ::rust::String serialize_tmpfiles_content () const noexcept;
-  ~RpmImporter () = delete;
+struct RpmImporter final : public ::rust::Opaque {
+  ::rust::String handle_translate_pathname(::rust::Str path) noexcept;
+  ::rust::String ostree_branch() const noexcept;
+  ::rust::String pkg_name() const noexcept;
+  bool doc_files_are_filtered() const noexcept;
+  void doc_files_insert(::rust::Str path) noexcept;
+  bool doc_files_contains(::rust::Str path) const noexcept;
+  void rpmfi_overrides_insert(::rust::Str path, ::std::uint64_t index) noexcept;
+  bool rpmfi_overrides_contains(::rust::Str path) const noexcept;
+  ::std::uint64_t rpmfi_overrides_get(::rust::Str path) const noexcept;
+  bool is_ima_enabled() const noexcept;
+  void tweak_imported_file_info(::rpmostreecxx::GFileInfo const &file_info) const noexcept;
+  bool is_file_filtered(::rust::Str path, ::rpmostreecxx::GFileInfo const &file_info) const;
+  void translate_to_tmpfiles_entry(::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username, ::rust::Str groupname);
+  bool has_tmpfiles_entries() const noexcept;
+  ::rust::String serialize_tmpfiles_content() const noexcept;
+  ~RpmImporter() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporter
@@ -1640,81 +1401,73 @@ private:
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryEntry
 // A history entry in the journal. It may represent multiple consecutive boots
 // into the same deployment. This struct is exposed directly via FFI to C.
-struct HistoryEntry final
-{
+struct HistoryEntry final {
   // The deployment root timestamp.
-  ::std::uint64_t deploy_timestamp CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t deploy_timestamp CXX_DEFAULT_VALUE(0);
   // The command-line that was used to create the deployment, if any.
   ::rust::String deploy_cmdline;
   // The number of consecutive times the deployment was booted.
-  ::std::uint64_t boot_count CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t boot_count CXX_DEFAULT_VALUE(0);
   // The first time the deployment was booted if multiple consecutive times.
-  ::std::uint64_t first_boot_timestamp CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t first_boot_timestamp CXX_DEFAULT_VALUE(0);
   // The last time the deployment was booted if multiple consecutive times.
-  ::std::uint64_t last_boot_timestamp CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t last_boot_timestamp CXX_DEFAULT_VALUE(0);
   // `true` if there are no more entries.
-  bool eof CXX_DEFAULT_VALUE (false);
+  bool eof CXX_DEFAULT_VALUE(false);
 
-  bool operator== (HistoryEntry const &) const noexcept;
-  bool operator!= (HistoryEntry const &) const noexcept;
+  bool operator==(HistoryEntry const &) const noexcept;
+  bool operator!=(HistoryEntry const &) const noexcept;
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryEntry
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryCtx
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryCtx
-struct HistoryCtx final : public ::rust::Opaque
-{
-  ::rpmostreecxx::HistoryEntry next_entry ();
-  ~HistoryCtx () = delete;
+struct HistoryCtx final : public ::rust::Opaque {
+  ::rpmostreecxx::HistoryEntry next_entry();
+  ~HistoryCtx() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryCtx
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$TokioHandle
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$TokioHandle
-struct TokioHandle final : public ::rust::Opaque
-{
-  ::rust::Box<::rpmostreecxx::TokioEnterGuard> enter () const noexcept;
-  ~TokioHandle () = delete;
+struct TokioHandle final : public ::rust::Opaque {
+  ::rust::Box<::rpmostreecxx::TokioEnterGuard> enter() const noexcept;
+  ~TokioHandle() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$TokioHandle
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$TokioEnterGuard
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$TokioEnterGuard
-struct TokioEnterGuard final : public ::rust::Opaque
-{
-  ~TokioEnterGuard () = delete;
+struct TokioEnterGuard final : public ::rust::Opaque {
+  ~TokioEnterGuard() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$TokioEnterGuard
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$RepoMetadataTarget
 #define CXXBRIDGE1_ENUM_rpmostreecxx$RepoMetadataTarget
-enum class RepoMetadataTarget : ::std::uint8_t
-{
+enum class RepoMetadataTarget : ::std::uint8_t {
   Inline = 0,
   Detached = 1,
   Disabled = 2,
@@ -1723,8 +1476,7 @@ enum class RepoMetadataTarget : ::std::uint8_t
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$AdvisoriesMetadataTarget
 #define CXXBRIDGE1_ENUM_rpmostreecxx$AdvisoriesMetadataTarget
-enum class AdvisoriesMetadataTarget : ::std::uint8_t
-{
+enum class AdvisoriesMetadataTarget : ::std::uint8_t {
   Inline = 0,
   Detached = 1,
   Disabled = 2,
@@ -1733,43 +1485,39 @@ enum class AdvisoriesMetadataTarget : ::std::uint8_t
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Refspec
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Refspec
-struct Refspec final
-{
+struct Refspec final {
   ::rpmostreecxx::RefspecType kind;
   ::rust::String refspec;
 
-  bool operator== (Refspec const &) const noexcept;
-  bool operator!= (Refspec const &) const noexcept;
+  bool operator==(Refspec const &) const noexcept;
+  bool operator!=(Refspec const &) const noexcept;
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$Refspec
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$OverrideReplacementType
 #define CXXBRIDGE1_ENUM_rpmostreecxx$OverrideReplacementType
-enum class OverrideReplacementType : ::std::uint8_t
-{
+enum class OverrideReplacementType : ::std::uint8_t {
   Repo = 0,
 };
 #endif // CXXBRIDGE1_ENUM_rpmostreecxx$OverrideReplacementType
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacement
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacement
-struct OverrideReplacement final
-{
+struct OverrideReplacement final {
   ::rust::String from;
   ::rpmostreecxx::OverrideReplacementType from_kind;
   ::rust::Vec<::rust::String> packages;
 
-  bool operator== (OverrideReplacement const &) const noexcept;
-  bool operator!= (OverrideReplacement const &) const noexcept;
+  bool operator==(OverrideReplacement const &) const noexcept;
+  bool operator!=(OverrideReplacement const &) const noexcept;
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacement
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$OptUsrLocal
 #define CXXBRIDGE1_ENUM_rpmostreecxx$OptUsrLocal
-enum class OptUsrLocal : ::std::uint8_t
-{
+enum class OptUsrLocal : ::std::uint8_t {
   Var = 0,
   Root = 1,
   StateOverlay = 2,
@@ -1778,131 +1526,125 @@ enum class OptUsrLocal : ::std::uint8_t
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Treefile
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Treefile
-struct Treefile final : public ::rust::Opaque
-{
-  ::rust::Str get_workdir () const noexcept;
-  ::std::int32_t get_passwd_fd () noexcept;
-  ::std::int32_t get_group_fd () noexcept;
-  ::rust::String get_json_string () const noexcept;
-  ::rust::Vec<::rust::String> get_ostree_layers () const noexcept;
-  ::rust::Vec<::rust::String> get_ostree_override_layers () const noexcept;
-  ::rust::Vec<::rust::String> get_all_ostree_layers () const noexcept;
-  ::rust::Vec<::rust::String> get_repos () const noexcept;
-  ::rust::Vec<::rust::String> get_packages () const noexcept;
-  ::rust::String require_automatic_version_prefix () const;
-  bool add_packages (::rust::Vec<::rust::String> packages, bool allow_existing);
-  bool has_packages () const noexcept;
-  ::rust::Vec<::rust::String> get_local_packages () const noexcept;
-  bool add_local_packages (::rust::Vec<::rust::String> packages, bool allow_existing);
-  ::rust::Vec<::rust::String> get_local_fileoverride_packages () const noexcept;
-  bool add_local_fileoverride_packages (::rust::Vec<::rust::String> packages, bool allow_existing);
-  bool remove_packages (::rust::Vec<::rust::String> packages, bool allow_noent);
-  ::rust::Vec<::rpmostreecxx::OverrideReplacement> get_packages_override_replace () const noexcept;
-  bool has_packages_override_replace () const noexcept;
-  bool add_packages_override_replace (::rpmostreecxx::OverrideReplacement replacement) noexcept;
-  bool remove_package_override_replace (::rust::Str package) noexcept;
-  ::rust::Vec<::rust::String> get_packages_override_replace_local () const noexcept;
-  void add_packages_override_replace_local (::rust::Vec<::rust::String> packages);
-  bool remove_package_override_replace_local (::rust::Str package) noexcept;
-  ::rust::Vec<::rust::String> get_packages_override_remove () const noexcept;
-  void add_packages_override_remove (::rust::Vec<::rust::String> packages);
-  bool remove_package_override_remove (::rust::Str package) noexcept;
-  bool has_packages_override_remove_name (::rust::Str name) const noexcept;
-  bool remove_all_overrides () noexcept;
-  bool remove_all_packages () noexcept;
-  ::rust::Vec<::rust::String> get_exclude_packages () const noexcept;
-  ::rust::String get_platform_module () const noexcept;
-  ::rust::Vec<::rust::String> get_install_langs () const noexcept;
-  ::rust::String format_install_langs_macro () const noexcept;
-  ::rust::Vec<::rust::String> get_lockfile_repos () const noexcept;
-  ::rust::Str get_ref () const noexcept;
-  bool get_cliwrap () const noexcept;
-  ::rust::Vec<::rust::String> get_cliwrap_binaries () const noexcept;
-  void set_cliwrap (bool enabled) noexcept;
-  ::rust::Vec<::rust::String> get_container_cmd () const noexcept;
-  bool get_readonly_executables () const noexcept;
-  bool get_documentation () const noexcept;
-  bool get_recommends () const noexcept;
-  bool get_selinux () const noexcept;
-  bool get_sysusers_is_forced () const noexcept;
-  ::std::uint32_t get_selinux_label_version () const noexcept;
-  ::rust::String get_gpg_key () const noexcept;
-  ::rust::String get_automatic_version_suffix () const noexcept;
-  bool get_container () const noexcept;
-  bool get_machineid_compat () const noexcept;
-  ::rust::Vec<::rust::String> get_etc_group_members () const noexcept;
-  bool get_boot_location_is_modules () const noexcept;
-  bool use_kernel_install () const noexcept;
-  bool get_ima () const noexcept;
-  ::rust::String get_releasever () const noexcept;
-  ::rpmostreecxx::RepoMetadataTarget get_repo_metadata_target () const noexcept;
-  ::rpmostreecxx::AdvisoriesMetadataTarget get_advisories_metadata_target () const noexcept;
-  bool rpmdb_backend_is_target () const noexcept;
-  bool should_normalize_rpmdb () const noexcept;
-  ::rpmostreecxx::OptUsrLocal get_opt_usrlocal () const noexcept;
-  ::rust::Vec<::rust::String> get_files_remove_regex (::rust::Str package) const noexcept;
-  ::rust::String get_checksum (::rpmostreecxx::OstreeRepo const &repo) const;
-  ::rust::String get_ostree_ref () const noexcept;
-  ::rust::Slice<::rpmostreecxx::RepoPackage const> get_repo_packages () const noexcept;
-  void clear_repo_packages () noexcept;
-  void prettyprint_json_stdout () const noexcept;
-  void print_deprecation_warnings () const noexcept;
-  void print_experimental_notices () const noexcept;
-  void sanitycheck_externals () const;
-  ::rust::Box<::rpmostreecxx::RpmImporterFlags>
-  importer_flags (::rust::Str pkg_name) const noexcept;
-  ::rust::String write_repovars (::std::int32_t workdir_dfd_raw) const;
-  void set_releasever (::rust::Str releasever);
-  void set_recommends (bool val);
-  void enable_repo (::rust::Str repo);
-  void disable_repo (::rust::Str repo);
-  void validate_for_container () const;
-  ::rpmostreecxx::Refspec get_base_refspec () const noexcept;
-  void rebase (::rust::Str new_refspec, ::rust::Str custom_origin_url,
-               ::rust::Str custom_origin_description) noexcept;
-  ::rust::String get_origin_custom_url () const noexcept;
-  ::rust::String get_origin_custom_description () const noexcept;
-  ::rust::String get_override_commit () const noexcept;
-  void set_override_commit (::rust::Str checksum) noexcept;
-  ::rust::Vec<::rust::String> get_initramfs_etc_files () const noexcept;
-  bool has_initramfs_etc_files () const noexcept;
-  bool initramfs_etc_files_track (::rust::Vec<::rust::String> files) noexcept;
-  bool initramfs_etc_files_untrack (::rust::Vec<::rust::String> files) noexcept;
-  bool initramfs_etc_files_untrack_all () noexcept;
-  bool get_initramfs_regenerate () const noexcept;
-  ::rust::Vec<::rust::String> get_initramfs_args () const noexcept;
-  void set_initramfs_regenerate (bool enabled, ::rust::Vec<::rust::String> args) noexcept;
-  ::rust::String get_unconfigured_state () const noexcept;
-  bool may_require_local_assembly () const noexcept;
-  bool has_any_packages () const noexcept;
-  bool merge_treefile (::rust::Str treefile);
-  bool get_no_initramfs () const noexcept;
-  ~Treefile () = delete;
+struct Treefile final : public ::rust::Opaque {
+  ::rust::Str get_workdir() const noexcept;
+  ::std::int32_t get_passwd_fd() noexcept;
+  ::std::int32_t get_group_fd() noexcept;
+  ::rust::String get_json_string() const noexcept;
+  ::rust::Vec<::rust::String> get_ostree_layers() const noexcept;
+  ::rust::Vec<::rust::String> get_ostree_override_layers() const noexcept;
+  ::rust::Vec<::rust::String> get_all_ostree_layers() const noexcept;
+  ::rust::Vec<::rust::String> get_repos() const noexcept;
+  ::rust::Vec<::rust::String> get_packages() const noexcept;
+  ::rust::String require_automatic_version_prefix() const;
+  bool add_packages(::rust::Vec<::rust::String> packages, bool allow_existing);
+  bool has_packages() const noexcept;
+  ::rust::Vec<::rust::String> get_local_packages() const noexcept;
+  bool add_local_packages(::rust::Vec<::rust::String> packages, bool allow_existing);
+  ::rust::Vec<::rust::String> get_local_fileoverride_packages() const noexcept;
+  bool add_local_fileoverride_packages(::rust::Vec<::rust::String> packages, bool allow_existing);
+  bool remove_packages(::rust::Vec<::rust::String> packages, bool allow_noent);
+  ::rust::Vec<::rpmostreecxx::OverrideReplacement> get_packages_override_replace() const noexcept;
+  bool has_packages_override_replace() const noexcept;
+  bool add_packages_override_replace(::rpmostreecxx::OverrideReplacement replacement) noexcept;
+  bool remove_package_override_replace(::rust::Str package) noexcept;
+  ::rust::Vec<::rust::String> get_packages_override_replace_local() const noexcept;
+  void add_packages_override_replace_local(::rust::Vec<::rust::String> packages);
+  bool remove_package_override_replace_local(::rust::Str package) noexcept;
+  ::rust::Vec<::rust::String> get_packages_override_remove() const noexcept;
+  void add_packages_override_remove(::rust::Vec<::rust::String> packages);
+  bool remove_package_override_remove(::rust::Str package) noexcept;
+  bool has_packages_override_remove_name(::rust::Str name) const noexcept;
+  bool remove_all_overrides() noexcept;
+  bool remove_all_packages() noexcept;
+  ::rust::Vec<::rust::String> get_exclude_packages() const noexcept;
+  ::rust::String get_platform_module() const noexcept;
+  ::rust::Vec<::rust::String> get_install_langs() const noexcept;
+  ::rust::String format_install_langs_macro() const noexcept;
+  ::rust::Vec<::rust::String> get_lockfile_repos() const noexcept;
+  ::rust::Str get_ref() const noexcept;
+  bool get_cliwrap() const noexcept;
+  ::rust::Vec<::rust::String> get_cliwrap_binaries() const noexcept;
+  void set_cliwrap(bool enabled) noexcept;
+  ::rust::Vec<::rust::String> get_container_cmd() const noexcept;
+  bool get_readonly_executables() const noexcept;
+  bool get_documentation() const noexcept;
+  bool get_recommends() const noexcept;
+  bool get_selinux() const noexcept;
+  bool get_sysusers_is_forced() const noexcept;
+  ::std::uint32_t get_selinux_label_version() const noexcept;
+  ::rust::String get_gpg_key() const noexcept;
+  ::rust::String get_automatic_version_suffix() const noexcept;
+  bool get_container() const noexcept;
+  bool get_machineid_compat() const noexcept;
+  ::rust::Vec<::rust::String> get_etc_group_members() const noexcept;
+  bool get_boot_location_is_modules() const noexcept;
+  bool use_kernel_install() const noexcept;
+  bool get_ima() const noexcept;
+  ::rust::String get_releasever() const noexcept;
+  ::rpmostreecxx::RepoMetadataTarget get_repo_metadata_target() const noexcept;
+  ::rpmostreecxx::AdvisoriesMetadataTarget get_advisories_metadata_target() const noexcept;
+  bool rpmdb_backend_is_target() const noexcept;
+  bool should_normalize_rpmdb() const noexcept;
+  ::rpmostreecxx::OptUsrLocal get_opt_usrlocal() const noexcept;
+  ::rust::Vec<::rust::String> get_files_remove_regex(::rust::Str package) const noexcept;
+  ::rust::String get_checksum(::rpmostreecxx::OstreeRepo const &repo) const;
+  ::rust::String get_ostree_ref() const noexcept;
+  ::rust::Slice<::rpmostreecxx::RepoPackage const> get_repo_packages() const noexcept;
+  void clear_repo_packages() noexcept;
+  void prettyprint_json_stdout() const noexcept;
+  void print_deprecation_warnings() const noexcept;
+  void print_experimental_notices() const noexcept;
+  void sanitycheck_externals() const;
+  ::rust::Box<::rpmostreecxx::RpmImporterFlags> importer_flags(::rust::Str pkg_name) const noexcept;
+  ::rust::String write_repovars(::std::int32_t workdir_dfd_raw) const;
+  void set_releasever(::rust::Str releasever);
+  void set_recommends(bool val);
+  void enable_repo(::rust::Str repo);
+  void disable_repo(::rust::Str repo);
+  void validate_for_container() const;
+  ::rpmostreecxx::Refspec get_base_refspec() const noexcept;
+  void rebase(::rust::Str new_refspec, ::rust::Str custom_origin_url, ::rust::Str custom_origin_description) noexcept;
+  ::rust::String get_origin_custom_url() const noexcept;
+  ::rust::String get_origin_custom_description() const noexcept;
+  ::rust::String get_override_commit() const noexcept;
+  void set_override_commit(::rust::Str checksum) noexcept;
+  ::rust::Vec<::rust::String> get_initramfs_etc_files() const noexcept;
+  bool has_initramfs_etc_files() const noexcept;
+  bool initramfs_etc_files_track(::rust::Vec<::rust::String> files) noexcept;
+  bool initramfs_etc_files_untrack(::rust::Vec<::rust::String> files) noexcept;
+  bool initramfs_etc_files_untrack_all() noexcept;
+  bool get_initramfs_regenerate() const noexcept;
+  ::rust::Vec<::rust::String> get_initramfs_args() const noexcept;
+  void set_initramfs_regenerate(bool enabled, ::rust::Vec<::rust::String> args) noexcept;
+  ::rust::String get_unconfigured_state() const noexcept;
+  bool may_require_local_assembly() const noexcept;
+  bool has_any_packages() const noexcept;
+  bool merge_treefile(::rust::Str treefile);
+  bool get_no_initramfs() const noexcept;
+  ~Treefile() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$Treefile
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$RepoPackage
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$RepoPackage
-struct RepoPackage final : public ::rust::Opaque
-{
-  ::rust::Str get_repo () const noexcept;
-  ::rust::Vec<::rust::String> get_packages () const noexcept;
-  ~RepoPackage () = delete;
+struct RepoPackage final : public ::rust::Opaque {
+  ::rust::Str get_repo() const noexcept;
+  ::rust::Vec<::rust::String> get_packages() const noexcept;
+  ~RepoPackage() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$RepoPackage
@@ -1912,8 +1654,7 @@ private:
 // A copy of LiveFsState that is bridged to C++; the main
 // change here is we can't use Option<> yet, so empty values
 // are represented by the empty string.
-struct LiveApplyState final
-{
+struct LiveApplyState final {
   ::rust::String inprogress;
   ::rust::String commit;
 
@@ -1923,72 +1664,64 @@ struct LiveApplyState final
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdDB
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdDB
-struct PasswdDB final : public ::rust::Opaque
-{
-  ::rust::String lookup_user (::std::uint32_t uid) const;
-  ::rust::String lookup_group (::std::uint32_t gid) const;
-  ~PasswdDB () = delete;
+struct PasswdDB final : public ::rust::Opaque {
+  ::rust::String lookup_user(::std::uint32_t uid) const;
+  ::rust::String lookup_group(::std::uint32_t gid) const;
+  ~PasswdDB() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdDB
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdEntries
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdEntries
-struct PasswdEntries final : public ::rust::Opaque
-{
-  void add_group_content (::std::int32_t rootfs, ::rust::Str path);
-  void add_passwd_content (::std::int32_t rootfs, ::rust::Str path);
-  bool contains_group (::rust::Str user) const noexcept;
-  bool contains_user (::rust::Str user) const noexcept;
-  ::std::uint32_t lookup_user_id (::rust::Str user) const;
-  ::std::uint32_t lookup_group_id (::rust::Str group) const;
-  ~PasswdEntries () = delete;
+struct PasswdEntries final : public ::rust::Opaque {
+  void add_group_content(::std::int32_t rootfs, ::rust::Str path);
+  void add_passwd_content(::std::int32_t rootfs, ::rust::Str path);
+  bool contains_group(::rust::Str user) const noexcept;
+  bool contains_user(::rust::Str user) const noexcept;
+  ::std::uint32_t lookup_user_id(::rust::Str user) const;
+  ::std::uint32_t lookup_group_id(::rust::Str group) const;
+  ~PasswdEntries() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdEntries
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Extensions
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Extensions
-struct Extensions final : public ::rust::Opaque
-{
-  ::rust::Vec<::rust::String> get_repos () const noexcept;
-  ::rust::Vec<::rust::String> get_os_extension_packages () const noexcept;
-  ::rust::Vec<::rust::String> get_development_packages () const noexcept;
-  bool state_checksum_changed (::rust::Str chksum, ::rust::Str output_dir) const;
-  void update_state_checksum (::rust::Str chksum, ::rust::Str output_dir) const;
-  void serialize_to_dir (::rust::Str output_dir) const;
-  ::rust::Box<::rpmostreecxx::Treefile>
-  generate_treefile (::rpmostreecxx::Treefile const &src) const;
-  ~Extensions () = delete;
+struct Extensions final : public ::rust::Opaque {
+  ::rust::Vec<::rust::String> get_repos() const noexcept;
+  ::rust::Vec<::rust::String> get_os_extension_packages() const noexcept;
+  ::rust::Vec<::rust::String> get_development_packages() const noexcept;
+  bool state_checksum_changed(::rust::Str chksum, ::rust::Str output_dir) const;
+  void update_state_checksum(::rust::Str chksum, ::rust::Str output_dir) const;
+  void serialize_to_dir(::rust::Str output_dir) const;
+  ::rust::Box<::rpmostreecxx::Treefile> generate_treefile(::rpmostreecxx::Treefile const &src) const;
+  ~Extensions() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$Extensions
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$LockedPackage
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$LockedPackage
-struct LockedPackage final
-{
+struct LockedPackage final {
   ::rust::String name;
   ::rust::String evr;
   ::rust::String arch;
@@ -2000,4950 +1733,3262 @@ struct LockedPackage final
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$LockfileConfig
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$LockfileConfig
-struct LockfileConfig final : public ::rust::Opaque
-{
-  ::rust::Vec<::rpmostreecxx::LockedPackage> get_locked_packages () const;
-  ~LockfileConfig () = delete;
+struct LockfileConfig final : public ::rust::Opaque {
+  ::rust::Vec<::rpmostreecxx::LockedPackage> get_locked_packages() const;
+  ~LockfileConfig() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$LockfileConfig
 
-static_assert (::std::is_enum<RpmOstreeDiffPrintFormat>::value, "expected enum");
-static_assert (sizeof (RpmOstreeDiffPrintFormat) == sizeof (::std::uint8_t), "incorrect size");
-static_assert (
-    static_cast<::std::uint8_t> (RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_SUMMARY)
-        == 0,
-    "disagrees with the value in #[cxx::bridge]");
-static_assert (
-    static_cast<::std::uint8_t> (RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_ALIGNED)
-        == 1,
-    "disagrees with the value in #[cxx::bridge]");
-static_assert (static_cast<::std::uint8_t> (
-                   RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE)
-                   == 2,
-               "disagrees with the value in #[cxx::bridge]");
-} // namespace rpmostreecxx
+static_assert(::std::is_enum<RpmOstreeDiffPrintFormat>::value, "expected enum");
+static_assert(sizeof(RpmOstreeDiffPrintFormat) == sizeof(::std::uint8_t), "incorrect size");
+static_assert(static_cast<::std::uint8_t>(RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_SUMMARY) == 0, "disagrees with the value in #[cxx::bridge]");
+static_assert(static_cast<::std::uint8_t>(RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_ALIGNED) == 1, "disagrees with the value in #[cxx::bridge]");
+static_assert(static_cast<::std::uint8_t>(RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE) == 2, "disagrees with the value in #[cxx::bridge]");
 
-static_assert (
-    ::rust::IsRelocatable<::rpmostreecxx::GObject>::value,
-    "type rpmostreecxx::GObject should be trivially move constructible and trivially destructible "
-    "in C++ to be used as a non-pinned mutable reference in signature of `get` in Rust");
-static_assert (::rust::IsRelocatable<::dnfcxx::FFIDnfPackage>::value,
-               "type dnfcxx::FFIDnfPackage should be trivially move constructible and trivially "
-               "destructible in C++ to be used as a non-pinned mutable reference in signature of "
-               "`get_repodata_chksum_repr` in Rust");
+extern "C" {
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$is_bare_split_xattrs(bool *return$) noexcept;
 
-namespace rpmostreecxx
-{
-extern "C"
-{
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$is_bare_split_xattrs (bool *return$) noexcept;
+bool rpmostreecxx$cxxbridge1$194$is_http_arg(::rust::Str arg) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$is_http_arg (::rust::Str arg) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$is_ostree_container(bool *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$is_ostree_container (bool *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$get_system_host_type(::rpmostreecxx::SystemHostType *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$get_system_host_type (::rpmostreecxx::SystemHostType *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$require_system_host_type(::rpmostreecxx::SystemHostType t) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$require_system_host_type (::rpmostreecxx::SystemHostType t) noexcept;
+bool rpmostreecxx$cxxbridge1$194$is_rpm_arg(::rust::Str arg) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$is_rpm_arg (::rust::Str arg) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$client_start_daemon() noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$client_start_daemon () noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$client_handle_fd_argument(::rust::Str arg, ::rust::Str arch, bool is_replace, ::rust::Vec<::std::int32_t> *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$client_handle_fd_argument (::rust::Str arg, ::rust::Str arch,
-                                                     bool is_replace,
-                                                     ::rust::Vec<::std::int32_t> *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$client_render_download_progress(::rpmostreecxx::GVariant const &progress, ::rust::String *return$) noexcept;
 
-  void
-  rpmostreecxx$cxxbridge1$client_render_download_progress (::rpmostreecxx::GVariant const &progress,
-                                                           ::rust::String *return$) noexcept;
+bool rpmostreecxx$cxxbridge1$194$running_in_container() noexcept;
 
-  bool rpmostreecxx$cxxbridge1$running_in_container () noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$confirm(bool *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$confirm (bool *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$confirm_or_abort() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$Bubblewrap$operator$sizeof() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$Bubblewrap$operator$alignof() noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$confirm_or_abort () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$Bubblewrap$operator$sizeof () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$Bubblewrap$operator$alignof () noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$bubblewrap_selftest() noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$bubblewrap_selftest () noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$bubblewrap_run_sync(::std::int32_t rootfs_dfd, ::rust::Vec<::rust::String> const &args, bool capture_stdout, ::rpmostreecxx::BubblewrapMutability mutability, ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$bubblewrap_run_sync (
-      ::std::int32_t rootfs_dfd, ::rust::Vec<::rust::String> const &args, bool capture_stdout,
-      ::rpmostreecxx::BubblewrapMutability mutability,
-      ::rust::Vec<::std::uint8_t> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$bubblewrap_new(::std::int32_t rootfs_fd, ::rust::Box<::rpmostreecxx::Bubblewrap> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$bubblewrap_new (
-      ::std::int32_t rootfs_fd, ::rust::Box<::rpmostreecxx::Bubblewrap> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$bubblewrap_new_with_mutability(::std::int32_t rootfs_fd, ::rpmostreecxx::BubblewrapMutability mutability, ::rust::Box<::rpmostreecxx::Bubblewrap> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$bubblewrap_new_with_mutability (
-      ::std::int32_t rootfs_fd, ::rpmostreecxx::BubblewrapMutability mutability,
-      ::rust::Box<::rpmostreecxx::Bubblewrap> *return$) noexcept;
+::std::int32_t rpmostreecxx$cxxbridge1$194$Bubblewrap$get_rootfs_fd(::rpmostreecxx::Bubblewrap const &self) noexcept;
 
-  ::std::int32_t rpmostreecxx$cxxbridge1$Bubblewrap$get_rootfs_fd (
-      ::rpmostreecxx::Bubblewrap const &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$Bubblewrap$append_bwrap_arg(::rpmostreecxx::Bubblewrap &self, ::rust::Str arg) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Bubblewrap$append_bwrap_arg (::rpmostreecxx::Bubblewrap &self,
-                                                            ::rust::Str arg) noexcept;
+void rpmostreecxx$cxxbridge1$194$Bubblewrap$append_child_arg(::rpmostreecxx::Bubblewrap &self, ::rust::Str arg) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Bubblewrap$append_child_arg (::rpmostreecxx::Bubblewrap &self,
-                                                            ::rust::Str arg) noexcept;
+void rpmostreecxx$cxxbridge1$194$Bubblewrap$setenv(::rpmostreecxx::Bubblewrap &self, ::rust::Str k, ::rust::Str v) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Bubblewrap$setenv (::rpmostreecxx::Bubblewrap &self, ::rust::Str k,
-                                                  ::rust::Str v) noexcept;
+void rpmostreecxx$cxxbridge1$194$Bubblewrap$take_fd(::rpmostreecxx::Bubblewrap &self, ::std::int32_t source_fd, ::std::int32_t target_fd) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Bubblewrap$take_fd (::rpmostreecxx::Bubblewrap &self,
-                                                   ::std::int32_t source_fd,
-                                                   ::std::int32_t target_fd) noexcept;
+void rpmostreecxx$cxxbridge1$194$Bubblewrap$set_inherit_stdin(::rpmostreecxx::Bubblewrap &self) noexcept;
 
-  void
-  rpmostreecxx$cxxbridge1$Bubblewrap$set_inherit_stdin (::rpmostreecxx::Bubblewrap &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdin_fd(::rpmostreecxx::Bubblewrap &self, ::std::int32_t source_fd) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Bubblewrap$take_stdin_fd (::rpmostreecxx::Bubblewrap &self,
-                                                         ::std::int32_t source_fd) noexcept;
+void rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdout_fd(::rpmostreecxx::Bubblewrap &self, ::std::int32_t source_fd) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Bubblewrap$take_stdout_fd (::rpmostreecxx::Bubblewrap &self,
-                                                          ::std::int32_t source_fd) noexcept;
+void rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stderr_fd(::rpmostreecxx::Bubblewrap &self, ::std::int32_t source_fd) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Bubblewrap$take_stderr_fd (::rpmostreecxx::Bubblewrap &self,
-                                                          ::std::int32_t source_fd) noexcept;
+void rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdout_and_stderr_fd(::rpmostreecxx::Bubblewrap &self, ::std::int32_t source_fd) noexcept;
 
-  void
-  rpmostreecxx$cxxbridge1$Bubblewrap$take_stdout_and_stderr_fd (::rpmostreecxx::Bubblewrap &self,
-                                                                ::std::int32_t source_fd) noexcept;
+void rpmostreecxx$cxxbridge1$194$Bubblewrap$bind_read(::rpmostreecxx::Bubblewrap &self, ::rust::Str src, ::rust::Str dest) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Bubblewrap$bind_read (::rpmostreecxx::Bubblewrap &self,
-                                                     ::rust::Str src, ::rust::Str dest) noexcept;
+void rpmostreecxx$cxxbridge1$194$Bubblewrap$bind_readwrite(::rpmostreecxx::Bubblewrap &self, ::rust::Str src, ::rust::Str dest) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Bubblewrap$bind_readwrite (::rpmostreecxx::Bubblewrap &self,
-                                                          ::rust::Str src,
-                                                          ::rust::Str dest) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Bubblewrap$setup_compat_var(::rpmostreecxx::Bubblewrap &self) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$Bubblewrap$setup_compat_var (::rpmostreecxx::Bubblewrap &self) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Bubblewrap$run(::rpmostreecxx::Bubblewrap &self, ::rpmostreecxx::GCancellable const &cancellable) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$Bubblewrap$run (::rpmostreecxx::Bubblewrap &self,
-                                          ::rpmostreecxx::GCancellable const &cancellable) noexcept;
+::rpmostreecxx::BubblewrapMutability rpmostreecxx$cxxbridge1$194$mutability_for_unified_core(bool unified_core) noexcept;
 
-  ::rpmostreecxx::BubblewrapMutability
-  rpmostreecxx$cxxbridge1$mutability_for_unified_core (bool unified_core) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$usroverlay_entrypoint(::rust::Vec<::rust::String> const &args) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$usroverlay_entrypoint (::rust::Vec<::rust::String> const &args) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$applylive_entrypoint(::rust::Vec<::rust::String> const &args) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$applylive_entrypoint (::rust::Vec<::rust::String> const &args) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$applylive_finish(::rpmostreecxx::OstreeSysroot const &sysroot) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$applylive_finish (::rpmostreecxx::OstreeSysroot const &sysroot) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$composeutil_legacy_prep_dev_and_run(::std::int32_t rootfs_dfd) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$composeutil_legacy_prep_dev_and_run (::std::int32_t rootfs_dfd) noexcept;
+void rpmostreecxx$cxxbridge1$194$print_ostree_txn_stats(::rpmostreecxx::OstreeRepoTransactionStats &stats) noexcept;
 
-  void rpmostreecxx$cxxbridge1$print_ostree_txn_stats (
-      ::rpmostreecxx::OstreeRepoTransactionStats &stats) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$write_commit_id(::rust::Str target_path, ::rust::Str revision) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$write_commit_id (::rust::Str target_path,
-                                                                ::rust::Str revision) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$cliwrap_write_wrappers(::std::int32_t rootfs) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$cliwrap_write_wrappers (::std::int32_t rootfs) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$cliwrap_write_some_wrappers(::std::int32_t rootfs, ::rust::Vec<::rust::String> const &args) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$cliwrap_write_some_wrappers (
-      ::std::int32_t rootfs, ::rust::Vec<::rust::String> const &args) noexcept;
+void rpmostreecxx$cxxbridge1$194$cliwrap_destdir(::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$cliwrap_destdir (::rust::String *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$container_encapsulate(::rust::Vec<::rust::String> *args) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$container_encapsulate (::rust::Vec<::rust::String> *args) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deploy_from_self_entrypoint(::rust::Vec<::rust::String> *args) noexcept;
+bool rpmostreecxx$cxxbridge1$194$PrunedContainerInfo$operator$eq(PrunedContainerInfo const &, PrunedContainerInfo const &) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$deploy_from_self_entrypoint (::rust::Vec<::rust::String> *args) noexcept;
-  bool
-  rpmostreecxx$cxxbridge1$PrunedContainerInfo$operator$eq (PrunedContainerInfo const &,
-                                                           PrunedContainerInfo const &) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$pull_container(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref, ::rust::Str digest_override, ::rust::Box<::rpmostreecxx::ContainerImageState> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$pull_container (
-      ::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable,
-      ::rust::Str imgref, ::rust::Str digest_override,
-      ::rust::Box<::rpmostreecxx::ContainerImageState> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$container_prune(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::PrunedContainerInfo *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$container_prune (::rpmostreecxx::OstreeSysroot const &sysroot,
-                                           ::rpmostreecxx::PrunedContainerInfo *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$query_container_image_commit(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str c, ::rust::Box<::rpmostreecxx::ContainerImageState> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$query_container_image_commit (
-      ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str c,
-      ::rust::Box<::rpmostreecxx::ContainerImageState> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$purge_refspec(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$purge_refspec (::rpmostreecxx::OstreeRepo const &repo,
-                                         ::rust::Str refspec) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$check_container_update(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref, bool *return$) noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$TempEtcGuard$operator$sizeof() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$TempEtcGuard$operator$alignof() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$operator$sizeof() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$operator$alignof() noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$check_container_update (::rpmostreecxx::OstreeRepo const &repo,
-                                                  ::rpmostreecxx::GCancellable const &cancellable,
-                                                  ::rust::Str imgref, bool *return$) noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$TempEtcGuard$operator$sizeof () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$TempEtcGuard$operator$alignof () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$FilesystemScriptPrep$operator$sizeof () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$FilesystemScriptPrep$operator$alignof () noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$prepare_tempetc_guard(::std::int32_t rootfs, ::rust::Box<::rpmostreecxx::TempEtcGuard> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$prepare_tempetc_guard (
-      ::std::int32_t rootfs, ::rust::Box<::rpmostreecxx::TempEtcGuard> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$TempEtcGuard$undo(::rpmostreecxx::TempEtcGuard const &self) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$TempEtcGuard$undo (::rpmostreecxx::TempEtcGuard const &self) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$prepare_filesystem_script_prep(::std::int32_t rootfs, ::rust::Box<::rpmostreecxx::FilesystemScriptPrep> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$prepare_filesystem_script_prep (
-      ::std::int32_t rootfs, ::rust::Box<::rpmostreecxx::FilesystemScriptPrep> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$undo(::rpmostreecxx::FilesystemScriptPrep &self) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$FilesystemScriptPrep$undo (
-      ::rpmostreecxx::FilesystemScriptPrep &self) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$run_depmod(::std::int32_t rootfs_dfd, ::rust::Str kver, bool unified_core) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$run_depmod (::std::int32_t rootfs_dfd,
-                                                           ::rust::Str kver,
-                                                           bool unified_core) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$run_sysusers(::std::int32_t rootfs_dfd, bool force) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$run_sysusers (::std::int32_t rootfs_dfd,
-                                                             bool force) noexcept;
+void rpmostreecxx$cxxbridge1$194$log_treefile(::rpmostreecxx::Treefile const &tf) noexcept;
 
-  void rpmostreecxx$cxxbridge1$log_treefile (::rpmostreecxx::Treefile const &tf) noexcept;
+bool rpmostreecxx$cxxbridge1$194$is_container_image_reference(::rust::Str refspec) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$is_container_image_reference (::rust::Str refspec) noexcept;
+bool rpmostreecxx$cxxbridge1$194$is_container_image_digest_reference(::rust::Str refspec) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$is_container_image_digest_reference (::rust::Str refspec) noexcept;
+::rpmostreecxx::RefspecType rpmostreecxx$cxxbridge1$194$refspec_classify(::rust::Str refspec) noexcept;
 
-  ::rpmostreecxx::RefspecType
-  rpmostreecxx$cxxbridge1$refspec_classify (::rust::Str refspec) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$verify_kernel_hmac(::std::int32_t rootfs, ::rust::Str moddir) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$verify_kernel_hmac (::std::int32_t rootfs,
-                                                                   ::rust::Str moddir) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$stage_container_rpms(::rust::Vec<::rust::String> *rpms, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$stage_container_rpms (::rust::Vec<::rust::String> *rpms,
-                                                ::rust::Vec<::rust::String> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$stage_container_rpm_raw_fds(::rust::Vec<::std::int32_t> *fds, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$stage_container_rpm_raw_fds (
-      ::rust::Vec<::std::int32_t> *fds, ::rust::Vec<::rust::String> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$commit_has_matching_sepolicy(::rpmostreecxx::GVariant const &commit, ::rpmostreecxx::OstreeSePolicy const &policy, bool *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$commit_has_matching_sepolicy (
-      ::rpmostreecxx::GVariant const &commit, ::rpmostreecxx::OstreeSePolicy const &policy,
-      bool *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$get_header_variant(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str cachebranch, ::rpmostreecxx::GVariant **return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$get_header_variant (::rpmostreecxx::OstreeRepo const &repo,
-                                              ::rust::Str cachebranch,
-                                              ::rpmostreecxx::GVariant **return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_build_chunked_oci_entrypoint(::rust::Vec<::rust::String> *args) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$compose_build_chunked_oci_entrypoint (
-      ::rust::Vec<::rust::String> *args) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_image(::rust::Vec<::rust::String> *args) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$compose_image (::rust::Vec<::rust::String> *args) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_rootfs_entrypoint(::rust::Vec<::rust::String> *args) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$compose_rootfs_entrypoint (::rust::Vec<::rust::String> *args) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$configure_build_repo_from_target(::rpmostreecxx::OstreeRepo const &build_repo, ::rpmostreecxx::OstreeRepo const &target_repo) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$configure_build_repo_from_target (
-      ::rpmostreecxx::OstreeRepo const &build_repo,
-      ::rpmostreecxx::OstreeRepo const &target_repo) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_prepare_rootfs(::std::int32_t src_rootfs_dfd, ::std::int32_t dest_rootfs_dfd, ::rpmostreecxx::Treefile &treefile) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$compose_prepare_rootfs (::std::int32_t src_rootfs_dfd,
-                                                  ::std::int32_t dest_rootfs_dfd,
-                                                  ::rpmostreecxx::Treefile &treefile) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$composepost_nsswitch_altfiles(::std::int32_t rootfs_dfd) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$composepost_nsswitch_altfiles (::std::int32_t rootfs_dfd) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_postprocess(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile, ::rust::Str next_version, bool unified_core) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$compose_postprocess (
-      ::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile, ::rust::Str next_version,
-      bool unified_core) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_postprocess_final_pre(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$compose_postprocess_final_pre (
-      ::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_postprocess_final(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$compose_postprocess_final (
-      ::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$convert_var_to_tmpfiles_d(::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable const &cancellable) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$convert_var_to_tmpfiles_d (
-      ::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable const &cancellable) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$rootfs_prepare_links(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile, bool skip_usrlocal) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$rootfs_prepare_links (::std::int32_t rootfs_dfd,
-                                                ::rpmostreecxx::Treefile const &treefile,
-                                                bool skip_usrlocal) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$workaround_selinux_cross_labeling(::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable &cancellable) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$workaround_selinux_cross_labeling (
-      ::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable &cancellable) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$postprocess_cleanup_rpmdb(::std::int32_t rootfs_dfd) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$postprocess_cleanup_rpmdb (::std::int32_t rootfs_dfd) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$rewrite_rpmdb_for_target(::std::int32_t rootfs_dfd, bool normalize) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$rewrite_rpmdb_for_target (::std::int32_t rootfs_dfd,
-                                                                         bool normalize) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$directory_size(::std::int32_t dfd, ::rpmostreecxx::GCancellable const &cancellable, ::std::uint64_t *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$directory_size (::std::int32_t dfd,
-                                          ::rpmostreecxx::GCancellable const &cancellable,
-                                          ::std::uint64_t *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$container_rebuild(::rust::Str treefile) noexcept {
+  void (*container_rebuild$)(::rust::Str) = ::rpmostreecxx::container_rebuild;
+  ::rust::repr::PtrLen throw$;
+  ::rust::behavior::trycatch(
+      [&] {
+        container_rebuild$(treefile);
+        throw$.ptr = nullptr;
+      },
+      ::rust::detail::Fail(throw$));
+  return throw$;
+}
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$container_rebuild (::rust::Str treefile) noexcept
-  {
-    void (*container_rebuild$) (::rust::Str) = ::rpmostreecxx::container_rebuild;
-    ::rust::repr::PtrLen throw$;
-    ::rust::behavior::trycatch (
-        [&] {
-          container_rebuild$ (treefile);
-          throw$.ptr = nullptr;
-        },
-        ::rust::detail::Fail (throw$));
-    return throw$;
-  }
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_for_id(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id, ::rpmostreecxx::OstreeDeployment **return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$deployment_for_id (::rpmostreecxx::OstreeSysroot &sysroot,
-                                             ::rust::Str deploy_id,
-                                             ::rpmostreecxx::OstreeDeployment **return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_checksum_for_id(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id, ::rust::String *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$deployment_checksum_for_id (::rpmostreecxx::OstreeSysroot &sysroot,
-                                                      ::rust::Str deploy_id,
-                                                      ::rust::String *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_get_base(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str opt_deploy_id, ::rust::Str opt_os_name, ::rpmostreecxx::OstreeDeployment **return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$deployment_get_base (::rpmostreecxx::OstreeSysroot &sysroot,
-                                               ::rust::Str opt_deploy_id, ::rust::Str opt_os_name,
-                                               ::rpmostreecxx::OstreeDeployment **return$) noexcept;
+bool rpmostreecxx$cxxbridge1$194$deployment_add_manifest_diff(::rpmostreecxx::GVariantDict const &dict, ::rpmostreecxx::ExportedManifestDiff const &diff) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$deployment_add_manifest_diff (
-      ::rpmostreecxx::GVariantDict const &dict,
-      ::rpmostreecxx::ExportedManifestDiff const &diff) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$daemon_sanitycheck_environment(::rpmostreecxx::OstreeSysroot const &sysroot) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$daemon_sanitycheck_environment (
-      ::rpmostreecxx::OstreeSysroot const &sysroot) noexcept;
+void rpmostreecxx$cxxbridge1$194$deployment_generate_id(::rpmostreecxx::OstreeDeployment const &deployment, ::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$deployment_generate_id (
-      ::rpmostreecxx::OstreeDeployment const &deployment, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_populate_variant(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::GVariantDict const &dict) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$deployment_populate_variant (
-      ::rpmostreecxx::OstreeSysroot const &sysroot,
-      ::rpmostreecxx::OstreeDeployment const &deployment,
-      ::rpmostreecxx::GVariantDict const &dict) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$generate_baselayer_refs(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$generate_baselayer_refs (
-      ::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeRepo const &repo,
-      ::rpmostreecxx::GCancellable const &cancellable) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$variant_add_remote_status(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec, ::rust::Str base_checksum, ::rpmostreecxx::GVariantDict const &dict) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$variant_add_remote_status (
-      ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec, ::rust::Str base_checksum,
-      ::rpmostreecxx::GVariantDict const &dict) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_layeredmeta_from_commit(::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::GVariant const &commit, ::rpmostreecxx::DeploymentLayeredMeta *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$deployment_layeredmeta_from_commit (
-      ::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::GVariant const &commit,
-      ::rpmostreecxx::DeploymentLayeredMeta *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_layeredmeta_load(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::DeploymentLayeredMeta *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$deployment_layeredmeta_load (
-      ::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::OstreeDeployment const &deployment,
-      ::rpmostreecxx::DeploymentLayeredMeta *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$parse_override_source(::rust::Str source, ::rpmostreecxx::OverrideReplacementSource *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$parse_override_source (
-      ::rust::Str source, ::rpmostreecxx::OverrideReplacementSource *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$parse_revision(::rust::Str source, ::rpmostreecxx::ParsedRevision *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$parse_revision (::rust::Str source,
-                                          ::rpmostreecxx::ParsedRevision *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$generate_object_path(::rust::Str base, ::rust::Str next_segment, ::rust::String *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$generate_object_path (::rust::Str base, ::rust::Str next_segment,
-                                                ::rust::String *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$failpoint(::rust::Str p) noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$RpmImporterFlags$operator$sizeof() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$RpmImporterFlags$operator$alignof() noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$failpoint (::rust::Str p) noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$RpmImporterFlags$operator$sizeof () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$RpmImporterFlags$operator$alignof () noexcept;
+::rpmostreecxx::RpmImporterFlags *rpmostreecxx$cxxbridge1$194$rpm_importer_flags_new_empty() noexcept;
 
-  ::rpmostreecxx::RpmImporterFlags *
-  rpmostreecxx$cxxbridge1$rpm_importer_flags_new_empty () noexcept;
+bool rpmostreecxx$cxxbridge1$194$RpmImporterFlags$is_ima_enabled(::rpmostreecxx::RpmImporterFlags const &self) noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$RpmImporter$operator$sizeof() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$RpmImporter$operator$alignof() noexcept;
 
-  bool rpmostreecxx$cxxbridge1$RpmImporterFlags$is_ima_enabled (
-      ::rpmostreecxx::RpmImporterFlags const &self) noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$RpmImporter$operator$sizeof () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$RpmImporter$operator$alignof () noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$rpm_importer_new(::rust::Str pkg_name, ::rust::Str ostree_branch, ::rpmostreecxx::RpmImporterFlags const &flags, ::rust::Box<::rpmostreecxx::RpmImporter> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$rpm_importer_new (
-      ::rust::Str pkg_name, ::rust::Str ostree_branch,
-      ::rpmostreecxx::RpmImporterFlags const &flags,
-      ::rust::Box<::rpmostreecxx::RpmImporter> *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$RpmImporter$handle_translate_pathname(::rpmostreecxx::RpmImporter &self, ::rust::Str path, ::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$RpmImporter$handle_translate_pathname (
-      ::rpmostreecxx::RpmImporter &self, ::rust::Str path, ::rust::String *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$RpmImporter$ostree_branch(::rpmostreecxx::RpmImporter const &self, ::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$RpmImporter$ostree_branch (::rpmostreecxx::RpmImporter const &self,
-                                                          ::rust::String *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$RpmImporter$pkg_name(::rpmostreecxx::RpmImporter const &self, ::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$RpmImporter$pkg_name (::rpmostreecxx::RpmImporter const &self,
-                                                     ::rust::String *return$) noexcept;
+bool rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_are_filtered(::rpmostreecxx::RpmImporter const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$RpmImporter$doc_files_are_filtered (
-      ::rpmostreecxx::RpmImporter const &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_insert(::rpmostreecxx::RpmImporter &self, ::rust::Str path) noexcept;
 
-  void rpmostreecxx$cxxbridge1$RpmImporter$doc_files_insert (::rpmostreecxx::RpmImporter &self,
-                                                             ::rust::Str path) noexcept;
+bool rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_contains(::rpmostreecxx::RpmImporter const &self, ::rust::Str path) noexcept;
 
-  bool
-  rpmostreecxx$cxxbridge1$RpmImporter$doc_files_contains (::rpmostreecxx::RpmImporter const &self,
-                                                          ::rust::Str path) noexcept;
+void rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_insert(::rpmostreecxx::RpmImporter &self, ::rust::Str path, ::std::uint64_t index) noexcept;
 
-  void rpmostreecxx$cxxbridge1$RpmImporter$rpmfi_overrides_insert (
-      ::rpmostreecxx::RpmImporter &self, ::rust::Str path, ::std::uint64_t index) noexcept;
+bool rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_contains(::rpmostreecxx::RpmImporter const &self, ::rust::Str path) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$RpmImporter$rpmfi_overrides_contains (
-      ::rpmostreecxx::RpmImporter const &self, ::rust::Str path) noexcept;
+::std::uint64_t rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_get(::rpmostreecxx::RpmImporter const &self, ::rust::Str path) noexcept;
 
-  ::std::uint64_t
-  rpmostreecxx$cxxbridge1$RpmImporter$rpmfi_overrides_get (::rpmostreecxx::RpmImporter const &self,
-                                                           ::rust::Str path) noexcept;
+bool rpmostreecxx$cxxbridge1$194$RpmImporter$is_ima_enabled(::rpmostreecxx::RpmImporter const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$RpmImporter$is_ima_enabled (
-      ::rpmostreecxx::RpmImporter const &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$RpmImporter$tweak_imported_file_info(::rpmostreecxx::RpmImporter const &self, ::rpmostreecxx::GFileInfo const &file_info) noexcept;
 
-  void rpmostreecxx$cxxbridge1$RpmImporter$tweak_imported_file_info (
-      ::rpmostreecxx::RpmImporter const &self, ::rpmostreecxx::GFileInfo const &file_info) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$RpmImporter$is_file_filtered(::rpmostreecxx::RpmImporter const &self, ::rust::Str path, ::rpmostreecxx::GFileInfo const &file_info, bool *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$RpmImporter$is_file_filtered (
-      ::rpmostreecxx::RpmImporter const &self, ::rust::Str path,
-      ::rpmostreecxx::GFileInfo const &file_info, bool *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$RpmImporter$translate_to_tmpfiles_entry(::rpmostreecxx::RpmImporter &self, ::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username, ::rust::Str groupname) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$RpmImporter$translate_to_tmpfiles_entry (
-      ::rpmostreecxx::RpmImporter &self, ::rust::Str abs_path,
-      ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username,
-      ::rust::Str groupname) noexcept;
+bool rpmostreecxx$cxxbridge1$194$RpmImporter$has_tmpfiles_entries(::rpmostreecxx::RpmImporter const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$RpmImporter$has_tmpfiles_entries (
-      ::rpmostreecxx::RpmImporter const &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$RpmImporter$serialize_tmpfiles_content(::rpmostreecxx::RpmImporter const &self, ::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$RpmImporter$serialize_tmpfiles_content (
-      ::rpmostreecxx::RpmImporter const &self, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$tmpfiles_translate(::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username, ::rust::Str groupname, ::rust::String *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$tmpfiles_translate (
-      ::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username,
-      ::rust::Str groupname, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$append_dracut_random_cpio(::std::int32_t fd) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$append_dracut_random_cpio (::std::int32_t fd) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$initramfs_overlay_generate(::rust::Vec<::rust::String> const &files, ::rpmostreecxx::GCancellable &cancellable, ::std::int32_t *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$initramfs_overlay_generate (::rust::Vec<::rust::String> const &files,
-                                                      ::rpmostreecxx::GCancellable &cancellable,
-                                                      ::std::int32_t *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$journal_print_staging_failure() noexcept;
 
-  void rpmostreecxx$cxxbridge1$journal_print_staging_failure () noexcept;
+void rpmostreecxx$cxxbridge1$194$console_progress_begin_task(::rust::Str msg) noexcept;
 
-  void rpmostreecxx$cxxbridge1$console_progress_begin_task (::rust::Str msg) noexcept;
+void rpmostreecxx$cxxbridge1$194$console_progress_begin_n_items(::rust::Str msg, ::std::uint64_t n) noexcept;
 
-  void rpmostreecxx$cxxbridge1$console_progress_begin_n_items (::rust::Str msg,
-                                                               ::std::uint64_t n) noexcept;
+void rpmostreecxx$cxxbridge1$194$console_progress_begin_percent(::rust::Str msg) noexcept;
 
-  void rpmostreecxx$cxxbridge1$console_progress_begin_percent (::rust::Str msg) noexcept;
+void rpmostreecxx$cxxbridge1$194$console_progress_set_message(::rust::Str msg) noexcept;
 
-  void rpmostreecxx$cxxbridge1$console_progress_set_message (::rust::Str msg) noexcept;
+void rpmostreecxx$cxxbridge1$194$console_progress_set_sub_message(::rust::Str msg) noexcept;
 
-  void rpmostreecxx$cxxbridge1$console_progress_set_sub_message (::rust::Str msg) noexcept;
+void rpmostreecxx$cxxbridge1$194$console_progress_update(::std::uint64_t n) noexcept;
 
-  void rpmostreecxx$cxxbridge1$console_progress_update (::std::uint64_t n) noexcept;
+void rpmostreecxx$cxxbridge1$194$console_progress_end(::rust::Str suffix) noexcept;
+bool rpmostreecxx$cxxbridge1$194$HistoryEntry$operator$eq(HistoryEntry const &, HistoryEntry const &) noexcept;
+bool rpmostreecxx$cxxbridge1$194$HistoryEntry$operator$ne(HistoryEntry const &, HistoryEntry const &) noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$HistoryCtx$operator$sizeof() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$HistoryCtx$operator$alignof() noexcept;
 
-  void rpmostreecxx$cxxbridge1$console_progress_end (::rust::Str suffix) noexcept;
-  bool rpmostreecxx$cxxbridge1$HistoryEntry$operator$eq (HistoryEntry const &,
-                                                         HistoryEntry const &) noexcept;
-  bool rpmostreecxx$cxxbridge1$HistoryEntry$operator$ne (HistoryEntry const &,
-                                                         HistoryEntry const &) noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$HistoryCtx$operator$sizeof () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$HistoryCtx$operator$alignof () noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$history_ctx_new(::rust::Box<::rpmostreecxx::HistoryCtx> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$history_ctx_new (
-      ::rust::Box<::rpmostreecxx::HistoryCtx> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$HistoryCtx$next_entry(::rpmostreecxx::HistoryCtx &self, ::rpmostreecxx::HistoryEntry *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$HistoryCtx$next_entry (::rpmostreecxx::HistoryCtx &self,
-                                                 ::rpmostreecxx::HistoryEntry *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$history_prune() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$TokioHandle$operator$sizeof() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$TokioHandle$operator$alignof() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$TokioEnterGuard$operator$sizeof() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$TokioEnterGuard$operator$alignof() noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$history_prune () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$TokioHandle$operator$sizeof () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$TokioHandle$operator$alignof () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$TokioEnterGuard$operator$sizeof () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$TokioEnterGuard$operator$alignof () noexcept;
+::rpmostreecxx::TokioHandle *rpmostreecxx$cxxbridge1$194$tokio_handle_get() noexcept;
 
-  ::rpmostreecxx::TokioHandle *rpmostreecxx$cxxbridge1$tokio_handle_get () noexcept;
+::rpmostreecxx::TokioEnterGuard *rpmostreecxx$cxxbridge1$194$TokioHandle$enter(::rpmostreecxx::TokioHandle const &self) noexcept;
 
-  ::rpmostreecxx::TokioEnterGuard *
-  rpmostreecxx$cxxbridge1$TokioHandle$enter (::rpmostreecxx::TokioHandle const &self) noexcept;
+bool rpmostreecxx$cxxbridge1$194$script_is_ignored(::rust::Str pkg, ::rust::Str script, bool use_kernel_install) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$script_is_ignored (::rust::Str pkg, ::rust::Str script,
-                                                  bool use_kernel_install) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$testutils_entrypoint(::rust::Vec<::rust::String> *argv) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$testutils_entrypoint (::rust::Vec<::rust::String> *argv) noexcept;
+void rpmostreecxx$cxxbridge1$194$maybe_shell_quote(::rust::Str input, ::rust::String *return$) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Refspec$operator$eq(Refspec const &, Refspec const &) noexcept;
+bool rpmostreecxx$cxxbridge1$194$OverrideReplacement$operator$eq(OverrideReplacement const &, OverrideReplacement const &) noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$Treefile$operator$sizeof() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$Treefile$operator$alignof() noexcept;
 
-  void rpmostreecxx$cxxbridge1$maybe_shell_quote (::rust::Str input,
-                                                  ::rust::String *return$) noexcept;
-  bool rpmostreecxx$cxxbridge1$Refspec$operator$eq (Refspec const &, Refspec const &) noexcept;
-  bool
-  rpmostreecxx$cxxbridge1$OverrideReplacement$operator$eq (OverrideReplacement const &,
-                                                           OverrideReplacement const &) noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$Treefile$operator$sizeof () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$Treefile$operator$alignof () noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new(::rust::Str filename, ::rust::Str basearch, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$treefile_new (::rust::Str filename, ::rust::Str basearch,
-                                        ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new_empty(::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$treefile_new_empty (
-      ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new_from_string(::rust::Str buf, bool client, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$treefile_new_from_string (
-      ::rust::Str buf, bool client, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new_compose(::rust::Str filename, ::rust::Str basearch, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$treefile_new_compose (
-      ::rust::Str filename, ::rust::Str basearch,
-      ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new_client(::rust::Str filename, ::rust::Str basearch, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$treefile_new_client (
-      ::rust::Str filename, ::rust::Str basearch,
-      ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new_client_from_etc(::rust::Str basearch, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$treefile_new_client_from_etc (
-      ::rust::Str basearch, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_delete_client_etc(::std::uint32_t *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$treefile_delete_client_etc (::std::uint32_t *return$) noexcept;
+::rust::repr::Fat rpmostreecxx$cxxbridge1$194$Treefile$get_workdir(::rpmostreecxx::Treefile const &self) noexcept;
 
-  ::rust::repr::Fat
-  rpmostreecxx$cxxbridge1$Treefile$get_workdir (::rpmostreecxx::Treefile const &self) noexcept;
+::std::int32_t rpmostreecxx$cxxbridge1$194$Treefile$get_passwd_fd(::rpmostreecxx::Treefile &self) noexcept;
 
-  ::std::int32_t
-  rpmostreecxx$cxxbridge1$Treefile$get_passwd_fd (::rpmostreecxx::Treefile &self) noexcept;
+::std::int32_t rpmostreecxx$cxxbridge1$194$Treefile$get_group_fd(::rpmostreecxx::Treefile &self) noexcept;
 
-  ::std::int32_t
-  rpmostreecxx$cxxbridge1$Treefile$get_group_fd (::rpmostreecxx::Treefile &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_json_string(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_json_string (::rpmostreecxx::Treefile const &self,
-                                                         ::rust::String *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_layers(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_ostree_layers (
-      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_override_layers(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_ostree_override_layers (
-      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_all_ostree_layers(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_all_ostree_layers (
-      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_repos(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_repos (::rpmostreecxx::Treefile const &self,
-                                                   ::rust::Vec<::rust::String> *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_packages(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void
-  rpmostreecxx$cxxbridge1$Treefile$get_packages (::rpmostreecxx::Treefile const &self,
-                                                 ::rust::Vec<::rust::String> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$require_automatic_version_prefix(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$Treefile$require_automatic_version_prefix (
-      ::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$add_packages(::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages, bool allow_existing, bool *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$Treefile$add_packages (::rpmostreecxx::Treefile &self,
-                                                 ::rust::Vec<::rust::String> *packages,
-                                                 bool allow_existing, bool *return$) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$has_packages(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool
-  rpmostreecxx$cxxbridge1$Treefile$has_packages (::rpmostreecxx::Treefile const &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_local_packages(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_local_packages (
-      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$add_local_packages(::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages, bool allow_existing, bool *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$Treefile$add_local_packages (::rpmostreecxx::Treefile &self,
-                                                       ::rust::Vec<::rust::String> *packages,
-                                                       bool allow_existing, bool *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_local_fileoverride_packages(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_local_fileoverride_packages (
-      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$add_local_fileoverride_packages(::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages, bool allow_existing, bool *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$Treefile$add_local_fileoverride_packages (
-      ::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages, bool allow_existing,
-      bool *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$remove_packages(::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages, bool allow_noent, bool *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$Treefile$remove_packages (::rpmostreecxx::Treefile &self,
-                                                    ::rust::Vec<::rust::String> *packages,
-                                                    bool allow_noent, bool *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_replace(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rpmostreecxx::OverrideReplacement> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_packages_override_replace (
-      ::rpmostreecxx::Treefile const &self,
-      ::rust::Vec<::rpmostreecxx::OverrideReplacement> *return$) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$has_packages_override_replace(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$has_packages_override_replace (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_replace(::rpmostreecxx::Treefile &self, ::rpmostreecxx::OverrideReplacement *replacement) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$add_packages_override_replace (
-      ::rpmostreecxx::Treefile &self, ::rpmostreecxx::OverrideReplacement *replacement) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_replace(::rpmostreecxx::Treefile &self, ::rust::Str package) noexcept;
 
-  bool
-  rpmostreecxx$cxxbridge1$Treefile$remove_package_override_replace (::rpmostreecxx::Treefile &self,
-                                                                    ::rust::Str package) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_replace_local(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_packages_override_replace_local (
-      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_replace_local(::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$Treefile$add_packages_override_replace_local (
-      ::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_replace_local(::rpmostreecxx::Treefile &self, ::rust::Str package) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$remove_package_override_replace_local (
-      ::rpmostreecxx::Treefile &self, ::rust::Str package) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_remove(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_packages_override_remove (
-      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_remove(::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$Treefile$add_packages_override_remove (
-      ::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_remove(::rpmostreecxx::Treefile &self, ::rust::Str package) noexcept;
 
-  bool
-  rpmostreecxx$cxxbridge1$Treefile$remove_package_override_remove (::rpmostreecxx::Treefile &self,
-                                                                   ::rust::Str package) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$has_packages_override_remove_name(::rpmostreecxx::Treefile const &self, ::rust::Str name) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$has_packages_override_remove_name (
-      ::rpmostreecxx::Treefile const &self, ::rust::Str name) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$remove_all_overrides(::rpmostreecxx::Treefile &self) noexcept;
 
-  bool
-  rpmostreecxx$cxxbridge1$Treefile$remove_all_overrides (::rpmostreecxx::Treefile &self) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$remove_all_packages(::rpmostreecxx::Treefile &self) noexcept;
 
-  bool
-  rpmostreecxx$cxxbridge1$Treefile$remove_all_packages (::rpmostreecxx::Treefile &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_exclude_packages(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_exclude_packages (
-      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_platform_module(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_platform_module (::rpmostreecxx::Treefile const &self,
-                                                             ::rust::String *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_install_langs(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_install_langs (
-      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$format_install_langs_macro(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
 
-  void
-  rpmostreecxx$cxxbridge1$Treefile$format_install_langs_macro (::rpmostreecxx::Treefile const &self,
-                                                               ::rust::String *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_lockfile_repos(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_lockfile_repos (
-      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+::rust::repr::Fat rpmostreecxx$cxxbridge1$194$Treefile$get_ref(::rpmostreecxx::Treefile const &self) noexcept;
 
-  ::rust::repr::Fat
-  rpmostreecxx$cxxbridge1$Treefile$get_ref (::rpmostreecxx::Treefile const &self) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$get_cliwrap(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$get_cliwrap (::rpmostreecxx::Treefile const &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_cliwrap_binaries(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_cliwrap_binaries (
-      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$set_cliwrap(::rpmostreecxx::Treefile &self, bool enabled) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$set_cliwrap (::rpmostreecxx::Treefile &self,
-                                                     bool enabled) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_container_cmd(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_container_cmd (
-      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$get_readonly_executables(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$get_readonly_executables (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$get_documentation(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$get_documentation (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$get_recommends(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool
-  rpmostreecxx$cxxbridge1$Treefile$get_recommends (::rpmostreecxx::Treefile const &self) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$get_selinux(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$get_selinux (::rpmostreecxx::Treefile const &self) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$get_sysusers_is_forced(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$get_sysusers_is_forced (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+::std::uint32_t rpmostreecxx$cxxbridge1$194$Treefile$get_selinux_label_version(::rpmostreecxx::Treefile const &self) noexcept;
 
-  ::std::uint32_t rpmostreecxx$cxxbridge1$Treefile$get_selinux_label_version (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_gpg_key(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_gpg_key (::rpmostreecxx::Treefile const &self,
-                                                     ::rust::String *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_automatic_version_suffix(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_automatic_version_suffix (
-      ::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$get_container(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool
-  rpmostreecxx$cxxbridge1$Treefile$get_container (::rpmostreecxx::Treefile const &self) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$get_machineid_compat(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$get_machineid_compat (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_etc_group_members(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_etc_group_members (
-      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$get_boot_location_is_modules(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$get_boot_location_is_modules (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$use_kernel_install(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$use_kernel_install (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$get_ima(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$get_ima (::rpmostreecxx::Treefile const &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_releasever(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_releasever (::rpmostreecxx::Treefile const &self,
-                                                        ::rust::String *return$) noexcept;
+::rpmostreecxx::RepoMetadataTarget rpmostreecxx$cxxbridge1$194$Treefile$get_repo_metadata_target(::rpmostreecxx::Treefile const &self) noexcept;
 
-  ::rpmostreecxx::RepoMetadataTarget rpmostreecxx$cxxbridge1$Treefile$get_repo_metadata_target (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+::rpmostreecxx::AdvisoriesMetadataTarget rpmostreecxx$cxxbridge1$194$Treefile$get_advisories_metadata_target(::rpmostreecxx::Treefile const &self) noexcept;
 
-  ::rpmostreecxx::AdvisoriesMetadataTarget
-  rpmostreecxx$cxxbridge1$Treefile$get_advisories_metadata_target (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$rpmdb_backend_is_target(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$rpmdb_backend_is_target (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$should_normalize_rpmdb(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$should_normalize_rpmdb (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+::rpmostreecxx::OptUsrLocal rpmostreecxx$cxxbridge1$194$Treefile$get_opt_usrlocal(::rpmostreecxx::Treefile const &self) noexcept;
 
-  ::rpmostreecxx::OptUsrLocal
-  rpmostreecxx$cxxbridge1$Treefile$get_opt_usrlocal (::rpmostreecxx::Treefile const &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_files_remove_regex(::rpmostreecxx::Treefile const &self, ::rust::Str package, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_files_remove_regex (
-      ::rpmostreecxx::Treefile const &self, ::rust::Str package,
-      ::rust::Vec<::rust::String> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$get_checksum(::rpmostreecxx::Treefile const &self, ::rpmostreecxx::OstreeRepo const &repo, ::rust::String *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$Treefile$get_checksum (::rpmostreecxx::Treefile const &self,
-                                                 ::rpmostreecxx::OstreeRepo const &repo,
-                                                 ::rust::String *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_ref(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_ostree_ref (::rpmostreecxx::Treefile const &self,
-                                                        ::rust::String *return$) noexcept;
+::rust::repr::Fat rpmostreecxx$cxxbridge1$194$Treefile$get_repo_packages(::rpmostreecxx::Treefile const &self) noexcept;
 
-  ::rust::repr::Fat rpmostreecxx$cxxbridge1$Treefile$get_repo_packages (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$clear_repo_packages(::rpmostreecxx::Treefile &self) noexcept;
 
-  void
-  rpmostreecxx$cxxbridge1$Treefile$clear_repo_packages (::rpmostreecxx::Treefile &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$prettyprint_json_stdout(::rpmostreecxx::Treefile const &self) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$prettyprint_json_stdout (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$print_deprecation_warnings(::rpmostreecxx::Treefile const &self) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$print_deprecation_warnings (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$print_experimental_notices(::rpmostreecxx::Treefile const &self) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$print_experimental_notices (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$sanitycheck_externals(::rpmostreecxx::Treefile const &self) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$Treefile$sanitycheck_externals (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+::rpmostreecxx::RpmImporterFlags *rpmostreecxx$cxxbridge1$194$Treefile$importer_flags(::rpmostreecxx::Treefile const &self, ::rust::Str pkg_name) noexcept;
 
-  ::rpmostreecxx::RpmImporterFlags *
-  rpmostreecxx$cxxbridge1$Treefile$importer_flags (::rpmostreecxx::Treefile const &self,
-                                                   ::rust::Str pkg_name) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$write_repovars(::rpmostreecxx::Treefile const &self, ::std::int32_t workdir_dfd_raw, ::rust::String *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$Treefile$write_repovars (::rpmostreecxx::Treefile const &self,
-                                                   ::std::int32_t workdir_dfd_raw,
-                                                   ::rust::String *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$set_releasever(::rpmostreecxx::Treefile &self, ::rust::Str releasever) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$Treefile$set_releasever (::rpmostreecxx::Treefile &self,
-                                                   ::rust::Str releasever) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$set_recommends(::rpmostreecxx::Treefile &self, bool val) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$Treefile$set_recommends (::rpmostreecxx::Treefile &self,
-                                                   bool val) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$enable_repo(::rpmostreecxx::Treefile &self, ::rust::Str repo) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$Treefile$enable_repo (::rpmostreecxx::Treefile &self,
-                                                                     ::rust::Str repo) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$disable_repo(::rpmostreecxx::Treefile &self, ::rust::Str repo) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$Treefile$disable_repo (::rpmostreecxx::Treefile &self,
-                                                 ::rust::Str repo) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$validate_for_container(::rpmostreecxx::Treefile const &self) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$Treefile$validate_for_container (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_base_refspec(::rpmostreecxx::Treefile const &self, ::rpmostreecxx::Refspec *return$) noexcept;
 
-  void
-  rpmostreecxx$cxxbridge1$Treefile$get_base_refspec (::rpmostreecxx::Treefile const &self,
-                                                     ::rpmostreecxx::Refspec *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$rebase(::rpmostreecxx::Treefile &self, ::rust::Str new_refspec, ::rust::Str custom_origin_url, ::rust::Str custom_origin_description) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$rebase (::rpmostreecxx::Treefile &self,
-                                                ::rust::Str new_refspec,
-                                                ::rust::Str custom_origin_url,
-                                                ::rust::Str custom_origin_description) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_origin_custom_url(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_origin_custom_url (::rpmostreecxx::Treefile const &self,
-                                                               ::rust::String *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_origin_custom_description(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_origin_custom_description (
-      ::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_override_commit(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_override_commit (::rpmostreecxx::Treefile const &self,
-                                                             ::rust::String *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$set_override_commit(::rpmostreecxx::Treefile &self, ::rust::Str checksum) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$set_override_commit (::rpmostreecxx::Treefile &self,
-                                                             ::rust::Str checksum) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_etc_files(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_initramfs_etc_files (
-      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$has_initramfs_etc_files(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$has_initramfs_etc_files (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_track(::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *files) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$initramfs_etc_files_track (
-      ::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *files) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_untrack(::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *files) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$initramfs_etc_files_untrack (
-      ::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *files) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_untrack_all(::rpmostreecxx::Treefile &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$initramfs_etc_files_untrack_all (
-      ::rpmostreecxx::Treefile &self) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_regenerate(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$get_initramfs_regenerate (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_args(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$get_initramfs_args (
-      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$set_initramfs_regenerate(::rpmostreecxx::Treefile &self, bool enabled, ::rust::Vec<::rust::String> *args) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Treefile$set_initramfs_regenerate (
-      ::rpmostreecxx::Treefile &self, bool enabled, ::rust::Vec<::rust::String> *args) noexcept;
+void rpmostreecxx$cxxbridge1$194$Treefile$get_unconfigured_state(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
 
-  void
-  rpmostreecxx$cxxbridge1$Treefile$get_unconfigured_state (::rpmostreecxx::Treefile const &self,
-                                                           ::rust::String *return$) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$may_require_local_assembly(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool rpmostreecxx$cxxbridge1$Treefile$may_require_local_assembly (
-      ::rpmostreecxx::Treefile const &self) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$has_any_packages(::rpmostreecxx::Treefile const &self) noexcept;
 
-  bool
-  rpmostreecxx$cxxbridge1$Treefile$has_any_packages (::rpmostreecxx::Treefile const &self) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$merge_treefile(::rpmostreecxx::Treefile &self, ::rust::Str treefile, bool *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$Treefile$merge_treefile (::rpmostreecxx::Treefile &self,
-                                                   ::rust::Str treefile, bool *return$) noexcept;
+bool rpmostreecxx$cxxbridge1$194$Treefile$get_no_initramfs(::rpmostreecxx::Treefile const &self) noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$RepoPackage$operator$sizeof() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$RepoPackage$operator$alignof() noexcept;
 
-  bool
-  rpmostreecxx$cxxbridge1$Treefile$get_no_initramfs (::rpmostreecxx::Treefile const &self) noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$RepoPackage$operator$sizeof () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$RepoPackage$operator$alignof () noexcept;
+::rust::repr::Fat rpmostreecxx$cxxbridge1$194$RepoPackage$get_repo(::rpmostreecxx::RepoPackage const &self) noexcept;
 
-  ::rust::repr::Fat
-  rpmostreecxx$cxxbridge1$RepoPackage$get_repo (::rpmostreecxx::RepoPackage const &self) noexcept;
+void rpmostreecxx$cxxbridge1$194$RepoPackage$get_packages(::rpmostreecxx::RepoPackage const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void
-  rpmostreecxx$cxxbridge1$RepoPackage$get_packages (::rpmostreecxx::RepoPackage const &self,
-                                                    ::rust::Vec<::rust::String> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$varsubstitute(::rust::Str s, ::rust::Vec<::rpmostreecxx::StringMapping> const &vars, ::rust::String *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$varsubstitute (::rust::Str s,
-                                         ::rust::Vec<::rpmostreecxx::StringMapping> const &vars,
-                                         ::rust::String *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$get_features(::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$get_features (::rust::Vec<::rust::String> *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$get_rpm_basearch(::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$get_rpm_basearch (::rust::String *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$sealed_memfd(::rust::Str description, ::rust::Slice<::std::uint8_t const> content, ::std::int32_t *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$sealed_memfd (::rust::Str description,
-                                        ::rust::Slice<::std::uint8_t const> content,
-                                        ::std::int32_t *return$) noexcept;
+bool rpmostreecxx$cxxbridge1$194$running_in_systemd() noexcept;
 
-  bool rpmostreecxx$cxxbridge1$running_in_systemd () noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$calculate_advisories_diff(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str checksum_from, ::rust::Str checksum_to, ::rpmostreecxx::GVariant **return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$calculate_advisories_diff (
-      ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str checksum_from, ::rust::Str checksum_to,
-      ::rpmostreecxx::GVariant **return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$translate_path_for_ostree(::rust::Str path, ::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$translate_path_for_ostree (::rust::Str path,
-                                                          ::rust::String *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$get_live_apply_state(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::LiveApplyState *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$get_live_apply_state (::rpmostreecxx::OstreeSysroot const &sysroot,
-                                                ::rpmostreecxx::OstreeDeployment const &deployment,
-                                                ::rpmostreecxx::LiveApplyState *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$has_live_apply_state(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment, bool *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$has_live_apply_state (::rpmostreecxx::OstreeSysroot const &sysroot,
-                                                ::rpmostreecxx::OstreeDeployment const &deployment,
-                                                bool *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$applylive_sync_ref(::rpmostreecxx::OstreeSysroot const &sysroot) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$applylive_sync_ref (
-      ::rpmostreecxx::OstreeSysroot const &sysroot) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$transaction_apply_live(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::GVariant const &target) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$transaction_apply_live (::rpmostreecxx::OstreeSysroot const &sysroot,
-                                                  ::rpmostreecxx::GVariant const &target) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$normalize_etc_shadow(::std::int32_t rootfs_dfd) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$normalize_etc_shadow (::std::int32_t rootfs_dfd) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$prepare_rpm_layering(::std::int32_t rootfs, ::std::int32_t merge_passwd_dir, bool *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$prepare_rpm_layering (
-      ::std::int32_t rootfs, ::std::int32_t merge_passwd_dir, bool *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$complete_rpm_layering(::std::int32_t rootfs) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$complete_rpm_layering (::std::int32_t rootfs) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deduplicate_tmpfiles_entries(::std::int32_t rootfs) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$deduplicate_tmpfiles_entries (::std::int32_t rootfs) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$passwd_cleanup(::std::int32_t rootfs) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$passwd_cleanup (::std::int32_t rootfs) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$migrate_group_except_root(::std::int32_t rootfs, ::rust::Vec<::rust::String> const &preserved_groups) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$migrate_group_except_root (
-      ::std::int32_t rootfs, ::rust::Vec<::rust::String> const &preserved_groups) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$migrate_passwd_except_root(::std::int32_t rootfs) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$migrate_passwd_except_root (::std::int32_t rootfs) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$passwd_compose_prep(::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$passwd_compose_prep (::std::int32_t rootfs,
-                                               ::rpmostreecxx::Treefile &treefile) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$passwd_compose_prep_repo(::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile, ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str previous_checksum, bool unified_core) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$passwd_compose_prep_repo (
-      ::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile,
-      ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str previous_checksum,
-      bool unified_core) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$dir_contains_uid(::std::int32_t dirfd, ::std::uint32_t id, bool *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$dir_contains_uid (::std::int32_t dirfd,
-                                                                 ::std::uint32_t id,
-                                                                 bool *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$dir_contains_gid(::std::int32_t dirfd, ::std::uint32_t id, bool *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$dir_contains_gid (::std::int32_t dirfd,
-                                                                 ::std::uint32_t id,
-                                                                 bool *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$check_passwd_group_entries(::rpmostreecxx::OstreeRepo const &ffi_repo, ::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile, ::rust::Str previous_rev) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$check_passwd_group_entries (
-      ::rpmostreecxx::OstreeRepo const &ffi_repo, ::std::int32_t rootfs_dfd,
-      ::rpmostreecxx::Treefile &treefile, ::rust::Str previous_rev) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$passwddb_open(::std::int32_t rootfs, ::rust::Box<::rpmostreecxx::PasswdDB> *return$) noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$PasswdDB$operator$sizeof() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$PasswdDB$operator$alignof() noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$passwddb_open (::std::int32_t rootfs,
-                                         ::rust::Box<::rpmostreecxx::PasswdDB> *return$) noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$PasswdDB$operator$sizeof () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$PasswdDB$operator$alignof () noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdDB$lookup_user(::rpmostreecxx::PasswdDB const &self, ::std::uint32_t uid, ::rust::String *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$PasswdDB$lookup_user (
-      ::rpmostreecxx::PasswdDB const &self, ::std::uint32_t uid, ::rust::String *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdDB$lookup_group(::rpmostreecxx::PasswdDB const &self, ::std::uint32_t gid, ::rust::String *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$PasswdDB$lookup_group (
-      ::rpmostreecxx::PasswdDB const &self, ::std::uint32_t gid, ::rust::String *return$) noexcept;
+::rpmostreecxx::PasswdEntries *rpmostreecxx$cxxbridge1$194$new_passwd_entries() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$PasswdEntries$operator$sizeof() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$PasswdEntries$operator$alignof() noexcept;
 
-  ::rpmostreecxx::PasswdEntries *rpmostreecxx$cxxbridge1$new_passwd_entries () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$PasswdEntries$operator$sizeof () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$PasswdEntries$operator$alignof () noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdEntries$add_group_content(::rpmostreecxx::PasswdEntries &self, ::std::int32_t rootfs, ::rust::Str path) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$PasswdEntries$add_group_content (
-      ::rpmostreecxx::PasswdEntries &self, ::std::int32_t rootfs, ::rust::Str path) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdEntries$add_passwd_content(::rpmostreecxx::PasswdEntries &self, ::std::int32_t rootfs, ::rust::Str path) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$PasswdEntries$add_passwd_content (
-      ::rpmostreecxx::PasswdEntries &self, ::std::int32_t rootfs, ::rust::Str path) noexcept;
+bool rpmostreecxx$cxxbridge1$194$PasswdEntries$contains_group(::rpmostreecxx::PasswdEntries const &self, ::rust::Str user) noexcept;
 
-  bool
-  rpmostreecxx$cxxbridge1$PasswdEntries$contains_group (::rpmostreecxx::PasswdEntries const &self,
-                                                        ::rust::Str user) noexcept;
+bool rpmostreecxx$cxxbridge1$194$PasswdEntries$contains_user(::rpmostreecxx::PasswdEntries const &self, ::rust::Str user) noexcept;
 
-  bool
-  rpmostreecxx$cxxbridge1$PasswdEntries$contains_user (::rpmostreecxx::PasswdEntries const &self,
-                                                       ::rust::Str user) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdEntries$lookup_user_id(::rpmostreecxx::PasswdEntries const &self, ::rust::Str user, ::std::uint32_t *return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$PasswdEntries$lookup_user_id (::rpmostreecxx::PasswdEntries const &self,
-                                                        ::rust::Str user,
-                                                        ::std::uint32_t *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdEntries$lookup_group_id(::rpmostreecxx::PasswdEntries const &self, ::rust::Str group, ::std::uint32_t *return$) noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$Extensions$operator$sizeof() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$Extensions$operator$alignof() noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$PasswdEntries$lookup_group_id (::rpmostreecxx::PasswdEntries const &self,
-                                                         ::rust::Str group,
-                                                         ::std::uint32_t *return$) noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$Extensions$operator$sizeof () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$Extensions$operator$alignof () noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$extensions_load(::rust::Str path, ::rust::Str basearch, ::rust::Vec<::rpmostreecxx::StringMapping> const &base_pkgs, ::rust::Box<::rpmostreecxx::Extensions> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$extensions_load (
-      ::rust::Str path, ::rust::Str basearch,
-      ::rust::Vec<::rpmostreecxx::StringMapping> const &base_pkgs,
-      ::rust::Box<::rpmostreecxx::Extensions> *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Extensions$get_repos(::rpmostreecxx::Extensions const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Extensions$get_repos (::rpmostreecxx::Extensions const &self,
-                                                     ::rust::Vec<::rust::String> *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Extensions$get_os_extension_packages(::rpmostreecxx::Extensions const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Extensions$get_os_extension_packages (
-      ::rpmostreecxx::Extensions const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$Extensions$get_development_packages(::rpmostreecxx::Extensions const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$Extensions$get_development_packages (
-      ::rpmostreecxx::Extensions const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Extensions$state_checksum_changed(::rpmostreecxx::Extensions const &self, ::rust::Str chksum, ::rust::Str output_dir, bool *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$Extensions$state_checksum_changed (
-      ::rpmostreecxx::Extensions const &self, ::rust::Str chksum, ::rust::Str output_dir,
-      bool *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Extensions$update_state_checksum(::rpmostreecxx::Extensions const &self, ::rust::Str chksum, ::rust::Str output_dir) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$Extensions$update_state_checksum (
-      ::rpmostreecxx::Extensions const &self, ::rust::Str chksum, ::rust::Str output_dir) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Extensions$serialize_to_dir(::rpmostreecxx::Extensions const &self, ::rust::Str output_dir) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$Extensions$serialize_to_dir (::rpmostreecxx::Extensions const &self,
-                                                       ::rust::Str output_dir) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Extensions$generate_treefile(::rpmostreecxx::Extensions const &self, ::rpmostreecxx::Treefile const &src, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$LockfileConfig$operator$sizeof() noexcept;
+::std::size_t rpmostreecxx$cxxbridge1$194$LockfileConfig$operator$alignof() noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$Extensions$generate_treefile (
-      ::rpmostreecxx::Extensions const &self, ::rpmostreecxx::Treefile const &src,
-      ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$LockfileConfig$operator$sizeof () noexcept;
-  ::std::size_t rpmostreecxx$cxxbridge1$LockfileConfig$operator$alignof () noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$lockfile_read(::rust::Vec<::rust::String> const &filenames, ::rust::Box<::rpmostreecxx::LockfileConfig> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$lockfile_read (
-      ::rust::Vec<::rust::String> const &filenames,
-      ::rust::Box<::rpmostreecxx::LockfileConfig> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$lockfile_write(::rust::Str filename, ::rpmostreecxx::CxxGObjectArray &packages, ::rpmostreecxx::CxxGObjectArray &rpmmd_repos) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$lockfile_write (::rust::Str filename,
-                                          ::rpmostreecxx::CxxGObjectArray &packages,
-                                          ::rpmostreecxx::CxxGObjectArray &rpmmd_repos) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$LockfileConfig$get_locked_packages(::rpmostreecxx::LockfileConfig const &self, ::rust::Vec<::rpmostreecxx::LockedPackage> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$LockfileConfig$get_locked_packages (
-      ::rpmostreecxx::LockfileConfig const &self,
-      ::rust::Vec<::rpmostreecxx::LockedPackage> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$origin_to_treefile(::rpmostreecxx::GKeyFile const &kf, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
 
-  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$origin_to_treefile (
-      ::rpmostreecxx::GKeyFile const &kf, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_to_origin(::rpmostreecxx::Treefile const &tf, ::rpmostreecxx::GKeyFile **return$) noexcept;
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$treefile_to_origin (::rpmostreecxx::Treefile const &tf,
-                                              ::rpmostreecxx::GKeyFile **return$) noexcept;
+void rpmostreecxx$cxxbridge1$194$origin_validate_roundtrip(::rpmostreecxx::GKeyFile const &kf) noexcept;
 
-  void
-  rpmostreecxx$cxxbridge1$origin_validate_roundtrip (::rpmostreecxx::GKeyFile const &kf) noexcept;
+void rpmostreecxx$cxxbridge1$194$cache_branch_to_nevra(::rust::Str nevra, ::rust::String *return$) noexcept;
 
-  void rpmostreecxx$cxxbridge1$cache_branch_to_nevra (::rust::Str nevra,
-                                                      ::rust::String *return$) noexcept;
+::std::uint32_t rpmostreecxx$cxxbridge1$194$CxxGObjectArray$length(::rpmostreecxx::CxxGObjectArray &self) noexcept {
+  ::std::uint32_t (::rpmostreecxx::CxxGObjectArray::*length$)() = &::rpmostreecxx::CxxGObjectArray::length;
+  return (self.*length$)();
+}
 
-  ::std::uint32_t
-  rpmostreecxx$cxxbridge1$CxxGObjectArray$length (::rpmostreecxx::CxxGObjectArray &self) noexcept
-  {
-    ::std::uint32_t (::rpmostreecxx::CxxGObjectArray::*length$) ()
-        = &::rpmostreecxx::CxxGObjectArray::length;
-    return (self.*length$) ();
-  }
+void rpmostreecxx$cxxbridge1$194$CxxGObjectArray$get(::rpmostreecxx::CxxGObjectArray &self, ::std::uint32_t i, ::rpmostreecxx::GObject **return$) noexcept {
+  ::rpmostreecxx::GObject &(::rpmostreecxx::CxxGObjectArray::*get$)(::std::uint32_t) = &::rpmostreecxx::CxxGObjectArray::get;
+  new (return$) ::rpmostreecxx::GObject *(&(self.*get$)(i));
+}
 
-  ::rpmostreecxx::GObject *
-  rpmostreecxx$cxxbridge1$CxxGObjectArray$get (::rpmostreecxx::CxxGObjectArray &self,
-                                               ::std::uint32_t i) noexcept
-  {
-    ::rpmostreecxx::GObject &(::rpmostreecxx::CxxGObjectArray::*get$) (::std::uint32_t)
-        = &::rpmostreecxx::CxxGObjectArray::get;
-    return &(self.*get$) (i);
-  }
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$util_next_version(::rust::Str auto_version_prefix, ::rust::Str version_suffix, ::rust::Str last_version, ::rust::String *return$) noexcept {
+  ::rust::String (*util_next_version$)(::rust::Str, ::rust::Str, ::rust::Str) = ::rpmostreecxx::util_next_version;
+  ::rust::repr::PtrLen throw$;
+  ::rust::behavior::trycatch(
+      [&] {
+        new (return$) ::rust::String(util_next_version$(auto_version_prefix, version_suffix, last_version));
+        throw$.ptr = nullptr;
+      },
+      ::rust::detail::Fail(throw$));
+  return throw$;
+}
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$util_next_version (::rust::Str auto_version_prefix,
-                                             ::rust::Str version_suffix, ::rust::Str last_version,
-                                             ::rust::String *return$) noexcept
-  {
-    ::rust::String (*util_next_version$) (::rust::Str, ::rust::Str, ::rust::Str)
-        = ::rpmostreecxx::util_next_version;
-    ::rust::repr::PtrLen throw$;
-    ::rust::behavior::trycatch (
-        [&] {
-          new (return$)::rust::String (
-              util_next_version$ (auto_version_prefix, version_suffix, last_version));
-          throw$.ptr = nullptr;
-        },
-        ::rust::detail::Fail (throw$));
-    return throw$;
-  }
+::std::int32_t rpmostreecxx$cxxbridge1$194$testutil_validate_cxxrs_passthrough(::rpmostreecxx::OstreeRepo const &repo) noexcept {
+  ::std::int32_t (*testutil_validate_cxxrs_passthrough$)(::rpmostreecxx::OstreeRepo const &) = ::rpmostreecxx::testutil_validate_cxxrs_passthrough;
+  return testutil_validate_cxxrs_passthrough$(repo);
+}
 
-  ::std::int32_t
-  rpmostreecxx$cxxbridge1$testutil_validate_cxxrs_passthrough (
-      ::rpmostreecxx::OstreeRepo const &repo) noexcept
-  {
-    ::std::int32_t (*testutil_validate_cxxrs_passthrough$) (::rpmostreecxx::OstreeRepo const &)
-        = ::rpmostreecxx::testutil_validate_cxxrs_passthrough;
-    return testutil_validate_cxxrs_passthrough$ (repo);
-  }
+void rpmostreecxx$cxxbridge1$194$early_main() noexcept {
+  void (*early_main$)() = ::rpmostreecxx::early_main;
+  early_main$();
+}
 
-  void
-  rpmostreecxx$cxxbridge1$early_main () noexcept
-  {
-    void (*early_main$) () = ::rpmostreecxx::early_main;
-    early_main$ ();
-  }
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$rpmostree_main(::rust::Slice<::rust::Str const> args, ::std::int32_t *return$) noexcept {
+  ::std::int32_t (*rpmostree_main$)(::rust::Slice<::rust::Str const>) = ::rpmostreecxx::rpmostree_main;
+  ::rust::repr::PtrLen throw$;
+  ::rust::behavior::trycatch(
+      [&] {
+        new (return$) ::std::int32_t(rpmostree_main$(args));
+        throw$.ptr = nullptr;
+      },
+      ::rust::detail::Fail(throw$));
+  return throw$;
+}
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$rpmostree_main (::rust::Slice<::rust::Str const> args,
-                                          ::std::int32_t *return$) noexcept
-  {
-    ::std::int32_t (*rpmostree_main$) (::rust::Slice<::rust::Str const>)
-        = ::rpmostreecxx::rpmostree_main;
-    ::rust::repr::PtrLen throw$;
-    ::rust::behavior::trycatch (
-        [&] {
-          new (return$)::std::int32_t (rpmostree_main$ (args));
-          throw$.ptr = nullptr;
-        },
-        ::rust::detail::Fail (throw$));
-    return throw$;
-  }
+void rpmostreecxx$cxxbridge1$194$rpmostree_process_global_teardown() noexcept {
+  void (*rpmostree_process_global_teardown$)() = ::rpmostreecxx::rpmostree_process_global_teardown;
+  rpmostree_process_global_teardown$();
+}
 
-  void
-  rpmostreecxx$cxxbridge1$rpmostree_process_global_teardown () noexcept
-  {
-    void (*rpmostree_process_global_teardown$) ()
-        = ::rpmostreecxx::rpmostree_process_global_teardown;
-    rpmostree_process_global_teardown$ ();
-  }
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$c_unit_tests() noexcept {
+  void (*c_unit_tests$)() = ::rpmostreecxx::c_unit_tests;
+  ::rust::repr::PtrLen throw$;
+  ::rust::behavior::trycatch(
+      [&] {
+        c_unit_tests$();
+        throw$.ptr = nullptr;
+      },
+      ::rust::detail::Fail(throw$));
+  return throw$;
+}
 
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$c_unit_tests () noexcept
-  {
-    void (*c_unit_tests$) () = ::rpmostreecxx::c_unit_tests;
-    ::rust::repr::PtrLen throw$;
-    ::rust::behavior::trycatch (
-        [&] {
-          c_unit_tests$ ();
-          throw$.ptr = nullptr;
-        },
-        ::rust::detail::Fail (throw$));
-    return throw$;
-  }
-
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$client_require_root () noexcept
-  {
-    void (*client_require_root$) () = ::rpmostreecxx::client_require_root;
-    ::rust::repr::PtrLen throw$;
-    ::rust::behavior::trycatch (
-        [&] {
-          client_require_root$ ();
-          throw$.ptr = nullptr;
-        },
-        ::rust::detail::Fail (throw$));
-    return throw$;
-  }
-
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$new_client_connection (
-      ::rpmostreecxx::ClientConnection **return$) noexcept
-  {
-    ::std::unique_ptr<::rpmostreecxx::ClientConnection> (*new_client_connection$) ()
-        = ::rpmostreecxx::new_client_connection;
-    ::rust::repr::PtrLen throw$;
-    ::rust::behavior::trycatch (
-        [&] {
-          new (return$)::rpmostreecxx::ClientConnection *(new_client_connection$ ().release ());
-          throw$.ptr = nullptr;
-        },
-        ::rust::detail::Fail (throw$));
-    return throw$;
-  }
-
-  ::rpmostreecxx::GDBusConnection const *
-  rpmostreecxx$cxxbridge1$ClientConnection$get_connection (
-      ::rpmostreecxx::ClientConnection &self) noexcept
-  {
-    ::rpmostreecxx::GDBusConnection const &(::rpmostreecxx::ClientConnection::*get_connection$) ()
-        = &::rpmostreecxx::ClientConnection::get_connection;
-    return &(self.*get_connection$) ();
-  }
-
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$ClientConnection$transaction_connect_progress_sync (
-      ::rpmostreecxx::ClientConnection const &self, ::rust::Str address) noexcept
-  {
-    void (::rpmostreecxx::ClientConnection::*transaction_connect_progress_sync$) (::rust::Str) const
-        = &::rpmostreecxx::ClientConnection::transaction_connect_progress_sync;
-    ::rust::repr::PtrLen throw$;
-    ::rust::behavior::trycatch (
-        [&] {
-          (self.*transaction_connect_progress_sync$) (address);
-          throw$.ptr = nullptr;
-        },
-        ::rust::detail::Fail (throw$));
-    return throw$;
-  }
-
-  ::std::int32_t
-  rpmostreecxx$cxxbridge1$RPMDiff$n_removed (::rpmostreecxx::RPMDiff const &self) noexcept
-  {
-    ::std::int32_t (::rpmostreecxx::RPMDiff::*n_removed$) () const
-        = &::rpmostreecxx::RPMDiff::n_removed;
-    return (self.*n_removed$) ();
-  }
-
-  ::std::int32_t
-  rpmostreecxx$cxxbridge1$RPMDiff$n_added (::rpmostreecxx::RPMDiff const &self) noexcept
-  {
-    ::std::int32_t (::rpmostreecxx::RPMDiff::*n_added$) () const
-        = &::rpmostreecxx::RPMDiff::n_added;
-    return (self.*n_added$) ();
-  }
-
-  ::std::int32_t
-  rpmostreecxx$cxxbridge1$RPMDiff$n_modified (::rpmostreecxx::RPMDiff const &self) noexcept
-  {
-    ::std::int32_t (::rpmostreecxx::RPMDiff::*n_modified$) () const
-        = &::rpmostreecxx::RPMDiff::n_modified;
-    return (self.*n_modified$) ();
-  }
-
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$rpmdb_diff (::rpmostreecxx::OstreeRepo const &repo,
-                                      ::std::string const &src, ::std::string const &dest,
-                                      bool allow_noent, ::rpmostreecxx::RPMDiff **return$) noexcept
-  {
-    ::std::unique_ptr<::rpmostreecxx::RPMDiff> (*rpmdb_diff$) (
-        ::rpmostreecxx::OstreeRepo const &, ::std::string const &, ::std::string const &, bool)
-        = ::rpmostreecxx::rpmdb_diff;
-    ::rust::repr::PtrLen throw$;
-    ::rust::behavior::trycatch (
-        [&] {
-          new (return$)::rpmostreecxx::RPMDiff *(
-              rpmdb_diff$ (repo, src, dest, allow_noent).release ());
-          throw$.ptr = nullptr;
-        },
-        ::rust::detail::Fail (throw$));
-    return throw$;
-  }
-
-  void
-  rpmostreecxx$cxxbridge1$RPMDiff$print (::rpmostreecxx::RPMDiff const &self) noexcept
-  {
-    void (::rpmostreecxx::RPMDiff::*print$) () const = &::rpmostreecxx::RPMDiff::print;
-    (self.*print$) ();
-  }
-
-  void
-  rpmostreecxx$cxxbridge1$print_treepkg_diff_from_sysroot_path (
-      ::rust::Str sysroot_path, ::rpmostreecxx::RpmOstreeDiffPrintFormat format,
-      ::std::uint32_t max_key_len, ::rpmostreecxx::GCancellable *cancellable) noexcept
-  {
-    void (*print_treepkg_diff_from_sysroot_path$) (::rust::Str,
-                                                   ::rpmostreecxx::RpmOstreeDiffPrintFormat,
-                                                   ::std::uint32_t, ::rpmostreecxx::GCancellable *)
-        = ::rpmostreecxx::print_treepkg_diff_from_sysroot_path;
-    print_treepkg_diff_from_sysroot_path$ (sysroot_path, format, max_key_len, cancellable);
-  }
-
-  ::rpmostreecxx::Progress *
-  rpmostreecxx$cxxbridge1$progress_begin_task (::rust::Str msg) noexcept
-  {
-    ::std::unique_ptr<::rpmostreecxx::Progress> (*progress_begin_task$) (::rust::Str)
-        = ::rpmostreecxx::progress_begin_task;
-    return progress_begin_task$ (msg).release ();
-  }
-
-  void
-  rpmostreecxx$cxxbridge1$Progress$end (::rpmostreecxx::Progress &self, ::rust::Str msg) noexcept
-  {
-    void (::rpmostreecxx::Progress::*end$) (::rust::Str) = &::rpmostreecxx::Progress::end;
-    (self.*end$) (msg);
-  }
-
-  void
-  rpmostreecxx$cxxbridge1$output_message (::rust::Str msg) noexcept
-  {
-    void (*output_message$) (::rust::Str) = ::rpmostreecxx::output_message;
-    output_message$ (msg);
-  }
-
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$nevra_to_cache_branch (::std::string const &nevra,
-                                                 ::rust::String *return$) noexcept
-  {
-    ::rust::String (*nevra_to_cache_branch$) (::std::string const &)
-        = ::rpmostreecxx::nevra_to_cache_branch;
-    ::rust::repr::PtrLen throw$;
-    ::rust::behavior::trycatch (
-        [&] {
-          new (return$)::rust::String (nevra_to_cache_branch$ (nevra));
-          throw$.ptr = nullptr;
-        },
-        ::rust::detail::Fail (throw$));
-    return throw$;
-  }
-
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$get_repodata_chksum_repr (::dnfcxx::FFIDnfPackage &pkg,
-                                                    ::rust::String *return$) noexcept
-  {
-    ::rust::String (*get_repodata_chksum_repr$) (::dnfcxx::FFIDnfPackage &)
-        = ::rpmostreecxx::get_repodata_chksum_repr;
-    ::rust::repr::PtrLen throw$;
-    ::rust::behavior::trycatch (
-        [&] {
-          new (return$)::rust::String (get_repodata_chksum_repr$ (pkg));
-          throw$.ptr = nullptr;
-        },
-        ::rust::detail::Fail (throw$));
-    return throw$;
-  }
-
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$rpmts_for_commit (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str rev,
-                                            ::rpmostreecxx::RpmTs **return$) noexcept
-  {
-    ::std::unique_ptr<::rpmostreecxx::RpmTs> (*rpmts_for_commit$) (
-        ::rpmostreecxx::OstreeRepo const &, ::rust::Str)
-        = ::rpmostreecxx::rpmts_for_commit;
-    ::rust::repr::PtrLen throw$;
-    ::rust::behavior::trycatch (
-        [&] {
-          new (return$)::rpmostreecxx::RpmTs *(rpmts_for_commit$ (repo, rev).release ());
-          throw$.ptr = nullptr;
-        },
-        ::rust::detail::Fail (throw$));
-    return throw$;
-  }
-
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$rpmdb_package_name_list (::std::int32_t dfd, ::rust::String const *path,
-                                                   ::rust::Vec<::rust::String> *return$) noexcept
-  {
-    ::rust::Vec<::rust::String> (*rpmdb_package_name_list$) (::std::int32_t, ::rust::String)
-        = ::rpmostreecxx::rpmdb_package_name_list;
-    ::rust::repr::PtrLen throw$;
-    ::rust::behavior::trycatch (
-        [&] {
-          new (return$)::rust::Vec<::rust::String> (
-              rpmdb_package_name_list$ (dfd, ::rust::String (::rust::unsafe_bitcopy, *path)));
-          throw$.ptr = nullptr;
-        },
-        ::rust::detail::Fail (throw$));
-    return throw$;
-  }
-
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$RpmTs$package_meta (::rpmostreecxx::RpmTs const &self, ::rust::Str name,
-                                              ::rust::Str arch,
-                                              ::rpmostreecxx::PackageMeta **return$) noexcept
-  {
-    ::std::unique_ptr<::rpmostreecxx::PackageMeta> (::rpmostreecxx::RpmTs::*package_meta$) (
-        ::rust::Str, ::rust::Str) const
-        = &::rpmostreecxx::RpmTs::package_meta;
-    ::rust::repr::PtrLen throw$;
-    ::rust::behavior::trycatch (
-        [&] {
-          new (return$)::rpmostreecxx::PackageMeta *((self.*package_meta$) (name, arch).release ());
-          throw$.ptr = nullptr;
-        },
-        ::rust::detail::Fail (throw$));
-    return throw$;
-  }
-
-  ::std::uint64_t
-  rpmostreecxx$cxxbridge1$PackageMeta$size (::rpmostreecxx::PackageMeta const &self) noexcept
-  {
-    ::std::uint64_t (::rpmostreecxx::PackageMeta::*size$) () const
-        = &::rpmostreecxx::PackageMeta::size;
-    return (self.*size$) ();
-  }
-
-  ::std::uint64_t
-  rpmostreecxx$cxxbridge1$PackageMeta$buildtime (::rpmostreecxx::PackageMeta const &self) noexcept
-  {
-    ::std::uint64_t (::rpmostreecxx::PackageMeta::*buildtime$) () const
-        = &::rpmostreecxx::PackageMeta::buildtime;
-    return (self.*buildtime$) ();
-  }
-
-  void
-  rpmostreecxx$cxxbridge1$PackageMeta$changelogs (::rpmostreecxx::PackageMeta const &self,
-                                                  ::rust::Vec<::std::uint64_t> *return$) noexcept
-  {
-    ::rust::Vec<::std::uint64_t> (::rpmostreecxx::PackageMeta::*changelogs$) () const
-        = &::rpmostreecxx::PackageMeta::changelogs;
-    new (return$)::rust::Vec<::std::uint64_t> ((self.*changelogs$) ());
-  }
-
-  ::rust::repr::Fat
-  rpmostreecxx$cxxbridge1$PackageMeta$src_pkg (::rpmostreecxx::PackageMeta const &self) noexcept
-  {
-    ::rust::Str (::rpmostreecxx::PackageMeta::*src_pkg$) () const
-        = &::rpmostreecxx::PackageMeta::src_pkg;
-    return ::rust::impl<::rust::Str>::repr ((self.*src_pkg$) ());
-  }
-
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$PackageMeta$provided_paths (::rpmostreecxx::PackageMeta const &self,
-                                                      ::rust::Vec<::rust::String> *return$) noexcept
-  {
-    ::rust::Vec<::rust::String> (::rpmostreecxx::PackageMeta::*provided_paths$) () const
-        = &::rpmostreecxx::PackageMeta::provided_paths;
-    ::rust::repr::PtrLen throw$;
-    ::rust::behavior::trycatch (
-        [&] {
-          new (return$)::rust::Vec<::rust::String> ((self.*provided_paths$) ());
-          throw$.ptr = nullptr;
-        },
-        ::rust::detail::Fail (throw$));
-    return throw$;
-  }
-
-  ::rust::repr::PtrLen
-  rpmostreecxx$cxxbridge1$package_variant_list_for_commit (
-      ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str rev,
-      ::rpmostreecxx::GCancellable const &cancellable, ::rpmostreecxx::GVariant **return$) noexcept
-  {
-    ::rpmostreecxx::GVariant *(*package_variant_list_for_commit$) (
-        ::rpmostreecxx::OstreeRepo const &, ::rust::Str, ::rpmostreecxx::GCancellable const &)
-        = ::rpmostreecxx::package_variant_list_for_commit;
-    ::rust::repr::PtrLen throw$;
-    ::rust::behavior::trycatch (
-        [&] {
-          new (return$)::rpmostreecxx::GVariant *(
-              package_variant_list_for_commit$ (repo, rev, cancellable));
-          throw$.ptr = nullptr;
-        },
-        ::rust::detail::Fail (throw$));
-    return throw$;
-  }
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$client_require_root() noexcept {
+  void (*client_require_root$)() = ::rpmostreecxx::client_require_root;
+  ::rust::repr::PtrLen throw$;
+  ::rust::behavior::trycatch(
+      [&] {
+        client_require_root$();
+        throw$.ptr = nullptr;
+      },
+      ::rust::detail::Fail(throw$));
+  return throw$;
+}
+
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$new_client_connection(::rpmostreecxx::ClientConnection **return$) noexcept {
+  ::std::unique_ptr<::rpmostreecxx::ClientConnection> (*new_client_connection$)() = ::rpmostreecxx::new_client_connection;
+  ::rust::repr::PtrLen throw$;
+  ::rust::behavior::trycatch(
+      [&] {
+        new (return$) ::rpmostreecxx::ClientConnection *(new_client_connection$().release());
+        throw$.ptr = nullptr;
+      },
+      ::rust::detail::Fail(throw$));
+  return throw$;
+}
+
+::rpmostreecxx::GDBusConnection const *rpmostreecxx$cxxbridge1$194$ClientConnection$get_connection(::rpmostreecxx::ClientConnection &self) noexcept {
+  ::rpmostreecxx::GDBusConnection const &(::rpmostreecxx::ClientConnection::*get_connection$)() = &::rpmostreecxx::ClientConnection::get_connection;
+  return &(self.*get_connection$)();
+}
+
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$ClientConnection$transaction_connect_progress_sync(::rpmostreecxx::ClientConnection const &self, ::rust::Str address) noexcept {
+  void (::rpmostreecxx::ClientConnection::*transaction_connect_progress_sync$)(::rust::Str) const = &::rpmostreecxx::ClientConnection::transaction_connect_progress_sync;
+  ::rust::repr::PtrLen throw$;
+  ::rust::behavior::trycatch(
+      [&] {
+        (self.*transaction_connect_progress_sync$)(address);
+        throw$.ptr = nullptr;
+      },
+      ::rust::detail::Fail(throw$));
+  return throw$;
+}
+
+::std::int32_t rpmostreecxx$cxxbridge1$194$RPMDiff$n_removed(::rpmostreecxx::RPMDiff const &self) noexcept {
+  ::std::int32_t (::rpmostreecxx::RPMDiff::*n_removed$)() const = &::rpmostreecxx::RPMDiff::n_removed;
+  return (self.*n_removed$)();
+}
+
+::std::int32_t rpmostreecxx$cxxbridge1$194$RPMDiff$n_added(::rpmostreecxx::RPMDiff const &self) noexcept {
+  ::std::int32_t (::rpmostreecxx::RPMDiff::*n_added$)() const = &::rpmostreecxx::RPMDiff::n_added;
+  return (self.*n_added$)();
+}
+
+::std::int32_t rpmostreecxx$cxxbridge1$194$RPMDiff$n_modified(::rpmostreecxx::RPMDiff const &self) noexcept {
+  ::std::int32_t (::rpmostreecxx::RPMDiff::*n_modified$)() const = &::rpmostreecxx::RPMDiff::n_modified;
+  return (self.*n_modified$)();
+}
+
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$rpmdb_diff(::rpmostreecxx::OstreeRepo const &repo, ::std::string const &src, ::std::string const &dest, bool allow_noent, ::rpmostreecxx::RPMDiff **return$) noexcept {
+  ::std::unique_ptr<::rpmostreecxx::RPMDiff> (*rpmdb_diff$)(::rpmostreecxx::OstreeRepo const &, ::std::string const &, ::std::string const &, bool) = ::rpmostreecxx::rpmdb_diff;
+  ::rust::repr::PtrLen throw$;
+  ::rust::behavior::trycatch(
+      [&] {
+        new (return$) ::rpmostreecxx::RPMDiff *(rpmdb_diff$(repo, src, dest, allow_noent).release());
+        throw$.ptr = nullptr;
+      },
+      ::rust::detail::Fail(throw$));
+  return throw$;
+}
+
+void rpmostreecxx$cxxbridge1$194$RPMDiff$print(::rpmostreecxx::RPMDiff const &self) noexcept {
+  void (::rpmostreecxx::RPMDiff::*print$)() const = &::rpmostreecxx::RPMDiff::print;
+  (self.*print$)();
+}
+
+void rpmostreecxx$cxxbridge1$194$print_treepkg_diff_from_sysroot_path(::rust::Str sysroot_path, ::rpmostreecxx::RpmOstreeDiffPrintFormat format, ::std::uint32_t max_key_len, ::rpmostreecxx::GCancellable *cancellable) noexcept {
+  void (*print_treepkg_diff_from_sysroot_path$)(::rust::Str, ::rpmostreecxx::RpmOstreeDiffPrintFormat, ::std::uint32_t, ::rpmostreecxx::GCancellable *) = ::rpmostreecxx::print_treepkg_diff_from_sysroot_path;
+  print_treepkg_diff_from_sysroot_path$(sysroot_path, format, max_key_len, cancellable);
+}
+
+::rpmostreecxx::Progress *rpmostreecxx$cxxbridge1$194$progress_begin_task(::rust::Str msg) noexcept {
+  ::std::unique_ptr<::rpmostreecxx::Progress> (*progress_begin_task$)(::rust::Str) = ::rpmostreecxx::progress_begin_task;
+  return progress_begin_task$(msg).release();
+}
+
+void rpmostreecxx$cxxbridge1$194$Progress$end(::rpmostreecxx::Progress &self, ::rust::Str msg) noexcept {
+  void (::rpmostreecxx::Progress::*end$)(::rust::Str) = &::rpmostreecxx::Progress::end;
+  (self.*end$)(msg);
+}
+
+void rpmostreecxx$cxxbridge1$194$output_message(::rust::Str msg) noexcept {
+  void (*output_message$)(::rust::Str) = ::rpmostreecxx::output_message;
+  output_message$(msg);
+}
+
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$nevra_to_cache_branch(::std::string const &nevra, ::rust::String *return$) noexcept {
+  ::rust::String (*nevra_to_cache_branch$)(::std::string const &) = ::rpmostreecxx::nevra_to_cache_branch;
+  ::rust::repr::PtrLen throw$;
+  ::rust::behavior::trycatch(
+      [&] {
+        new (return$) ::rust::String(nevra_to_cache_branch$(nevra));
+        throw$.ptr = nullptr;
+      },
+      ::rust::detail::Fail(throw$));
+  return throw$;
+}
+
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$get_repodata_chksum_repr(::dnfcxx::FFIDnfPackage &pkg, ::rust::String *return$) noexcept {
+  ::rust::String (*get_repodata_chksum_repr$)(::dnfcxx::FFIDnfPackage &) = ::rpmostreecxx::get_repodata_chksum_repr;
+  ::rust::repr::PtrLen throw$;
+  ::rust::behavior::trycatch(
+      [&] {
+        new (return$) ::rust::String(get_repodata_chksum_repr$(pkg));
+        throw$.ptr = nullptr;
+      },
+      ::rust::detail::Fail(throw$));
+  return throw$;
+}
+
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$rpmts_for_commit(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str rev, ::rpmostreecxx::RpmTs **return$) noexcept {
+  ::std::unique_ptr<::rpmostreecxx::RpmTs> (*rpmts_for_commit$)(::rpmostreecxx::OstreeRepo const &, ::rust::Str) = ::rpmostreecxx::rpmts_for_commit;
+  ::rust::repr::PtrLen throw$;
+  ::rust::behavior::trycatch(
+      [&] {
+        new (return$) ::rpmostreecxx::RpmTs *(rpmts_for_commit$(repo, rev).release());
+        throw$.ptr = nullptr;
+      },
+      ::rust::detail::Fail(throw$));
+  return throw$;
+}
+
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$rpmdb_package_name_list(::std::int32_t dfd, ::rust::String const *path, ::rust::Vec<::rust::String> *return$) noexcept {
+  ::rust::Vec<::rust::String> (*rpmdb_package_name_list$)(::std::int32_t, ::rust::String) = ::rpmostreecxx::rpmdb_package_name_list;
+  ::rust::repr::PtrLen throw$;
+  ::rust::behavior::trycatch(
+      [&] {
+        new (return$) ::rust::Vec<::rust::String>(rpmdb_package_name_list$(dfd, ::rust::String(::rust::unsafe_bitcopy, *path)));
+        throw$.ptr = nullptr;
+      },
+      ::rust::detail::Fail(throw$));
+  return throw$;
+}
+
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$RpmTs$package_meta(::rpmostreecxx::RpmTs const &self, ::rust::Str name, ::rust::Str arch, ::rpmostreecxx::PackageMeta **return$) noexcept {
+  ::std::unique_ptr<::rpmostreecxx::PackageMeta> (::rpmostreecxx::RpmTs::*package_meta$)(::rust::Str, ::rust::Str) const = &::rpmostreecxx::RpmTs::package_meta;
+  ::rust::repr::PtrLen throw$;
+  ::rust::behavior::trycatch(
+      [&] {
+        new (return$) ::rpmostreecxx::PackageMeta *((self.*package_meta$)(name, arch).release());
+        throw$.ptr = nullptr;
+      },
+      ::rust::detail::Fail(throw$));
+  return throw$;
+}
+
+::std::uint64_t rpmostreecxx$cxxbridge1$194$PackageMeta$size(::rpmostreecxx::PackageMeta const &self) noexcept {
+  ::std::uint64_t (::rpmostreecxx::PackageMeta::*size$)() const = &::rpmostreecxx::PackageMeta::size;
+  return (self.*size$)();
+}
+
+::std::uint64_t rpmostreecxx$cxxbridge1$194$PackageMeta$buildtime(::rpmostreecxx::PackageMeta const &self) noexcept {
+  ::std::uint64_t (::rpmostreecxx::PackageMeta::*buildtime$)() const = &::rpmostreecxx::PackageMeta::buildtime;
+  return (self.*buildtime$)();
+}
+
+void rpmostreecxx$cxxbridge1$194$PackageMeta$changelogs(::rpmostreecxx::PackageMeta const &self, ::rust::Vec<::std::uint64_t> *return$) noexcept {
+  ::rust::Vec<::std::uint64_t> (::rpmostreecxx::PackageMeta::*changelogs$)() const = &::rpmostreecxx::PackageMeta::changelogs;
+  new (return$) ::rust::Vec<::std::uint64_t>((self.*changelogs$)());
+}
+
+void rpmostreecxx$cxxbridge1$194$PackageMeta$src_pkg(::rpmostreecxx::PackageMeta const &self, ::rust::Str *return$) noexcept {
+  ::rust::Str (::rpmostreecxx::PackageMeta::*src_pkg$)() const = &::rpmostreecxx::PackageMeta::src_pkg;
+  new (return$) ::rust::Str((self.*src_pkg$)());
+}
+
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PackageMeta$provided_paths(::rpmostreecxx::PackageMeta const &self, ::rust::Vec<::rust::String> *return$) noexcept {
+  ::rust::Vec<::rust::String> (::rpmostreecxx::PackageMeta::*provided_paths$)() const = &::rpmostreecxx::PackageMeta::provided_paths;
+  ::rust::repr::PtrLen throw$;
+  ::rust::behavior::trycatch(
+      [&] {
+        new (return$) ::rust::Vec<::rust::String>((self.*provided_paths$)());
+        throw$.ptr = nullptr;
+      },
+      ::rust::detail::Fail(throw$));
+  return throw$;
+}
+
+::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$package_variant_list_for_commit(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str rev, ::rpmostreecxx::GCancellable const &cancellable, ::rpmostreecxx::GVariant **return$) noexcept {
+  ::rpmostreecxx::GVariant *(*package_variant_list_for_commit$)(::rpmostreecxx::OstreeRepo const &, ::rust::Str, ::rpmostreecxx::GCancellable const &) = ::rpmostreecxx::package_variant_list_for_commit;
+  ::rust::repr::PtrLen throw$;
+  ::rust::behavior::trycatch(
+      [&] {
+        new (return$) ::rpmostreecxx::GVariant *(package_variant_list_for_commit$(repo, rev, cancellable));
+        throw$.ptr = nullptr;
+      },
+      ::rust::detail::Fail(throw$));
+  return throw$;
+}
 } // extern "C"
 
-bool
-is_bare_split_xattrs ()
-{
+bool is_bare_split_xattrs() {
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$is_bare_split_xattrs (&return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$is_bare_split_xattrs(&return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-bool
-is_http_arg (::rust::Str arg) noexcept
-{
-  return rpmostreecxx$cxxbridge1$is_http_arg (arg);
+bool is_http_arg(::rust::Str arg) noexcept {
+  return rpmostreecxx$cxxbridge1$194$is_http_arg(arg);
 }
 
-bool
-is_ostree_container ()
-{
+bool is_ostree_container() {
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$is_ostree_container (&return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$is_ostree_container(&return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rpmostreecxx::SystemHostType
-get_system_host_type ()
-{
+::rpmostreecxx::SystemHostType get_system_host_type() {
   ::rust::MaybeUninit<::rpmostreecxx::SystemHostType> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$get_system_host_type (&return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$get_system_host_type(&return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-require_system_host_type (::rpmostreecxx::SystemHostType t)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$require_system_host_type (t);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void require_system_host_type(::rpmostreecxx::SystemHostType t) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$require_system_host_type(t);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-bool
-is_rpm_arg (::rust::Str arg) noexcept
-{
-  return rpmostreecxx$cxxbridge1$is_rpm_arg (arg);
+bool is_rpm_arg(::rust::Str arg) noexcept {
+  return rpmostreecxx$cxxbridge1$194$is_rpm_arg(arg);
 }
 
-void
-client_start_daemon ()
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$client_start_daemon ();
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void client_start_daemon() {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$client_start_daemon();
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::rust::Vec<::std::int32_t>
-client_handle_fd_argument (::rust::Str arg, ::rust::Str arch, bool is_replace)
-{
+::rust::Vec<::std::int32_t> client_handle_fd_argument(::rust::Str arg, ::rust::Str arch, bool is_replace) {
   ::rust::MaybeUninit<::rust::Vec<::std::int32_t>> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$client_handle_fd_argument (arg, arch, is_replace, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$client_handle_fd_argument(arg, arch, is_replace, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::String
-client_render_download_progress (::rpmostreecxx::GVariant const &progress) noexcept
-{
+::rust::String client_render_download_progress(::rpmostreecxx::GVariant const &progress) noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$client_render_download_progress (progress, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$client_render_download_progress(progress, &return$.value);
+  return ::std::move(return$.value);
 }
 
-bool
-running_in_container () noexcept
-{
-  return rpmostreecxx$cxxbridge1$running_in_container ();
+bool running_in_container() noexcept {
+  return rpmostreecxx$cxxbridge1$194$running_in_container();
 }
 
-bool
-confirm ()
-{
+bool confirm() {
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$confirm (&return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$confirm(&return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-confirm_or_abort ()
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$confirm_or_abort ();
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void confirm_or_abort() {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$confirm_or_abort();
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::std::size_t
-Bubblewrap::layout::size () noexcept
-{
-  return rpmostreecxx$cxxbridge1$Bubblewrap$operator$sizeof ();
+::std::size_t Bubblewrap::layout::size() noexcept {
+  return rpmostreecxx$cxxbridge1$194$Bubblewrap$operator$sizeof();
 }
 
-::std::size_t
-Bubblewrap::layout::align () noexcept
-{
-  return rpmostreecxx$cxxbridge1$Bubblewrap$operator$alignof ();
+::std::size_t Bubblewrap::layout::align() noexcept {
+  return rpmostreecxx$cxxbridge1$194$Bubblewrap$operator$alignof();
 }
 
-void
-bubblewrap_selftest ()
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$bubblewrap_selftest ();
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void bubblewrap_selftest() {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$bubblewrap_selftest();
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::rust::Vec<::std::uint8_t>
-bubblewrap_run_sync (::std::int32_t rootfs_dfd, ::rust::Vec<::rust::String> const &args,
-                     bool capture_stdout, ::rpmostreecxx::BubblewrapMutability mutability)
-{
+::rust::Vec<::std::uint8_t> bubblewrap_run_sync(::std::int32_t rootfs_dfd, ::rust::Vec<::rust::String> const &args, bool capture_stdout, ::rpmostreecxx::BubblewrapMutability mutability) {
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$bubblewrap_run_sync (
-      rootfs_dfd, args, capture_stdout, mutability, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$bubblewrap_run_sync(rootfs_dfd, args, capture_stdout, mutability, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::Box<::rpmostreecxx::Bubblewrap>
-bubblewrap_new (::std::int32_t rootfs_fd)
-{
+::rust::Box<::rpmostreecxx::Bubblewrap> bubblewrap_new(::std::int32_t rootfs_fd) {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Bubblewrap>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$bubblewrap_new (rootfs_fd, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$bubblewrap_new(rootfs_fd, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::Box<::rpmostreecxx::Bubblewrap>
-bubblewrap_new_with_mutability (::std::int32_t rootfs_fd,
-                                ::rpmostreecxx::BubblewrapMutability mutability)
-{
+::rust::Box<::rpmostreecxx::Bubblewrap> bubblewrap_new_with_mutability(::std::int32_t rootfs_fd, ::rpmostreecxx::BubblewrapMutability mutability) {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Bubblewrap>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$bubblewrap_new_with_mutability (
-      rootfs_fd, mutability, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$bubblewrap_new_with_mutability(rootfs_fd, mutability, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::std::int32_t
-Bubblewrap::get_rootfs_fd () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Bubblewrap$get_rootfs_fd (*this);
+::std::int32_t Bubblewrap::get_rootfs_fd() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Bubblewrap$get_rootfs_fd(*this);
 }
 
-void
-Bubblewrap::append_bwrap_arg (::rust::Str arg) noexcept
-{
-  rpmostreecxx$cxxbridge1$Bubblewrap$append_bwrap_arg (*this, arg);
+void Bubblewrap::append_bwrap_arg(::rust::Str arg) noexcept {
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$append_bwrap_arg(*this, arg);
 }
 
-void
-Bubblewrap::append_child_arg (::rust::Str arg) noexcept
-{
-  rpmostreecxx$cxxbridge1$Bubblewrap$append_child_arg (*this, arg);
+void Bubblewrap::append_child_arg(::rust::Str arg) noexcept {
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$append_child_arg(*this, arg);
 }
 
-void
-Bubblewrap::setenv (::rust::Str k, ::rust::Str v) noexcept
-{
-  rpmostreecxx$cxxbridge1$Bubblewrap$setenv (*this, k, v);
+void Bubblewrap::setenv(::rust::Str k, ::rust::Str v) noexcept {
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$setenv(*this, k, v);
 }
 
-void
-Bubblewrap::take_fd (::std::int32_t source_fd, ::std::int32_t target_fd) noexcept
-{
-  rpmostreecxx$cxxbridge1$Bubblewrap$take_fd (*this, source_fd, target_fd);
+void Bubblewrap::take_fd(::std::int32_t source_fd, ::std::int32_t target_fd) noexcept {
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$take_fd(*this, source_fd, target_fd);
 }
 
-void
-Bubblewrap::set_inherit_stdin () noexcept
-{
-  rpmostreecxx$cxxbridge1$Bubblewrap$set_inherit_stdin (*this);
+void Bubblewrap::set_inherit_stdin() noexcept {
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$set_inherit_stdin(*this);
 }
 
-void
-Bubblewrap::take_stdin_fd (::std::int32_t source_fd) noexcept
-{
-  rpmostreecxx$cxxbridge1$Bubblewrap$take_stdin_fd (*this, source_fd);
+void Bubblewrap::take_stdin_fd(::std::int32_t source_fd) noexcept {
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdin_fd(*this, source_fd);
 }
 
-void
-Bubblewrap::take_stdout_fd (::std::int32_t source_fd) noexcept
-{
-  rpmostreecxx$cxxbridge1$Bubblewrap$take_stdout_fd (*this, source_fd);
+void Bubblewrap::take_stdout_fd(::std::int32_t source_fd) noexcept {
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdout_fd(*this, source_fd);
 }
 
-void
-Bubblewrap::take_stderr_fd (::std::int32_t source_fd) noexcept
-{
-  rpmostreecxx$cxxbridge1$Bubblewrap$take_stderr_fd (*this, source_fd);
+void Bubblewrap::take_stderr_fd(::std::int32_t source_fd) noexcept {
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stderr_fd(*this, source_fd);
 }
 
-void
-Bubblewrap::take_stdout_and_stderr_fd (::std::int32_t source_fd) noexcept
-{
-  rpmostreecxx$cxxbridge1$Bubblewrap$take_stdout_and_stderr_fd (*this, source_fd);
+void Bubblewrap::take_stdout_and_stderr_fd(::std::int32_t source_fd) noexcept {
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdout_and_stderr_fd(*this, source_fd);
 }
 
-void
-Bubblewrap::bind_read (::rust::Str src, ::rust::Str dest) noexcept
-{
-  rpmostreecxx$cxxbridge1$Bubblewrap$bind_read (*this, src, dest);
+void Bubblewrap::bind_read(::rust::Str src, ::rust::Str dest) noexcept {
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$bind_read(*this, src, dest);
 }
 
-void
-Bubblewrap::bind_readwrite (::rust::Str src, ::rust::Str dest) noexcept
-{
-  rpmostreecxx$cxxbridge1$Bubblewrap$bind_readwrite (*this, src, dest);
+void Bubblewrap::bind_readwrite(::rust::Str src, ::rust::Str dest) noexcept {
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$bind_readwrite(*this, src, dest);
 }
 
-void
-Bubblewrap::setup_compat_var ()
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Bubblewrap$setup_compat_var (*this);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void Bubblewrap::setup_compat_var() {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Bubblewrap$setup_compat_var(*this);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-Bubblewrap::run (::rpmostreecxx::GCancellable const &cancellable)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Bubblewrap$run (*this, cancellable);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void Bubblewrap::run(::rpmostreecxx::GCancellable const &cancellable) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Bubblewrap$run(*this, cancellable);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::rpmostreecxx::BubblewrapMutability
-mutability_for_unified_core (bool unified_core) noexcept
-{
-  return rpmostreecxx$cxxbridge1$mutability_for_unified_core (unified_core);
+::rpmostreecxx::BubblewrapMutability mutability_for_unified_core(bool unified_core) noexcept {
+  return rpmostreecxx$cxxbridge1$194$mutability_for_unified_core(unified_core);
 }
 
-void
-usroverlay_entrypoint (::rust::Vec<::rust::String> const &args)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$usroverlay_entrypoint (args);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void usroverlay_entrypoint(::rust::Vec<::rust::String> const &args) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$usroverlay_entrypoint(args);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-applylive_entrypoint (::rust::Vec<::rust::String> const &args)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$applylive_entrypoint (args);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void applylive_entrypoint(::rust::Vec<::rust::String> const &args) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$applylive_entrypoint(args);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-applylive_finish (::rpmostreecxx::OstreeSysroot const &sysroot)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$applylive_finish (sysroot);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void applylive_finish(::rpmostreecxx::OstreeSysroot const &sysroot) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$applylive_finish(sysroot);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-composeutil_legacy_prep_dev_and_run (::std::int32_t rootfs_dfd)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$composeutil_legacy_prep_dev_and_run (rootfs_dfd);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void composeutil_legacy_prep_dev_and_run(::std::int32_t rootfs_dfd) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$composeutil_legacy_prep_dev_and_run(rootfs_dfd);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-print_ostree_txn_stats (::rpmostreecxx::OstreeRepoTransactionStats &stats) noexcept
-{
-  rpmostreecxx$cxxbridge1$print_ostree_txn_stats (stats);
+void print_ostree_txn_stats(::rpmostreecxx::OstreeRepoTransactionStats &stats) noexcept {
+  rpmostreecxx$cxxbridge1$194$print_ostree_txn_stats(stats);
 }
 
-void
-write_commit_id (::rust::Str target_path, ::rust::Str revision)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$write_commit_id (target_path, revision);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void write_commit_id(::rust::Str target_path, ::rust::Str revision) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$write_commit_id(target_path, revision);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-cliwrap_write_wrappers (::std::int32_t rootfs)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$cliwrap_write_wrappers (rootfs);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void cliwrap_write_wrappers(::std::int32_t rootfs) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$cliwrap_write_wrappers(rootfs);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-cliwrap_write_some_wrappers (::std::int32_t rootfs, ::rust::Vec<::rust::String> const &args)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$cliwrap_write_some_wrappers (rootfs, args);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void cliwrap_write_some_wrappers(::std::int32_t rootfs, ::rust::Vec<::rust::String> const &args) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$cliwrap_write_some_wrappers(rootfs, args);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::rust::String
-cliwrap_destdir () noexcept
-{
+::rust::String cliwrap_destdir() noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$cliwrap_destdir (&return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$cliwrap_destdir(&return$.value);
+  return ::std::move(return$.value);
 }
 
-void
-container_encapsulate (::rust::Vec<::rust::String> args)
-{
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$ (::std::move (args));
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$container_encapsulate (&args$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void container_encapsulate(::rust::Vec<::rust::String> args) {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$(::std::move(args));
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$container_encapsulate(&args$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-deploy_from_self_entrypoint (::rust::Vec<::rust::String> args)
-{
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$ (::std::move (args));
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$deploy_from_self_entrypoint (&args$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void deploy_from_self_entrypoint(::rust::Vec<::rust::String> args) {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$(::std::move(args));
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deploy_from_self_entrypoint(&args$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-bool
-PrunedContainerInfo::operator== (PrunedContainerInfo const &rhs) const noexcept
-{
-  return rpmostreecxx$cxxbridge1$PrunedContainerInfo$operator$eq (*this, rhs);
+bool PrunedContainerInfo::operator==(PrunedContainerInfo const &rhs) const noexcept {
+  return rpmostreecxx$cxxbridge1$194$PrunedContainerInfo$operator$eq(*this, rhs);
 }
 
-bool
-PrunedContainerInfo::operator!= (PrunedContainerInfo const &rhs) const noexcept
-{
+bool PrunedContainerInfo::operator!=(PrunedContainerInfo const &rhs) const noexcept {
   return !(*this == rhs);
 }
 
-::rust::Box<::rpmostreecxx::ContainerImageState>
-pull_container (::rpmostreecxx::OstreeRepo const &repo,
-                ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref,
-                ::rust::Str digest_override)
-{
+::rust::Box<::rpmostreecxx::ContainerImageState> pull_container(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref, ::rust::Str digest_override) {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::ContainerImageState>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$pull_container (
-      repo, cancellable, imgref, digest_override, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$pull_container(repo, cancellable, imgref, digest_override, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rpmostreecxx::PrunedContainerInfo
-container_prune (::rpmostreecxx::OstreeSysroot const &sysroot)
-{
+::rpmostreecxx::PrunedContainerInfo container_prune(::rpmostreecxx::OstreeSysroot const &sysroot) {
   ::rust::MaybeUninit<::rpmostreecxx::PrunedContainerInfo> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$container_prune (sysroot, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$container_prune(sysroot, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::Box<::rpmostreecxx::ContainerImageState>
-query_container_image_commit (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str c)
-{
+::rust::Box<::rpmostreecxx::ContainerImageState> query_container_image_commit(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str c) {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::ContainerImageState>> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$query_container_image_commit (repo, c, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$query_container_image_commit(repo, c, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-purge_refspec (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$purge_refspec (repo, refspec);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void purge_refspec(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$purge_refspec(repo, refspec);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-bool
-check_container_update (::rpmostreecxx::OstreeRepo const &repo,
-                        ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref)
-{
+bool check_container_update(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref) {
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$check_container_update (repo, cancellable, imgref, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$check_container_update(repo, cancellable, imgref, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::std::size_t
-TempEtcGuard::layout::size () noexcept
-{
-  return rpmostreecxx$cxxbridge1$TempEtcGuard$operator$sizeof ();
+::std::size_t TempEtcGuard::layout::size() noexcept {
+  return rpmostreecxx$cxxbridge1$194$TempEtcGuard$operator$sizeof();
 }
 
-::std::size_t
-TempEtcGuard::layout::align () noexcept
-{
-  return rpmostreecxx$cxxbridge1$TempEtcGuard$operator$alignof ();
+::std::size_t TempEtcGuard::layout::align() noexcept {
+  return rpmostreecxx$cxxbridge1$194$TempEtcGuard$operator$alignof();
 }
 
-::std::size_t
-FilesystemScriptPrep::layout::size () noexcept
-{
-  return rpmostreecxx$cxxbridge1$FilesystemScriptPrep$operator$sizeof ();
+::std::size_t FilesystemScriptPrep::layout::size() noexcept {
+  return rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$operator$sizeof();
 }
 
-::std::size_t
-FilesystemScriptPrep::layout::align () noexcept
-{
-  return rpmostreecxx$cxxbridge1$FilesystemScriptPrep$operator$alignof ();
+::std::size_t FilesystemScriptPrep::layout::align() noexcept {
+  return rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$operator$alignof();
 }
 
-::rust::Box<::rpmostreecxx::TempEtcGuard>
-prepare_tempetc_guard (::std::int32_t rootfs)
-{
+::rust::Box<::rpmostreecxx::TempEtcGuard> prepare_tempetc_guard(::std::int32_t rootfs) {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::TempEtcGuard>> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$prepare_tempetc_guard (rootfs, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$prepare_tempetc_guard(rootfs, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-TempEtcGuard::undo () const
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$TempEtcGuard$undo (*this);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void TempEtcGuard::undo() const {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$TempEtcGuard$undo(*this);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::rust::Box<::rpmostreecxx::FilesystemScriptPrep>
-prepare_filesystem_script_prep (::std::int32_t rootfs)
-{
+::rust::Box<::rpmostreecxx::FilesystemScriptPrep> prepare_filesystem_script_prep(::std::int32_t rootfs) {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::FilesystemScriptPrep>> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$prepare_filesystem_script_prep (rootfs, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$prepare_filesystem_script_prep(rootfs, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-FilesystemScriptPrep::undo ()
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$FilesystemScriptPrep$undo (*this);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void FilesystemScriptPrep::undo() {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$undo(*this);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-run_depmod (::std::int32_t rootfs_dfd, ::rust::Str kver, bool unified_core)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$run_depmod (rootfs_dfd, kver, unified_core);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void run_depmod(::std::int32_t rootfs_dfd, ::rust::Str kver, bool unified_core) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$run_depmod(rootfs_dfd, kver, unified_core);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-run_sysusers (::std::int32_t rootfs_dfd, bool force)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$run_sysusers (rootfs_dfd, force);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void run_sysusers(::std::int32_t rootfs_dfd, bool force) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$run_sysusers(rootfs_dfd, force);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-log_treefile (::rpmostreecxx::Treefile const &tf) noexcept
-{
-  rpmostreecxx$cxxbridge1$log_treefile (tf);
+void log_treefile(::rpmostreecxx::Treefile const &tf) noexcept {
+  rpmostreecxx$cxxbridge1$194$log_treefile(tf);
 }
 
-bool
-is_container_image_reference (::rust::Str refspec) noexcept
-{
-  return rpmostreecxx$cxxbridge1$is_container_image_reference (refspec);
+bool is_container_image_reference(::rust::Str refspec) noexcept {
+  return rpmostreecxx$cxxbridge1$194$is_container_image_reference(refspec);
 }
 
-bool
-is_container_image_digest_reference (::rust::Str refspec) noexcept
-{
-  return rpmostreecxx$cxxbridge1$is_container_image_digest_reference (refspec);
+bool is_container_image_digest_reference(::rust::Str refspec) noexcept {
+  return rpmostreecxx$cxxbridge1$194$is_container_image_digest_reference(refspec);
 }
 
-::rpmostreecxx::RefspecType
-refspec_classify (::rust::Str refspec) noexcept
-{
-  return rpmostreecxx$cxxbridge1$refspec_classify (refspec);
+::rpmostreecxx::RefspecType refspec_classify(::rust::Str refspec) noexcept {
+  return rpmostreecxx$cxxbridge1$194$refspec_classify(refspec);
 }
 
-void
-verify_kernel_hmac (::std::int32_t rootfs, ::rust::Str moddir)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$verify_kernel_hmac (rootfs, moddir);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void verify_kernel_hmac(::std::int32_t rootfs, ::rust::Str moddir) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$verify_kernel_hmac(rootfs, moddir);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::rust::Vec<::rust::String>
-stage_container_rpms (::rust::Vec<::rust::String> rpms)
-{
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> rpms$ (::std::move (rpms));
+::rust::Vec<::rust::String> stage_container_rpms(::rust::Vec<::rust::String> rpms) {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> rpms$(::std::move(rpms));
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$stage_container_rpms (&rpms$.value, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$stage_container_rpms(&rpms$.value, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::Vec<::rust::String>
-stage_container_rpm_raw_fds (::rust::Vec<::std::int32_t> fds)
-{
-  ::rust::ManuallyDrop<::rust::Vec<::std::int32_t>> fds$ (::std::move (fds));
+::rust::Vec<::rust::String> stage_container_rpm_raw_fds(::rust::Vec<::std::int32_t> fds) {
+  ::rust::ManuallyDrop<::rust::Vec<::std::int32_t>> fds$(::std::move(fds));
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$stage_container_rpm_raw_fds (&fds$.value, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$stage_container_rpm_raw_fds(&fds$.value, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-bool
-commit_has_matching_sepolicy (::rpmostreecxx::GVariant const &commit,
-                              ::rpmostreecxx::OstreeSePolicy const &policy)
-{
+bool commit_has_matching_sepolicy(::rpmostreecxx::GVariant const &commit, ::rpmostreecxx::OstreeSePolicy const &policy) {
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$commit_has_matching_sepolicy (commit, policy, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$commit_has_matching_sepolicy(commit, policy, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rpmostreecxx::GVariant *
-get_header_variant (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str cachebranch)
-{
+::rpmostreecxx::GVariant *get_header_variant(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str cachebranch) {
   ::rust::MaybeUninit<::rpmostreecxx::GVariant *> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$get_header_variant (repo, cachebranch, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$get_header_variant(repo, cachebranch, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-compose_build_chunked_oci_entrypoint (::rust::Vec<::rust::String> args)
-{
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$ (::std::move (args));
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$compose_build_chunked_oci_entrypoint (&args$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void compose_build_chunked_oci_entrypoint(::rust::Vec<::rust::String> args) {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$(::std::move(args));
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_build_chunked_oci_entrypoint(&args$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-compose_image (::rust::Vec<::rust::String> args)
-{
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$ (::std::move (args));
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$compose_image (&args$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void compose_image(::rust::Vec<::rust::String> args) {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$(::std::move(args));
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_image(&args$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-compose_rootfs_entrypoint (::rust::Vec<::rust::String> args)
-{
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$ (::std::move (args));
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$compose_rootfs_entrypoint (&args$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void compose_rootfs_entrypoint(::rust::Vec<::rust::String> args) {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$(::std::move(args));
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_rootfs_entrypoint(&args$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-configure_build_repo_from_target (::rpmostreecxx::OstreeRepo const &build_repo,
-                                  ::rpmostreecxx::OstreeRepo const &target_repo)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$configure_build_repo_from_target (build_repo, target_repo);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void configure_build_repo_from_target(::rpmostreecxx::OstreeRepo const &build_repo, ::rpmostreecxx::OstreeRepo const &target_repo) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$configure_build_repo_from_target(build_repo, target_repo);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-compose_prepare_rootfs (::std::int32_t src_rootfs_dfd, ::std::int32_t dest_rootfs_dfd,
-                        ::rpmostreecxx::Treefile &treefile)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$compose_prepare_rootfs (src_rootfs_dfd, dest_rootfs_dfd, treefile);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void compose_prepare_rootfs(::std::int32_t src_rootfs_dfd, ::std::int32_t dest_rootfs_dfd, ::rpmostreecxx::Treefile &treefile) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_prepare_rootfs(src_rootfs_dfd, dest_rootfs_dfd, treefile);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-composepost_nsswitch_altfiles (::std::int32_t rootfs_dfd)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$composepost_nsswitch_altfiles (rootfs_dfd);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void composepost_nsswitch_altfiles(::std::int32_t rootfs_dfd) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$composepost_nsswitch_altfiles(rootfs_dfd);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-compose_postprocess (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile,
-                     ::rust::Str next_version, bool unified_core)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$compose_postprocess (
-      rootfs_dfd, treefile, next_version, unified_core);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void compose_postprocess(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile, ::rust::Str next_version, bool unified_core) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_postprocess(rootfs_dfd, treefile, next_version, unified_core);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-compose_postprocess_final_pre (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$compose_postprocess_final_pre (rootfs_dfd, treefile);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void compose_postprocess_final_pre(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_postprocess_final_pre(rootfs_dfd, treefile);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-compose_postprocess_final (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$compose_postprocess_final (rootfs_dfd, treefile);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void compose_postprocess_final(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_postprocess_final(rootfs_dfd, treefile);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-convert_var_to_tmpfiles_d (::std::int32_t rootfs_dfd,
-                           ::rpmostreecxx::GCancellable const &cancellable)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$convert_var_to_tmpfiles_d (rootfs_dfd, cancellable);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void convert_var_to_tmpfiles_d(::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable const &cancellable) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$convert_var_to_tmpfiles_d(rootfs_dfd, cancellable);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-rootfs_prepare_links (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile,
-                      bool skip_usrlocal)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$rootfs_prepare_links (rootfs_dfd, treefile, skip_usrlocal);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void rootfs_prepare_links(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile, bool skip_usrlocal) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$rootfs_prepare_links(rootfs_dfd, treefile, skip_usrlocal);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-workaround_selinux_cross_labeling (::std::int32_t rootfs_dfd,
-                                   ::rpmostreecxx::GCancellable &cancellable)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$workaround_selinux_cross_labeling (rootfs_dfd, cancellable);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void workaround_selinux_cross_labeling(::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable &cancellable) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$workaround_selinux_cross_labeling(rootfs_dfd, cancellable);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-postprocess_cleanup_rpmdb (::std::int32_t rootfs_dfd)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$postprocess_cleanup_rpmdb (rootfs_dfd);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void postprocess_cleanup_rpmdb(::std::int32_t rootfs_dfd) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$postprocess_cleanup_rpmdb(rootfs_dfd);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-rewrite_rpmdb_for_target (::std::int32_t rootfs_dfd, bool normalize)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$rewrite_rpmdb_for_target (rootfs_dfd, normalize);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void rewrite_rpmdb_for_target(::std::int32_t rootfs_dfd, bool normalize) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$rewrite_rpmdb_for_target(rootfs_dfd, normalize);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::std::uint64_t
-directory_size (::std::int32_t dfd, ::rpmostreecxx::GCancellable const &cancellable)
-{
+::std::uint64_t directory_size(::std::int32_t dfd, ::rpmostreecxx::GCancellable const &cancellable) {
   ::rust::MaybeUninit<::std::uint64_t> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$directory_size (dfd, cancellable, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$directory_size(dfd, cancellable, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rpmostreecxx::OstreeDeployment *
-deployment_for_id (::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id)
-{
+::rpmostreecxx::OstreeDeployment *deployment_for_id(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id) {
   ::rust::MaybeUninit<::rpmostreecxx::OstreeDeployment *> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$deployment_for_id (sysroot, deploy_id, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deployment_for_id(sysroot, deploy_id, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::String
-deployment_checksum_for_id (::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id)
-{
+::rust::String deployment_checksum_for_id(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id) {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$deployment_checksum_for_id (sysroot, deploy_id, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deployment_checksum_for_id(sysroot, deploy_id, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rpmostreecxx::OstreeDeployment *
-deployment_get_base (::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str opt_deploy_id,
-                     ::rust::Str opt_os_name)
-{
+::rpmostreecxx::OstreeDeployment *deployment_get_base(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str opt_deploy_id, ::rust::Str opt_os_name) {
   ::rust::MaybeUninit<::rpmostreecxx::OstreeDeployment *> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$deployment_get_base (
-      sysroot, opt_deploy_id, opt_os_name, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deployment_get_base(sysroot, opt_deploy_id, opt_os_name, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-bool
-deployment_add_manifest_diff (::rpmostreecxx::GVariantDict const &dict,
-                              ::rpmostreecxx::ExportedManifestDiff const &diff) noexcept
-{
-  return rpmostreecxx$cxxbridge1$deployment_add_manifest_diff (dict, diff);
+bool deployment_add_manifest_diff(::rpmostreecxx::GVariantDict const &dict, ::rpmostreecxx::ExportedManifestDiff const &diff) noexcept {
+  return rpmostreecxx$cxxbridge1$194$deployment_add_manifest_diff(dict, diff);
 }
 
-void
-daemon_sanitycheck_environment (::rpmostreecxx::OstreeSysroot const &sysroot)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$daemon_sanitycheck_environment (sysroot);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void daemon_sanitycheck_environment(::rpmostreecxx::OstreeSysroot const &sysroot) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$daemon_sanitycheck_environment(sysroot);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::rust::String
-deployment_generate_id (::rpmostreecxx::OstreeDeployment const &deployment) noexcept
-{
+::rust::String deployment_generate_id(::rpmostreecxx::OstreeDeployment const &deployment) noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$deployment_generate_id (deployment, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$deployment_generate_id(deployment, &return$.value);
+  return ::std::move(return$.value);
 }
 
-void
-deployment_populate_variant (::rpmostreecxx::OstreeSysroot const &sysroot,
-                             ::rpmostreecxx::OstreeDeployment const &deployment,
-                             ::rpmostreecxx::GVariantDict const &dict)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$deployment_populate_variant (sysroot, deployment, dict);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void deployment_populate_variant(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::GVariantDict const &dict) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deployment_populate_variant(sysroot, deployment, dict);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-generate_baselayer_refs (::rpmostreecxx::OstreeSysroot const &sysroot,
-                         ::rpmostreecxx::OstreeRepo const &repo,
-                         ::rpmostreecxx::GCancellable const &cancellable)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$generate_baselayer_refs (sysroot, repo, cancellable);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void generate_baselayer_refs(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$generate_baselayer_refs(sysroot, repo, cancellable);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-variant_add_remote_status (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec,
-                           ::rust::Str base_checksum, ::rpmostreecxx::GVariantDict const &dict)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$variant_add_remote_status (repo, refspec, base_checksum, dict);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void variant_add_remote_status(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec, ::rust::Str base_checksum, ::rpmostreecxx::GVariantDict const &dict) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$variant_add_remote_status(repo, refspec, base_checksum, dict);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::rpmostreecxx::DeploymentLayeredMeta
-deployment_layeredmeta_from_commit (::rpmostreecxx::OstreeDeployment const &deployment,
-                                    ::rpmostreecxx::GVariant const &commit)
-{
+::rpmostreecxx::DeploymentLayeredMeta deployment_layeredmeta_from_commit(::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::GVariant const &commit) {
   ::rust::MaybeUninit<::rpmostreecxx::DeploymentLayeredMeta> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$deployment_layeredmeta_from_commit (
-      deployment, commit, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deployment_layeredmeta_from_commit(deployment, commit, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rpmostreecxx::DeploymentLayeredMeta
-deployment_layeredmeta_load (::rpmostreecxx::OstreeRepo const &repo,
-                             ::rpmostreecxx::OstreeDeployment const &deployment)
-{
+::rpmostreecxx::DeploymentLayeredMeta deployment_layeredmeta_load(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::OstreeDeployment const &deployment) {
   ::rust::MaybeUninit<::rpmostreecxx::DeploymentLayeredMeta> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$deployment_layeredmeta_load (repo, deployment, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deployment_layeredmeta_load(repo, deployment, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rpmostreecxx::OverrideReplacementSource
-parse_override_source (::rust::Str source)
-{
+::rpmostreecxx::OverrideReplacementSource parse_override_source(::rust::Str source) {
   ::rust::MaybeUninit<::rpmostreecxx::OverrideReplacementSource> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$parse_override_source (source, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$parse_override_source(source, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rpmostreecxx::ParsedRevision
-parse_revision (::rust::Str source)
-{
+::rpmostreecxx::ParsedRevision parse_revision(::rust::Str source) {
   ::rust::MaybeUninit<::rpmostreecxx::ParsedRevision> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$parse_revision (source, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$parse_revision(source, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::String
-generate_object_path (::rust::Str base, ::rust::Str next_segment)
-{
+::rust::String generate_object_path(::rust::Str base, ::rust::Str next_segment) {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$generate_object_path (base, next_segment, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$generate_object_path(base, next_segment, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-failpoint (::rust::Str p)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$failpoint (p);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void failpoint(::rust::Str p) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$failpoint(p);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::std::size_t
-RpmImporterFlags::layout::size () noexcept
-{
-  return rpmostreecxx$cxxbridge1$RpmImporterFlags$operator$sizeof ();
+::std::size_t RpmImporterFlags::layout::size() noexcept {
+  return rpmostreecxx$cxxbridge1$194$RpmImporterFlags$operator$sizeof();
 }
 
-::std::size_t
-RpmImporterFlags::layout::align () noexcept
-{
-  return rpmostreecxx$cxxbridge1$RpmImporterFlags$operator$alignof ();
+::std::size_t RpmImporterFlags::layout::align() noexcept {
+  return rpmostreecxx$cxxbridge1$194$RpmImporterFlags$operator$alignof();
 }
 
-::rust::Box<::rpmostreecxx::RpmImporterFlags>
-rpm_importer_flags_new_empty () noexcept
-{
-  return ::rust::Box<::rpmostreecxx::RpmImporterFlags>::from_raw (
-      rpmostreecxx$cxxbridge1$rpm_importer_flags_new_empty ());
+::rust::Box<::rpmostreecxx::RpmImporterFlags> rpm_importer_flags_new_empty() noexcept {
+  return ::rust::Box<::rpmostreecxx::RpmImporterFlags>::from_raw(rpmostreecxx$cxxbridge1$194$rpm_importer_flags_new_empty());
 }
 
-bool
-RpmImporterFlags::is_ima_enabled () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$RpmImporterFlags$is_ima_enabled (*this);
+bool RpmImporterFlags::is_ima_enabled() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$RpmImporterFlags$is_ima_enabled(*this);
 }
 
-::std::size_t
-RpmImporter::layout::size () noexcept
-{
-  return rpmostreecxx$cxxbridge1$RpmImporter$operator$sizeof ();
+::std::size_t RpmImporter::layout::size() noexcept {
+  return rpmostreecxx$cxxbridge1$194$RpmImporter$operator$sizeof();
 }
 
-::std::size_t
-RpmImporter::layout::align () noexcept
-{
-  return rpmostreecxx$cxxbridge1$RpmImporter$operator$alignof ();
+::std::size_t RpmImporter::layout::align() noexcept {
+  return rpmostreecxx$cxxbridge1$194$RpmImporter$operator$alignof();
 }
 
-::rust::Box<::rpmostreecxx::RpmImporter>
-rpm_importer_new (::rust::Str pkg_name, ::rust::Str ostree_branch,
-                  ::rpmostreecxx::RpmImporterFlags const &flags)
-{
+::rust::Box<::rpmostreecxx::RpmImporter> rpm_importer_new(::rust::Str pkg_name, ::rust::Str ostree_branch, ::rpmostreecxx::RpmImporterFlags const &flags) {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::RpmImporter>> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$rpm_importer_new (pkg_name, ostree_branch, flags, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$rpm_importer_new(pkg_name, ostree_branch, flags, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::String
-RpmImporter::handle_translate_pathname (::rust::Str path) noexcept
-{
+::rust::String RpmImporter::handle_translate_pathname(::rust::Str path) noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$RpmImporter$handle_translate_pathname (*this, path, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$RpmImporter$handle_translate_pathname(*this, path, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::String
-RpmImporter::ostree_branch () const noexcept
-{
+::rust::String RpmImporter::ostree_branch() const noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$RpmImporter$ostree_branch (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$RpmImporter$ostree_branch(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::String
-RpmImporter::pkg_name () const noexcept
-{
+::rust::String RpmImporter::pkg_name() const noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$RpmImporter$pkg_name (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$RpmImporter$pkg_name(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-bool
-RpmImporter::doc_files_are_filtered () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$RpmImporter$doc_files_are_filtered (*this);
+bool RpmImporter::doc_files_are_filtered() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_are_filtered(*this);
 }
 
-void
-RpmImporter::doc_files_insert (::rust::Str path) noexcept
-{
-  rpmostreecxx$cxxbridge1$RpmImporter$doc_files_insert (*this, path);
+void RpmImporter::doc_files_insert(::rust::Str path) noexcept {
+  rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_insert(*this, path);
 }
 
-bool
-RpmImporter::doc_files_contains (::rust::Str path) const noexcept
-{
-  return rpmostreecxx$cxxbridge1$RpmImporter$doc_files_contains (*this, path);
+bool RpmImporter::doc_files_contains(::rust::Str path) const noexcept {
+  return rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_contains(*this, path);
 }
 
-void
-RpmImporter::rpmfi_overrides_insert (::rust::Str path, ::std::uint64_t index) noexcept
-{
-  rpmostreecxx$cxxbridge1$RpmImporter$rpmfi_overrides_insert (*this, path, index);
+void RpmImporter::rpmfi_overrides_insert(::rust::Str path, ::std::uint64_t index) noexcept {
+  rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_insert(*this, path, index);
 }
 
-bool
-RpmImporter::rpmfi_overrides_contains (::rust::Str path) const noexcept
-{
-  return rpmostreecxx$cxxbridge1$RpmImporter$rpmfi_overrides_contains (*this, path);
+bool RpmImporter::rpmfi_overrides_contains(::rust::Str path) const noexcept {
+  return rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_contains(*this, path);
 }
 
-::std::uint64_t
-RpmImporter::rpmfi_overrides_get (::rust::Str path) const noexcept
-{
-  return rpmostreecxx$cxxbridge1$RpmImporter$rpmfi_overrides_get (*this, path);
+::std::uint64_t RpmImporter::rpmfi_overrides_get(::rust::Str path) const noexcept {
+  return rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_get(*this, path);
 }
 
-bool
-RpmImporter::is_ima_enabled () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$RpmImporter$is_ima_enabled (*this);
+bool RpmImporter::is_ima_enabled() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$RpmImporter$is_ima_enabled(*this);
 }
 
-void
-RpmImporter::tweak_imported_file_info (::rpmostreecxx::GFileInfo const &file_info) const noexcept
-{
-  rpmostreecxx$cxxbridge1$RpmImporter$tweak_imported_file_info (*this, file_info);
+void RpmImporter::tweak_imported_file_info(::rpmostreecxx::GFileInfo const &file_info) const noexcept {
+  rpmostreecxx$cxxbridge1$194$RpmImporter$tweak_imported_file_info(*this, file_info);
 }
 
-bool
-RpmImporter::is_file_filtered (::rust::Str path, ::rpmostreecxx::GFileInfo const &file_info) const
-{
+bool RpmImporter::is_file_filtered(::rust::Str path, ::rpmostreecxx::GFileInfo const &file_info) const {
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$RpmImporter$is_file_filtered (
-      *this, path, file_info, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$RpmImporter$is_file_filtered(*this, path, file_info, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-RpmImporter::translate_to_tmpfiles_entry (::rust::Str abs_path,
-                                          ::rpmostreecxx::GFileInfo const &file_info,
-                                          ::rust::Str username, ::rust::Str groupname)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$RpmImporter$translate_to_tmpfiles_entry (
-      *this, abs_path, file_info, username, groupname);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void RpmImporter::translate_to_tmpfiles_entry(::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username, ::rust::Str groupname) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$RpmImporter$translate_to_tmpfiles_entry(*this, abs_path, file_info, username, groupname);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-bool
-RpmImporter::has_tmpfiles_entries () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$RpmImporter$has_tmpfiles_entries (*this);
+bool RpmImporter::has_tmpfiles_entries() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$RpmImporter$has_tmpfiles_entries(*this);
 }
 
-::rust::String
-RpmImporter::serialize_tmpfiles_content () const noexcept
-{
+::rust::String RpmImporter::serialize_tmpfiles_content() const noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$RpmImporter$serialize_tmpfiles_content (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$RpmImporter$serialize_tmpfiles_content(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::String
-tmpfiles_translate (::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info,
-                    ::rust::Str username, ::rust::Str groupname)
-{
+::rust::String tmpfiles_translate(::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username, ::rust::Str groupname) {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$tmpfiles_translate (
-      abs_path, file_info, username, groupname, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$tmpfiles_translate(abs_path, file_info, username, groupname, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-append_dracut_random_cpio (::std::int32_t fd)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$append_dracut_random_cpio (fd);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void append_dracut_random_cpio(::std::int32_t fd) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$append_dracut_random_cpio(fd);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::std::int32_t
-initramfs_overlay_generate (::rust::Vec<::rust::String> const &files,
-                            ::rpmostreecxx::GCancellable &cancellable)
-{
+::std::int32_t initramfs_overlay_generate(::rust::Vec<::rust::String> const &files, ::rpmostreecxx::GCancellable &cancellable) {
   ::rust::MaybeUninit<::std::int32_t> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$initramfs_overlay_generate (files, cancellable, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$initramfs_overlay_generate(files, cancellable, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-journal_print_staging_failure () noexcept
-{
-  rpmostreecxx$cxxbridge1$journal_print_staging_failure ();
+void journal_print_staging_failure() noexcept {
+  rpmostreecxx$cxxbridge1$194$journal_print_staging_failure();
 }
 
-void
-console_progress_begin_task (::rust::Str msg) noexcept
-{
-  rpmostreecxx$cxxbridge1$console_progress_begin_task (msg);
+void console_progress_begin_task(::rust::Str msg) noexcept {
+  rpmostreecxx$cxxbridge1$194$console_progress_begin_task(msg);
 }
 
-void
-console_progress_begin_n_items (::rust::Str msg, ::std::uint64_t n) noexcept
-{
-  rpmostreecxx$cxxbridge1$console_progress_begin_n_items (msg, n);
+void console_progress_begin_n_items(::rust::Str msg, ::std::uint64_t n) noexcept {
+  rpmostreecxx$cxxbridge1$194$console_progress_begin_n_items(msg, n);
 }
 
-void
-console_progress_begin_percent (::rust::Str msg) noexcept
-{
-  rpmostreecxx$cxxbridge1$console_progress_begin_percent (msg);
+void console_progress_begin_percent(::rust::Str msg) noexcept {
+  rpmostreecxx$cxxbridge1$194$console_progress_begin_percent(msg);
 }
 
-void
-console_progress_set_message (::rust::Str msg) noexcept
-{
-  rpmostreecxx$cxxbridge1$console_progress_set_message (msg);
+void console_progress_set_message(::rust::Str msg) noexcept {
+  rpmostreecxx$cxxbridge1$194$console_progress_set_message(msg);
 }
 
-void
-console_progress_set_sub_message (::rust::Str msg) noexcept
-{
-  rpmostreecxx$cxxbridge1$console_progress_set_sub_message (msg);
+void console_progress_set_sub_message(::rust::Str msg) noexcept {
+  rpmostreecxx$cxxbridge1$194$console_progress_set_sub_message(msg);
 }
 
-void
-console_progress_update (::std::uint64_t n) noexcept
-{
-  rpmostreecxx$cxxbridge1$console_progress_update (n);
+void console_progress_update(::std::uint64_t n) noexcept {
+  rpmostreecxx$cxxbridge1$194$console_progress_update(n);
 }
 
-void
-console_progress_end (::rust::Str suffix) noexcept
-{
-  rpmostreecxx$cxxbridge1$console_progress_end (suffix);
+void console_progress_end(::rust::Str suffix) noexcept {
+  rpmostreecxx$cxxbridge1$194$console_progress_end(suffix);
 }
 
-bool
-HistoryEntry::operator== (HistoryEntry const &rhs) const noexcept
-{
-  return rpmostreecxx$cxxbridge1$HistoryEntry$operator$eq (*this, rhs);
+bool HistoryEntry::operator==(HistoryEntry const &rhs) const noexcept {
+  return rpmostreecxx$cxxbridge1$194$HistoryEntry$operator$eq(*this, rhs);
 }
 
-bool
-HistoryEntry::operator!= (HistoryEntry const &rhs) const noexcept
-{
-  return rpmostreecxx$cxxbridge1$HistoryEntry$operator$ne (*this, rhs);
+bool HistoryEntry::operator!=(HistoryEntry const &rhs) const noexcept {
+  return rpmostreecxx$cxxbridge1$194$HistoryEntry$operator$ne(*this, rhs);
 }
 
-::std::size_t
-HistoryCtx::layout::size () noexcept
-{
-  return rpmostreecxx$cxxbridge1$HistoryCtx$operator$sizeof ();
+::std::size_t HistoryCtx::layout::size() noexcept {
+  return rpmostreecxx$cxxbridge1$194$HistoryCtx$operator$sizeof();
 }
 
-::std::size_t
-HistoryCtx::layout::align () noexcept
-{
-  return rpmostreecxx$cxxbridge1$HistoryCtx$operator$alignof ();
+::std::size_t HistoryCtx::layout::align() noexcept {
+  return rpmostreecxx$cxxbridge1$194$HistoryCtx$operator$alignof();
 }
 
-::rust::Box<::rpmostreecxx::HistoryCtx>
-history_ctx_new ()
-{
+::rust::Box<::rpmostreecxx::HistoryCtx> history_ctx_new() {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::HistoryCtx>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$history_ctx_new (&return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$history_ctx_new(&return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rpmostreecxx::HistoryEntry
-HistoryCtx::next_entry ()
-{
+::rpmostreecxx::HistoryEntry HistoryCtx::next_entry() {
   ::rust::MaybeUninit<::rpmostreecxx::HistoryEntry> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$HistoryCtx$next_entry (*this, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$HistoryCtx$next_entry(*this, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-history_prune ()
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$history_prune ();
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void history_prune() {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$history_prune();
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::std::size_t
-TokioHandle::layout::size () noexcept
-{
-  return rpmostreecxx$cxxbridge1$TokioHandle$operator$sizeof ();
+::std::size_t TokioHandle::layout::size() noexcept {
+  return rpmostreecxx$cxxbridge1$194$TokioHandle$operator$sizeof();
 }
 
-::std::size_t
-TokioHandle::layout::align () noexcept
-{
-  return rpmostreecxx$cxxbridge1$TokioHandle$operator$alignof ();
+::std::size_t TokioHandle::layout::align() noexcept {
+  return rpmostreecxx$cxxbridge1$194$TokioHandle$operator$alignof();
 }
 
-::std::size_t
-TokioEnterGuard::layout::size () noexcept
-{
-  return rpmostreecxx$cxxbridge1$TokioEnterGuard$operator$sizeof ();
+::std::size_t TokioEnterGuard::layout::size() noexcept {
+  return rpmostreecxx$cxxbridge1$194$TokioEnterGuard$operator$sizeof();
 }
 
-::std::size_t
-TokioEnterGuard::layout::align () noexcept
-{
-  return rpmostreecxx$cxxbridge1$TokioEnterGuard$operator$alignof ();
+::std::size_t TokioEnterGuard::layout::align() noexcept {
+  return rpmostreecxx$cxxbridge1$194$TokioEnterGuard$operator$alignof();
 }
 
-::rust::Box<::rpmostreecxx::TokioHandle>
-tokio_handle_get () noexcept
-{
-  return ::rust::Box<::rpmostreecxx::TokioHandle>::from_raw (
-      rpmostreecxx$cxxbridge1$tokio_handle_get ());
+::rust::Box<::rpmostreecxx::TokioHandle> tokio_handle_get() noexcept {
+  return ::rust::Box<::rpmostreecxx::TokioHandle>::from_raw(rpmostreecxx$cxxbridge1$194$tokio_handle_get());
 }
 
-::rust::Box<::rpmostreecxx::TokioEnterGuard>
-TokioHandle::enter () const noexcept
-{
-  return ::rust::Box<::rpmostreecxx::TokioEnterGuard>::from_raw (
-      rpmostreecxx$cxxbridge1$TokioHandle$enter (*this));
+::rust::Box<::rpmostreecxx::TokioEnterGuard> TokioHandle::enter() const noexcept {
+  return ::rust::Box<::rpmostreecxx::TokioEnterGuard>::from_raw(rpmostreecxx$cxxbridge1$194$TokioHandle$enter(*this));
 }
 
-bool
-script_is_ignored (::rust::Str pkg, ::rust::Str script, bool use_kernel_install) noexcept
-{
-  return rpmostreecxx$cxxbridge1$script_is_ignored (pkg, script, use_kernel_install);
+bool script_is_ignored(::rust::Str pkg, ::rust::Str script, bool use_kernel_install) noexcept {
+  return rpmostreecxx$cxxbridge1$194$script_is_ignored(pkg, script, use_kernel_install);
 }
 
-void
-testutils_entrypoint (::rust::Vec<::rust::String> argv)
-{
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> argv$ (::std::move (argv));
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$testutils_entrypoint (&argv$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void testutils_entrypoint(::rust::Vec<::rust::String> argv) {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> argv$(::std::move(argv));
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$testutils_entrypoint(&argv$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::rust::String
-maybe_shell_quote (::rust::Str input) noexcept
-{
+::rust::String maybe_shell_quote(::rust::Str input) noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$maybe_shell_quote (input, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$maybe_shell_quote(input, &return$.value);
+  return ::std::move(return$.value);
 }
 
-bool
-Refspec::operator== (Refspec const &rhs) const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Refspec$operator$eq (*this, rhs);
+bool Refspec::operator==(Refspec const &rhs) const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Refspec$operator$eq(*this, rhs);
 }
 
-bool
-Refspec::operator!= (Refspec const &rhs) const noexcept
-{
+bool Refspec::operator!=(Refspec const &rhs) const noexcept {
   return !(*this == rhs);
 }
 
-bool
-OverrideReplacement::operator== (OverrideReplacement const &rhs) const noexcept
-{
-  return rpmostreecxx$cxxbridge1$OverrideReplacement$operator$eq (*this, rhs);
+bool OverrideReplacement::operator==(OverrideReplacement const &rhs) const noexcept {
+  return rpmostreecxx$cxxbridge1$194$OverrideReplacement$operator$eq(*this, rhs);
 }
 
-bool
-OverrideReplacement::operator!= (OverrideReplacement const &rhs) const noexcept
-{
+bool OverrideReplacement::operator!=(OverrideReplacement const &rhs) const noexcept {
   return !(*this == rhs);
 }
 
-::std::size_t
-Treefile::layout::size () noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$operator$sizeof ();
+::std::size_t Treefile::layout::size() noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$operator$sizeof();
 }
 
-::std::size_t
-Treefile::layout::align () noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$operator$alignof ();
+::std::size_t Treefile::layout::align() noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$operator$alignof();
 }
 
-::rust::Box<::rpmostreecxx::Treefile>
-treefile_new (::rust::Str filename, ::rust::Str basearch)
-{
+::rust::Box<::rpmostreecxx::Treefile> treefile_new(::rust::Str filename, ::rust::Str basearch) {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Treefile>> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$treefile_new (filename, basearch, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_new(filename, basearch, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::Box<::rpmostreecxx::Treefile>
-treefile_new_empty ()
-{
+::rust::Box<::rpmostreecxx::Treefile> treefile_new_empty() {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Treefile>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$treefile_new_empty (&return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_new_empty(&return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::Box<::rpmostreecxx::Treefile>
-treefile_new_from_string (::rust::Str buf, bool client)
-{
+::rust::Box<::rpmostreecxx::Treefile> treefile_new_from_string(::rust::Str buf, bool client) {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Treefile>> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$treefile_new_from_string (buf, client, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_new_from_string(buf, client, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::Box<::rpmostreecxx::Treefile>
-treefile_new_compose (::rust::Str filename, ::rust::Str basearch)
-{
+::rust::Box<::rpmostreecxx::Treefile> treefile_new_compose(::rust::Str filename, ::rust::Str basearch) {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Treefile>> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$treefile_new_compose (filename, basearch, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_new_compose(filename, basearch, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::Box<::rpmostreecxx::Treefile>
-treefile_new_client (::rust::Str filename, ::rust::Str basearch)
-{
+::rust::Box<::rpmostreecxx::Treefile> treefile_new_client(::rust::Str filename, ::rust::Str basearch) {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Treefile>> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$treefile_new_client (filename, basearch, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_new_client(filename, basearch, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::Box<::rpmostreecxx::Treefile>
-treefile_new_client_from_etc (::rust::Str basearch)
-{
+::rust::Box<::rpmostreecxx::Treefile> treefile_new_client_from_etc(::rust::Str basearch) {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Treefile>> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$treefile_new_client_from_etc (basearch, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_new_client_from_etc(basearch, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::std::uint32_t
-treefile_delete_client_etc ()
-{
+::std::uint32_t treefile_delete_client_etc() {
   ::rust::MaybeUninit<::std::uint32_t> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$treefile_delete_client_etc (&return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_delete_client_etc(&return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::Str
-Treefile::get_workdir () const noexcept
-{
-  return ::rust::impl<::rust::Str>::new_unchecked (
-      rpmostreecxx$cxxbridge1$Treefile$get_workdir (*this));
+::rust::Str Treefile::get_workdir() const noexcept {
+  return ::rust::impl<::rust::Str>::new_unchecked(rpmostreecxx$cxxbridge1$194$Treefile$get_workdir(*this));
 }
 
-::std::int32_t
-Treefile::get_passwd_fd () noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_passwd_fd (*this);
+::std::int32_t Treefile::get_passwd_fd() noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_passwd_fd(*this);
 }
 
-::std::int32_t
-Treefile::get_group_fd () noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_group_fd (*this);
+::std::int32_t Treefile::get_group_fd() noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_group_fd(*this);
 }
 
-::rust::String
-Treefile::get_json_string () const noexcept
-{
+::rust::String Treefile::get_json_string() const noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_json_string (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_json_string(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_ostree_layers () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_ostree_layers() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_ostree_layers (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_layers(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_ostree_override_layers () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_ostree_override_layers() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_ostree_override_layers (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_override_layers(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_all_ostree_layers () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_all_ostree_layers() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_all_ostree_layers (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_all_ostree_layers(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_repos () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_repos() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_repos (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_repos(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_packages () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_packages() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_packages (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_packages(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::String
-Treefile::require_automatic_version_prefix () const
-{
+::rust::String Treefile::require_automatic_version_prefix() const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$Treefile$require_automatic_version_prefix (*this, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$require_automatic_version_prefix(*this, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-bool
-Treefile::add_packages (::rust::Vec<::rust::String> packages, bool allow_existing)
-{
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$ (::std::move (packages));
+bool Treefile::add_packages(::rust::Vec<::rust::String> packages, bool allow_existing) {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$(::std::move(packages));
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Treefile$add_packages (
-      *this, &packages$.value, allow_existing, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$add_packages(*this, &packages$.value, allow_existing, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-bool
-Treefile::has_packages () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$has_packages (*this);
+bool Treefile::has_packages() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$has_packages(*this);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_local_packages () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_local_packages() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_local_packages (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_local_packages(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-bool
-Treefile::add_local_packages (::rust::Vec<::rust::String> packages, bool allow_existing)
-{
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$ (::std::move (packages));
+bool Treefile::add_local_packages(::rust::Vec<::rust::String> packages, bool allow_existing) {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$(::std::move(packages));
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Treefile$add_local_packages (
-      *this, &packages$.value, allow_existing, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$add_local_packages(*this, &packages$.value, allow_existing, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_local_fileoverride_packages () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_local_fileoverride_packages() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_local_fileoverride_packages (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_local_fileoverride_packages(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-bool
-Treefile::add_local_fileoverride_packages (::rust::Vec<::rust::String> packages,
-                                           bool allow_existing)
-{
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$ (::std::move (packages));
+bool Treefile::add_local_fileoverride_packages(::rust::Vec<::rust::String> packages, bool allow_existing) {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$(::std::move(packages));
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Treefile$add_local_fileoverride_packages (
-      *this, &packages$.value, allow_existing, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$add_local_fileoverride_packages(*this, &packages$.value, allow_existing, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-bool
-Treefile::remove_packages (::rust::Vec<::rust::String> packages, bool allow_noent)
-{
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$ (::std::move (packages));
+bool Treefile::remove_packages(::rust::Vec<::rust::String> packages, bool allow_noent) {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$(::std::move(packages));
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Treefile$remove_packages (
-      *this, &packages$.value, allow_noent, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$remove_packages(*this, &packages$.value, allow_noent, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::Vec<::rpmostreecxx::OverrideReplacement>
-Treefile::get_packages_override_replace () const noexcept
-{
+::rust::Vec<::rpmostreecxx::OverrideReplacement> Treefile::get_packages_override_replace() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rpmostreecxx::OverrideReplacement>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_packages_override_replace (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_replace(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-bool
-Treefile::has_packages_override_replace () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$has_packages_override_replace (*this);
+bool Treefile::has_packages_override_replace() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$has_packages_override_replace(*this);
 }
 
-bool
-Treefile::add_packages_override_replace (::rpmostreecxx::OverrideReplacement replacement) noexcept
-{
-  ::rust::ManuallyDrop<::rpmostreecxx::OverrideReplacement> replacement$ (
-      ::std::move (replacement));
-  return rpmostreecxx$cxxbridge1$Treefile$add_packages_override_replace (*this,
-                                                                         &replacement$.value);
+bool Treefile::add_packages_override_replace(::rpmostreecxx::OverrideReplacement replacement) noexcept {
+  ::rust::ManuallyDrop<::rpmostreecxx::OverrideReplacement> replacement$(::std::move(replacement));
+  return rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_replace(*this, &replacement$.value);
 }
 
-bool
-Treefile::remove_package_override_replace (::rust::Str package) noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$remove_package_override_replace (*this, package);
+bool Treefile::remove_package_override_replace(::rust::Str package) noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_replace(*this, package);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_packages_override_replace_local () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_packages_override_replace_local() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_packages_override_replace_local (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_replace_local(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-void
-Treefile::add_packages_override_replace_local (::rust::Vec<::rust::String> packages)
-{
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$ (::std::move (packages));
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$Treefile$add_packages_override_replace_local (*this,
-                                                                              &packages$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void Treefile::add_packages_override_replace_local(::rust::Vec<::rust::String> packages) {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$(::std::move(packages));
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_replace_local(*this, &packages$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-bool
-Treefile::remove_package_override_replace_local (::rust::Str package) noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$remove_package_override_replace_local (*this, package);
+bool Treefile::remove_package_override_replace_local(::rust::Str package) noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_replace_local(*this, package);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_packages_override_remove () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_packages_override_remove() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_packages_override_remove (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_remove(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-void
-Treefile::add_packages_override_remove (::rust::Vec<::rust::String> packages)
-{
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$ (::std::move (packages));
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$Treefile$add_packages_override_remove (*this, &packages$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void Treefile::add_packages_override_remove(::rust::Vec<::rust::String> packages) {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$(::std::move(packages));
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_remove(*this, &packages$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-bool
-Treefile::remove_package_override_remove (::rust::Str package) noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$remove_package_override_remove (*this, package);
+bool Treefile::remove_package_override_remove(::rust::Str package) noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_remove(*this, package);
 }
 
-bool
-Treefile::has_packages_override_remove_name (::rust::Str name) const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$has_packages_override_remove_name (*this, name);
+bool Treefile::has_packages_override_remove_name(::rust::Str name) const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$has_packages_override_remove_name(*this, name);
 }
 
-bool
-Treefile::remove_all_overrides () noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$remove_all_overrides (*this);
+bool Treefile::remove_all_overrides() noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$remove_all_overrides(*this);
 }
 
-bool
-Treefile::remove_all_packages () noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$remove_all_packages (*this);
+bool Treefile::remove_all_packages() noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$remove_all_packages(*this);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_exclude_packages () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_exclude_packages() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_exclude_packages (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_exclude_packages(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::String
-Treefile::get_platform_module () const noexcept
-{
+::rust::String Treefile::get_platform_module() const noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_platform_module (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_platform_module(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_install_langs () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_install_langs() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_install_langs (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_install_langs(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::String
-Treefile::format_install_langs_macro () const noexcept
-{
+::rust::String Treefile::format_install_langs_macro() const noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$Treefile$format_install_langs_macro (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$format_install_langs_macro(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_lockfile_repos () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_lockfile_repos() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_lockfile_repos (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_lockfile_repos(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::Str
-Treefile::get_ref () const noexcept
-{
-  return ::rust::impl<::rust::Str>::new_unchecked (
-      rpmostreecxx$cxxbridge1$Treefile$get_ref (*this));
+::rust::Str Treefile::get_ref() const noexcept {
+  return ::rust::impl<::rust::Str>::new_unchecked(rpmostreecxx$cxxbridge1$194$Treefile$get_ref(*this));
 }
 
-bool
-Treefile::get_cliwrap () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_cliwrap (*this);
+bool Treefile::get_cliwrap() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_cliwrap(*this);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_cliwrap_binaries () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_cliwrap_binaries() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_cliwrap_binaries (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_cliwrap_binaries(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-void
-Treefile::set_cliwrap (bool enabled) noexcept
-{
-  rpmostreecxx$cxxbridge1$Treefile$set_cliwrap (*this, enabled);
+void Treefile::set_cliwrap(bool enabled) noexcept {
+  rpmostreecxx$cxxbridge1$194$Treefile$set_cliwrap(*this, enabled);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_container_cmd () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_container_cmd() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_container_cmd (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_container_cmd(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-bool
-Treefile::get_readonly_executables () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_readonly_executables (*this);
+bool Treefile::get_readonly_executables() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_readonly_executables(*this);
 }
 
-bool
-Treefile::get_documentation () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_documentation (*this);
+bool Treefile::get_documentation() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_documentation(*this);
 }
 
-bool
-Treefile::get_recommends () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_recommends (*this);
+bool Treefile::get_recommends() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_recommends(*this);
 }
 
-bool
-Treefile::get_selinux () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_selinux (*this);
+bool Treefile::get_selinux() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_selinux(*this);
 }
 
-bool
-Treefile::get_sysusers_is_forced () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_sysusers_is_forced (*this);
+bool Treefile::get_sysusers_is_forced() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_sysusers_is_forced(*this);
 }
 
-::std::uint32_t
-Treefile::get_selinux_label_version () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_selinux_label_version (*this);
+::std::uint32_t Treefile::get_selinux_label_version() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_selinux_label_version(*this);
 }
 
-::rust::String
-Treefile::get_gpg_key () const noexcept
-{
+::rust::String Treefile::get_gpg_key() const noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_gpg_key (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_gpg_key(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::String
-Treefile::get_automatic_version_suffix () const noexcept
-{
+::rust::String Treefile::get_automatic_version_suffix() const noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_automatic_version_suffix (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_automatic_version_suffix(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-bool
-Treefile::get_container () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_container (*this);
+bool Treefile::get_container() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_container(*this);
 }
 
-bool
-Treefile::get_machineid_compat () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_machineid_compat (*this);
+bool Treefile::get_machineid_compat() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_machineid_compat(*this);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_etc_group_members () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_etc_group_members() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_etc_group_members (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_etc_group_members(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-bool
-Treefile::get_boot_location_is_modules () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_boot_location_is_modules (*this);
+bool Treefile::get_boot_location_is_modules() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_boot_location_is_modules(*this);
 }
 
-bool
-Treefile::use_kernel_install () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$use_kernel_install (*this);
+bool Treefile::use_kernel_install() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$use_kernel_install(*this);
 }
 
-bool
-Treefile::get_ima () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_ima (*this);
+bool Treefile::get_ima() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_ima(*this);
 }
 
-::rust::String
-Treefile::get_releasever () const noexcept
-{
+::rust::String Treefile::get_releasever() const noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_releasever (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_releasever(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rpmostreecxx::RepoMetadataTarget
-Treefile::get_repo_metadata_target () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_repo_metadata_target (*this);
+::rpmostreecxx::RepoMetadataTarget Treefile::get_repo_metadata_target() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_repo_metadata_target(*this);
 }
 
-::rpmostreecxx::AdvisoriesMetadataTarget
-Treefile::get_advisories_metadata_target () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_advisories_metadata_target (*this);
+::rpmostreecxx::AdvisoriesMetadataTarget Treefile::get_advisories_metadata_target() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_advisories_metadata_target(*this);
 }
 
-bool
-Treefile::rpmdb_backend_is_target () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$rpmdb_backend_is_target (*this);
+bool Treefile::rpmdb_backend_is_target() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$rpmdb_backend_is_target(*this);
 }
 
-bool
-Treefile::should_normalize_rpmdb () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$should_normalize_rpmdb (*this);
+bool Treefile::should_normalize_rpmdb() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$should_normalize_rpmdb(*this);
 }
 
-::rpmostreecxx::OptUsrLocal
-Treefile::get_opt_usrlocal () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_opt_usrlocal (*this);
+::rpmostreecxx::OptUsrLocal Treefile::get_opt_usrlocal() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_opt_usrlocal(*this);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_files_remove_regex (::rust::Str package) const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_files_remove_regex(::rust::Str package) const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_files_remove_regex (*this, package, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_files_remove_regex(*this, package, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::String
-Treefile::get_checksum (::rpmostreecxx::OstreeRepo const &repo) const
-{
+::rust::String Treefile::get_checksum(::rpmostreecxx::OstreeRepo const &repo) const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$Treefile$get_checksum (*this, repo, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$get_checksum(*this, repo, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::String
-Treefile::get_ostree_ref () const noexcept
-{
+::rust::String Treefile::get_ostree_ref() const noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_ostree_ref (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_ref(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::Slice<::rpmostreecxx::RepoPackage const>
-Treefile::get_repo_packages () const noexcept
-{
-  return ::rust::impl<::rust::Slice<::rpmostreecxx::RepoPackage const>>::slice (
-      rpmostreecxx$cxxbridge1$Treefile$get_repo_packages (*this));
+::rust::Slice<::rpmostreecxx::RepoPackage const> Treefile::get_repo_packages() const noexcept {
+  return ::rust::impl<::rust::Slice<::rpmostreecxx::RepoPackage const>>::slice(rpmostreecxx$cxxbridge1$194$Treefile$get_repo_packages(*this));
 }
 
-void
-Treefile::clear_repo_packages () noexcept
-{
-  rpmostreecxx$cxxbridge1$Treefile$clear_repo_packages (*this);
+void Treefile::clear_repo_packages() noexcept {
+  rpmostreecxx$cxxbridge1$194$Treefile$clear_repo_packages(*this);
 }
 
-void
-Treefile::prettyprint_json_stdout () const noexcept
-{
-  rpmostreecxx$cxxbridge1$Treefile$prettyprint_json_stdout (*this);
+void Treefile::prettyprint_json_stdout() const noexcept {
+  rpmostreecxx$cxxbridge1$194$Treefile$prettyprint_json_stdout(*this);
 }
 
-void
-Treefile::print_deprecation_warnings () const noexcept
-{
-  rpmostreecxx$cxxbridge1$Treefile$print_deprecation_warnings (*this);
+void Treefile::print_deprecation_warnings() const noexcept {
+  rpmostreecxx$cxxbridge1$194$Treefile$print_deprecation_warnings(*this);
 }
 
-void
-Treefile::print_experimental_notices () const noexcept
-{
-  rpmostreecxx$cxxbridge1$Treefile$print_experimental_notices (*this);
+void Treefile::print_experimental_notices() const noexcept {
+  rpmostreecxx$cxxbridge1$194$Treefile$print_experimental_notices(*this);
 }
 
-void
-Treefile::sanitycheck_externals () const
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Treefile$sanitycheck_externals (*this);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void Treefile::sanitycheck_externals() const {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$sanitycheck_externals(*this);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::rust::Box<::rpmostreecxx::RpmImporterFlags>
-Treefile::importer_flags (::rust::Str pkg_name) const noexcept
-{
-  return ::rust::Box<::rpmostreecxx::RpmImporterFlags>::from_raw (
-      rpmostreecxx$cxxbridge1$Treefile$importer_flags (*this, pkg_name));
+::rust::Box<::rpmostreecxx::RpmImporterFlags> Treefile::importer_flags(::rust::Str pkg_name) const noexcept {
+  return ::rust::Box<::rpmostreecxx::RpmImporterFlags>::from_raw(rpmostreecxx$cxxbridge1$194$Treefile$importer_flags(*this, pkg_name));
 }
 
-::rust::String
-Treefile::write_repovars (::std::int32_t workdir_dfd_raw) const
-{
+::rust::String Treefile::write_repovars(::std::int32_t workdir_dfd_raw) const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$Treefile$write_repovars (*this, workdir_dfd_raw, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$write_repovars(*this, workdir_dfd_raw, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-Treefile::set_releasever (::rust::Str releasever)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Treefile$set_releasever (*this, releasever);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void Treefile::set_releasever(::rust::Str releasever) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$set_releasever(*this, releasever);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-Treefile::set_recommends (bool val)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Treefile$set_recommends (*this, val);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void Treefile::set_recommends(bool val) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$set_recommends(*this, val);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-Treefile::enable_repo (::rust::Str repo)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Treefile$enable_repo (*this, repo);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void Treefile::enable_repo(::rust::Str repo) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$enable_repo(*this, repo);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-Treefile::disable_repo (::rust::Str repo)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Treefile$disable_repo (*this, repo);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void Treefile::disable_repo(::rust::Str repo) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$disable_repo(*this, repo);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-Treefile::validate_for_container () const
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Treefile$validate_for_container (*this);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void Treefile::validate_for_container() const {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$validate_for_container(*this);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::rpmostreecxx::Refspec
-Treefile::get_base_refspec () const noexcept
-{
+::rpmostreecxx::Refspec Treefile::get_base_refspec() const noexcept {
   ::rust::MaybeUninit<::rpmostreecxx::Refspec> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_base_refspec (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_base_refspec(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-void
-Treefile::rebase (::rust::Str new_refspec, ::rust::Str custom_origin_url,
-                  ::rust::Str custom_origin_description) noexcept
-{
-  rpmostreecxx$cxxbridge1$Treefile$rebase (*this, new_refspec, custom_origin_url,
-                                           custom_origin_description);
+void Treefile::rebase(::rust::Str new_refspec, ::rust::Str custom_origin_url, ::rust::Str custom_origin_description) noexcept {
+  rpmostreecxx$cxxbridge1$194$Treefile$rebase(*this, new_refspec, custom_origin_url, custom_origin_description);
 }
 
-::rust::String
-Treefile::get_origin_custom_url () const noexcept
-{
+::rust::String Treefile::get_origin_custom_url() const noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_origin_custom_url (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_origin_custom_url(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::String
-Treefile::get_origin_custom_description () const noexcept
-{
+::rust::String Treefile::get_origin_custom_description() const noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_origin_custom_description (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_origin_custom_description(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::String
-Treefile::get_override_commit () const noexcept
-{
+::rust::String Treefile::get_override_commit() const noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_override_commit (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_override_commit(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-void
-Treefile::set_override_commit (::rust::Str checksum) noexcept
-{
-  rpmostreecxx$cxxbridge1$Treefile$set_override_commit (*this, checksum);
+void Treefile::set_override_commit(::rust::Str checksum) noexcept {
+  rpmostreecxx$cxxbridge1$194$Treefile$set_override_commit(*this, checksum);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_initramfs_etc_files () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_initramfs_etc_files() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_initramfs_etc_files (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_etc_files(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-bool
-Treefile::has_initramfs_etc_files () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$has_initramfs_etc_files (*this);
+bool Treefile::has_initramfs_etc_files() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$has_initramfs_etc_files(*this);
 }
 
-bool
-Treefile::initramfs_etc_files_track (::rust::Vec<::rust::String> files) noexcept
-{
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> files$ (::std::move (files));
-  return rpmostreecxx$cxxbridge1$Treefile$initramfs_etc_files_track (*this, &files$.value);
+bool Treefile::initramfs_etc_files_track(::rust::Vec<::rust::String> files) noexcept {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> files$(::std::move(files));
+  return rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_track(*this, &files$.value);
 }
 
-bool
-Treefile::initramfs_etc_files_untrack (::rust::Vec<::rust::String> files) noexcept
-{
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> files$ (::std::move (files));
-  return rpmostreecxx$cxxbridge1$Treefile$initramfs_etc_files_untrack (*this, &files$.value);
+bool Treefile::initramfs_etc_files_untrack(::rust::Vec<::rust::String> files) noexcept {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> files$(::std::move(files));
+  return rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_untrack(*this, &files$.value);
 }
 
-bool
-Treefile::initramfs_etc_files_untrack_all () noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$initramfs_etc_files_untrack_all (*this);
+bool Treefile::initramfs_etc_files_untrack_all() noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_untrack_all(*this);
 }
 
-bool
-Treefile::get_initramfs_regenerate () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_initramfs_regenerate (*this);
+bool Treefile::get_initramfs_regenerate() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_regenerate(*this);
 }
 
-::rust::Vec<::rust::String>
-Treefile::get_initramfs_args () const noexcept
-{
+::rust::Vec<::rust::String> Treefile::get_initramfs_args() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_initramfs_args (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_args(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-void
-Treefile::set_initramfs_regenerate (bool enabled, ::rust::Vec<::rust::String> args) noexcept
-{
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$ (::std::move (args));
-  rpmostreecxx$cxxbridge1$Treefile$set_initramfs_regenerate (*this, enabled, &args$.value);
+void Treefile::set_initramfs_regenerate(bool enabled, ::rust::Vec<::rust::String> args) noexcept {
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$(::std::move(args));
+  rpmostreecxx$cxxbridge1$194$Treefile$set_initramfs_regenerate(*this, enabled, &args$.value);
 }
 
-::rust::String
-Treefile::get_unconfigured_state () const noexcept
-{
+::rust::String Treefile::get_unconfigured_state() const noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$Treefile$get_unconfigured_state (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_unconfigured_state(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-bool
-Treefile::may_require_local_assembly () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$may_require_local_assembly (*this);
+bool Treefile::may_require_local_assembly() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$may_require_local_assembly(*this);
 }
 
-bool
-Treefile::has_any_packages () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$has_any_packages (*this);
+bool Treefile::has_any_packages() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$has_any_packages(*this);
 }
 
-bool
-Treefile::merge_treefile (::rust::Str treefile)
-{
+bool Treefile::merge_treefile(::rust::Str treefile) {
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$Treefile$merge_treefile (*this, treefile, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$merge_treefile(*this, treefile, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-bool
-Treefile::get_no_initramfs () const noexcept
-{
-  return rpmostreecxx$cxxbridge1$Treefile$get_no_initramfs (*this);
+bool Treefile::get_no_initramfs() const noexcept {
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_no_initramfs(*this);
 }
 
-::std::size_t
-RepoPackage::layout::size () noexcept
-{
-  return rpmostreecxx$cxxbridge1$RepoPackage$operator$sizeof ();
+::std::size_t RepoPackage::layout::size() noexcept {
+  return rpmostreecxx$cxxbridge1$194$RepoPackage$operator$sizeof();
 }
 
-::std::size_t
-RepoPackage::layout::align () noexcept
-{
-  return rpmostreecxx$cxxbridge1$RepoPackage$operator$alignof ();
+::std::size_t RepoPackage::layout::align() noexcept {
+  return rpmostreecxx$cxxbridge1$194$RepoPackage$operator$alignof();
 }
 
-::rust::Str
-RepoPackage::get_repo () const noexcept
-{
-  return ::rust::impl<::rust::Str>::new_unchecked (
-      rpmostreecxx$cxxbridge1$RepoPackage$get_repo (*this));
+::rust::Str RepoPackage::get_repo() const noexcept {
+  return ::rust::impl<::rust::Str>::new_unchecked(rpmostreecxx$cxxbridge1$194$RepoPackage$get_repo(*this));
 }
 
-::rust::Vec<::rust::String>
-RepoPackage::get_packages () const noexcept
-{
+::rust::Vec<::rust::String> RepoPackage::get_packages() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$RepoPackage$get_packages (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$RepoPackage$get_packages(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::String
-varsubstitute (::rust::Str s, ::rust::Vec<::rpmostreecxx::StringMapping> const &vars)
-{
+::rust::String varsubstitute(::rust::Str s, ::rust::Vec<::rpmostreecxx::StringMapping> const &vars) {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$varsubstitute (s, vars, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$varsubstitute(s, vars, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::Vec<::rust::String>
-get_features () noexcept
-{
+::rust::Vec<::rust::String> get_features() noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$get_features (&return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$get_features(&return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::String
-get_rpm_basearch () noexcept
-{
+::rust::String get_rpm_basearch() noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$get_rpm_basearch (&return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$get_rpm_basearch(&return$.value);
+  return ::std::move(return$.value);
 }
 
-::std::int32_t
-sealed_memfd (::rust::Str description, ::rust::Slice<::std::uint8_t const> content)
-{
+::std::int32_t sealed_memfd(::rust::Str description, ::rust::Slice<::std::uint8_t const> content) {
   ::rust::MaybeUninit<::std::int32_t> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$sealed_memfd (description, content, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$sealed_memfd(description, content, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-bool
-running_in_systemd () noexcept
-{
-  return rpmostreecxx$cxxbridge1$running_in_systemd ();
+bool running_in_systemd() noexcept {
+  return rpmostreecxx$cxxbridge1$194$running_in_systemd();
 }
 
-::rpmostreecxx::GVariant *
-calculate_advisories_diff (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str checksum_from,
-                           ::rust::Str checksum_to)
-{
+::rpmostreecxx::GVariant *calculate_advisories_diff(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str checksum_from, ::rust::Str checksum_to) {
   ::rust::MaybeUninit<::rpmostreecxx::GVariant *> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$calculate_advisories_diff (
-      repo, checksum_from, checksum_to, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$calculate_advisories_diff(repo, checksum_from, checksum_to, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::String
-translate_path_for_ostree (::rust::Str path) noexcept
-{
+::rust::String translate_path_for_ostree(::rust::Str path) noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$translate_path_for_ostree (path, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$translate_path_for_ostree(path, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rpmostreecxx::LiveApplyState
-get_live_apply_state (::rpmostreecxx::OstreeSysroot const &sysroot,
-                      ::rpmostreecxx::OstreeDeployment const &deployment)
-{
+::rpmostreecxx::LiveApplyState get_live_apply_state(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment) {
   ::rust::MaybeUninit<::rpmostreecxx::LiveApplyState> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$get_live_apply_state (sysroot, deployment, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$get_live_apply_state(sysroot, deployment, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-bool
-has_live_apply_state (::rpmostreecxx::OstreeSysroot const &sysroot,
-                      ::rpmostreecxx::OstreeDeployment const &deployment)
-{
+bool has_live_apply_state(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment) {
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$has_live_apply_state (sysroot, deployment, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$has_live_apply_state(sysroot, deployment, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-applylive_sync_ref (::rpmostreecxx::OstreeSysroot const &sysroot)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$applylive_sync_ref (sysroot);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void applylive_sync_ref(::rpmostreecxx::OstreeSysroot const &sysroot) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$applylive_sync_ref(sysroot);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-transaction_apply_live (::rpmostreecxx::OstreeSysroot const &sysroot,
-                        ::rpmostreecxx::GVariant const &target)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$transaction_apply_live (sysroot, target);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void transaction_apply_live(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::GVariant const &target) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$transaction_apply_live(sysroot, target);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-normalize_etc_shadow (::std::int32_t rootfs_dfd)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$normalize_etc_shadow (rootfs_dfd);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void normalize_etc_shadow(::std::int32_t rootfs_dfd) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$normalize_etc_shadow(rootfs_dfd);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-bool
-prepare_rpm_layering (::std::int32_t rootfs, ::std::int32_t merge_passwd_dir)
-{
+bool prepare_rpm_layering(::std::int32_t rootfs, ::std::int32_t merge_passwd_dir) {
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$prepare_rpm_layering (rootfs, merge_passwd_dir, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$prepare_rpm_layering(rootfs, merge_passwd_dir, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-complete_rpm_layering (::std::int32_t rootfs)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$complete_rpm_layering (rootfs);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void complete_rpm_layering(::std::int32_t rootfs) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$complete_rpm_layering(rootfs);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-deduplicate_tmpfiles_entries (::std::int32_t rootfs)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$deduplicate_tmpfiles_entries (rootfs);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void deduplicate_tmpfiles_entries(::std::int32_t rootfs) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deduplicate_tmpfiles_entries(rootfs);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-passwd_cleanup (::std::int32_t rootfs)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$passwd_cleanup (rootfs);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void passwd_cleanup(::std::int32_t rootfs) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$passwd_cleanup(rootfs);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-migrate_group_except_root (::std::int32_t rootfs,
-                           ::rust::Vec<::rust::String> const &preserved_groups)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$migrate_group_except_root (rootfs, preserved_groups);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void migrate_group_except_root(::std::int32_t rootfs, ::rust::Vec<::rust::String> const &preserved_groups) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$migrate_group_except_root(rootfs, preserved_groups);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-migrate_passwd_except_root (::std::int32_t rootfs)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$migrate_passwd_except_root (rootfs);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void migrate_passwd_except_root(::std::int32_t rootfs) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$migrate_passwd_except_root(rootfs);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-passwd_compose_prep (::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$passwd_compose_prep (rootfs, treefile);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void passwd_compose_prep(::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$passwd_compose_prep(rootfs, treefile);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-passwd_compose_prep_repo (::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile,
-                          ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str previous_checksum,
-                          bool unified_core)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$passwd_compose_prep_repo (
-      rootfs, treefile, repo, previous_checksum, unified_core);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void passwd_compose_prep_repo(::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile, ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str previous_checksum, bool unified_core) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$passwd_compose_prep_repo(rootfs, treefile, repo, previous_checksum, unified_core);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-bool
-dir_contains_uid (::std::int32_t dirfd, ::std::uint32_t id)
-{
+bool dir_contains_uid(::std::int32_t dirfd, ::std::uint32_t id) {
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$dir_contains_uid (dirfd, id, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$dir_contains_uid(dirfd, id, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-bool
-dir_contains_gid (::std::int32_t dirfd, ::std::uint32_t id)
-{
+bool dir_contains_gid(::std::int32_t dirfd, ::std::uint32_t id) {
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$dir_contains_gid (dirfd, id, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$dir_contains_gid(dirfd, id, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-check_passwd_group_entries (::rpmostreecxx::OstreeRepo const &ffi_repo, ::std::int32_t rootfs_dfd,
-                            ::rpmostreecxx::Treefile &treefile, ::rust::Str previous_rev)
-{
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$check_passwd_group_entries (
-      ffi_repo, rootfs_dfd, treefile, previous_rev);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void check_passwd_group_entries(::rpmostreecxx::OstreeRepo const &ffi_repo, ::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile, ::rust::Str previous_rev) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$check_passwd_group_entries(ffi_repo, rootfs_dfd, treefile, previous_rev);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::rust::Box<::rpmostreecxx::PasswdDB>
-passwddb_open (::std::int32_t rootfs)
-{
+::rust::Box<::rpmostreecxx::PasswdDB> passwddb_open(::std::int32_t rootfs) {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::PasswdDB>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$passwddb_open (rootfs, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$passwddb_open(rootfs, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::std::size_t
-PasswdDB::layout::size () noexcept
-{
-  return rpmostreecxx$cxxbridge1$PasswdDB$operator$sizeof ();
+::std::size_t PasswdDB::layout::size() noexcept {
+  return rpmostreecxx$cxxbridge1$194$PasswdDB$operator$sizeof();
 }
 
-::std::size_t
-PasswdDB::layout::align () noexcept
-{
-  return rpmostreecxx$cxxbridge1$PasswdDB$operator$alignof ();
+::std::size_t PasswdDB::layout::align() noexcept {
+  return rpmostreecxx$cxxbridge1$194$PasswdDB$operator$alignof();
 }
 
-::rust::String
-PasswdDB::lookup_user (::std::uint32_t uid) const
-{
+::rust::String PasswdDB::lookup_user(::std::uint32_t uid) const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$PasswdDB$lookup_user (*this, uid, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$PasswdDB$lookup_user(*this, uid, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::String
-PasswdDB::lookup_group (::std::uint32_t gid) const
-{
+::rust::String PasswdDB::lookup_group(::std::uint32_t gid) const {
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$PasswdDB$lookup_group (*this, gid, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$PasswdDB$lookup_group(*this, gid, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::Box<::rpmostreecxx::PasswdEntries>
-new_passwd_entries () noexcept
-{
-  return ::rust::Box<::rpmostreecxx::PasswdEntries>::from_raw (
-      rpmostreecxx$cxxbridge1$new_passwd_entries ());
+::rust::Box<::rpmostreecxx::PasswdEntries> new_passwd_entries() noexcept {
+  return ::rust::Box<::rpmostreecxx::PasswdEntries>::from_raw(rpmostreecxx$cxxbridge1$194$new_passwd_entries());
 }
 
-::std::size_t
-PasswdEntries::layout::size () noexcept
-{
-  return rpmostreecxx$cxxbridge1$PasswdEntries$operator$sizeof ();
+::std::size_t PasswdEntries::layout::size() noexcept {
+  return rpmostreecxx$cxxbridge1$194$PasswdEntries$operator$sizeof();
 }
 
-::std::size_t
-PasswdEntries::layout::align () noexcept
-{
-  return rpmostreecxx$cxxbridge1$PasswdEntries$operator$alignof ();
+::std::size_t PasswdEntries::layout::align() noexcept {
+  return rpmostreecxx$cxxbridge1$194$PasswdEntries$operator$alignof();
 }
 
-void
-PasswdEntries::add_group_content (::std::int32_t rootfs, ::rust::Str path)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$PasswdEntries$add_group_content (*this, rootfs, path);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void PasswdEntries::add_group_content(::std::int32_t rootfs, ::rust::Str path) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$PasswdEntries$add_group_content(*this, rootfs, path);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-PasswdEntries::add_passwd_content (::std::int32_t rootfs, ::rust::Str path)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$PasswdEntries$add_passwd_content (*this, rootfs, path);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void PasswdEntries::add_passwd_content(::std::int32_t rootfs, ::rust::Str path) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$PasswdEntries$add_passwd_content(*this, rootfs, path);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-bool
-PasswdEntries::contains_group (::rust::Str user) const noexcept
-{
-  return rpmostreecxx$cxxbridge1$PasswdEntries$contains_group (*this, user);
+bool PasswdEntries::contains_group(::rust::Str user) const noexcept {
+  return rpmostreecxx$cxxbridge1$194$PasswdEntries$contains_group(*this, user);
 }
 
-bool
-PasswdEntries::contains_user (::rust::Str user) const noexcept
-{
-  return rpmostreecxx$cxxbridge1$PasswdEntries$contains_user (*this, user);
+bool PasswdEntries::contains_user(::rust::Str user) const noexcept {
+  return rpmostreecxx$cxxbridge1$194$PasswdEntries$contains_user(*this, user);
 }
 
-::std::uint32_t
-PasswdEntries::lookup_user_id (::rust::Str user) const
-{
+::std::uint32_t PasswdEntries::lookup_user_id(::rust::Str user) const {
   ::rust::MaybeUninit<::std::uint32_t> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$PasswdEntries$lookup_user_id (*this, user, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$PasswdEntries$lookup_user_id(*this, user, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::std::uint32_t
-PasswdEntries::lookup_group_id (::rust::Str group) const
-{
+::std::uint32_t PasswdEntries::lookup_group_id(::rust::Str group) const {
   ::rust::MaybeUninit<::std::uint32_t> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$PasswdEntries$lookup_group_id (*this, group, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$PasswdEntries$lookup_group_id(*this, group, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::std::size_t
-Extensions::layout::size () noexcept
-{
-  return rpmostreecxx$cxxbridge1$Extensions$operator$sizeof ();
+::std::size_t Extensions::layout::size() noexcept {
+  return rpmostreecxx$cxxbridge1$194$Extensions$operator$sizeof();
 }
 
-::std::size_t
-Extensions::layout::align () noexcept
-{
-  return rpmostreecxx$cxxbridge1$Extensions$operator$alignof ();
+::std::size_t Extensions::layout::align() noexcept {
+  return rpmostreecxx$cxxbridge1$194$Extensions$operator$alignof();
 }
 
-::rust::Box<::rpmostreecxx::Extensions>
-extensions_load (::rust::Str path, ::rust::Str basearch,
-                 ::rust::Vec<::rpmostreecxx::StringMapping> const &base_pkgs)
-{
+::rust::Box<::rpmostreecxx::Extensions> extensions_load(::rust::Str path, ::rust::Str basearch, ::rust::Vec<::rpmostreecxx::StringMapping> const &base_pkgs) {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Extensions>> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$extensions_load (path, basearch, base_pkgs, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$extensions_load(path, basearch, base_pkgs, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::Vec<::rust::String>
-Extensions::get_repos () const noexcept
-{
+::rust::Vec<::rust::String> Extensions::get_repos() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Extensions$get_repos (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Extensions$get_repos(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::Vec<::rust::String>
-Extensions::get_os_extension_packages () const noexcept
-{
+::rust::Vec<::rust::String> Extensions::get_os_extension_packages() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Extensions$get_os_extension_packages (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Extensions$get_os_extension_packages(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-::rust::Vec<::rust::String>
-Extensions::get_development_packages () const noexcept
-{
+::rust::Vec<::rust::String> Extensions::get_development_packages() const noexcept {
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$Extensions$get_development_packages (*this, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$Extensions$get_development_packages(*this, &return$.value);
+  return ::std::move(return$.value);
 }
 
-bool
-Extensions::state_checksum_changed (::rust::Str chksum, ::rust::Str output_dir) const
-{
+bool Extensions::state_checksum_changed(::rust::Str chksum, ::rust::Str output_dir) const {
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$Extensions$state_checksum_changed (
-      *this, chksum, output_dir, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Extensions$state_checksum_changed(*this, chksum, output_dir, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-Extensions::update_state_checksum (::rust::Str chksum, ::rust::Str output_dir) const
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$Extensions$update_state_checksum (*this, chksum, output_dir);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void Extensions::update_state_checksum(::rust::Str chksum, ::rust::Str output_dir) const {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Extensions$update_state_checksum(*this, chksum, output_dir);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-void
-Extensions::serialize_to_dir (::rust::Str output_dir) const
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$Extensions$serialize_to_dir (*this, output_dir);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void Extensions::serialize_to_dir(::rust::Str output_dir) const {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Extensions$serialize_to_dir(*this, output_dir);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::rust::Box<::rpmostreecxx::Treefile>
-Extensions::generate_treefile (::rpmostreecxx::Treefile const &src) const
-{
+::rust::Box<::rpmostreecxx::Treefile> Extensions::generate_treefile(::rpmostreecxx::Treefile const &src) const {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Treefile>> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$Extensions$generate_treefile (*this, src, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Extensions$generate_treefile(*this, src, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::std::size_t
-LockfileConfig::layout::size () noexcept
-{
-  return rpmostreecxx$cxxbridge1$LockfileConfig$operator$sizeof ();
+::std::size_t LockfileConfig::layout::size() noexcept {
+  return rpmostreecxx$cxxbridge1$194$LockfileConfig$operator$sizeof();
 }
 
-::std::size_t
-LockfileConfig::layout::align () noexcept
-{
-  return rpmostreecxx$cxxbridge1$LockfileConfig$operator$alignof ();
+::std::size_t LockfileConfig::layout::align() noexcept {
+  return rpmostreecxx$cxxbridge1$194$LockfileConfig$operator$alignof();
 }
 
-::rust::Box<::rpmostreecxx::LockfileConfig>
-lockfile_read (::rust::Vec<::rust::String> const &filenames)
-{
+::rust::Box<::rpmostreecxx::LockfileConfig> lockfile_read(::rust::Vec<::rust::String> const &filenames) {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::LockfileConfig>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$lockfile_read (filenames, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$lockfile_read(filenames, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-lockfile_write (::rust::Str filename, ::rpmostreecxx::CxxGObjectArray &packages,
-                ::rpmostreecxx::CxxGObjectArray &rpmmd_repos)
-{
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$lockfile_write (filename, packages, rpmmd_repos);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
+void lockfile_write(::rust::Str filename, ::rpmostreecxx::CxxGObjectArray &packages, ::rpmostreecxx::CxxGObjectArray &rpmmd_repos) {
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$lockfile_write(filename, packages, rpmmd_repos);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
 }
 
-::rust::Vec<::rpmostreecxx::LockedPackage>
-LockfileConfig::get_locked_packages () const
-{
+::rust::Vec<::rpmostreecxx::LockedPackage> LockfileConfig::get_locked_packages() const {
   ::rust::MaybeUninit<::rust::Vec<::rpmostreecxx::LockedPackage>> return$;
-  ::rust::repr::PtrLen error$
-      = rpmostreecxx$cxxbridge1$LockfileConfig$get_locked_packages (*this, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$LockfileConfig$get_locked_packages(*this, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rust::Box<::rpmostreecxx::Treefile>
-origin_to_treefile (::rpmostreecxx::GKeyFile const &kf)
-{
+::rust::Box<::rpmostreecxx::Treefile> origin_to_treefile(::rpmostreecxx::GKeyFile const &kf) {
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Treefile>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$origin_to_treefile (kf, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$origin_to_treefile(kf, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-::rpmostreecxx::GKeyFile *
-treefile_to_origin (::rpmostreecxx::Treefile const &tf)
-{
+::rpmostreecxx::GKeyFile *treefile_to_origin(::rpmostreecxx::Treefile const &tf) {
   ::rust::MaybeUninit<::rpmostreecxx::GKeyFile *> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$treefile_to_origin (tf, &return$.value);
-  if (error$.ptr)
-    {
-      throw ::rust::impl<::rust::Error>::error (error$);
-    }
-  return ::std::move (return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_to_origin(tf, &return$.value);
+  if (error$.ptr) {
+    throw ::rust::impl<::rust::Error>::error(error$);
+  }
+  return ::std::move(return$.value);
 }
 
-void
-origin_validate_roundtrip (::rpmostreecxx::GKeyFile const &kf) noexcept
-{
-  rpmostreecxx$cxxbridge1$origin_validate_roundtrip (kf);
+void origin_validate_roundtrip(::rpmostreecxx::GKeyFile const &kf) noexcept {
+  rpmostreecxx$cxxbridge1$194$origin_validate_roundtrip(kf);
 }
 
-::rust::String
-cache_branch_to_nevra (::rust::Str nevra) noexcept
-{
+::rust::String cache_branch_to_nevra(::rust::Str nevra) noexcept {
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$cache_branch_to_nevra (nevra, &return$.value);
-  return ::std::move (return$.value);
+  rpmostreecxx$cxxbridge1$194$cache_branch_to_nevra(nevra, &return$.value);
+  return ::std::move(return$.value);
 }
 } // namespace rpmostreecxx
 
-extern "C"
-{
-  ::rpmostreecxx::Bubblewrap *cxxbridge1$box$rpmostreecxx$Bubblewrap$alloc () noexcept;
-  void cxxbridge1$box$rpmostreecxx$Bubblewrap$dealloc (::rpmostreecxx::Bubblewrap *) noexcept;
-  void cxxbridge1$box$rpmostreecxx$Bubblewrap$drop (
-      ::rust::Box<::rpmostreecxx::Bubblewrap> *ptr) noexcept;
+extern "C" {
+::rpmostreecxx::Bubblewrap *cxxbridge1$box$rpmostreecxx$Bubblewrap$alloc() noexcept;
+void cxxbridge1$box$rpmostreecxx$Bubblewrap$dealloc(::rpmostreecxx::Bubblewrap *) noexcept;
+void cxxbridge1$box$rpmostreecxx$Bubblewrap$drop(::rust::Box<::rpmostreecxx::Bubblewrap> *ptr) noexcept;
 
-  ::rpmostreecxx::ContainerImageState *
-  cxxbridge1$box$rpmostreecxx$ContainerImageState$alloc () noexcept;
-  void cxxbridge1$box$rpmostreecxx$ContainerImageState$dealloc (
-      ::rpmostreecxx::ContainerImageState *) noexcept;
-  void cxxbridge1$box$rpmostreecxx$ContainerImageState$drop (
-      ::rust::Box<::rpmostreecxx::ContainerImageState> *ptr) noexcept;
+::rpmostreecxx::ContainerImageState *cxxbridge1$box$rpmostreecxx$ContainerImageState$alloc() noexcept;
+void cxxbridge1$box$rpmostreecxx$ContainerImageState$dealloc(::rpmostreecxx::ContainerImageState *) noexcept;
+void cxxbridge1$box$rpmostreecxx$ContainerImageState$drop(::rust::Box<::rpmostreecxx::ContainerImageState> *ptr) noexcept;
 
-  ::rpmostreecxx::TempEtcGuard *cxxbridge1$box$rpmostreecxx$TempEtcGuard$alloc () noexcept;
-  void cxxbridge1$box$rpmostreecxx$TempEtcGuard$dealloc (::rpmostreecxx::TempEtcGuard *) noexcept;
-  void cxxbridge1$box$rpmostreecxx$TempEtcGuard$drop (
-      ::rust::Box<::rpmostreecxx::TempEtcGuard> *ptr) noexcept;
+::rpmostreecxx::TempEtcGuard *cxxbridge1$box$rpmostreecxx$TempEtcGuard$alloc() noexcept;
+void cxxbridge1$box$rpmostreecxx$TempEtcGuard$dealloc(::rpmostreecxx::TempEtcGuard *) noexcept;
+void cxxbridge1$box$rpmostreecxx$TempEtcGuard$drop(::rust::Box<::rpmostreecxx::TempEtcGuard> *ptr) noexcept;
 
-  ::rpmostreecxx::FilesystemScriptPrep *
-  cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$alloc () noexcept;
-  void cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$dealloc (
-      ::rpmostreecxx::FilesystemScriptPrep *) noexcept;
-  void cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$drop (
-      ::rust::Box<::rpmostreecxx::FilesystemScriptPrep> *ptr) noexcept;
+::rpmostreecxx::FilesystemScriptPrep *cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$alloc() noexcept;
+void cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$dealloc(::rpmostreecxx::FilesystemScriptPrep *) noexcept;
+void cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$drop(::rust::Box<::rpmostreecxx::FilesystemScriptPrep> *ptr) noexcept;
 
-  ::rpmostreecxx::RpmImporterFlags *cxxbridge1$box$rpmostreecxx$RpmImporterFlags$alloc () noexcept;
-  void cxxbridge1$box$rpmostreecxx$RpmImporterFlags$dealloc (
-      ::rpmostreecxx::RpmImporterFlags *) noexcept;
-  void cxxbridge1$box$rpmostreecxx$RpmImporterFlags$drop (
-      ::rust::Box<::rpmostreecxx::RpmImporterFlags> *ptr) noexcept;
+::rpmostreecxx::RpmImporterFlags *cxxbridge1$box$rpmostreecxx$RpmImporterFlags$alloc() noexcept;
+void cxxbridge1$box$rpmostreecxx$RpmImporterFlags$dealloc(::rpmostreecxx::RpmImporterFlags *) noexcept;
+void cxxbridge1$box$rpmostreecxx$RpmImporterFlags$drop(::rust::Box<::rpmostreecxx::RpmImporterFlags> *ptr) noexcept;
 
-  ::rpmostreecxx::RpmImporter *cxxbridge1$box$rpmostreecxx$RpmImporter$alloc () noexcept;
-  void cxxbridge1$box$rpmostreecxx$RpmImporter$dealloc (::rpmostreecxx::RpmImporter *) noexcept;
-  void cxxbridge1$box$rpmostreecxx$RpmImporter$drop (
-      ::rust::Box<::rpmostreecxx::RpmImporter> *ptr) noexcept;
+::rpmostreecxx::RpmImporter *cxxbridge1$box$rpmostreecxx$RpmImporter$alloc() noexcept;
+void cxxbridge1$box$rpmostreecxx$RpmImporter$dealloc(::rpmostreecxx::RpmImporter *) noexcept;
+void cxxbridge1$box$rpmostreecxx$RpmImporter$drop(::rust::Box<::rpmostreecxx::RpmImporter> *ptr) noexcept;
 
-  ::rpmostreecxx::HistoryCtx *cxxbridge1$box$rpmostreecxx$HistoryCtx$alloc () noexcept;
-  void cxxbridge1$box$rpmostreecxx$HistoryCtx$dealloc (::rpmostreecxx::HistoryCtx *) noexcept;
-  void cxxbridge1$box$rpmostreecxx$HistoryCtx$drop (
-      ::rust::Box<::rpmostreecxx::HistoryCtx> *ptr) noexcept;
+::rpmostreecxx::HistoryCtx *cxxbridge1$box$rpmostreecxx$HistoryCtx$alloc() noexcept;
+void cxxbridge1$box$rpmostreecxx$HistoryCtx$dealloc(::rpmostreecxx::HistoryCtx *) noexcept;
+void cxxbridge1$box$rpmostreecxx$HistoryCtx$drop(::rust::Box<::rpmostreecxx::HistoryCtx> *ptr) noexcept;
 
-  ::rpmostreecxx::TokioHandle *cxxbridge1$box$rpmostreecxx$TokioHandle$alloc () noexcept;
-  void cxxbridge1$box$rpmostreecxx$TokioHandle$dealloc (::rpmostreecxx::TokioHandle *) noexcept;
-  void cxxbridge1$box$rpmostreecxx$TokioHandle$drop (
-      ::rust::Box<::rpmostreecxx::TokioHandle> *ptr) noexcept;
+::rpmostreecxx::TokioHandle *cxxbridge1$box$rpmostreecxx$TokioHandle$alloc() noexcept;
+void cxxbridge1$box$rpmostreecxx$TokioHandle$dealloc(::rpmostreecxx::TokioHandle *) noexcept;
+void cxxbridge1$box$rpmostreecxx$TokioHandle$drop(::rust::Box<::rpmostreecxx::TokioHandle> *ptr) noexcept;
 
-  ::rpmostreecxx::TokioEnterGuard *cxxbridge1$box$rpmostreecxx$TokioEnterGuard$alloc () noexcept;
-  void
-  cxxbridge1$box$rpmostreecxx$TokioEnterGuard$dealloc (::rpmostreecxx::TokioEnterGuard *) noexcept;
-  void cxxbridge1$box$rpmostreecxx$TokioEnterGuard$drop (
-      ::rust::Box<::rpmostreecxx::TokioEnterGuard> *ptr) noexcept;
+::rpmostreecxx::TokioEnterGuard *cxxbridge1$box$rpmostreecxx$TokioEnterGuard$alloc() noexcept;
+void cxxbridge1$box$rpmostreecxx$TokioEnterGuard$dealloc(::rpmostreecxx::TokioEnterGuard *) noexcept;
+void cxxbridge1$box$rpmostreecxx$TokioEnterGuard$drop(::rust::Box<::rpmostreecxx::TokioEnterGuard> *ptr) noexcept;
 
-  ::rpmostreecxx::Treefile *cxxbridge1$box$rpmostreecxx$Treefile$alloc () noexcept;
-  void cxxbridge1$box$rpmostreecxx$Treefile$dealloc (::rpmostreecxx::Treefile *) noexcept;
-  void
-  cxxbridge1$box$rpmostreecxx$Treefile$drop (::rust::Box<::rpmostreecxx::Treefile> *ptr) noexcept;
+::rpmostreecxx::Treefile *cxxbridge1$box$rpmostreecxx$Treefile$alloc() noexcept;
+void cxxbridge1$box$rpmostreecxx$Treefile$dealloc(::rpmostreecxx::Treefile *) noexcept;
+void cxxbridge1$box$rpmostreecxx$Treefile$drop(::rust::Box<::rpmostreecxx::Treefile> *ptr) noexcept;
 
-  void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$new (
-      ::rust::Vec<::rpmostreecxx::OverrideReplacement> const *ptr) noexcept;
-  void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$drop (
-      ::rust::Vec<::rpmostreecxx::OverrideReplacement> *ptr) noexcept;
-  ::std::size_t cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$len (
-      ::rust::Vec<::rpmostreecxx::OverrideReplacement> const *ptr) noexcept;
-  ::std::size_t cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$capacity (
-      ::rust::Vec<::rpmostreecxx::OverrideReplacement> const *ptr) noexcept;
-  ::rpmostreecxx::OverrideReplacement const *
-  cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$data (
-      ::rust::Vec<::rpmostreecxx::OverrideReplacement> const *ptr) noexcept;
-  void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$reserve_total (
-      ::rust::Vec<::rpmostreecxx::OverrideReplacement> *ptr, ::std::size_t new_cap) noexcept;
-  void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$set_len (
-      ::rust::Vec<::rpmostreecxx::OverrideReplacement> *ptr, ::std::size_t len) noexcept;
-  void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$truncate (
-      ::rust::Vec<::rpmostreecxx::OverrideReplacement> *ptr, ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$new(::rust::Vec<::rpmostreecxx::OverrideReplacement> const *ptr) noexcept;
+void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$drop(::rust::Vec<::rpmostreecxx::OverrideReplacement> *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$len(::rust::Vec<::rpmostreecxx::OverrideReplacement> const *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$capacity(::rust::Vec<::rpmostreecxx::OverrideReplacement> const *ptr) noexcept;
+::rpmostreecxx::OverrideReplacement const *cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$data(::rust::Vec<::rpmostreecxx::OverrideReplacement> const *ptr) noexcept;
+void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$reserve_total(::rust::Vec<::rpmostreecxx::OverrideReplacement> *ptr, ::std::size_t new_cap) noexcept;
+void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$set_len(::rust::Vec<::rpmostreecxx::OverrideReplacement> *ptr, ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$truncate(::rust::Vec<::rpmostreecxx::OverrideReplacement> *ptr, ::std::size_t len) noexcept;
 
-  void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$new (
-      ::rust::Vec<::rpmostreecxx::StringMapping> const *ptr) noexcept;
-  void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$drop (
-      ::rust::Vec<::rpmostreecxx::StringMapping> *ptr) noexcept;
-  ::std::size_t cxxbridge1$rust_vec$rpmostreecxx$StringMapping$len (
-      ::rust::Vec<::rpmostreecxx::StringMapping> const *ptr) noexcept;
-  ::std::size_t cxxbridge1$rust_vec$rpmostreecxx$StringMapping$capacity (
-      ::rust::Vec<::rpmostreecxx::StringMapping> const *ptr) noexcept;
-  ::rpmostreecxx::StringMapping const *cxxbridge1$rust_vec$rpmostreecxx$StringMapping$data (
-      ::rust::Vec<::rpmostreecxx::StringMapping> const *ptr) noexcept;
-  void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$reserve_total (
-      ::rust::Vec<::rpmostreecxx::StringMapping> *ptr, ::std::size_t new_cap) noexcept;
-  void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$set_len (
-      ::rust::Vec<::rpmostreecxx::StringMapping> *ptr, ::std::size_t len) noexcept;
-  void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$truncate (
-      ::rust::Vec<::rpmostreecxx::StringMapping> *ptr, ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$new(::rust::Vec<::rpmostreecxx::StringMapping> const *ptr) noexcept;
+void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$drop(::rust::Vec<::rpmostreecxx::StringMapping> *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$rpmostreecxx$StringMapping$len(::rust::Vec<::rpmostreecxx::StringMapping> const *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$rpmostreecxx$StringMapping$capacity(::rust::Vec<::rpmostreecxx::StringMapping> const *ptr) noexcept;
+::rpmostreecxx::StringMapping const *cxxbridge1$rust_vec$rpmostreecxx$StringMapping$data(::rust::Vec<::rpmostreecxx::StringMapping> const *ptr) noexcept;
+void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$reserve_total(::rust::Vec<::rpmostreecxx::StringMapping> *ptr, ::std::size_t new_cap) noexcept;
+void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$set_len(::rust::Vec<::rpmostreecxx::StringMapping> *ptr, ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$truncate(::rust::Vec<::rpmostreecxx::StringMapping> *ptr, ::std::size_t len) noexcept;
 
-  ::rpmostreecxx::PasswdDB *cxxbridge1$box$rpmostreecxx$PasswdDB$alloc () noexcept;
-  void cxxbridge1$box$rpmostreecxx$PasswdDB$dealloc (::rpmostreecxx::PasswdDB *) noexcept;
-  void
-  cxxbridge1$box$rpmostreecxx$PasswdDB$drop (::rust::Box<::rpmostreecxx::PasswdDB> *ptr) noexcept;
+::rpmostreecxx::PasswdDB *cxxbridge1$box$rpmostreecxx$PasswdDB$alloc() noexcept;
+void cxxbridge1$box$rpmostreecxx$PasswdDB$dealloc(::rpmostreecxx::PasswdDB *) noexcept;
+void cxxbridge1$box$rpmostreecxx$PasswdDB$drop(::rust::Box<::rpmostreecxx::PasswdDB> *ptr) noexcept;
 
-  ::rpmostreecxx::PasswdEntries *cxxbridge1$box$rpmostreecxx$PasswdEntries$alloc () noexcept;
-  void cxxbridge1$box$rpmostreecxx$PasswdEntries$dealloc (::rpmostreecxx::PasswdEntries *) noexcept;
-  void cxxbridge1$box$rpmostreecxx$PasswdEntries$drop (
-      ::rust::Box<::rpmostreecxx::PasswdEntries> *ptr) noexcept;
+::rpmostreecxx::PasswdEntries *cxxbridge1$box$rpmostreecxx$PasswdEntries$alloc() noexcept;
+void cxxbridge1$box$rpmostreecxx$PasswdEntries$dealloc(::rpmostreecxx::PasswdEntries *) noexcept;
+void cxxbridge1$box$rpmostreecxx$PasswdEntries$drop(::rust::Box<::rpmostreecxx::PasswdEntries> *ptr) noexcept;
 
-  ::rpmostreecxx::Extensions *cxxbridge1$box$rpmostreecxx$Extensions$alloc () noexcept;
-  void cxxbridge1$box$rpmostreecxx$Extensions$dealloc (::rpmostreecxx::Extensions *) noexcept;
-  void cxxbridge1$box$rpmostreecxx$Extensions$drop (
-      ::rust::Box<::rpmostreecxx::Extensions> *ptr) noexcept;
+::rpmostreecxx::Extensions *cxxbridge1$box$rpmostreecxx$Extensions$alloc() noexcept;
+void cxxbridge1$box$rpmostreecxx$Extensions$dealloc(::rpmostreecxx::Extensions *) noexcept;
+void cxxbridge1$box$rpmostreecxx$Extensions$drop(::rust::Box<::rpmostreecxx::Extensions> *ptr) noexcept;
 
-  ::rpmostreecxx::LockfileConfig *cxxbridge1$box$rpmostreecxx$LockfileConfig$alloc () noexcept;
-  void
-  cxxbridge1$box$rpmostreecxx$LockfileConfig$dealloc (::rpmostreecxx::LockfileConfig *) noexcept;
-  void cxxbridge1$box$rpmostreecxx$LockfileConfig$drop (
-      ::rust::Box<::rpmostreecxx::LockfileConfig> *ptr) noexcept;
+::rpmostreecxx::LockfileConfig *cxxbridge1$box$rpmostreecxx$LockfileConfig$alloc() noexcept;
+void cxxbridge1$box$rpmostreecxx$LockfileConfig$dealloc(::rpmostreecxx::LockfileConfig *) noexcept;
+void cxxbridge1$box$rpmostreecxx$LockfileConfig$drop(::rust::Box<::rpmostreecxx::LockfileConfig> *ptr) noexcept;
 
-  void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$new (
-      ::rust::Vec<::rpmostreecxx::LockedPackage> const *ptr) noexcept;
-  void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$drop (
-      ::rust::Vec<::rpmostreecxx::LockedPackage> *ptr) noexcept;
-  ::std::size_t cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$len (
-      ::rust::Vec<::rpmostreecxx::LockedPackage> const *ptr) noexcept;
-  ::std::size_t cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$capacity (
-      ::rust::Vec<::rpmostreecxx::LockedPackage> const *ptr) noexcept;
-  ::rpmostreecxx::LockedPackage const *cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$data (
-      ::rust::Vec<::rpmostreecxx::LockedPackage> const *ptr) noexcept;
-  void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$reserve_total (
-      ::rust::Vec<::rpmostreecxx::LockedPackage> *ptr, ::std::size_t new_cap) noexcept;
-  void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$set_len (
-      ::rust::Vec<::rpmostreecxx::LockedPackage> *ptr, ::std::size_t len) noexcept;
-  void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$truncate (
-      ::rust::Vec<::rpmostreecxx::LockedPackage> *ptr, ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$new(::rust::Vec<::rpmostreecxx::LockedPackage> const *ptr) noexcept;
+void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$drop(::rust::Vec<::rpmostreecxx::LockedPackage> *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$len(::rust::Vec<::rpmostreecxx::LockedPackage> const *ptr) noexcept;
+::std::size_t cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$capacity(::rust::Vec<::rpmostreecxx::LockedPackage> const *ptr) noexcept;
+::rpmostreecxx::LockedPackage const *cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$data(::rust::Vec<::rpmostreecxx::LockedPackage> const *ptr) noexcept;
+void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$reserve_total(::rust::Vec<::rpmostreecxx::LockedPackage> *ptr, ::std::size_t new_cap) noexcept;
+void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$set_len(::rust::Vec<::rpmostreecxx::LockedPackage> *ptr, ::std::size_t len) noexcept;
+void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$truncate(::rust::Vec<::rpmostreecxx::LockedPackage> *ptr, ::std::size_t len) noexcept;
 
-  static_assert (::rust::detail::is_complete<::rpmostreecxx::ClientConnection>::value,
-                 "definition of ClientConnection is required");
-  static_assert (sizeof (::std::unique_ptr<::rpmostreecxx::ClientConnection>) == sizeof (void *),
-                 "");
-  static_assert (alignof (::std::unique_ptr<::rpmostreecxx::ClientConnection>) == alignof (void *),
-                 "");
-  void
-  cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$null (
-      ::std::unique_ptr<::rpmostreecxx::ClientConnection> *ptr) noexcept
-  {
-    ::new (ptr)::std::unique_ptr<::rpmostreecxx::ClientConnection> ();
-  }
-  void
-  cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$raw (
-      ::std::unique_ptr<::rpmostreecxx::ClientConnection> *ptr,
-      ::rpmostreecxx::ClientConnection *raw) noexcept
-  {
-    ::new (ptr)::std::unique_ptr<::rpmostreecxx::ClientConnection> (raw);
-  }
-  ::rpmostreecxx::ClientConnection const *
-  cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$get (
-      ::std::unique_ptr<::rpmostreecxx::ClientConnection> const &ptr) noexcept
-  {
-    return ptr.get ();
-  }
-  ::rpmostreecxx::ClientConnection *
-  cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$release (
-      ::std::unique_ptr<::rpmostreecxx::ClientConnection> &ptr) noexcept
-  {
-    return ptr.release ();
-  }
-  void
-  cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$drop (
-      ::std::unique_ptr<::rpmostreecxx::ClientConnection> *ptr) noexcept
-  {
-    ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::ClientConnection>::value>{}(ptr);
-  }
+static_assert(::rust::detail::is_complete<::std::remove_extent<::rpmostreecxx::ClientConnection>::type>::value, "definition of `::rpmostreecxx::ClientConnection` is required");
+static_assert(sizeof(::std::unique_ptr<::rpmostreecxx::ClientConnection>) == sizeof(void *), "");
+static_assert(alignof(::std::unique_ptr<::rpmostreecxx::ClientConnection>) == alignof(void *), "");
+void cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$null(::std::unique_ptr<::rpmostreecxx::ClientConnection> *ptr) noexcept {
+  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::ClientConnection>();
+}
+void cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$raw(::std::unique_ptr<::rpmostreecxx::ClientConnection> *ptr, ::std::unique_ptr<::rpmostreecxx::ClientConnection>::pointer raw) noexcept {
+  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::ClientConnection>(raw);
+}
+::std::unique_ptr<::rpmostreecxx::ClientConnection>::element_type const *cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$get(::std::unique_ptr<::rpmostreecxx::ClientConnection> const &ptr) noexcept {
+  return ptr.get();
+}
+::std::unique_ptr<::rpmostreecxx::ClientConnection>::pointer cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$release(::std::unique_ptr<::rpmostreecxx::ClientConnection> &ptr) noexcept {
+  return ptr.release();
+}
+void cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$drop(::std::unique_ptr<::rpmostreecxx::ClientConnection> *ptr) noexcept {
+  ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::ClientConnection>::value>{}(ptr);
+}
 
-  static_assert (::rust::detail::is_complete<::rpmostreecxx::RPMDiff>::value,
-                 "definition of RPMDiff is required");
-  static_assert (sizeof (::std::unique_ptr<::rpmostreecxx::RPMDiff>) == sizeof (void *), "");
-  static_assert (alignof (::std::unique_ptr<::rpmostreecxx::RPMDiff>) == alignof (void *), "");
-  void
-  cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$null (
-      ::std::unique_ptr<::rpmostreecxx::RPMDiff> *ptr) noexcept
-  {
-    ::new (ptr)::std::unique_ptr<::rpmostreecxx::RPMDiff> ();
-  }
-  void
-  cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$raw (::std::unique_ptr<::rpmostreecxx::RPMDiff> *ptr,
-                                                  ::rpmostreecxx::RPMDiff *raw) noexcept
-  {
-    ::new (ptr)::std::unique_ptr<::rpmostreecxx::RPMDiff> (raw);
-  }
-  ::rpmostreecxx::RPMDiff const *
-  cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$get (
-      ::std::unique_ptr<::rpmostreecxx::RPMDiff> const &ptr) noexcept
-  {
-    return ptr.get ();
-  }
-  ::rpmostreecxx::RPMDiff *
-  cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$release (
-      ::std::unique_ptr<::rpmostreecxx::RPMDiff> &ptr) noexcept
-  {
-    return ptr.release ();
-  }
-  void
-  cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$drop (
-      ::std::unique_ptr<::rpmostreecxx::RPMDiff> *ptr) noexcept
-  {
-    ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::RPMDiff>::value>{}(ptr);
-  }
+static_assert(::rust::detail::is_complete<::std::remove_extent<::rpmostreecxx::RPMDiff>::type>::value, "definition of `::rpmostreecxx::RPMDiff` is required");
+static_assert(sizeof(::std::unique_ptr<::rpmostreecxx::RPMDiff>) == sizeof(void *), "");
+static_assert(alignof(::std::unique_ptr<::rpmostreecxx::RPMDiff>) == alignof(void *), "");
+void cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$null(::std::unique_ptr<::rpmostreecxx::RPMDiff> *ptr) noexcept {
+  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::RPMDiff>();
+}
+void cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$raw(::std::unique_ptr<::rpmostreecxx::RPMDiff> *ptr, ::std::unique_ptr<::rpmostreecxx::RPMDiff>::pointer raw) noexcept {
+  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::RPMDiff>(raw);
+}
+::std::unique_ptr<::rpmostreecxx::RPMDiff>::element_type const *cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$get(::std::unique_ptr<::rpmostreecxx::RPMDiff> const &ptr) noexcept {
+  return ptr.get();
+}
+::std::unique_ptr<::rpmostreecxx::RPMDiff>::pointer cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$release(::std::unique_ptr<::rpmostreecxx::RPMDiff> &ptr) noexcept {
+  return ptr.release();
+}
+void cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$drop(::std::unique_ptr<::rpmostreecxx::RPMDiff> *ptr) noexcept {
+  ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::RPMDiff>::value>{}(ptr);
+}
 
-  static_assert (::rust::detail::is_complete<::rpmostreecxx::Progress>::value,
-                 "definition of Progress is required");
-  static_assert (sizeof (::std::unique_ptr<::rpmostreecxx::Progress>) == sizeof (void *), "");
-  static_assert (alignof (::std::unique_ptr<::rpmostreecxx::Progress>) == alignof (void *), "");
-  void
-  cxxbridge1$unique_ptr$rpmostreecxx$Progress$null (
-      ::std::unique_ptr<::rpmostreecxx::Progress> *ptr) noexcept
-  {
-    ::new (ptr)::std::unique_ptr<::rpmostreecxx::Progress> ();
-  }
-  void
-  cxxbridge1$unique_ptr$rpmostreecxx$Progress$raw (::std::unique_ptr<::rpmostreecxx::Progress> *ptr,
-                                                   ::rpmostreecxx::Progress *raw) noexcept
-  {
-    ::new (ptr)::std::unique_ptr<::rpmostreecxx::Progress> (raw);
-  }
-  ::rpmostreecxx::Progress const *
-  cxxbridge1$unique_ptr$rpmostreecxx$Progress$get (
-      ::std::unique_ptr<::rpmostreecxx::Progress> const &ptr) noexcept
-  {
-    return ptr.get ();
-  }
-  ::rpmostreecxx::Progress *
-  cxxbridge1$unique_ptr$rpmostreecxx$Progress$release (
-      ::std::unique_ptr<::rpmostreecxx::Progress> &ptr) noexcept
-  {
-    return ptr.release ();
-  }
-  void
-  cxxbridge1$unique_ptr$rpmostreecxx$Progress$drop (
-      ::std::unique_ptr<::rpmostreecxx::Progress> *ptr) noexcept
-  {
-    ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::Progress>::value>{}(ptr);
-  }
+static_assert(::rust::detail::is_complete<::std::remove_extent<::rpmostreecxx::Progress>::type>::value, "definition of `::rpmostreecxx::Progress` is required");
+static_assert(sizeof(::std::unique_ptr<::rpmostreecxx::Progress>) == sizeof(void *), "");
+static_assert(alignof(::std::unique_ptr<::rpmostreecxx::Progress>) == alignof(void *), "");
+void cxxbridge1$unique_ptr$rpmostreecxx$Progress$null(::std::unique_ptr<::rpmostreecxx::Progress> *ptr) noexcept {
+  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::Progress>();
+}
+void cxxbridge1$unique_ptr$rpmostreecxx$Progress$raw(::std::unique_ptr<::rpmostreecxx::Progress> *ptr, ::std::unique_ptr<::rpmostreecxx::Progress>::pointer raw) noexcept {
+  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::Progress>(raw);
+}
+::std::unique_ptr<::rpmostreecxx::Progress>::element_type const *cxxbridge1$unique_ptr$rpmostreecxx$Progress$get(::std::unique_ptr<::rpmostreecxx::Progress> const &ptr) noexcept {
+  return ptr.get();
+}
+::std::unique_ptr<::rpmostreecxx::Progress>::pointer cxxbridge1$unique_ptr$rpmostreecxx$Progress$release(::std::unique_ptr<::rpmostreecxx::Progress> &ptr) noexcept {
+  return ptr.release();
+}
+void cxxbridge1$unique_ptr$rpmostreecxx$Progress$drop(::std::unique_ptr<::rpmostreecxx::Progress> *ptr) noexcept {
+  ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::Progress>::value>{}(ptr);
+}
 
-  static_assert (::rust::detail::is_complete<::rpmostreecxx::RpmTs>::value,
-                 "definition of RpmTs is required");
-  static_assert (sizeof (::std::unique_ptr<::rpmostreecxx::RpmTs>) == sizeof (void *), "");
-  static_assert (alignof (::std::unique_ptr<::rpmostreecxx::RpmTs>) == alignof (void *), "");
-  void
-  cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$null (
-      ::std::unique_ptr<::rpmostreecxx::RpmTs> *ptr) noexcept
-  {
-    ::new (ptr)::std::unique_ptr<::rpmostreecxx::RpmTs> ();
-  }
-  void
-  cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$raw (::std::unique_ptr<::rpmostreecxx::RpmTs> *ptr,
-                                                ::rpmostreecxx::RpmTs *raw) noexcept
-  {
-    ::new (ptr)::std::unique_ptr<::rpmostreecxx::RpmTs> (raw);
-  }
-  ::rpmostreecxx::RpmTs const *
-  cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$get (
-      ::std::unique_ptr<::rpmostreecxx::RpmTs> const &ptr) noexcept
-  {
-    return ptr.get ();
-  }
-  ::rpmostreecxx::RpmTs *
-  cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$release (
-      ::std::unique_ptr<::rpmostreecxx::RpmTs> &ptr) noexcept
-  {
-    return ptr.release ();
-  }
-  void
-  cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$drop (
-      ::std::unique_ptr<::rpmostreecxx::RpmTs> *ptr) noexcept
-  {
-    ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::RpmTs>::value>{}(ptr);
-  }
+static_assert(::rust::detail::is_complete<::std::remove_extent<::rpmostreecxx::RpmTs>::type>::value, "definition of `::rpmostreecxx::RpmTs` is required");
+static_assert(sizeof(::std::unique_ptr<::rpmostreecxx::RpmTs>) == sizeof(void *), "");
+static_assert(alignof(::std::unique_ptr<::rpmostreecxx::RpmTs>) == alignof(void *), "");
+void cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$null(::std::unique_ptr<::rpmostreecxx::RpmTs> *ptr) noexcept {
+  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::RpmTs>();
+}
+void cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$raw(::std::unique_ptr<::rpmostreecxx::RpmTs> *ptr, ::std::unique_ptr<::rpmostreecxx::RpmTs>::pointer raw) noexcept {
+  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::RpmTs>(raw);
+}
+::std::unique_ptr<::rpmostreecxx::RpmTs>::element_type const *cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$get(::std::unique_ptr<::rpmostreecxx::RpmTs> const &ptr) noexcept {
+  return ptr.get();
+}
+::std::unique_ptr<::rpmostreecxx::RpmTs>::pointer cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$release(::std::unique_ptr<::rpmostreecxx::RpmTs> &ptr) noexcept {
+  return ptr.release();
+}
+void cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$drop(::std::unique_ptr<::rpmostreecxx::RpmTs> *ptr) noexcept {
+  ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::RpmTs>::value>{}(ptr);
+}
 
-  static_assert (::rust::detail::is_complete<::rpmostreecxx::PackageMeta>::value,
-                 "definition of PackageMeta is required");
-  static_assert (sizeof (::std::unique_ptr<::rpmostreecxx::PackageMeta>) == sizeof (void *), "");
-  static_assert (alignof (::std::unique_ptr<::rpmostreecxx::PackageMeta>) == alignof (void *), "");
-  void
-  cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$null (
-      ::std::unique_ptr<::rpmostreecxx::PackageMeta> *ptr) noexcept
-  {
-    ::new (ptr)::std::unique_ptr<::rpmostreecxx::PackageMeta> ();
-  }
-  void
-  cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$raw (
-      ::std::unique_ptr<::rpmostreecxx::PackageMeta> *ptr,
-      ::rpmostreecxx::PackageMeta *raw) noexcept
-  {
-    ::new (ptr)::std::unique_ptr<::rpmostreecxx::PackageMeta> (raw);
-  }
-  ::rpmostreecxx::PackageMeta const *
-  cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$get (
-      ::std::unique_ptr<::rpmostreecxx::PackageMeta> const &ptr) noexcept
-  {
-    return ptr.get ();
-  }
-  ::rpmostreecxx::PackageMeta *
-  cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$release (
-      ::std::unique_ptr<::rpmostreecxx::PackageMeta> &ptr) noexcept
-  {
-    return ptr.release ();
-  }
-  void
-  cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$drop (
-      ::std::unique_ptr<::rpmostreecxx::PackageMeta> *ptr) noexcept
-  {
-    ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::PackageMeta>::value>{}(ptr);
-  }
+static_assert(::rust::detail::is_complete<::std::remove_extent<::rpmostreecxx::PackageMeta>::type>::value, "definition of `::rpmostreecxx::PackageMeta` is required");
+static_assert(sizeof(::std::unique_ptr<::rpmostreecxx::PackageMeta>) == sizeof(void *), "");
+static_assert(alignof(::std::unique_ptr<::rpmostreecxx::PackageMeta>) == alignof(void *), "");
+void cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$null(::std::unique_ptr<::rpmostreecxx::PackageMeta> *ptr) noexcept {
+  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::PackageMeta>();
+}
+void cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$raw(::std::unique_ptr<::rpmostreecxx::PackageMeta> *ptr, ::std::unique_ptr<::rpmostreecxx::PackageMeta>::pointer raw) noexcept {
+  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::PackageMeta>(raw);
+}
+::std::unique_ptr<::rpmostreecxx::PackageMeta>::element_type const *cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$get(::std::unique_ptr<::rpmostreecxx::PackageMeta> const &ptr) noexcept {
+  return ptr.get();
+}
+::std::unique_ptr<::rpmostreecxx::PackageMeta>::pointer cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$release(::std::unique_ptr<::rpmostreecxx::PackageMeta> &ptr) noexcept {
+  return ptr.release();
+}
+void cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$drop(::std::unique_ptr<::rpmostreecxx::PackageMeta> *ptr) noexcept {
+  ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::PackageMeta>::value>{}(ptr);
+}
 } // extern "C"
 
-namespace rust
-{
-inline namespace cxxbridge1
-{
+namespace rust {
+inline namespace cxxbridge1 {
 template <>
-::rpmostreecxx::Bubblewrap *
-Box<::rpmostreecxx::Bubblewrap>::allocation::alloc () noexcept
-{
-  return cxxbridge1$box$rpmostreecxx$Bubblewrap$alloc ();
+::rpmostreecxx::Bubblewrap *Box<::rpmostreecxx::Bubblewrap>::allocation::alloc() noexcept {
+  return cxxbridge1$box$rpmostreecxx$Bubblewrap$alloc();
 }
 template <>
-void
-Box<::rpmostreecxx::Bubblewrap>::allocation::dealloc (::rpmostreecxx::Bubblewrap *ptr) noexcept
-{
-  cxxbridge1$box$rpmostreecxx$Bubblewrap$dealloc (ptr);
+void Box<::rpmostreecxx::Bubblewrap>::allocation::dealloc(::rpmostreecxx::Bubblewrap *ptr) noexcept {
+  cxxbridge1$box$rpmostreecxx$Bubblewrap$dealloc(ptr);
 }
 template <>
-void
-Box<::rpmostreecxx::Bubblewrap>::drop () noexcept
-{
-  cxxbridge1$box$rpmostreecxx$Bubblewrap$drop (this);
+void Box<::rpmostreecxx::Bubblewrap>::drop() noexcept {
+  cxxbridge1$box$rpmostreecxx$Bubblewrap$drop(this);
 }
 template <>
-::rpmostreecxx::ContainerImageState *
-Box<::rpmostreecxx::ContainerImageState>::allocation::alloc () noexcept
-{
-  return cxxbridge1$box$rpmostreecxx$ContainerImageState$alloc ();
+::rpmostreecxx::ContainerImageState *Box<::rpmostreecxx::ContainerImageState>::allocation::alloc() noexcept {
+  return cxxbridge1$box$rpmostreecxx$ContainerImageState$alloc();
 }
 template <>
-void
-Box<::rpmostreecxx::ContainerImageState>::allocation::dealloc (
-    ::rpmostreecxx::ContainerImageState *ptr) noexcept
-{
-  cxxbridge1$box$rpmostreecxx$ContainerImageState$dealloc (ptr);
+void Box<::rpmostreecxx::ContainerImageState>::allocation::dealloc(::rpmostreecxx::ContainerImageState *ptr) noexcept {
+  cxxbridge1$box$rpmostreecxx$ContainerImageState$dealloc(ptr);
 }
 template <>
-void
-Box<::rpmostreecxx::ContainerImageState>::drop () noexcept
-{
-  cxxbridge1$box$rpmostreecxx$ContainerImageState$drop (this);
+void Box<::rpmostreecxx::ContainerImageState>::drop() noexcept {
+  cxxbridge1$box$rpmostreecxx$ContainerImageState$drop(this);
 }
 template <>
-::rpmostreecxx::TempEtcGuard *
-Box<::rpmostreecxx::TempEtcGuard>::allocation::alloc () noexcept
-{
-  return cxxbridge1$box$rpmostreecxx$TempEtcGuard$alloc ();
+::rpmostreecxx::TempEtcGuard *Box<::rpmostreecxx::TempEtcGuard>::allocation::alloc() noexcept {
+  return cxxbridge1$box$rpmostreecxx$TempEtcGuard$alloc();
 }
 template <>
-void
-Box<::rpmostreecxx::TempEtcGuard>::allocation::dealloc (::rpmostreecxx::TempEtcGuard *ptr) noexcept
-{
-  cxxbridge1$box$rpmostreecxx$TempEtcGuard$dealloc (ptr);
+void Box<::rpmostreecxx::TempEtcGuard>::allocation::dealloc(::rpmostreecxx::TempEtcGuard *ptr) noexcept {
+  cxxbridge1$box$rpmostreecxx$TempEtcGuard$dealloc(ptr);
 }
 template <>
-void
-Box<::rpmostreecxx::TempEtcGuard>::drop () noexcept
-{
-  cxxbridge1$box$rpmostreecxx$TempEtcGuard$drop (this);
+void Box<::rpmostreecxx::TempEtcGuard>::drop() noexcept {
+  cxxbridge1$box$rpmostreecxx$TempEtcGuard$drop(this);
 }
 template <>
-::rpmostreecxx::FilesystemScriptPrep *
-Box<::rpmostreecxx::FilesystemScriptPrep>::allocation::alloc () noexcept
-{
-  return cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$alloc ();
+::rpmostreecxx::FilesystemScriptPrep *Box<::rpmostreecxx::FilesystemScriptPrep>::allocation::alloc() noexcept {
+  return cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$alloc();
 }
 template <>
-void
-Box<::rpmostreecxx::FilesystemScriptPrep>::allocation::dealloc (
-    ::rpmostreecxx::FilesystemScriptPrep *ptr) noexcept
-{
-  cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$dealloc (ptr);
+void Box<::rpmostreecxx::FilesystemScriptPrep>::allocation::dealloc(::rpmostreecxx::FilesystemScriptPrep *ptr) noexcept {
+  cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$dealloc(ptr);
 }
 template <>
-void
-Box<::rpmostreecxx::FilesystemScriptPrep>::drop () noexcept
-{
-  cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$drop (this);
+void Box<::rpmostreecxx::FilesystemScriptPrep>::drop() noexcept {
+  cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$drop(this);
 }
 template <>
-::rpmostreecxx::RpmImporterFlags *
-Box<::rpmostreecxx::RpmImporterFlags>::allocation::alloc () noexcept
-{
-  return cxxbridge1$box$rpmostreecxx$RpmImporterFlags$alloc ();
+::rpmostreecxx::RpmImporterFlags *Box<::rpmostreecxx::RpmImporterFlags>::allocation::alloc() noexcept {
+  return cxxbridge1$box$rpmostreecxx$RpmImporterFlags$alloc();
 }
 template <>
-void
-Box<::rpmostreecxx::RpmImporterFlags>::allocation::dealloc (
-    ::rpmostreecxx::RpmImporterFlags *ptr) noexcept
-{
-  cxxbridge1$box$rpmostreecxx$RpmImporterFlags$dealloc (ptr);
+void Box<::rpmostreecxx::RpmImporterFlags>::allocation::dealloc(::rpmostreecxx::RpmImporterFlags *ptr) noexcept {
+  cxxbridge1$box$rpmostreecxx$RpmImporterFlags$dealloc(ptr);
 }
 template <>
-void
-Box<::rpmostreecxx::RpmImporterFlags>::drop () noexcept
-{
-  cxxbridge1$box$rpmostreecxx$RpmImporterFlags$drop (this);
+void Box<::rpmostreecxx::RpmImporterFlags>::drop() noexcept {
+  cxxbridge1$box$rpmostreecxx$RpmImporterFlags$drop(this);
 }
 template <>
-::rpmostreecxx::RpmImporter *
-Box<::rpmostreecxx::RpmImporter>::allocation::alloc () noexcept
-{
-  return cxxbridge1$box$rpmostreecxx$RpmImporter$alloc ();
+::rpmostreecxx::RpmImporter *Box<::rpmostreecxx::RpmImporter>::allocation::alloc() noexcept {
+  return cxxbridge1$box$rpmostreecxx$RpmImporter$alloc();
 }
 template <>
-void
-Box<::rpmostreecxx::RpmImporter>::allocation::dealloc (::rpmostreecxx::RpmImporter *ptr) noexcept
-{
-  cxxbridge1$box$rpmostreecxx$RpmImporter$dealloc (ptr);
+void Box<::rpmostreecxx::RpmImporter>::allocation::dealloc(::rpmostreecxx::RpmImporter *ptr) noexcept {
+  cxxbridge1$box$rpmostreecxx$RpmImporter$dealloc(ptr);
 }
 template <>
-void
-Box<::rpmostreecxx::RpmImporter>::drop () noexcept
-{
-  cxxbridge1$box$rpmostreecxx$RpmImporter$drop (this);
+void Box<::rpmostreecxx::RpmImporter>::drop() noexcept {
+  cxxbridge1$box$rpmostreecxx$RpmImporter$drop(this);
 }
 template <>
-::rpmostreecxx::HistoryCtx *
-Box<::rpmostreecxx::HistoryCtx>::allocation::alloc () noexcept
-{
-  return cxxbridge1$box$rpmostreecxx$HistoryCtx$alloc ();
+::rpmostreecxx::HistoryCtx *Box<::rpmostreecxx::HistoryCtx>::allocation::alloc() noexcept {
+  return cxxbridge1$box$rpmostreecxx$HistoryCtx$alloc();
 }
 template <>
-void
-Box<::rpmostreecxx::HistoryCtx>::allocation::dealloc (::rpmostreecxx::HistoryCtx *ptr) noexcept
-{
-  cxxbridge1$box$rpmostreecxx$HistoryCtx$dealloc (ptr);
+void Box<::rpmostreecxx::HistoryCtx>::allocation::dealloc(::rpmostreecxx::HistoryCtx *ptr) noexcept {
+  cxxbridge1$box$rpmostreecxx$HistoryCtx$dealloc(ptr);
 }
 template <>
-void
-Box<::rpmostreecxx::HistoryCtx>::drop () noexcept
-{
-  cxxbridge1$box$rpmostreecxx$HistoryCtx$drop (this);
+void Box<::rpmostreecxx::HistoryCtx>::drop() noexcept {
+  cxxbridge1$box$rpmostreecxx$HistoryCtx$drop(this);
 }
 template <>
-::rpmostreecxx::TokioHandle *
-Box<::rpmostreecxx::TokioHandle>::allocation::alloc () noexcept
-{
-  return cxxbridge1$box$rpmostreecxx$TokioHandle$alloc ();
+::rpmostreecxx::TokioHandle *Box<::rpmostreecxx::TokioHandle>::allocation::alloc() noexcept {
+  return cxxbridge1$box$rpmostreecxx$TokioHandle$alloc();
 }
 template <>
-void
-Box<::rpmostreecxx::TokioHandle>::allocation::dealloc (::rpmostreecxx::TokioHandle *ptr) noexcept
-{
-  cxxbridge1$box$rpmostreecxx$TokioHandle$dealloc (ptr);
+void Box<::rpmostreecxx::TokioHandle>::allocation::dealloc(::rpmostreecxx::TokioHandle *ptr) noexcept {
+  cxxbridge1$box$rpmostreecxx$TokioHandle$dealloc(ptr);
 }
 template <>
-void
-Box<::rpmostreecxx::TokioHandle>::drop () noexcept
-{
-  cxxbridge1$box$rpmostreecxx$TokioHandle$drop (this);
+void Box<::rpmostreecxx::TokioHandle>::drop() noexcept {
+  cxxbridge1$box$rpmostreecxx$TokioHandle$drop(this);
 }
 template <>
-::rpmostreecxx::TokioEnterGuard *
-Box<::rpmostreecxx::TokioEnterGuard>::allocation::alloc () noexcept
-{
-  return cxxbridge1$box$rpmostreecxx$TokioEnterGuard$alloc ();
+::rpmostreecxx::TokioEnterGuard *Box<::rpmostreecxx::TokioEnterGuard>::allocation::alloc() noexcept {
+  return cxxbridge1$box$rpmostreecxx$TokioEnterGuard$alloc();
 }
 template <>
-void
-Box<::rpmostreecxx::TokioEnterGuard>::allocation::dealloc (
-    ::rpmostreecxx::TokioEnterGuard *ptr) noexcept
-{
-  cxxbridge1$box$rpmostreecxx$TokioEnterGuard$dealloc (ptr);
+void Box<::rpmostreecxx::TokioEnterGuard>::allocation::dealloc(::rpmostreecxx::TokioEnterGuard *ptr) noexcept {
+  cxxbridge1$box$rpmostreecxx$TokioEnterGuard$dealloc(ptr);
 }
 template <>
-void
-Box<::rpmostreecxx::TokioEnterGuard>::drop () noexcept
-{
-  cxxbridge1$box$rpmostreecxx$TokioEnterGuard$drop (this);
+void Box<::rpmostreecxx::TokioEnterGuard>::drop() noexcept {
+  cxxbridge1$box$rpmostreecxx$TokioEnterGuard$drop(this);
 }
 template <>
-::rpmostreecxx::Treefile *
-Box<::rpmostreecxx::Treefile>::allocation::alloc () noexcept
-{
-  return cxxbridge1$box$rpmostreecxx$Treefile$alloc ();
+::rpmostreecxx::Treefile *Box<::rpmostreecxx::Treefile>::allocation::alloc() noexcept {
+  return cxxbridge1$box$rpmostreecxx$Treefile$alloc();
 }
 template <>
-void
-Box<::rpmostreecxx::Treefile>::allocation::dealloc (::rpmostreecxx::Treefile *ptr) noexcept
-{
-  cxxbridge1$box$rpmostreecxx$Treefile$dealloc (ptr);
+void Box<::rpmostreecxx::Treefile>::allocation::dealloc(::rpmostreecxx::Treefile *ptr) noexcept {
+  cxxbridge1$box$rpmostreecxx$Treefile$dealloc(ptr);
 }
 template <>
-void
-Box<::rpmostreecxx::Treefile>::drop () noexcept
-{
-  cxxbridge1$box$rpmostreecxx$Treefile$drop (this);
-}
-template <> Vec<::rpmostreecxx::OverrideReplacement>::Vec () noexcept
-{
-  cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$new (this);
+void Box<::rpmostreecxx::Treefile>::drop() noexcept {
+  cxxbridge1$box$rpmostreecxx$Treefile$drop(this);
 }
 template <>
-void
-Vec<::rpmostreecxx::OverrideReplacement>::drop () noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$drop (this);
+Vec<::rpmostreecxx::OverrideReplacement>::Vec() noexcept {
+  cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$new(this);
 }
 template <>
-::std::size_t
-Vec<::rpmostreecxx::OverrideReplacement>::size () const noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$len (this);
+void Vec<::rpmostreecxx::OverrideReplacement>::drop() noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$drop(this);
 }
 template <>
-::std::size_t
-Vec<::rpmostreecxx::OverrideReplacement>::capacity () const noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$capacity (this);
+::std::size_t Vec<::rpmostreecxx::OverrideReplacement>::size() const noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$len(this);
 }
 template <>
-::rpmostreecxx::OverrideReplacement const *
-Vec<::rpmostreecxx::OverrideReplacement>::data () const noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$data (this);
+::std::size_t Vec<::rpmostreecxx::OverrideReplacement>::capacity() const noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$capacity(this);
 }
 template <>
-void
-Vec<::rpmostreecxx::OverrideReplacement>::reserve_total (::std::size_t new_cap) noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$reserve_total (this, new_cap);
+::rpmostreecxx::OverrideReplacement const *Vec<::rpmostreecxx::OverrideReplacement>::data() const noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$data(this);
 }
 template <>
-void
-Vec<::rpmostreecxx::OverrideReplacement>::set_len (::std::size_t len) noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$set_len (this, len);
+void Vec<::rpmostreecxx::OverrideReplacement>::reserve_total(::std::size_t new_cap) noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$reserve_total(this, new_cap);
 }
 template <>
-void
-Vec<::rpmostreecxx::OverrideReplacement>::truncate (::std::size_t len)
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$truncate (this, len);
-}
-template <> Vec<::rpmostreecxx::StringMapping>::Vec () noexcept
-{
-  cxxbridge1$rust_vec$rpmostreecxx$StringMapping$new (this);
+void Vec<::rpmostreecxx::OverrideReplacement>::set_len(::std::size_t len) noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$set_len(this, len);
 }
 template <>
-void
-Vec<::rpmostreecxx::StringMapping>::drop () noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$drop (this);
+void Vec<::rpmostreecxx::OverrideReplacement>::truncate(::std::size_t len) {
+  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$truncate(this, len);
 }
 template <>
-::std::size_t
-Vec<::rpmostreecxx::StringMapping>::size () const noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$len (this);
+Vec<::rpmostreecxx::StringMapping>::Vec() noexcept {
+  cxxbridge1$rust_vec$rpmostreecxx$StringMapping$new(this);
 }
 template <>
-::std::size_t
-Vec<::rpmostreecxx::StringMapping>::capacity () const noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$capacity (this);
+void Vec<::rpmostreecxx::StringMapping>::drop() noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$drop(this);
 }
 template <>
-::rpmostreecxx::StringMapping const *
-Vec<::rpmostreecxx::StringMapping>::data () const noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$data (this);
+::std::size_t Vec<::rpmostreecxx::StringMapping>::size() const noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$len(this);
 }
 template <>
-void
-Vec<::rpmostreecxx::StringMapping>::reserve_total (::std::size_t new_cap) noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$reserve_total (this, new_cap);
+::std::size_t Vec<::rpmostreecxx::StringMapping>::capacity() const noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$capacity(this);
 }
 template <>
-void
-Vec<::rpmostreecxx::StringMapping>::set_len (::std::size_t len) noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$set_len (this, len);
+::rpmostreecxx::StringMapping const *Vec<::rpmostreecxx::StringMapping>::data() const noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$data(this);
 }
 template <>
-void
-Vec<::rpmostreecxx::StringMapping>::truncate (::std::size_t len)
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$truncate (this, len);
+void Vec<::rpmostreecxx::StringMapping>::reserve_total(::std::size_t new_cap) noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$reserve_total(this, new_cap);
 }
 template <>
-::rpmostreecxx::PasswdDB *
-Box<::rpmostreecxx::PasswdDB>::allocation::alloc () noexcept
-{
-  return cxxbridge1$box$rpmostreecxx$PasswdDB$alloc ();
+void Vec<::rpmostreecxx::StringMapping>::set_len(::std::size_t len) noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$set_len(this, len);
 }
 template <>
-void
-Box<::rpmostreecxx::PasswdDB>::allocation::dealloc (::rpmostreecxx::PasswdDB *ptr) noexcept
-{
-  cxxbridge1$box$rpmostreecxx$PasswdDB$dealloc (ptr);
+void Vec<::rpmostreecxx::StringMapping>::truncate(::std::size_t len) {
+  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$truncate(this, len);
 }
 template <>
-void
-Box<::rpmostreecxx::PasswdDB>::drop () noexcept
-{
-  cxxbridge1$box$rpmostreecxx$PasswdDB$drop (this);
+::rpmostreecxx::PasswdDB *Box<::rpmostreecxx::PasswdDB>::allocation::alloc() noexcept {
+  return cxxbridge1$box$rpmostreecxx$PasswdDB$alloc();
 }
 template <>
-::rpmostreecxx::PasswdEntries *
-Box<::rpmostreecxx::PasswdEntries>::allocation::alloc () noexcept
-{
-  return cxxbridge1$box$rpmostreecxx$PasswdEntries$alloc ();
+void Box<::rpmostreecxx::PasswdDB>::allocation::dealloc(::rpmostreecxx::PasswdDB *ptr) noexcept {
+  cxxbridge1$box$rpmostreecxx$PasswdDB$dealloc(ptr);
 }
 template <>
-void
-Box<::rpmostreecxx::PasswdEntries>::allocation::dealloc (
-    ::rpmostreecxx::PasswdEntries *ptr) noexcept
-{
-  cxxbridge1$box$rpmostreecxx$PasswdEntries$dealloc (ptr);
+void Box<::rpmostreecxx::PasswdDB>::drop() noexcept {
+  cxxbridge1$box$rpmostreecxx$PasswdDB$drop(this);
 }
 template <>
-void
-Box<::rpmostreecxx::PasswdEntries>::drop () noexcept
-{
-  cxxbridge1$box$rpmostreecxx$PasswdEntries$drop (this);
+::rpmostreecxx::PasswdEntries *Box<::rpmostreecxx::PasswdEntries>::allocation::alloc() noexcept {
+  return cxxbridge1$box$rpmostreecxx$PasswdEntries$alloc();
 }
 template <>
-::rpmostreecxx::Extensions *
-Box<::rpmostreecxx::Extensions>::allocation::alloc () noexcept
-{
-  return cxxbridge1$box$rpmostreecxx$Extensions$alloc ();
+void Box<::rpmostreecxx::PasswdEntries>::allocation::dealloc(::rpmostreecxx::PasswdEntries *ptr) noexcept {
+  cxxbridge1$box$rpmostreecxx$PasswdEntries$dealloc(ptr);
 }
 template <>
-void
-Box<::rpmostreecxx::Extensions>::allocation::dealloc (::rpmostreecxx::Extensions *ptr) noexcept
-{
-  cxxbridge1$box$rpmostreecxx$Extensions$dealloc (ptr);
+void Box<::rpmostreecxx::PasswdEntries>::drop() noexcept {
+  cxxbridge1$box$rpmostreecxx$PasswdEntries$drop(this);
 }
 template <>
-void
-Box<::rpmostreecxx::Extensions>::drop () noexcept
-{
-  cxxbridge1$box$rpmostreecxx$Extensions$drop (this);
+::rpmostreecxx::Extensions *Box<::rpmostreecxx::Extensions>::allocation::alloc() noexcept {
+  return cxxbridge1$box$rpmostreecxx$Extensions$alloc();
 }
 template <>
-::rpmostreecxx::LockfileConfig *
-Box<::rpmostreecxx::LockfileConfig>::allocation::alloc () noexcept
-{
-  return cxxbridge1$box$rpmostreecxx$LockfileConfig$alloc ();
+void Box<::rpmostreecxx::Extensions>::allocation::dealloc(::rpmostreecxx::Extensions *ptr) noexcept {
+  cxxbridge1$box$rpmostreecxx$Extensions$dealloc(ptr);
 }
 template <>
-void
-Box<::rpmostreecxx::LockfileConfig>::allocation::dealloc (
-    ::rpmostreecxx::LockfileConfig *ptr) noexcept
-{
-  cxxbridge1$box$rpmostreecxx$LockfileConfig$dealloc (ptr);
+void Box<::rpmostreecxx::Extensions>::drop() noexcept {
+  cxxbridge1$box$rpmostreecxx$Extensions$drop(this);
 }
 template <>
-void
-Box<::rpmostreecxx::LockfileConfig>::drop () noexcept
-{
-  cxxbridge1$box$rpmostreecxx$LockfileConfig$drop (this);
-}
-template <> Vec<::rpmostreecxx::LockedPackage>::Vec () noexcept
-{
-  cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$new (this);
+::rpmostreecxx::LockfileConfig *Box<::rpmostreecxx::LockfileConfig>::allocation::alloc() noexcept {
+  return cxxbridge1$box$rpmostreecxx$LockfileConfig$alloc();
 }
 template <>
-void
-Vec<::rpmostreecxx::LockedPackage>::drop () noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$drop (this);
+void Box<::rpmostreecxx::LockfileConfig>::allocation::dealloc(::rpmostreecxx::LockfileConfig *ptr) noexcept {
+  cxxbridge1$box$rpmostreecxx$LockfileConfig$dealloc(ptr);
 }
 template <>
-::std::size_t
-Vec<::rpmostreecxx::LockedPackage>::size () const noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$len (this);
+void Box<::rpmostreecxx::LockfileConfig>::drop() noexcept {
+  cxxbridge1$box$rpmostreecxx$LockfileConfig$drop(this);
 }
 template <>
-::std::size_t
-Vec<::rpmostreecxx::LockedPackage>::capacity () const noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$capacity (this);
+Vec<::rpmostreecxx::LockedPackage>::Vec() noexcept {
+  cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$new(this);
 }
 template <>
-::rpmostreecxx::LockedPackage const *
-Vec<::rpmostreecxx::LockedPackage>::data () const noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$data (this);
+void Vec<::rpmostreecxx::LockedPackage>::drop() noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$drop(this);
 }
 template <>
-void
-Vec<::rpmostreecxx::LockedPackage>::reserve_total (::std::size_t new_cap) noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$reserve_total (this, new_cap);
+::std::size_t Vec<::rpmostreecxx::LockedPackage>::size() const noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$len(this);
 }
 template <>
-void
-Vec<::rpmostreecxx::LockedPackage>::set_len (::std::size_t len) noexcept
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$set_len (this, len);
+::std::size_t Vec<::rpmostreecxx::LockedPackage>::capacity() const noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$capacity(this);
 }
 template <>
-void
-Vec<::rpmostreecxx::LockedPackage>::truncate (::std::size_t len)
-{
-  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$truncate (this, len);
+::rpmostreecxx::LockedPackage const *Vec<::rpmostreecxx::LockedPackage>::data() const noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$data(this);
+}
+template <>
+void Vec<::rpmostreecxx::LockedPackage>::reserve_total(::std::size_t new_cap) noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$reserve_total(this, new_cap);
+}
+template <>
+void Vec<::rpmostreecxx::LockedPackage>::set_len(::std::size_t len) noexcept {
+  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$set_len(this, len);
+}
+template <>
+void Vec<::rpmostreecxx::LockedPackage>::truncate(::std::size_t len) {
+  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$truncate(this, len);
 }
 } // namespace cxxbridge1
 } // namespace rust

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1,15 +1,16 @@
 #pragma once
-#include "rpmostree-clientlib.h"
+#include "src/libpriv/rpmostree-cxxrs-prelude.h"
 #include "rpmostree-container.hpp"
 #include "rpmostree-cxxrsutil.hpp"
-#include "rpmostree-diff.hpp"
-#include "rpmostree-libbuiltin.h"
-#include "rpmostree-output.h"
-#include "rpmostree-package-variants.h"
-#include "rpmostree-rpm-util.h"
 #include "rpmostree-util.h"
 #include "rpmostreemain.h"
-#include "src/libpriv/rpmostree-cxxrs-prelude.h"
+#include "rpmostree-clientlib.h"
+#include "rpmostree-diff.hpp"
+#include "rpmostree-libbuiltin.h"
+#include "rpmostree-util.h"
+#include "rpmostree-output.h"
+#include "rpmostree-rpm-util.h"
+#include "rpmostree-package-variants.h"
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -30,98 +31,99 @@
 #include <ranges>
 #endif
 
-namespace rust
-{
-inline namespace cxxbridge1
-{
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdollar-in-identifier-extension"
+#endif // __clang__
+
+namespace rust {
+inline namespace cxxbridge1 {
 // #include "rust/cxx.h"
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception> void panic [[noreturn]] (const char *msg);
+template <typename Exception>
+void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 struct unsafe_bitcopy_t;
 
-namespace
-{
-template <typename T> class impl;
+namespace {
+template <typename T>
+class impl;
 } // namespace
 
-template <typename T>::std::size_t size_of ();
-template <typename T>::std::size_t align_of ();
+template <typename T>
+::std::size_t size_of();
+template <typename T>
+::std::size_t align_of();
 
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
-class String final
-{
+class String final {
 public:
-  String () noexcept;
-  String (const String &) noexcept;
-  String (String &&) noexcept;
-  ~String () noexcept;
+  String() noexcept;
+  String(const String &) noexcept;
+  String(String &&) noexcept;
+  ~String() noexcept;
 
-  String (const std::string &);
-  String (const char *);
-  String (const char *, std::size_t);
-  String (const char16_t *);
-  String (const char16_t *, std::size_t);
+  String(const std::string &);
+  String(const char *);
+  String(const char *, std::size_t);
+  String(const char16_t *);
+  String(const char16_t *, std::size_t);
 #ifdef __cpp_char8_t
-  String (const char8_t *s);
-  String (const char8_t *s, std::size_t len);
+  String(const char8_t *s);
+  String(const char8_t *s, std::size_t len);
 #endif
 
-  static String lossy (const std::string &) noexcept;
-  static String lossy (const char *) noexcept;
-  static String lossy (const char *, std::size_t) noexcept;
-  static String lossy (const char16_t *) noexcept;
-  static String lossy (const char16_t *, std::size_t) noexcept;
+  static String lossy(const std::string &) noexcept;
+  static String lossy(const char *) noexcept;
+  static String lossy(const char *, std::size_t) noexcept;
+  static String lossy(const char16_t *) noexcept;
+  static String lossy(const char16_t *, std::size_t) noexcept;
 
-  String &operator= (const String &) & noexcept;
-  String &operator= (String &&) & noexcept;
+  String &operator=(const String &) & noexcept;
+  String &operator=(String &&) & noexcept;
 
-  explicit operator std::string () const;
+  explicit operator std::string() const;
 
-  const char *data () const noexcept;
-  std::size_t size () const noexcept;
-  std::size_t length () const noexcept;
-  bool empty () const noexcept;
+  const char *data() const noexcept;
+  std::size_t size() const noexcept;
+  std::size_t length() const noexcept;
+  bool empty() const noexcept;
 
-  const char *c_str () noexcept;
+  const char *c_str() noexcept;
 
-  std::size_t capacity () const noexcept;
-  void reserve (size_t new_cap) noexcept;
+  std::size_t capacity() const noexcept;
+  void reserve(size_t new_cap) noexcept;
 
   using iterator = char *;
-  iterator begin () noexcept;
-  iterator end () noexcept;
+  iterator begin() noexcept;
+  iterator end() noexcept;
 
   using const_iterator = const char *;
-  const_iterator begin () const noexcept;
-  const_iterator end () const noexcept;
-  const_iterator cbegin () const noexcept;
-  const_iterator cend () const noexcept;
+  const_iterator begin() const noexcept;
+  const_iterator end() const noexcept;
+  const_iterator cbegin() const noexcept;
+  const_iterator cend() const noexcept;
 
-  bool operator== (const String &) const noexcept;
-  bool operator!= (const String &) const noexcept;
-  bool operator< (const String &) const noexcept;
-  bool operator<= (const String &) const noexcept;
-  bool operator> (const String &) const noexcept;
-  bool operator>= (const String &) const noexcept;
+  bool operator==(const String &) const noexcept;
+  bool operator!=(const String &) const noexcept;
+  bool operator<(const String &) const noexcept;
+  bool operator<=(const String &) const noexcept;
+  bool operator>(const String &) const noexcept;
+  bool operator>=(const String &) const noexcept;
 
-  void swap (String &) noexcept;
+  void swap(String &) noexcept;
 
-  String (unsafe_bitcopy_t, const String &) noexcept;
+  String(unsafe_bitcopy_t, const String &) noexcept;
 
 private:
   struct lossy_t;
-  String (lossy_t, const char *, std::size_t) noexcept;
-  String (lossy_t, const char16_t *, std::size_t) noexcept;
-  friend void
-  swap (String &lhs, String &rhs) noexcept
-  {
-    lhs.swap (rhs);
-  }
+  String(lossy_t, const char *, std::size_t) noexcept;
+  String(lossy_t, const char16_t *, std::size_t) noexcept;
+  friend void swap(String &lhs, String &rhs) noexcept { lhs.swap(rhs); }
 
   std::array<std::uintptr_t, 3> repr;
 };
@@ -129,49 +131,48 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_STR
 #define CXXBRIDGE1_RUST_STR
-class Str final
-{
+class Str final {
 public:
-  Str () noexcept;
-  Str (const String &) noexcept;
-  Str (const std::string &);
-  Str (const char *);
-  Str (const char *, std::size_t);
+  Str() noexcept;
+  Str(const String &) noexcept;
+  Str(const std::string &);
+  Str(const char *);
+  Str(const char *, std::size_t);
 
-  Str &operator= (const Str &) & noexcept = default;
+  Str &operator=(const Str &) & noexcept = default;
 
-  explicit operator std::string () const;
+  explicit operator std::string() const;
 #if __cplusplus >= 201703L
-  explicit operator std::string_view () const;
+  explicit operator std::string_view() const;
 #endif
 
-  const char *data () const noexcept;
-  std::size_t size () const noexcept;
-  std::size_t length () const noexcept;
-  bool empty () const noexcept;
+  const char *data() const noexcept;
+  std::size_t size() const noexcept;
+  std::size_t length() const noexcept;
+  bool empty() const noexcept;
 
-  Str (const Str &) noexcept = default;
-  ~Str () noexcept = default;
+  Str(const Str &) noexcept = default;
+  ~Str() noexcept = default;
 
   using iterator = const char *;
   using const_iterator = const char *;
-  const_iterator begin () const noexcept;
-  const_iterator end () const noexcept;
-  const_iterator cbegin () const noexcept;
-  const_iterator cend () const noexcept;
+  const_iterator begin() const noexcept;
+  const_iterator end() const noexcept;
+  const_iterator cbegin() const noexcept;
+  const_iterator cend() const noexcept;
 
-  bool operator== (const Str &) const noexcept;
-  bool operator!= (const Str &) const noexcept;
-  bool operator< (const Str &) const noexcept;
-  bool operator<= (const Str &) const noexcept;
-  bool operator> (const Str &) const noexcept;
-  bool operator>= (const Str &) const noexcept;
+  bool operator==(const Str &) const noexcept;
+  bool operator!=(const Str &) const noexcept;
+  bool operator<(const Str &) const noexcept;
+  bool operator<=(const Str &) const noexcept;
+  bool operator>(const Str &) const noexcept;
+  bool operator>=(const Str &) const noexcept;
 
-  void swap (Str &) noexcept;
+  void swap(Str &) noexcept;
 
 private:
   class uninit;
-  Str (uninit) noexcept;
+  Str(uninit) noexcept;
   friend impl<Str>;
 
   std::array<std::uintptr_t, 2> repr;
@@ -180,72 +181,72 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
-namespace detail
-{
-template <bool> struct copy_assignable_if
-{
-};
+namespace detail {
+template <bool>
+struct copy_assignable_if {};
 
-template <> struct copy_assignable_if<false>
-{
-  copy_assignable_if () noexcept = default;
-  copy_assignable_if (const copy_assignable_if &) noexcept = default;
-  copy_assignable_if &operator= (const copy_assignable_if &) & noexcept = delete;
-  copy_assignable_if &operator= (copy_assignable_if &&) & noexcept = default;
+template <>
+struct copy_assignable_if<false> {
+  copy_assignable_if() noexcept = default;
+  copy_assignable_if(const copy_assignable_if &) noexcept = default;
+  copy_assignable_if &operator=(const copy_assignable_if &) & noexcept = delete;
+  copy_assignable_if &operator=(copy_assignable_if &&) & noexcept = default;
 };
 } // namespace detail
 
 template <typename T>
-class Slice final : private detail::copy_assignable_if<std::is_const<T>::value>
-{
+class Slice final
+    : private detail::copy_assignable_if<std::is_const<T>::value> {
 public:
   using value_type = T;
 
-  Slice () noexcept;
-  Slice (T *, std::size_t count) noexcept;
+  Slice() noexcept;
+  Slice(T *, std::size_t count) noexcept;
 
-  template <typename C> explicit Slice (C &c) : Slice (c.data (), c.size ()) {}
+  template <typename C>
+  explicit Slice(C &c) : Slice(c.data(), c.size()) {}
 
-  Slice &operator= (const Slice<T> &) & noexcept = default;
-  Slice &operator= (Slice<T> &&) & noexcept = default;
+  Slice &operator=(const Slice<T> &) & noexcept = default;
+  Slice &operator=(Slice<T> &&) & noexcept = default;
 
-  T *data () const noexcept;
-  std::size_t size () const noexcept;
-  std::size_t length () const noexcept;
-  bool empty () const noexcept;
+  T *data() const noexcept;
+  std::size_t size() const noexcept;
+  std::size_t length() const noexcept;
+  bool empty() const noexcept;
 
-  T &operator[] (std::size_t n) const noexcept;
-  T &at (std::size_t n) const;
-  T &front () const noexcept;
-  T &back () const noexcept;
+  T &operator[](std::size_t n) const noexcept;
+  T &at(std::size_t n) const;
+  T &front() const noexcept;
+  T &back() const noexcept;
 
-  Slice (const Slice<T> &) noexcept = default;
-  ~Slice () noexcept = default;
+  Slice(const Slice<T> &) noexcept = default;
+  ~Slice() noexcept = default;
 
   class iterator;
-  iterator begin () const noexcept;
-  iterator end () const noexcept;
+  iterator begin() const noexcept;
+  iterator end() const noexcept;
 
-  void swap (Slice &) noexcept;
+  void swap(Slice &) noexcept;
 
 private:
   class uninit;
-  Slice (uninit) noexcept;
+  Slice(uninit) noexcept;
   friend impl<Slice>;
-  friend void sliceInit (void *, const void *, std::size_t) noexcept;
-  friend void *slicePtr (const void *) noexcept;
-  friend std::size_t sliceLen (const void *) noexcept;
+  friend void sliceInit(void *, const void *, std::size_t) noexcept;
+  friend void *slicePtr(const void *) noexcept;
+  friend std::size_t sliceLen(const void *) noexcept;
 
   std::array<std::uintptr_t, 2> repr;
 };
 
 #ifdef __cpp_deduction_guides
 template <typename C>
-explicit Slice (C &c) -> Slice<std::remove_reference_t<decltype (*std::declval<C> ().data ())>>;
+explicit Slice(C &c)
+    -> Slice<std::remove_reference_t<decltype(*std::declval<C>().data())>>;
 #endif // __cpp_deduction_guides
 
-template <typename T> class Slice<T>::iterator final
-{
+template <typename T>
+class Slice<T>::iterator final {
 public:
 #if __cplusplus >= 202002L
   using iterator_category = std::contiguous_iterator_tag;
@@ -257,32 +258,30 @@ public:
   using pointer = typename std::add_pointer<T>::type;
   using reference = typename std::add_lvalue_reference<T>::type;
 
-  reference operator* () const noexcept;
+  reference operator*() const noexcept;
   pointer operator->() const noexcept;
-  reference operator[] (difference_type) const noexcept;
+  reference operator[](difference_type) const noexcept;
 
-  iterator &operator++ () noexcept;
-  iterator operator++ (int) noexcept;
-  iterator &operator-- () noexcept;
-  iterator operator-- (int) noexcept;
+  iterator &operator++() noexcept;
+  iterator operator++(int) noexcept;
+  iterator &operator--() noexcept;
+  iterator operator--(int) noexcept;
 
-  iterator &operator+= (difference_type) noexcept;
-  iterator &operator-= (difference_type) noexcept;
-  iterator operator+ (difference_type) const noexcept;
-  friend inline iterator
-  operator+ (difference_type lhs, iterator rhs) noexcept
-  {
+  iterator &operator+=(difference_type) noexcept;
+  iterator &operator-=(difference_type) noexcept;
+  iterator operator+(difference_type) const noexcept;
+  friend inline iterator operator+(difference_type lhs, iterator rhs) noexcept {
     return rhs + lhs;
   }
-  iterator operator- (difference_type) const noexcept;
-  difference_type operator- (const iterator &) const noexcept;
+  iterator operator-(difference_type) const noexcept;
+  difference_type operator-(const iterator &) const noexcept;
 
-  bool operator== (const iterator &) const noexcept;
-  bool operator!= (const iterator &) const noexcept;
-  bool operator< (const iterator &) const noexcept;
-  bool operator<= (const iterator &) const noexcept;
-  bool operator> (const iterator &) const noexcept;
-  bool operator>= (const iterator &) const noexcept;
+  bool operator==(const iterator &) const noexcept;
+  bool operator!=(const iterator &) const noexcept;
+  bool operator<(const iterator &) const noexcept;
+  bool operator<=(const iterator &) const noexcept;
+  bool operator>(const iterator &) const noexcept;
+  bool operator>=(const iterator &) const noexcept;
 
 private:
   friend class Slice;
@@ -291,810 +290,683 @@ private:
 };
 
 #if __cplusplus >= 202002L
-static_assert (std::ranges::contiguous_range<rust::Slice<const uint8_t>>);
-static_assert (std::contiguous_iterator<rust::Slice<const uint8_t>::iterator>);
+static_assert(std::ranges::contiguous_range<rust::Slice<const uint8_t>>);
+static_assert(std::contiguous_iterator<rust::Slice<const uint8_t>::iterator>);
 #endif
 
-template <typename T> Slice<T>::Slice () noexcept
-{
-  sliceInit (this, reinterpret_cast<void *> (align_of<T> ()), 0);
-}
-
-template <typename T> Slice<T>::Slice (T *s, std::size_t count) noexcept
-{
-  assert (s != nullptr || count == 0);
-  sliceInit (this,
-             s == nullptr && count == 0 ? reinterpret_cast<void *> (align_of<T> ())
-                                        : const_cast<typename std::remove_const<T>::type *> (s),
-             count);
+template <typename T>
+Slice<T>::Slice() noexcept {
+  sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
 }
 
 template <typename T>
-T *
-Slice<T>::data () const noexcept
-{
-  return reinterpret_cast<T *> (slicePtr (this));
+Slice<T>::Slice(T *s, std::size_t count) noexcept {
+  assert(s != nullptr || count == 0);
+  sliceInit(this,
+            s == nullptr && count == 0
+                ? reinterpret_cast<void *>(align_of<T>())
+                : const_cast<typename std::remove_const<T>::type *>(s),
+            count);
 }
 
 template <typename T>
-std::size_t
-Slice<T>::size () const noexcept
-{
-  return sliceLen (this);
+T *Slice<T>::data() const noexcept {
+  return reinterpret_cast<T *>(slicePtr(this));
 }
 
 template <typename T>
-std::size_t
-Slice<T>::length () const noexcept
-{
-  return this->size ();
+std::size_t Slice<T>::size() const noexcept {
+  return sliceLen(this);
 }
 
 template <typename T>
-bool
-Slice<T>::empty () const noexcept
-{
-  return this->size () == 0;
+std::size_t Slice<T>::length() const noexcept {
+  return this->size();
 }
 
 template <typename T>
-T &
-Slice<T>::operator[] (std::size_t n) const noexcept
-{
-  assert (n < this->size ());
-  auto ptr = static_cast<char *> (slicePtr (this)) + size_of<T> () * n;
-  return *reinterpret_cast<T *> (ptr);
+bool Slice<T>::empty() const noexcept {
+  return this->size() == 0;
 }
 
 template <typename T>
-T &
-Slice<T>::at (std::size_t n) const
-{
-  if (n >= this->size ())
-    {
-      panic<std::out_of_range> ("rust::Slice index out of range");
-    }
+T &Slice<T>::operator[](std::size_t n) const noexcept {
+  assert(n < this->size());
+  auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
+  return *reinterpret_cast<T *>(ptr);
+}
+
+template <typename T>
+T &Slice<T>::at(std::size_t n) const {
+  if (n >= this->size()) {
+    panic<std::out_of_range>("rust::Slice index out of range");
+  }
   return (*this)[n];
 }
 
 template <typename T>
-T &
-Slice<T>::front () const noexcept
-{
-  assert (!this->empty ());
+T &Slice<T>::front() const noexcept {
+  assert(!this->empty());
   return (*this)[0];
 }
 
 template <typename T>
-T &
-Slice<T>::back () const noexcept
-{
-  assert (!this->empty ());
-  return (*this)[this->size () - 1];
+T &Slice<T>::back() const noexcept {
+  assert(!this->empty());
+  return (*this)[this->size() - 1];
 }
 
 template <typename T>
 typename Slice<T>::iterator::reference
-Slice<T>::iterator::operator* () const noexcept
-{
-  return *static_cast<T *> (this->pos);
+Slice<T>::iterator::operator*() const noexcept {
+  return *static_cast<T *>(this->pos);
 }
 
 template <typename T>
 typename Slice<T>::iterator::pointer
-Slice<T>::iterator::operator->() const noexcept
-{
-  return static_cast<T *> (this->pos);
+Slice<T>::iterator::operator->() const noexcept {
+  return static_cast<T *>(this->pos);
 }
 
 template <typename T>
-typename Slice<T>::iterator::reference
-Slice<T>::iterator::operator[] (typename Slice<T>::iterator::difference_type n) const noexcept
-{
-  auto ptr = static_cast<char *> (this->pos) + this->stride * n;
-  return *reinterpret_cast<T *> (ptr);
+typename Slice<T>::iterator::reference Slice<T>::iterator::operator[](
+    typename Slice<T>::iterator::difference_type n) const noexcept {
+  auto ptr = static_cast<char *>(this->pos) + this->stride * n;
+  return *reinterpret_cast<T *>(ptr);
 }
 
 template <typename T>
-typename Slice<T>::iterator &
-Slice<T>::iterator::operator++ () noexcept
-{
-  this->pos = static_cast<char *> (this->pos) + this->stride;
+typename Slice<T>::iterator &Slice<T>::iterator::operator++() noexcept {
+  this->pos = static_cast<char *>(this->pos) + this->stride;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::iterator::operator++ (int) noexcept
-{
-  auto ret = iterator (*this);
-  this->pos = static_cast<char *> (this->pos) + this->stride;
+typename Slice<T>::iterator Slice<T>::iterator::operator++(int) noexcept {
+  auto ret = iterator(*this);
+  this->pos = static_cast<char *>(this->pos) + this->stride;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator &
-Slice<T>::iterator::operator-- () noexcept
-{
-  this->pos = static_cast<char *> (this->pos) - this->stride;
+typename Slice<T>::iterator &Slice<T>::iterator::operator--() noexcept {
+  this->pos = static_cast<char *>(this->pos) - this->stride;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::iterator::operator-- (int) noexcept
-{
-  auto ret = iterator (*this);
-  this->pos = static_cast<char *> (this->pos) - this->stride;
+typename Slice<T>::iterator Slice<T>::iterator::operator--(int) noexcept {
+  auto ret = iterator(*this);
+  this->pos = static_cast<char *>(this->pos) - this->stride;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator &
-Slice<T>::iterator::operator+= (typename Slice<T>::iterator::difference_type n) noexcept
-{
-  this->pos = static_cast<char *> (this->pos) + this->stride * n;
+typename Slice<T>::iterator &Slice<T>::iterator::operator+=(
+    typename Slice<T>::iterator::difference_type n) noexcept {
+  this->pos = static_cast<char *>(this->pos) + this->stride * n;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator &
-Slice<T>::iterator::operator-= (typename Slice<T>::iterator::difference_type n) noexcept
-{
-  this->pos = static_cast<char *> (this->pos) - this->stride * n;
+typename Slice<T>::iterator &Slice<T>::iterator::operator-=(
+    typename Slice<T>::iterator::difference_type n) noexcept {
+  this->pos = static_cast<char *>(this->pos) - this->stride * n;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::iterator::operator+ (typename Slice<T>::iterator::difference_type n) const noexcept
-{
-  auto ret = iterator (*this);
-  ret.pos = static_cast<char *> (this->pos) + this->stride * n;
+typename Slice<T>::iterator Slice<T>::iterator::operator+(
+    typename Slice<T>::iterator::difference_type n) const noexcept {
+  auto ret = iterator(*this);
+  ret.pos = static_cast<char *>(this->pos) + this->stride * n;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::iterator::operator- (typename Slice<T>::iterator::difference_type n) const noexcept
-{
-  auto ret = iterator (*this);
-  ret.pos = static_cast<char *> (this->pos) - this->stride * n;
+typename Slice<T>::iterator Slice<T>::iterator::operator-(
+    typename Slice<T>::iterator::difference_type n) const noexcept {
+  auto ret = iterator(*this);
+  ret.pos = static_cast<char *>(this->pos) - this->stride * n;
   return ret;
 }
 
 template <typename T>
 typename Slice<T>::iterator::difference_type
-Slice<T>::iterator::operator- (const iterator &other) const noexcept
-{
-  auto diff = std::distance (static_cast<char *> (other.pos), static_cast<char *> (this->pos));
-  return diff / static_cast<typename Slice<T>::iterator::difference_type> (this->stride);
+Slice<T>::iterator::operator-(const iterator &other) const noexcept {
+  auto diff = std::distance(static_cast<char *>(other.pos),
+                            static_cast<char *>(this->pos));
+  return diff / static_cast<typename Slice<T>::iterator::difference_type>(
+                    this->stride);
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator== (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator==(const iterator &other) const noexcept {
   return this->pos == other.pos;
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator!= (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator!=(const iterator &other) const noexcept {
   return this->pos != other.pos;
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator< (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator<(const iterator &other) const noexcept {
   return this->pos < other.pos;
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator<= (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator<=(const iterator &other) const noexcept {
   return this->pos <= other.pos;
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator> (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator>(const iterator &other) const noexcept {
   return this->pos > other.pos;
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator>= (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator>=(const iterator &other) const noexcept {
   return this->pos >= other.pos;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::begin () const noexcept
-{
+typename Slice<T>::iterator Slice<T>::begin() const noexcept {
   iterator it;
-  it.pos = slicePtr (this);
-  it.stride = size_of<T> ();
+  it.pos = slicePtr(this);
+  it.stride = size_of<T>();
   return it;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::end () const noexcept
-{
-  iterator it = this->begin ();
-  it.pos = static_cast<char *> (it.pos) + it.stride * this->size ();
+typename Slice<T>::iterator Slice<T>::end() const noexcept {
+  iterator it = this->begin();
+  it.pos = static_cast<char *>(it.pos) + it.stride * this->size();
   return it;
 }
 
 template <typename T>
-void
-Slice<T>::swap (Slice &rhs) noexcept
-{
-  std::swap (*this, rhs);
+void Slice<T>::swap(Slice &rhs) noexcept {
+  std::swap(*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
 
 #ifndef CXXBRIDGE1_RUST_BOX
 #define CXXBRIDGE1_RUST_BOX
-template <typename T> class Box final
-{
+template <typename T>
+class Box final {
 public:
   using element_type = T;
-  using const_pointer = typename std::add_pointer<typename std::add_const<T>::type>::type;
+  using const_pointer =
+      typename std::add_pointer<typename std::add_const<T>::type>::type;
   using pointer = typename std::add_pointer<T>::type;
 
-  Box () = delete;
-  Box (Box &&) noexcept;
-  ~Box () noexcept;
+  Box() = delete;
+  Box(Box &&) noexcept;
+  ~Box() noexcept;
 
-  explicit Box (const T &);
-  explicit Box (T &&);
+  explicit Box(const T &);
+  explicit Box(T &&);
 
-  Box &operator= (Box &&) & noexcept;
+  Box &operator=(Box &&) & noexcept;
 
   const T *operator->() const noexcept;
-  const T &operator* () const noexcept;
+  const T &operator*() const noexcept;
   T *operator->() noexcept;
-  T &operator* () noexcept;
+  T &operator*() noexcept;
 
-  template <typename... Fields> static Box in_place (Fields &&...);
+  template <typename... Fields>
+  static Box in_place(Fields &&...);
 
-  void swap (Box &) noexcept;
+  void swap(Box &) noexcept;
 
-  static Box from_raw (T *) noexcept;
+  static Box from_raw(T *) noexcept;
 
-  T *into_raw () noexcept;
+  T *into_raw() noexcept;
 
   /* Deprecated */ using value_type = element_type;
 
 private:
   class uninit;
   class allocation;
-  Box (uninit) noexcept;
-  void drop () noexcept;
+  Box(uninit) noexcept;
+  void drop() noexcept;
 
-  friend void
-  swap (Box &lhs, Box &rhs) noexcept
-  {
-    lhs.swap (rhs);
-  }
+  friend void swap(Box &lhs, Box &rhs) noexcept { lhs.swap(rhs); }
 
   T *ptr;
 };
 
-template <typename T> class Box<T>::uninit
-{
-};
+template <typename T>
+class Box<T>::uninit {};
 
-template <typename T> class Box<T>::allocation
-{
-  static T *alloc () noexcept;
-  static void dealloc (T *) noexcept;
+template <typename T>
+class Box<T>::allocation {
+  static T *alloc() noexcept;
+  static void dealloc(T *) noexcept;
 
 public:
-  allocation () noexcept : ptr (alloc ()) {}
-  ~allocation () noexcept
-  {
-    if (this->ptr)
-      {
-        dealloc (this->ptr);
-      }
+  allocation() noexcept : ptr(alloc()) {}
+  ~allocation() noexcept {
+    if (this->ptr) {
+      dealloc(this->ptr);
+    }
   }
   T *ptr;
 };
 
-template <typename T> Box<T>::Box (Box &&other) noexcept : ptr (other.ptr) { other.ptr = nullptr; }
-
-template <typename T> Box<T>::Box (const T &val)
-{
-  allocation alloc;
-  ::new (alloc.ptr) T (val);
-  this->ptr = alloc.ptr;
-  alloc.ptr = nullptr;
-}
-
-template <typename T> Box<T>::Box (T &&val)
-{
-  allocation alloc;
-  ::new (alloc.ptr) T (std::move (val));
-  this->ptr = alloc.ptr;
-  alloc.ptr = nullptr;
-}
-
-template <typename T> Box<T>::~Box () noexcept
-{
-  if (this->ptr)
-    {
-      this->drop ();
-    }
+template <typename T>
+Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
+  other.ptr = nullptr;
 }
 
 template <typename T>
-Box<T> &
-Box<T>::operator= (Box &&other) & noexcept
-{
-  if (this->ptr)
-    {
-      this->drop ();
-    }
+Box<T>::Box(const T &val) {
+  allocation alloc;
+  ::new (alloc.ptr) T(val);
+  this->ptr = alloc.ptr;
+  alloc.ptr = nullptr;
+}
+
+template <typename T>
+Box<T>::Box(T &&val) {
+  allocation alloc;
+  ::new (alloc.ptr) T(std::move(val));
+  this->ptr = alloc.ptr;
+  alloc.ptr = nullptr;
+}
+
+template <typename T>
+Box<T>::~Box() noexcept {
+  if (this->ptr) {
+    this->drop();
+  }
+}
+
+template <typename T>
+Box<T> &Box<T>::operator=(Box &&other) & noexcept {
+  if (this->ptr) {
+    this->drop();
+  }
   this->ptr = other.ptr;
   other.ptr = nullptr;
   return *this;
 }
 
 template <typename T>
-const T *
-Box<T>::operator->() const noexcept
-{
+const T *Box<T>::operator->() const noexcept {
   return this->ptr;
 }
 
 template <typename T>
-const T &
-Box<T>::operator* () const noexcept
-{
+const T &Box<T>::operator*() const noexcept {
   return *this->ptr;
 }
 
 template <typename T>
-T *
-Box<T>::operator->() noexcept
-{
+T *Box<T>::operator->() noexcept {
   return this->ptr;
 }
 
 template <typename T>
-T &
-Box<T>::operator* () noexcept
-{
+T &Box<T>::operator*() noexcept {
   return *this->ptr;
 }
 
 template <typename T>
 template <typename... Fields>
-Box<T>
-Box<T>::in_place (Fields &&...fields)
-{
+Box<T> Box<T>::in_place(Fields &&...fields) {
   allocation alloc;
   auto ptr = alloc.ptr;
-  ::new (ptr) T{ std::forward<Fields> (fields)... };
+  ::new (ptr) T{std::forward<Fields>(fields)...};
   alloc.ptr = nullptr;
-  return from_raw (ptr);
+  return from_raw(ptr);
 }
 
 template <typename T>
-void
-Box<T>::swap (Box &rhs) noexcept
-{
+void Box<T>::swap(Box &rhs) noexcept {
   using std::swap;
-  swap (this->ptr, rhs.ptr);
+  swap(this->ptr, rhs.ptr);
 }
 
 template <typename T>
-Box<T>
-Box<T>::from_raw (T *raw) noexcept
-{
+Box<T> Box<T>::from_raw(T *raw) noexcept {
   Box box = uninit{};
   box.ptr = raw;
   return box;
 }
 
 template <typename T>
-T *
-Box<T>::into_raw () noexcept
-{
+T *Box<T>::into_raw() noexcept {
   T *raw = this->ptr;
   this->ptr = nullptr;
   return raw;
 }
 
-template <typename T> Box<T>::Box (uninit) noexcept {}
+template <typename T>
+Box<T>::Box(uninit) noexcept {}
 #endif // CXXBRIDGE1_RUST_BOX
 
 #ifndef CXXBRIDGE1_RUST_BITCOPY_T
 #define CXXBRIDGE1_RUST_BITCOPY_T
-struct unsafe_bitcopy_t final
-{
-  explicit unsafe_bitcopy_t () = default;
+struct unsafe_bitcopy_t final {
+  explicit unsafe_bitcopy_t() = default;
 };
 #endif // CXXBRIDGE1_RUST_BITCOPY_T
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T> class Vec final
-{
+template <typename T>
+class Vec final {
 public:
   using value_type = T;
 
-  Vec () noexcept;
-  Vec (std::initializer_list<T>);
-  Vec (const Vec &);
-  Vec (Vec &&) noexcept;
-  ~Vec () noexcept;
+  Vec() noexcept;
+  Vec(std::initializer_list<T>);
+  Vec(const Vec &);
+  Vec(Vec &&) noexcept;
+  ~Vec() noexcept;
 
-  Vec &operator= (Vec &&) & noexcept;
-  Vec &operator= (const Vec &) &;
+  Vec &operator=(Vec &&) & noexcept;
+  Vec &operator=(const Vec &) &;
 
-  std::size_t size () const noexcept;
-  bool empty () const noexcept;
-  const T *data () const noexcept;
-  T *data () noexcept;
-  std::size_t capacity () const noexcept;
+  std::size_t size() const noexcept;
+  bool empty() const noexcept;
+  const T *data() const noexcept;
+  T *data() noexcept;
+  std::size_t capacity() const noexcept;
 
-  const T &operator[] (std::size_t n) const noexcept;
-  const T &at (std::size_t n) const;
-  const T &front () const noexcept;
-  const T &back () const noexcept;
+  const T &operator[](std::size_t n) const noexcept;
+  const T &at(std::size_t n) const;
+  const T &front() const noexcept;
+  const T &back() const noexcept;
 
-  T &operator[] (std::size_t n) noexcept;
-  T &at (std::size_t n);
-  T &front () noexcept;
-  T &back () noexcept;
+  T &operator[](std::size_t n) noexcept;
+  T &at(std::size_t n);
+  T &front() noexcept;
+  T &back() noexcept;
 
-  void reserve (std::size_t new_cap);
-  void push_back (const T &value);
-  void push_back (T &&value);
-  template <typename... Args> void emplace_back (Args &&...args);
-  void truncate (std::size_t len);
-  void clear ();
+  void reserve(std::size_t new_cap);
+  void push_back(const T &value);
+  void push_back(T &&value);
+  template <typename... Args>
+  void emplace_back(Args &&...args);
+  void truncate(std::size_t len);
+  void clear();
 
   using iterator = typename Slice<T>::iterator;
-  iterator begin () noexcept;
-  iterator end () noexcept;
+  iterator begin() noexcept;
+  iterator end() noexcept;
 
   using const_iterator = typename Slice<const T>::iterator;
-  const_iterator begin () const noexcept;
-  const_iterator end () const noexcept;
-  const_iterator cbegin () const noexcept;
-  const_iterator cend () const noexcept;
+  const_iterator begin() const noexcept;
+  const_iterator end() const noexcept;
+  const_iterator cbegin() const noexcept;
+  const_iterator cend() const noexcept;
 
-  void swap (Vec &) noexcept;
+  void swap(Vec &) noexcept;
 
-  Vec (unsafe_bitcopy_t, const Vec &) noexcept;
+  Vec(unsafe_bitcopy_t, const Vec &) noexcept;
 
 private:
-  void reserve_total (std::size_t new_cap) noexcept;
-  void set_len (std::size_t len) noexcept;
-  void drop () noexcept;
+  void reserve_total(std::size_t new_cap) noexcept;
+  void set_len(std::size_t len) noexcept;
+  void drop() noexcept;
 
-  friend void
-  swap (Vec &lhs, Vec &rhs) noexcept
-  {
-    lhs.swap (rhs);
-  }
+  friend void swap(Vec &lhs, Vec &rhs) noexcept { lhs.swap(rhs); }
 
   std::array<std::uintptr_t, 3> repr;
 };
 
-template <typename T> Vec<T>::Vec (std::initializer_list<T> init) : Vec{}
-{
-  this->reserve_total (init.size ());
-  std::move (init.begin (), init.end (), std::back_inserter (*this));
+template <typename T>
+Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
+  this->reserve_total(init.size());
+  std::move(init.begin(), init.end(), std::back_inserter(*this));
 }
-
-template <typename T> Vec<T>::Vec (const Vec &other) : Vec ()
-{
-  this->reserve_total (other.size ());
-  std::copy (other.begin (), other.end (), std::back_inserter (*this));
-}
-
-template <typename T> Vec<T>::Vec (Vec &&other) noexcept : repr (other.repr)
-{
-  new (&other) Vec ();
-}
-
-template <typename T> Vec<T>::~Vec () noexcept { this->drop (); }
 
 template <typename T>
-Vec<T> &
-Vec<T>::operator= (Vec &&other) & noexcept
-{
-  this->drop ();
+Vec<T>::Vec(const Vec &other) : Vec() {
+  this->reserve_total(other.size());
+  std::copy(other.begin(), other.end(), std::back_inserter(*this));
+}
+
+template <typename T>
+Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
+  new (&other) Vec();
+}
+
+template <typename T>
+Vec<T>::~Vec() noexcept {
+  this->drop();
+}
+
+template <typename T>
+Vec<T> &Vec<T>::operator=(Vec &&other) & noexcept {
+  this->drop();
   this->repr = other.repr;
-  new (&other) Vec ();
+  new (&other) Vec();
   return *this;
 }
 
 template <typename T>
-Vec<T> &
-Vec<T>::operator= (const Vec &other) &
-{
-  if (this != &other)
-    {
-      this->drop ();
-      new (this) Vec (other);
-    }
+Vec<T> &Vec<T>::operator=(const Vec &other) & {
+  if (this != &other) {
+    this->drop();
+    new (this) Vec(other);
+  }
   return *this;
 }
 
 template <typename T>
-bool
-Vec<T>::empty () const noexcept
-{
-  return this->size () == 0;
+bool Vec<T>::empty() const noexcept {
+  return this->size() == 0;
 }
 
 template <typename T>
-T *
-Vec<T>::data () noexcept
-{
-  return const_cast<T *> (const_cast<const Vec<T> *> (this)->data ());
+T *Vec<T>::data() noexcept {
+  return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
 }
 
 template <typename T>
-const T &
-Vec<T>::operator[] (std::size_t n) const noexcept
-{
-  assert (n < this->size ());
-  auto data = reinterpret_cast<const char *> (this->data ());
-  return *reinterpret_cast<const T *> (data + n * size_of<T> ());
+const T &Vec<T>::operator[](std::size_t n) const noexcept {
+  assert(n < this->size());
+  auto data = reinterpret_cast<const char *>(this->data());
+  return *reinterpret_cast<const T *>(data + n * size_of<T>());
 }
 
 template <typename T>
-const T &
-Vec<T>::at (std::size_t n) const
-{
-  if (n >= this->size ())
-    {
-      panic<std::out_of_range> ("rust::Vec index out of range");
-    }
+const T &Vec<T>::at(std::size_t n) const {
+  if (n >= this->size()) {
+    panic<std::out_of_range>("rust::Vec index out of range");
+  }
   return (*this)[n];
 }
 
 template <typename T>
-const T &
-Vec<T>::front () const noexcept
-{
-  assert (!this->empty ());
+const T &Vec<T>::front() const noexcept {
+  assert(!this->empty());
   return (*this)[0];
 }
 
 template <typename T>
-const T &
-Vec<T>::back () const noexcept
-{
-  assert (!this->empty ());
-  return (*this)[this->size () - 1];
+const T &Vec<T>::back() const noexcept {
+  assert(!this->empty());
+  return (*this)[this->size() - 1];
 }
 
 template <typename T>
-T &
-Vec<T>::operator[] (std::size_t n) noexcept
-{
-  assert (n < this->size ());
-  auto data = reinterpret_cast<char *> (this->data ());
-  return *reinterpret_cast<T *> (data + n * size_of<T> ());
+T &Vec<T>::operator[](std::size_t n) noexcept {
+  assert(n < this->size());
+  auto data = reinterpret_cast<char *>(this->data());
+  return *reinterpret_cast<T *>(data + n * size_of<T>());
 }
 
 template <typename T>
-T &
-Vec<T>::at (std::size_t n)
-{
-  if (n >= this->size ())
-    {
-      panic<std::out_of_range> ("rust::Vec index out of range");
-    }
+T &Vec<T>::at(std::size_t n) {
+  if (n >= this->size()) {
+    panic<std::out_of_range>("rust::Vec index out of range");
+  }
   return (*this)[n];
 }
 
 template <typename T>
-T &
-Vec<T>::front () noexcept
-{
-  assert (!this->empty ());
+T &Vec<T>::front() noexcept {
+  assert(!this->empty());
   return (*this)[0];
 }
 
 template <typename T>
-T &
-Vec<T>::back () noexcept
-{
-  assert (!this->empty ());
-  return (*this)[this->size () - 1];
+T &Vec<T>::back() noexcept {
+  assert(!this->empty());
+  return (*this)[this->size() - 1];
 }
 
 template <typename T>
-void
-Vec<T>::reserve (std::size_t new_cap)
-{
-  this->reserve_total (new_cap);
+void Vec<T>::reserve(std::size_t new_cap) {
+  this->reserve_total(new_cap);
 }
 
 template <typename T>
-void
-Vec<T>::push_back (const T &value)
-{
-  this->emplace_back (value);
+void Vec<T>::push_back(const T &value) {
+  this->emplace_back(value);
 }
 
 template <typename T>
-void
-Vec<T>::push_back (T &&value)
-{
-  this->emplace_back (std::move (value));
+void Vec<T>::push_back(T &&value) {
+  this->emplace_back(std::move(value));
 }
 
 template <typename T>
 template <typename... Args>
-void
-Vec<T>::emplace_back (Args &&...args)
-{
-  auto size = this->size ();
-  this->reserve_total (size + 1);
-  ::new (reinterpret_cast<T *> (reinterpret_cast<char *> (this->data ()) + size * size_of<T> ()))
-      T (std::forward<Args> (args)...);
-  this->set_len (size + 1);
+void Vec<T>::emplace_back(Args &&...args) {
+  auto size = this->size();
+  this->reserve_total(size + 1);
+  ::new (reinterpret_cast<T *>(reinterpret_cast<char *>(this->data()) +
+                               size * size_of<T>()))
+      T(std::forward<Args>(args)...);
+  this->set_len(size + 1);
 }
 
 template <typename T>
-void
-Vec<T>::clear ()
-{
-  this->truncate (0);
+void Vec<T>::clear() {
+  this->truncate(0);
 }
 
 template <typename T>
-typename Vec<T>::iterator
-Vec<T>::begin () noexcept
-{
-  return Slice<T> (this->data (), this->size ()).begin ();
+typename Vec<T>::iterator Vec<T>::begin() noexcept {
+  return Slice<T>(this->data(), this->size()).begin();
 }
 
 template <typename T>
-typename Vec<T>::iterator
-Vec<T>::end () noexcept
-{
-  return Slice<T> (this->data (), this->size ()).end ();
+typename Vec<T>::iterator Vec<T>::end() noexcept {
+  return Slice<T>(this->data(), this->size()).end();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator
-Vec<T>::begin () const noexcept
-{
-  return this->cbegin ();
+typename Vec<T>::const_iterator Vec<T>::begin() const noexcept {
+  return this->cbegin();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator
-Vec<T>::end () const noexcept
-{
-  return this->cend ();
+typename Vec<T>::const_iterator Vec<T>::end() const noexcept {
+  return this->cend();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator
-Vec<T>::cbegin () const noexcept
-{
-  return Slice<const T> (this->data (), this->size ()).begin ();
+typename Vec<T>::const_iterator Vec<T>::cbegin() const noexcept {
+  return Slice<const T>(this->data(), this->size()).begin();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator
-Vec<T>::cend () const noexcept
-{
-  return Slice<const T> (this->data (), this->size ()).end ();
+typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
+  return Slice<const T>(this->data(), this->size()).end();
 }
 
 template <typename T>
-void
-Vec<T>::swap (Vec &rhs) noexcept
-{
+void Vec<T>::swap(Vec &rhs) noexcept {
   using std::swap;
-  swap (this->repr, rhs.repr);
+  swap(this->repr, rhs.repr);
 }
 
-template <typename T> Vec<T>::Vec (unsafe_bitcopy_t, const Vec &bits) noexcept : repr (bits.repr) {}
+template <typename T>
+Vec<T>::Vec(unsafe_bitcopy_t, const Vec &bits) noexcept : repr(bits.repr) {}
 #endif // CXXBRIDGE1_RUST_VEC
 
 #ifndef CXXBRIDGE1_RUST_OPAQUE
 #define CXXBRIDGE1_RUST_OPAQUE
-class Opaque
-{
+class Opaque {
 public:
-  Opaque () = delete;
-  Opaque (const Opaque &) = delete;
-  ~Opaque () = delete;
+  Opaque() = delete;
+  Opaque(const Opaque &) = delete;
+  ~Opaque() = delete;
 };
 #endif // CXXBRIDGE1_RUST_OPAQUE
 
 #ifndef CXXBRIDGE1_IS_COMPLETE
 #define CXXBRIDGE1_IS_COMPLETE
-namespace detail
-{
-namespace
-{
-template <typename T, typename = std::size_t> struct is_complete : std::false_type
-{
-};
-template <typename T> struct is_complete<T, decltype (sizeof (T))> : std::true_type
-{
-};
+namespace detail {
+namespace {
+template <typename T, typename = std::size_t>
+struct is_complete : std::false_type {};
+template <typename T>
+struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
 } // namespace
 } // namespace detail
 #endif // CXXBRIDGE1_IS_COMPLETE
 
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
-class layout
-{
-  template <typename T> friend std::size_t size_of ();
-  template <typename T> friend std::size_t align_of ();
+class layout {
   template <typename T>
-  static typename std::enable_if<std::is_base_of<Opaque, T>::value, std::size_t>::type
-  do_size_of ()
-  {
-    return T::layout::size ();
+  friend std::size_t size_of();
+  template <typename T>
+  friend std::size_t align_of();
+  template <typename T>
+  static typename std::enable_if<std::is_base_of<Opaque, T>::value,
+                                 std::size_t>::type
+  do_size_of() {
+    return T::layout::size();
   }
   template <typename T>
-  static typename std::enable_if<!std::is_base_of<Opaque, T>::value, std::size_t>::type
-  do_size_of ()
-  {
-    return sizeof (T);
+  static typename std::enable_if<!std::is_base_of<Opaque, T>::value,
+                                 std::size_t>::type
+  do_size_of() {
+    return sizeof(T);
   }
   template <typename T>
-  static typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
-  size_of ()
-  {
-    return do_size_of<T> ();
+  static
+      typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
+      size_of() {
+    return do_size_of<T>();
   }
   template <typename T>
-  static typename std::enable_if<std::is_base_of<Opaque, T>::value, std::size_t>::type
-  do_align_of ()
-  {
-    return T::layout::align ();
+  static typename std::enable_if<std::is_base_of<Opaque, T>::value,
+                                 std::size_t>::type
+  do_align_of() {
+    return T::layout::align();
   }
   template <typename T>
-  static typename std::enable_if<!std::is_base_of<Opaque, T>::value, std::size_t>::type
-  do_align_of ()
-  {
-    return alignof (T);
+  static typename std::enable_if<!std::is_base_of<Opaque, T>::value,
+                                 std::size_t>::type
+  do_align_of() {
+    return alignof(T);
   }
   template <typename T>
-  static typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
-  align_of ()
-  {
-    return do_align_of<T> ();
+  static
+      typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
+      align_of() {
+    return do_align_of<T>();
   }
 };
 
 template <typename T>
-std::size_t
-size_of ()
-{
-  return layout::size_of<T> ();
+std::size_t size_of() {
+  return layout::size_of<T>();
 }
 
 template <typename T>
-std::size_t
-align_of ()
-{
-  return layout::align_of<T> ();
+std::size_t align_of() {
+  return layout::align_of<T>();
 }
 #endif // CXXBRIDGE1_LAYOUT
 } // namespace cxxbridge1
@@ -1106,53 +978,51 @@ align_of ()
 #define CXX_DEFAULT_VALUE(value)
 #endif
 
-namespace rpmostreecxx
-{
-struct StringMapping;
-enum class SystemHostType : ::std::uint8_t;
-enum class BubblewrapMutability : ::std::uint8_t;
-struct Bubblewrap;
-struct ContainerImageState;
-struct ExportedManifestDiff;
-struct PrunedContainerInfo;
-enum class RefspecType : ::std::uint8_t;
-struct TempEtcGuard;
-struct FilesystemScriptPrep;
-struct DeploymentLayeredMeta;
-struct OverrideReplacementSource;
-enum class ParsedRevisionKind : ::std::uint8_t;
-struct ParsedRevision;
-struct RpmImporterFlags;
-struct RpmImporter;
-struct HistoryEntry;
-struct HistoryCtx;
-struct TokioHandle;
-struct TokioEnterGuard;
-enum class RepoMetadataTarget : ::std::uint8_t;
-enum class AdvisoriesMetadataTarget : ::std::uint8_t;
-struct Refspec;
-enum class OverrideReplacementType : ::std::uint8_t;
-struct OverrideReplacement;
-enum class OptUsrLocal : ::std::uint8_t;
-struct Treefile;
-struct RepoPackage;
-struct LiveApplyState;
-struct PasswdDB;
-struct PasswdEntries;
-struct Extensions;
-struct LockedPackage;
-struct LockfileConfig;
-using CxxGObjectArray = ::rpmostreecxx::CxxGObjectArray;
-using ClientConnection = ::rpmostreecxx::ClientConnection;
-using RPMDiff = ::rpmostreecxx::RPMDiff;
-using RpmOstreeDiffPrintFormat = ::rpmostreecxx::RpmOstreeDiffPrintFormat;
-using Progress = ::rpmostreecxx::Progress;
-using RpmTs = ::rpmostreecxx::RpmTs;
-using PackageMeta = ::rpmostreecxx::PackageMeta;
+namespace rpmostreecxx {
+  struct StringMapping;
+  enum class SystemHostType : ::std::uint8_t;
+  enum class BubblewrapMutability : ::std::uint8_t;
+  struct Bubblewrap;
+  struct ContainerImageState;
+  struct ExportedManifestDiff;
+  struct PrunedContainerInfo;
+  enum class RefspecType : ::std::uint8_t;
+  struct TempEtcGuard;
+  struct FilesystemScriptPrep;
+  struct DeploymentLayeredMeta;
+  struct OverrideReplacementSource;
+  enum class ParsedRevisionKind : ::std::uint8_t;
+  struct ParsedRevision;
+  struct RpmImporterFlags;
+  struct RpmImporter;
+  struct HistoryEntry;
+  struct HistoryCtx;
+  struct TokioHandle;
+  struct TokioEnterGuard;
+  enum class RepoMetadataTarget : ::std::uint8_t;
+  enum class AdvisoriesMetadataTarget : ::std::uint8_t;
+  struct Refspec;
+  enum class OverrideReplacementType : ::std::uint8_t;
+  struct OverrideReplacement;
+  enum class OptUsrLocal : ::std::uint8_t;
+  struct Treefile;
+  struct RepoPackage;
+  struct LiveApplyState;
+  struct PasswdDB;
+  struct PasswdEntries;
+  struct Extensions;
+  struct LockedPackage;
+  struct LockfileConfig;
+  using CxxGObjectArray = ::rpmostreecxx::CxxGObjectArray;
+  using ClientConnection = ::rpmostreecxx::ClientConnection;
+  using RPMDiff = ::rpmostreecxx::RPMDiff;
+  using RpmOstreeDiffPrintFormat = ::rpmostreecxx::RpmOstreeDiffPrintFormat;
+  using Progress = ::rpmostreecxx::Progress;
+  using RpmTs = ::rpmostreecxx::RpmTs;
+  using PackageMeta = ::rpmostreecxx::PackageMeta;
 }
 
-namespace rpmostreecxx
-{
+namespace rpmostreecxx {
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$StringMapping
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$StringMapping
 // Currently cxx-rs doesn't support mappings; like probably most projects,
@@ -1160,8 +1030,7 @@ namespace rpmostreecxx
 // our data sizes aren't large, we serialize this as a vector of strings pairs.
 // In the future it's also likely that cxx-rs will support a C++ string_view
 // so we could avoid duplicating in that direction.
-struct StringMapping final
-{
+struct StringMapping final {
   ::rust::String k;
   ::rust::String v;
 
@@ -1172,8 +1041,7 @@ struct StringMapping final
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$SystemHostType
 #define CXXBRIDGE1_ENUM_rpmostreecxx$SystemHostType
 // Classify the running system.
-enum class SystemHostType : ::std::uint8_t
-{
+enum class SystemHostType : ::std::uint8_t {
   OstreeContainer = 0,
   OstreeHost = 1,
   Unknown = 2,
@@ -1182,8 +1050,7 @@ enum class SystemHostType : ::std::uint8_t
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$BubblewrapMutability
 #define CXXBRIDGE1_ENUM_rpmostreecxx$BubblewrapMutability
-enum class BubblewrapMutability : ::std::uint8_t
-{
+enum class BubblewrapMutability : ::std::uint8_t {
   Immutable = 0,
   RoFiles = 1,
   MutateFreely = 2,
@@ -1192,52 +1059,49 @@ enum class BubblewrapMutability : ::std::uint8_t
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Bubblewrap
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Bubblewrap
-struct Bubblewrap final : public ::rust::Opaque
-{
-  ::std::int32_t get_rootfs_fd () const noexcept;
-  void append_bwrap_arg (::rust::Str arg) noexcept;
-  void append_child_arg (::rust::Str arg) noexcept;
-  void setenv (::rust::Str k, ::rust::Str v) noexcept;
-  void take_fd (::std::int32_t source_fd, ::std::int32_t target_fd) noexcept;
-  void set_inherit_stdin () noexcept;
-  void take_stdin_fd (::std::int32_t source_fd) noexcept;
-  void take_stdout_fd (::std::int32_t source_fd) noexcept;
-  void take_stderr_fd (::std::int32_t source_fd) noexcept;
-  void take_stdout_and_stderr_fd (::std::int32_t source_fd) noexcept;
-  void bind_read (::rust::Str src, ::rust::Str dest) noexcept;
-  void bind_readwrite (::rust::Str src, ::rust::Str dest) noexcept;
-  void setup_compat_var ();
-  void run (::rpmostreecxx::GCancellable const &cancellable);
-  ~Bubblewrap () = delete;
+struct Bubblewrap final : public ::rust::Opaque {
+  ::std::int32_t get_rootfs_fd() const noexcept;
+  void append_bwrap_arg(::rust::Str arg) noexcept;
+  void append_child_arg(::rust::Str arg) noexcept;
+  void setenv(::rust::Str k, ::rust::Str v) noexcept;
+  void take_fd(::std::int32_t source_fd, ::std::int32_t target_fd) noexcept;
+  void set_inherit_stdin() noexcept;
+  void take_stdin_fd(::std::int32_t source_fd) noexcept;
+  void take_stdout_fd(::std::int32_t source_fd) noexcept;
+  void take_stderr_fd(::std::int32_t source_fd) noexcept;
+  void take_stdout_and_stderr_fd(::std::int32_t source_fd) noexcept;
+  void bind_read(::rust::Str src, ::rust::Str dest) noexcept;
+  void bind_readwrite(::rust::Str src, ::rust::Str dest) noexcept;
+  void setup_compat_var();
+  void run(::rpmostreecxx::GCancellable const &cancellable);
+  ~Bubblewrap() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$Bubblewrap
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$ExportedManifestDiff
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$ExportedManifestDiff
-struct ExportedManifestDiff final
-{
+struct ExportedManifestDiff final {
   // Check if the struct is initialized
-  bool initialized CXX_DEFAULT_VALUE (false);
+  bool initialized CXX_DEFAULT_VALUE(false);
   // The total number of packages in the next upgrade
-  ::std::uint64_t total CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t total CXX_DEFAULT_VALUE(0);
   // The size of the total number of packages in the next upgrade
-  ::std::uint64_t total_size CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t total_size CXX_DEFAULT_VALUE(0);
   // The total number of removed packages in the next upgrade
-  ::std::uint64_t n_removed CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t n_removed CXX_DEFAULT_VALUE(0);
   // The size of total number of removed packages in the next upgrade
-  ::std::uint64_t removed_size CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t removed_size CXX_DEFAULT_VALUE(0);
   // The total number of added packages in the next upgrade
-  ::std::uint64_t n_added CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t n_added CXX_DEFAULT_VALUE(0);
   // The size of total number of added packages in the next upgrade
-  ::std::uint64_t added_size CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t added_size CXX_DEFAULT_VALUE(0);
   // The version of the next upgrade
   ::rust::String version;
 
@@ -1247,11 +1111,10 @@ struct ExportedManifestDiff final
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$ContainerImageState
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$ContainerImageState
-// `ContainerImageState` is currently identical to ostree-rs-ext's `LayeredImageState` struct,
-// because cxx.rs currently requires types used as extern Rust types to be defined by the same crate
+// `ContainerImageState` is currently identical to ostree-rs-ext's `LayeredImageState` struct, because
+// cxx.rs currently requires types used as extern Rust types to be defined by the same crate
 // that contains the bridge using them, so we redefine an `ContainerImport` struct here.
-struct ContainerImageState final
-{
+struct ContainerImageState final {
   ::rust::String base_commit;
   ::rust::String merge_commit;
   ::rust::String image_digest;
@@ -1265,21 +1128,19 @@ struct ContainerImageState final
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$PrunedContainerInfo
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$PrunedContainerInfo
-struct PrunedContainerInfo final
-{
-  ::std::uint32_t images CXX_DEFAULT_VALUE (0);
-  ::std::uint32_t layers CXX_DEFAULT_VALUE (0);
+struct PrunedContainerInfo final {
+  ::std::uint32_t images CXX_DEFAULT_VALUE(0);
+  ::std::uint32_t layers CXX_DEFAULT_VALUE(0);
 
-  bool operator== (PrunedContainerInfo const &) const noexcept;
-  bool operator!= (PrunedContainerInfo const &) const noexcept;
+  bool operator==(PrunedContainerInfo const &) const noexcept;
+  bool operator!=(PrunedContainerInfo const &) const noexcept;
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$PrunedContainerInfo
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$RefspecType
 #define CXXBRIDGE1_ENUM_rpmostreecxx$RefspecType
-enum class RefspecType : ::std::uint8_t
-{
+enum class RefspecType : ::std::uint8_t {
   Ostree = 0,
   Checksum = 1,
   Container = 2,
@@ -1288,45 +1149,40 @@ enum class RefspecType : ::std::uint8_t
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$TempEtcGuard
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$TempEtcGuard
-struct TempEtcGuard final : public ::rust::Opaque
-{
-  void undo () const;
-  ~TempEtcGuard () = delete;
+struct TempEtcGuard final : public ::rust::Opaque {
+  void undo() const;
+  ~TempEtcGuard() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$TempEtcGuard
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$FilesystemScriptPrep
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$FilesystemScriptPrep
-struct FilesystemScriptPrep final : public ::rust::Opaque
-{
-  void undo ();
-  ~FilesystemScriptPrep () = delete;
+struct FilesystemScriptPrep final : public ::rust::Opaque {
+  void undo();
+  ~FilesystemScriptPrep() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$FilesystemScriptPrep
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$DeploymentLayeredMeta
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$DeploymentLayeredMeta
-struct DeploymentLayeredMeta final
-{
-  bool is_layered CXX_DEFAULT_VALUE (false);
+struct DeploymentLayeredMeta final {
+  bool is_layered CXX_DEFAULT_VALUE(false);
   ::rust::String base_commit;
-  ::std::uint32_t clientlayer_version CXX_DEFAULT_VALUE (0);
+  ::std::uint32_t clientlayer_version CXX_DEFAULT_VALUE(0);
 
   using IsRelocatable = ::std::true_type;
 };
@@ -1334,8 +1190,7 @@ struct DeploymentLayeredMeta final
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacementSource
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacementSource
-struct OverrideReplacementSource final
-{
+struct OverrideReplacementSource final {
   ::rpmostreecxx::OverrideReplacementType kind;
   ::rust::String name;
 
@@ -1345,8 +1200,7 @@ struct OverrideReplacementSource final
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$ParsedRevisionKind
 #define CXXBRIDGE1_ENUM_rpmostreecxx$ParsedRevisionKind
-enum class ParsedRevisionKind : ::std::uint8_t
-{
+enum class ParsedRevisionKind : ::std::uint8_t {
   Version = 0,
   Checksum = 1,
 };
@@ -1354,8 +1208,7 @@ enum class ParsedRevisionKind : ::std::uint8_t
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$ParsedRevision
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$ParsedRevision
-struct ParsedRevision final
-{
+struct ParsedRevision final {
   ::rpmostreecxx::ParsedRevisionKind kind;
   ::rust::String value;
 
@@ -1365,50 +1218,44 @@ struct ParsedRevision final
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporterFlags
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporterFlags
-struct RpmImporterFlags final : public ::rust::Opaque
-{
-  bool is_ima_enabled () const noexcept;
-  ~RpmImporterFlags () = delete;
+struct RpmImporterFlags final : public ::rust::Opaque {
+  bool is_ima_enabled() const noexcept;
+  ~RpmImporterFlags() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporterFlags
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporter
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporter
-struct RpmImporter final : public ::rust::Opaque
-{
-  ::rust::String handle_translate_pathname (::rust::Str path) noexcept;
-  ::rust::String ostree_branch () const noexcept;
-  ::rust::String pkg_name () const noexcept;
-  bool doc_files_are_filtered () const noexcept;
-  void doc_files_insert (::rust::Str path) noexcept;
-  bool doc_files_contains (::rust::Str path) const noexcept;
-  void rpmfi_overrides_insert (::rust::Str path, ::std::uint64_t index) noexcept;
-  bool rpmfi_overrides_contains (::rust::Str path) const noexcept;
-  ::std::uint64_t rpmfi_overrides_get (::rust::Str path) const noexcept;
-  bool is_ima_enabled () const noexcept;
-  void tweak_imported_file_info (::rpmostreecxx::GFileInfo const &file_info) const noexcept;
-  bool is_file_filtered (::rust::Str path, ::rpmostreecxx::GFileInfo const &file_info) const;
-  void translate_to_tmpfiles_entry (::rust::Str abs_path,
-                                    ::rpmostreecxx::GFileInfo const &file_info,
-                                    ::rust::Str username, ::rust::Str groupname);
-  bool has_tmpfiles_entries () const noexcept;
-  ::rust::String serialize_tmpfiles_content () const noexcept;
-  ~RpmImporter () = delete;
+struct RpmImporter final : public ::rust::Opaque {
+  ::rust::String handle_translate_pathname(::rust::Str path) noexcept;
+  ::rust::String ostree_branch() const noexcept;
+  ::rust::String pkg_name() const noexcept;
+  bool doc_files_are_filtered() const noexcept;
+  void doc_files_insert(::rust::Str path) noexcept;
+  bool doc_files_contains(::rust::Str path) const noexcept;
+  void rpmfi_overrides_insert(::rust::Str path, ::std::uint64_t index) noexcept;
+  bool rpmfi_overrides_contains(::rust::Str path) const noexcept;
+  ::std::uint64_t rpmfi_overrides_get(::rust::Str path) const noexcept;
+  bool is_ima_enabled() const noexcept;
+  void tweak_imported_file_info(::rpmostreecxx::GFileInfo const &file_info) const noexcept;
+  bool is_file_filtered(::rust::Str path, ::rpmostreecxx::GFileInfo const &file_info) const;
+  void translate_to_tmpfiles_entry(::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username, ::rust::Str groupname);
+  bool has_tmpfiles_entries() const noexcept;
+  ::rust::String serialize_tmpfiles_content() const noexcept;
+  ~RpmImporter() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporter
@@ -1417,81 +1264,73 @@ private:
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryEntry
 // A history entry in the journal. It may represent multiple consecutive boots
 // into the same deployment. This struct is exposed directly via FFI to C.
-struct HistoryEntry final
-{
+struct HistoryEntry final {
   // The deployment root timestamp.
-  ::std::uint64_t deploy_timestamp CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t deploy_timestamp CXX_DEFAULT_VALUE(0);
   // The command-line that was used to create the deployment, if any.
   ::rust::String deploy_cmdline;
   // The number of consecutive times the deployment was booted.
-  ::std::uint64_t boot_count CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t boot_count CXX_DEFAULT_VALUE(0);
   // The first time the deployment was booted if multiple consecutive times.
-  ::std::uint64_t first_boot_timestamp CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t first_boot_timestamp CXX_DEFAULT_VALUE(0);
   // The last time the deployment was booted if multiple consecutive times.
-  ::std::uint64_t last_boot_timestamp CXX_DEFAULT_VALUE (0);
+  ::std::uint64_t last_boot_timestamp CXX_DEFAULT_VALUE(0);
   // `true` if there are no more entries.
-  bool eof CXX_DEFAULT_VALUE (false);
+  bool eof CXX_DEFAULT_VALUE(false);
 
-  bool operator== (HistoryEntry const &) const noexcept;
-  bool operator!= (HistoryEntry const &) const noexcept;
+  bool operator==(HistoryEntry const &) const noexcept;
+  bool operator!=(HistoryEntry const &) const noexcept;
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryEntry
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryCtx
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryCtx
-struct HistoryCtx final : public ::rust::Opaque
-{
-  ::rpmostreecxx::HistoryEntry next_entry ();
-  ~HistoryCtx () = delete;
+struct HistoryCtx final : public ::rust::Opaque {
+  ::rpmostreecxx::HistoryEntry next_entry();
+  ~HistoryCtx() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryCtx
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$TokioHandle
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$TokioHandle
-struct TokioHandle final : public ::rust::Opaque
-{
-  ::rust::Box<::rpmostreecxx::TokioEnterGuard> enter () const noexcept;
-  ~TokioHandle () = delete;
+struct TokioHandle final : public ::rust::Opaque {
+  ::rust::Box<::rpmostreecxx::TokioEnterGuard> enter() const noexcept;
+  ~TokioHandle() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$TokioHandle
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$TokioEnterGuard
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$TokioEnterGuard
-struct TokioEnterGuard final : public ::rust::Opaque
-{
-  ~TokioEnterGuard () = delete;
+struct TokioEnterGuard final : public ::rust::Opaque {
+  ~TokioEnterGuard() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$TokioEnterGuard
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$RepoMetadataTarget
 #define CXXBRIDGE1_ENUM_rpmostreecxx$RepoMetadataTarget
-enum class RepoMetadataTarget : ::std::uint8_t
-{
+enum class RepoMetadataTarget : ::std::uint8_t {
   Inline = 0,
   Detached = 1,
   Disabled = 2,
@@ -1500,8 +1339,7 @@ enum class RepoMetadataTarget : ::std::uint8_t
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$AdvisoriesMetadataTarget
 #define CXXBRIDGE1_ENUM_rpmostreecxx$AdvisoriesMetadataTarget
-enum class AdvisoriesMetadataTarget : ::std::uint8_t
-{
+enum class AdvisoriesMetadataTarget : ::std::uint8_t {
   Inline = 0,
   Detached = 1,
   Disabled = 2,
@@ -1510,43 +1348,39 @@ enum class AdvisoriesMetadataTarget : ::std::uint8_t
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Refspec
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Refspec
-struct Refspec final
-{
+struct Refspec final {
   ::rpmostreecxx::RefspecType kind;
   ::rust::String refspec;
 
-  bool operator== (Refspec const &) const noexcept;
-  bool operator!= (Refspec const &) const noexcept;
+  bool operator==(Refspec const &) const noexcept;
+  bool operator!=(Refspec const &) const noexcept;
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$Refspec
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$OverrideReplacementType
 #define CXXBRIDGE1_ENUM_rpmostreecxx$OverrideReplacementType
-enum class OverrideReplacementType : ::std::uint8_t
-{
+enum class OverrideReplacementType : ::std::uint8_t {
   Repo = 0,
 };
 #endif // CXXBRIDGE1_ENUM_rpmostreecxx$OverrideReplacementType
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacement
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacement
-struct OverrideReplacement final
-{
+struct OverrideReplacement final {
   ::rust::String from;
   ::rpmostreecxx::OverrideReplacementType from_kind;
   ::rust::Vec<::rust::String> packages;
 
-  bool operator== (OverrideReplacement const &) const noexcept;
-  bool operator!= (OverrideReplacement const &) const noexcept;
+  bool operator==(OverrideReplacement const &) const noexcept;
+  bool operator!=(OverrideReplacement const &) const noexcept;
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacement
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$OptUsrLocal
 #define CXXBRIDGE1_ENUM_rpmostreecxx$OptUsrLocal
-enum class OptUsrLocal : ::std::uint8_t
-{
+enum class OptUsrLocal : ::std::uint8_t {
   Var = 0,
   Root = 1,
   StateOverlay = 2,
@@ -1555,131 +1389,125 @@ enum class OptUsrLocal : ::std::uint8_t
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Treefile
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Treefile
-struct Treefile final : public ::rust::Opaque
-{
-  ::rust::Str get_workdir () const noexcept;
-  ::std::int32_t get_passwd_fd () noexcept;
-  ::std::int32_t get_group_fd () noexcept;
-  ::rust::String get_json_string () const noexcept;
-  ::rust::Vec<::rust::String> get_ostree_layers () const noexcept;
-  ::rust::Vec<::rust::String> get_ostree_override_layers () const noexcept;
-  ::rust::Vec<::rust::String> get_all_ostree_layers () const noexcept;
-  ::rust::Vec<::rust::String> get_repos () const noexcept;
-  ::rust::Vec<::rust::String> get_packages () const noexcept;
-  ::rust::String require_automatic_version_prefix () const;
-  bool add_packages (::rust::Vec<::rust::String> packages, bool allow_existing);
-  bool has_packages () const noexcept;
-  ::rust::Vec<::rust::String> get_local_packages () const noexcept;
-  bool add_local_packages (::rust::Vec<::rust::String> packages, bool allow_existing);
-  ::rust::Vec<::rust::String> get_local_fileoverride_packages () const noexcept;
-  bool add_local_fileoverride_packages (::rust::Vec<::rust::String> packages, bool allow_existing);
-  bool remove_packages (::rust::Vec<::rust::String> packages, bool allow_noent);
-  ::rust::Vec<::rpmostreecxx::OverrideReplacement> get_packages_override_replace () const noexcept;
-  bool has_packages_override_replace () const noexcept;
-  bool add_packages_override_replace (::rpmostreecxx::OverrideReplacement replacement) noexcept;
-  bool remove_package_override_replace (::rust::Str package) noexcept;
-  ::rust::Vec<::rust::String> get_packages_override_replace_local () const noexcept;
-  void add_packages_override_replace_local (::rust::Vec<::rust::String> packages);
-  bool remove_package_override_replace_local (::rust::Str package) noexcept;
-  ::rust::Vec<::rust::String> get_packages_override_remove () const noexcept;
-  void add_packages_override_remove (::rust::Vec<::rust::String> packages);
-  bool remove_package_override_remove (::rust::Str package) noexcept;
-  bool has_packages_override_remove_name (::rust::Str name) const noexcept;
-  bool remove_all_overrides () noexcept;
-  bool remove_all_packages () noexcept;
-  ::rust::Vec<::rust::String> get_exclude_packages () const noexcept;
-  ::rust::String get_platform_module () const noexcept;
-  ::rust::Vec<::rust::String> get_install_langs () const noexcept;
-  ::rust::String format_install_langs_macro () const noexcept;
-  ::rust::Vec<::rust::String> get_lockfile_repos () const noexcept;
-  ::rust::Str get_ref () const noexcept;
-  bool get_cliwrap () const noexcept;
-  ::rust::Vec<::rust::String> get_cliwrap_binaries () const noexcept;
-  void set_cliwrap (bool enabled) noexcept;
-  ::rust::Vec<::rust::String> get_container_cmd () const noexcept;
-  bool get_readonly_executables () const noexcept;
-  bool get_documentation () const noexcept;
-  bool get_recommends () const noexcept;
-  bool get_selinux () const noexcept;
-  bool get_sysusers_is_forced () const noexcept;
-  ::std::uint32_t get_selinux_label_version () const noexcept;
-  ::rust::String get_gpg_key () const noexcept;
-  ::rust::String get_automatic_version_suffix () const noexcept;
-  bool get_container () const noexcept;
-  bool get_machineid_compat () const noexcept;
-  ::rust::Vec<::rust::String> get_etc_group_members () const noexcept;
-  bool get_boot_location_is_modules () const noexcept;
-  bool use_kernel_install () const noexcept;
-  bool get_ima () const noexcept;
-  ::rust::String get_releasever () const noexcept;
-  ::rpmostreecxx::RepoMetadataTarget get_repo_metadata_target () const noexcept;
-  ::rpmostreecxx::AdvisoriesMetadataTarget get_advisories_metadata_target () const noexcept;
-  bool rpmdb_backend_is_target () const noexcept;
-  bool should_normalize_rpmdb () const noexcept;
-  ::rpmostreecxx::OptUsrLocal get_opt_usrlocal () const noexcept;
-  ::rust::Vec<::rust::String> get_files_remove_regex (::rust::Str package) const noexcept;
-  ::rust::String get_checksum (::rpmostreecxx::OstreeRepo const &repo) const;
-  ::rust::String get_ostree_ref () const noexcept;
-  ::rust::Slice<::rpmostreecxx::RepoPackage const> get_repo_packages () const noexcept;
-  void clear_repo_packages () noexcept;
-  void prettyprint_json_stdout () const noexcept;
-  void print_deprecation_warnings () const noexcept;
-  void print_experimental_notices () const noexcept;
-  void sanitycheck_externals () const;
-  ::rust::Box<::rpmostreecxx::RpmImporterFlags>
-  importer_flags (::rust::Str pkg_name) const noexcept;
-  ::rust::String write_repovars (::std::int32_t workdir_dfd_raw) const;
-  void set_releasever (::rust::Str releasever);
-  void set_recommends (bool val);
-  void enable_repo (::rust::Str repo);
-  void disable_repo (::rust::Str repo);
-  void validate_for_container () const;
-  ::rpmostreecxx::Refspec get_base_refspec () const noexcept;
-  void rebase (::rust::Str new_refspec, ::rust::Str custom_origin_url,
-               ::rust::Str custom_origin_description) noexcept;
-  ::rust::String get_origin_custom_url () const noexcept;
-  ::rust::String get_origin_custom_description () const noexcept;
-  ::rust::String get_override_commit () const noexcept;
-  void set_override_commit (::rust::Str checksum) noexcept;
-  ::rust::Vec<::rust::String> get_initramfs_etc_files () const noexcept;
-  bool has_initramfs_etc_files () const noexcept;
-  bool initramfs_etc_files_track (::rust::Vec<::rust::String> files) noexcept;
-  bool initramfs_etc_files_untrack (::rust::Vec<::rust::String> files) noexcept;
-  bool initramfs_etc_files_untrack_all () noexcept;
-  bool get_initramfs_regenerate () const noexcept;
-  ::rust::Vec<::rust::String> get_initramfs_args () const noexcept;
-  void set_initramfs_regenerate (bool enabled, ::rust::Vec<::rust::String> args) noexcept;
-  ::rust::String get_unconfigured_state () const noexcept;
-  bool may_require_local_assembly () const noexcept;
-  bool has_any_packages () const noexcept;
-  bool merge_treefile (::rust::Str treefile);
-  bool get_no_initramfs () const noexcept;
-  ~Treefile () = delete;
+struct Treefile final : public ::rust::Opaque {
+  ::rust::Str get_workdir() const noexcept;
+  ::std::int32_t get_passwd_fd() noexcept;
+  ::std::int32_t get_group_fd() noexcept;
+  ::rust::String get_json_string() const noexcept;
+  ::rust::Vec<::rust::String> get_ostree_layers() const noexcept;
+  ::rust::Vec<::rust::String> get_ostree_override_layers() const noexcept;
+  ::rust::Vec<::rust::String> get_all_ostree_layers() const noexcept;
+  ::rust::Vec<::rust::String> get_repos() const noexcept;
+  ::rust::Vec<::rust::String> get_packages() const noexcept;
+  ::rust::String require_automatic_version_prefix() const;
+  bool add_packages(::rust::Vec<::rust::String> packages, bool allow_existing);
+  bool has_packages() const noexcept;
+  ::rust::Vec<::rust::String> get_local_packages() const noexcept;
+  bool add_local_packages(::rust::Vec<::rust::String> packages, bool allow_existing);
+  ::rust::Vec<::rust::String> get_local_fileoverride_packages() const noexcept;
+  bool add_local_fileoverride_packages(::rust::Vec<::rust::String> packages, bool allow_existing);
+  bool remove_packages(::rust::Vec<::rust::String> packages, bool allow_noent);
+  ::rust::Vec<::rpmostreecxx::OverrideReplacement> get_packages_override_replace() const noexcept;
+  bool has_packages_override_replace() const noexcept;
+  bool add_packages_override_replace(::rpmostreecxx::OverrideReplacement replacement) noexcept;
+  bool remove_package_override_replace(::rust::Str package) noexcept;
+  ::rust::Vec<::rust::String> get_packages_override_replace_local() const noexcept;
+  void add_packages_override_replace_local(::rust::Vec<::rust::String> packages);
+  bool remove_package_override_replace_local(::rust::Str package) noexcept;
+  ::rust::Vec<::rust::String> get_packages_override_remove() const noexcept;
+  void add_packages_override_remove(::rust::Vec<::rust::String> packages);
+  bool remove_package_override_remove(::rust::Str package) noexcept;
+  bool has_packages_override_remove_name(::rust::Str name) const noexcept;
+  bool remove_all_overrides() noexcept;
+  bool remove_all_packages() noexcept;
+  ::rust::Vec<::rust::String> get_exclude_packages() const noexcept;
+  ::rust::String get_platform_module() const noexcept;
+  ::rust::Vec<::rust::String> get_install_langs() const noexcept;
+  ::rust::String format_install_langs_macro() const noexcept;
+  ::rust::Vec<::rust::String> get_lockfile_repos() const noexcept;
+  ::rust::Str get_ref() const noexcept;
+  bool get_cliwrap() const noexcept;
+  ::rust::Vec<::rust::String> get_cliwrap_binaries() const noexcept;
+  void set_cliwrap(bool enabled) noexcept;
+  ::rust::Vec<::rust::String> get_container_cmd() const noexcept;
+  bool get_readonly_executables() const noexcept;
+  bool get_documentation() const noexcept;
+  bool get_recommends() const noexcept;
+  bool get_selinux() const noexcept;
+  bool get_sysusers_is_forced() const noexcept;
+  ::std::uint32_t get_selinux_label_version() const noexcept;
+  ::rust::String get_gpg_key() const noexcept;
+  ::rust::String get_automatic_version_suffix() const noexcept;
+  bool get_container() const noexcept;
+  bool get_machineid_compat() const noexcept;
+  ::rust::Vec<::rust::String> get_etc_group_members() const noexcept;
+  bool get_boot_location_is_modules() const noexcept;
+  bool use_kernel_install() const noexcept;
+  bool get_ima() const noexcept;
+  ::rust::String get_releasever() const noexcept;
+  ::rpmostreecxx::RepoMetadataTarget get_repo_metadata_target() const noexcept;
+  ::rpmostreecxx::AdvisoriesMetadataTarget get_advisories_metadata_target() const noexcept;
+  bool rpmdb_backend_is_target() const noexcept;
+  bool should_normalize_rpmdb() const noexcept;
+  ::rpmostreecxx::OptUsrLocal get_opt_usrlocal() const noexcept;
+  ::rust::Vec<::rust::String> get_files_remove_regex(::rust::Str package) const noexcept;
+  ::rust::String get_checksum(::rpmostreecxx::OstreeRepo const &repo) const;
+  ::rust::String get_ostree_ref() const noexcept;
+  ::rust::Slice<::rpmostreecxx::RepoPackage const> get_repo_packages() const noexcept;
+  void clear_repo_packages() noexcept;
+  void prettyprint_json_stdout() const noexcept;
+  void print_deprecation_warnings() const noexcept;
+  void print_experimental_notices() const noexcept;
+  void sanitycheck_externals() const;
+  ::rust::Box<::rpmostreecxx::RpmImporterFlags> importer_flags(::rust::Str pkg_name) const noexcept;
+  ::rust::String write_repovars(::std::int32_t workdir_dfd_raw) const;
+  void set_releasever(::rust::Str releasever);
+  void set_recommends(bool val);
+  void enable_repo(::rust::Str repo);
+  void disable_repo(::rust::Str repo);
+  void validate_for_container() const;
+  ::rpmostreecxx::Refspec get_base_refspec() const noexcept;
+  void rebase(::rust::Str new_refspec, ::rust::Str custom_origin_url, ::rust::Str custom_origin_description) noexcept;
+  ::rust::String get_origin_custom_url() const noexcept;
+  ::rust::String get_origin_custom_description() const noexcept;
+  ::rust::String get_override_commit() const noexcept;
+  void set_override_commit(::rust::Str checksum) noexcept;
+  ::rust::Vec<::rust::String> get_initramfs_etc_files() const noexcept;
+  bool has_initramfs_etc_files() const noexcept;
+  bool initramfs_etc_files_track(::rust::Vec<::rust::String> files) noexcept;
+  bool initramfs_etc_files_untrack(::rust::Vec<::rust::String> files) noexcept;
+  bool initramfs_etc_files_untrack_all() noexcept;
+  bool get_initramfs_regenerate() const noexcept;
+  ::rust::Vec<::rust::String> get_initramfs_args() const noexcept;
+  void set_initramfs_regenerate(bool enabled, ::rust::Vec<::rust::String> args) noexcept;
+  ::rust::String get_unconfigured_state() const noexcept;
+  bool may_require_local_assembly() const noexcept;
+  bool has_any_packages() const noexcept;
+  bool merge_treefile(::rust::Str treefile);
+  bool get_no_initramfs() const noexcept;
+  ~Treefile() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$Treefile
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$RepoPackage
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$RepoPackage
-struct RepoPackage final : public ::rust::Opaque
-{
-  ::rust::Str get_repo () const noexcept;
-  ::rust::Vec<::rust::String> get_packages () const noexcept;
-  ~RepoPackage () = delete;
+struct RepoPackage final : public ::rust::Opaque {
+  ::rust::Str get_repo() const noexcept;
+  ::rust::Vec<::rust::String> get_packages() const noexcept;
+  ~RepoPackage() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$RepoPackage
@@ -1689,8 +1517,7 @@ private:
 // A copy of LiveFsState that is bridged to C++; the main
 // change here is we can't use Option<> yet, so empty values
 // are represented by the empty string.
-struct LiveApplyState final
-{
+struct LiveApplyState final {
   ::rust::String inprogress;
   ::rust::String commit;
 
@@ -1700,72 +1527,64 @@ struct LiveApplyState final
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdDB
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdDB
-struct PasswdDB final : public ::rust::Opaque
-{
-  ::rust::String lookup_user (::std::uint32_t uid) const;
-  ::rust::String lookup_group (::std::uint32_t gid) const;
-  ~PasswdDB () = delete;
+struct PasswdDB final : public ::rust::Opaque {
+  ::rust::String lookup_user(::std::uint32_t uid) const;
+  ::rust::String lookup_group(::std::uint32_t gid) const;
+  ~PasswdDB() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdDB
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdEntries
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdEntries
-struct PasswdEntries final : public ::rust::Opaque
-{
-  void add_group_content (::std::int32_t rootfs, ::rust::Str path);
-  void add_passwd_content (::std::int32_t rootfs, ::rust::Str path);
-  bool contains_group (::rust::Str user) const noexcept;
-  bool contains_user (::rust::Str user) const noexcept;
-  ::std::uint32_t lookup_user_id (::rust::Str user) const;
-  ::std::uint32_t lookup_group_id (::rust::Str group) const;
-  ~PasswdEntries () = delete;
+struct PasswdEntries final : public ::rust::Opaque {
+  void add_group_content(::std::int32_t rootfs, ::rust::Str path);
+  void add_passwd_content(::std::int32_t rootfs, ::rust::Str path);
+  bool contains_group(::rust::Str user) const noexcept;
+  bool contains_user(::rust::Str user) const noexcept;
+  ::std::uint32_t lookup_user_id(::rust::Str user) const;
+  ::std::uint32_t lookup_group_id(::rust::Str group) const;
+  ~PasswdEntries() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdEntries
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Extensions
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Extensions
-struct Extensions final : public ::rust::Opaque
-{
-  ::rust::Vec<::rust::String> get_repos () const noexcept;
-  ::rust::Vec<::rust::String> get_os_extension_packages () const noexcept;
-  ::rust::Vec<::rust::String> get_development_packages () const noexcept;
-  bool state_checksum_changed (::rust::Str chksum, ::rust::Str output_dir) const;
-  void update_state_checksum (::rust::Str chksum, ::rust::Str output_dir) const;
-  void serialize_to_dir (::rust::Str output_dir) const;
-  ::rust::Box<::rpmostreecxx::Treefile>
-  generate_treefile (::rpmostreecxx::Treefile const &src) const;
-  ~Extensions () = delete;
+struct Extensions final : public ::rust::Opaque {
+  ::rust::Vec<::rust::String> get_repos() const noexcept;
+  ::rust::Vec<::rust::String> get_os_extension_packages() const noexcept;
+  ::rust::Vec<::rust::String> get_development_packages() const noexcept;
+  bool state_checksum_changed(::rust::Str chksum, ::rust::Str output_dir) const;
+  void update_state_checksum(::rust::Str chksum, ::rust::Str output_dir) const;
+  void serialize_to_dir(::rust::Str output_dir) const;
+  ::rust::Box<::rpmostreecxx::Treefile> generate_treefile(::rpmostreecxx::Treefile const &src) const;
+  ~Extensions() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$Extensions
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$LockedPackage
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$LockedPackage
-struct LockedPackage final
-{
+struct LockedPackage final {
   ::rust::String name;
   ::rust::String evr;
   ::rust::String arch;
@@ -1777,361 +1596,294 @@ struct LockedPackage final
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$LockfileConfig
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$LockfileConfig
-struct LockfileConfig final : public ::rust::Opaque
-{
-  ::rust::Vec<::rpmostreecxx::LockedPackage> get_locked_packages () const;
-  ~LockfileConfig () = delete;
+struct LockfileConfig final : public ::rust::Opaque {
+  ::rust::Vec<::rpmostreecxx::LockedPackage> get_locked_packages() const;
+  ~LockfileConfig() = delete;
 
 private:
   friend ::rust::layout;
-  struct layout
-  {
-    static ::std::size_t size () noexcept;
-    static ::std::size_t align () noexcept;
+  struct layout {
+    static ::std::size_t size() noexcept;
+    static ::std::size_t align() noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$LockfileConfig
 
-static_assert (::std::is_enum<RpmOstreeDiffPrintFormat>::value, "expected enum");
-static_assert (sizeof (RpmOstreeDiffPrintFormat) == sizeof (::std::uint8_t), "incorrect size");
-static_assert (
-    static_cast<::std::uint8_t> (RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_SUMMARY)
-        == 0,
-    "disagrees with the value in #[cxx::bridge]");
-static_assert (
-    static_cast<::std::uint8_t> (RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_ALIGNED)
-        == 1,
-    "disagrees with the value in #[cxx::bridge]");
-static_assert (static_cast<::std::uint8_t> (
-                   RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE)
-                   == 2,
-               "disagrees with the value in #[cxx::bridge]");
+static_assert(::std::is_enum<RpmOstreeDiffPrintFormat>::value, "expected enum");
+static_assert(sizeof(RpmOstreeDiffPrintFormat) == sizeof(::std::uint8_t), "incorrect size");
+static_assert(static_cast<::std::uint8_t>(RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_SUMMARY) == 0, "disagrees with the value in #[cxx::bridge]");
+static_assert(static_cast<::std::uint8_t>(RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_ALIGNED) == 1, "disagrees with the value in #[cxx::bridge]");
+static_assert(static_cast<::std::uint8_t>(RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE) == 2, "disagrees with the value in #[cxx::bridge]");
 
-bool is_bare_split_xattrs ();
+bool is_bare_split_xattrs();
 
-bool is_http_arg (::rust::Str arg) noexcept;
+bool is_http_arg(::rust::Str arg) noexcept;
 
-bool is_ostree_container ();
+bool is_ostree_container();
 
-::rpmostreecxx::SystemHostType get_system_host_type ();
+::rpmostreecxx::SystemHostType get_system_host_type();
 
-void require_system_host_type (::rpmostreecxx::SystemHostType t);
+void require_system_host_type(::rpmostreecxx::SystemHostType t);
 
-bool is_rpm_arg (::rust::Str arg) noexcept;
+bool is_rpm_arg(::rust::Str arg) noexcept;
 
-void client_start_daemon ();
+void client_start_daemon();
 
-::rust::Vec<::std::int32_t> client_handle_fd_argument (::rust::Str arg, ::rust::Str arch,
-                                                       bool is_replace);
+::rust::Vec<::std::int32_t> client_handle_fd_argument(::rust::Str arg, ::rust::Str arch, bool is_replace);
 
-::rust::String client_render_download_progress (::rpmostreecxx::GVariant const &progress) noexcept;
+::rust::String client_render_download_progress(::rpmostreecxx::GVariant const &progress) noexcept;
 
-bool running_in_container () noexcept;
+bool running_in_container() noexcept;
 
-bool confirm ();
+bool confirm();
 
-void confirm_or_abort ();
+void confirm_or_abort();
 
-void bubblewrap_selftest ();
+void bubblewrap_selftest();
 
-::rust::Vec<::std::uint8_t> bubblewrap_run_sync (::std::int32_t rootfs_dfd,
-                                                 ::rust::Vec<::rust::String> const &args,
-                                                 bool capture_stdout,
-                                                 ::rpmostreecxx::BubblewrapMutability mutability);
+::rust::Vec<::std::uint8_t> bubblewrap_run_sync(::std::int32_t rootfs_dfd, ::rust::Vec<::rust::String> const &args, bool capture_stdout, ::rpmostreecxx::BubblewrapMutability mutability);
 
-::rust::Box<::rpmostreecxx::Bubblewrap> bubblewrap_new (::std::int32_t rootfs_fd);
+::rust::Box<::rpmostreecxx::Bubblewrap> bubblewrap_new(::std::int32_t rootfs_fd);
 
-::rust::Box<::rpmostreecxx::Bubblewrap>
-bubblewrap_new_with_mutability (::std::int32_t rootfs_fd,
-                                ::rpmostreecxx::BubblewrapMutability mutability);
+::rust::Box<::rpmostreecxx::Bubblewrap> bubblewrap_new_with_mutability(::std::int32_t rootfs_fd, ::rpmostreecxx::BubblewrapMutability mutability);
 
-::rpmostreecxx::BubblewrapMutability mutability_for_unified_core (bool unified_core) noexcept;
+::rpmostreecxx::BubblewrapMutability mutability_for_unified_core(bool unified_core) noexcept;
 
-void usroverlay_entrypoint (::rust::Vec<::rust::String> const &args);
+void usroverlay_entrypoint(::rust::Vec<::rust::String> const &args);
 
-void applylive_entrypoint (::rust::Vec<::rust::String> const &args);
+void applylive_entrypoint(::rust::Vec<::rust::String> const &args);
 
-void applylive_finish (::rpmostreecxx::OstreeSysroot const &sysroot);
+void applylive_finish(::rpmostreecxx::OstreeSysroot const &sysroot);
 
-void composeutil_legacy_prep_dev_and_run (::std::int32_t rootfs_dfd);
+void composeutil_legacy_prep_dev_and_run(::std::int32_t rootfs_dfd);
 
-void print_ostree_txn_stats (::rpmostreecxx::OstreeRepoTransactionStats &stats) noexcept;
+void print_ostree_txn_stats(::rpmostreecxx::OstreeRepoTransactionStats &stats) noexcept;
 
-void write_commit_id (::rust::Str target_path, ::rust::Str revision);
+void write_commit_id(::rust::Str target_path, ::rust::Str revision);
 
-void cliwrap_write_wrappers (::std::int32_t rootfs);
+void cliwrap_write_wrappers(::std::int32_t rootfs);
 
-void cliwrap_write_some_wrappers (::std::int32_t rootfs, ::rust::Vec<::rust::String> const &args);
+void cliwrap_write_some_wrappers(::std::int32_t rootfs, ::rust::Vec<::rust::String> const &args);
 
-::rust::String cliwrap_destdir () noexcept;
+::rust::String cliwrap_destdir() noexcept;
 
-void container_encapsulate (::rust::Vec<::rust::String> args);
+void container_encapsulate(::rust::Vec<::rust::String> args);
 
-void deploy_from_self_entrypoint (::rust::Vec<::rust::String> args);
+void deploy_from_self_entrypoint(::rust::Vec<::rust::String> args);
 
-::rust::Box<::rpmostreecxx::ContainerImageState>
-pull_container (::rpmostreecxx::OstreeRepo const &repo,
-                ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref,
-                ::rust::Str digest_override);
+::rust::Box<::rpmostreecxx::ContainerImageState> pull_container(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref, ::rust::Str digest_override);
 
-::rpmostreecxx::PrunedContainerInfo container_prune (::rpmostreecxx::OstreeSysroot const &sysroot);
+::rpmostreecxx::PrunedContainerInfo container_prune(::rpmostreecxx::OstreeSysroot const &sysroot);
 
-::rust::Box<::rpmostreecxx::ContainerImageState>
-query_container_image_commit (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str c);
+::rust::Box<::rpmostreecxx::ContainerImageState> query_container_image_commit(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str c);
 
-void purge_refspec (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec);
+void purge_refspec(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec);
 
-bool check_container_update (::rpmostreecxx::OstreeRepo const &repo,
-                             ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref);
+bool check_container_update(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref);
 
-::rust::Box<::rpmostreecxx::TempEtcGuard> prepare_tempetc_guard (::std::int32_t rootfs);
+::rust::Box<::rpmostreecxx::TempEtcGuard> prepare_tempetc_guard(::std::int32_t rootfs);
 
-::rust::Box<::rpmostreecxx::FilesystemScriptPrep>
-prepare_filesystem_script_prep (::std::int32_t rootfs);
+::rust::Box<::rpmostreecxx::FilesystemScriptPrep> prepare_filesystem_script_prep(::std::int32_t rootfs);
 
-void run_depmod (::std::int32_t rootfs_dfd, ::rust::Str kver, bool unified_core);
+void run_depmod(::std::int32_t rootfs_dfd, ::rust::Str kver, bool unified_core);
 
-void run_sysusers (::std::int32_t rootfs_dfd, bool force);
+void run_sysusers(::std::int32_t rootfs_dfd, bool force);
 
-void log_treefile (::rpmostreecxx::Treefile const &tf) noexcept;
+void log_treefile(::rpmostreecxx::Treefile const &tf) noexcept;
 
-bool is_container_image_reference (::rust::Str refspec) noexcept;
+bool is_container_image_reference(::rust::Str refspec) noexcept;
 
-bool is_container_image_digest_reference (::rust::Str refspec) noexcept;
+bool is_container_image_digest_reference(::rust::Str refspec) noexcept;
 
-::rpmostreecxx::RefspecType refspec_classify (::rust::Str refspec) noexcept;
+::rpmostreecxx::RefspecType refspec_classify(::rust::Str refspec) noexcept;
 
-void verify_kernel_hmac (::std::int32_t rootfs, ::rust::Str moddir);
+void verify_kernel_hmac(::std::int32_t rootfs, ::rust::Str moddir);
 
-::rust::Vec<::rust::String> stage_container_rpms (::rust::Vec<::rust::String> rpms);
+::rust::Vec<::rust::String> stage_container_rpms(::rust::Vec<::rust::String> rpms);
 
-::rust::Vec<::rust::String> stage_container_rpm_raw_fds (::rust::Vec<::std::int32_t> fds);
+::rust::Vec<::rust::String> stage_container_rpm_raw_fds(::rust::Vec<::std::int32_t> fds);
 
-bool commit_has_matching_sepolicy (::rpmostreecxx::GVariant const &commit,
-                                   ::rpmostreecxx::OstreeSePolicy const &policy);
+bool commit_has_matching_sepolicy(::rpmostreecxx::GVariant const &commit, ::rpmostreecxx::OstreeSePolicy const &policy);
 
-::rpmostreecxx::GVariant *get_header_variant (::rpmostreecxx::OstreeRepo const &repo,
-                                              ::rust::Str cachebranch);
+::rpmostreecxx::GVariant *get_header_variant(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str cachebranch);
 
-void compose_build_chunked_oci_entrypoint (::rust::Vec<::rust::String> args);
+void compose_build_chunked_oci_entrypoint(::rust::Vec<::rust::String> args);
 
-void compose_image (::rust::Vec<::rust::String> args);
+void compose_image(::rust::Vec<::rust::String> args);
 
-void compose_rootfs_entrypoint (::rust::Vec<::rust::String> args);
+void compose_rootfs_entrypoint(::rust::Vec<::rust::String> args);
 
-void configure_build_repo_from_target (::rpmostreecxx::OstreeRepo const &build_repo,
-                                       ::rpmostreecxx::OstreeRepo const &target_repo);
+void configure_build_repo_from_target(::rpmostreecxx::OstreeRepo const &build_repo, ::rpmostreecxx::OstreeRepo const &target_repo);
 
-void compose_prepare_rootfs (::std::int32_t src_rootfs_dfd, ::std::int32_t dest_rootfs_dfd,
-                             ::rpmostreecxx::Treefile &treefile);
+void compose_prepare_rootfs(::std::int32_t src_rootfs_dfd, ::std::int32_t dest_rootfs_dfd, ::rpmostreecxx::Treefile &treefile);
 
-void composepost_nsswitch_altfiles (::std::int32_t rootfs_dfd);
+void composepost_nsswitch_altfiles(::std::int32_t rootfs_dfd);
 
-void compose_postprocess (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile,
-                          ::rust::Str next_version, bool unified_core);
+void compose_postprocess(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile, ::rust::Str next_version, bool unified_core);
 
-void compose_postprocess_final_pre (::std::int32_t rootfs_dfd,
-                                    ::rpmostreecxx::Treefile const &treefile);
+void compose_postprocess_final_pre(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile);
 
-void compose_postprocess_final (::std::int32_t rootfs_dfd,
-                                ::rpmostreecxx::Treefile const &treefile);
+void compose_postprocess_final(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile);
 
-void convert_var_to_tmpfiles_d (::std::int32_t rootfs_dfd,
-                                ::rpmostreecxx::GCancellable const &cancellable);
+void convert_var_to_tmpfiles_d(::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable const &cancellable);
 
-void rootfs_prepare_links (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile,
-                           bool skip_usrlocal);
+void rootfs_prepare_links(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile, bool skip_usrlocal);
 
-void workaround_selinux_cross_labeling (::std::int32_t rootfs_dfd,
-                                        ::rpmostreecxx::GCancellable &cancellable);
+void workaround_selinux_cross_labeling(::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable &cancellable);
 
-void postprocess_cleanup_rpmdb (::std::int32_t rootfs_dfd);
+void postprocess_cleanup_rpmdb(::std::int32_t rootfs_dfd);
 
-void rewrite_rpmdb_for_target (::std::int32_t rootfs_dfd, bool normalize);
+void rewrite_rpmdb_for_target(::std::int32_t rootfs_dfd, bool normalize);
 
-::std::uint64_t directory_size (::std::int32_t dfd,
-                                ::rpmostreecxx::GCancellable const &cancellable);
+::std::uint64_t directory_size(::std::int32_t dfd, ::rpmostreecxx::GCancellable const &cancellable);
 
-::rpmostreecxx::OstreeDeployment *deployment_for_id (::rpmostreecxx::OstreeSysroot &sysroot,
-                                                     ::rust::Str deploy_id);
+::rpmostreecxx::OstreeDeployment *deployment_for_id(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id);
 
-::rust::String deployment_checksum_for_id (::rpmostreecxx::OstreeSysroot &sysroot,
-                                           ::rust::Str deploy_id);
+::rust::String deployment_checksum_for_id(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id);
 
-::rpmostreecxx::OstreeDeployment *deployment_get_base (::rpmostreecxx::OstreeSysroot &sysroot,
-                                                       ::rust::Str opt_deploy_id,
-                                                       ::rust::Str opt_os_name);
+::rpmostreecxx::OstreeDeployment *deployment_get_base(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str opt_deploy_id, ::rust::Str opt_os_name);
 
-bool deployment_add_manifest_diff (::rpmostreecxx::GVariantDict const &dict,
-                                   ::rpmostreecxx::ExportedManifestDiff const &diff) noexcept;
+bool deployment_add_manifest_diff(::rpmostreecxx::GVariantDict const &dict, ::rpmostreecxx::ExportedManifestDiff const &diff) noexcept;
 
-void daemon_sanitycheck_environment (::rpmostreecxx::OstreeSysroot const &sysroot);
+void daemon_sanitycheck_environment(::rpmostreecxx::OstreeSysroot const &sysroot);
 
-::rust::String deployment_generate_id (::rpmostreecxx::OstreeDeployment const &deployment) noexcept;
+::rust::String deployment_generate_id(::rpmostreecxx::OstreeDeployment const &deployment) noexcept;
 
-void deployment_populate_variant (::rpmostreecxx::OstreeSysroot const &sysroot,
-                                  ::rpmostreecxx::OstreeDeployment const &deployment,
-                                  ::rpmostreecxx::GVariantDict const &dict);
+void deployment_populate_variant(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::GVariantDict const &dict);
 
-void generate_baselayer_refs (::rpmostreecxx::OstreeSysroot const &sysroot,
-                              ::rpmostreecxx::OstreeRepo const &repo,
-                              ::rpmostreecxx::GCancellable const &cancellable);
+void generate_baselayer_refs(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable);
 
-void variant_add_remote_status (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec,
-                                ::rust::Str base_checksum,
-                                ::rpmostreecxx::GVariantDict const &dict);
+void variant_add_remote_status(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec, ::rust::Str base_checksum, ::rpmostreecxx::GVariantDict const &dict);
 
-::rpmostreecxx::DeploymentLayeredMeta
-deployment_layeredmeta_from_commit (::rpmostreecxx::OstreeDeployment const &deployment,
-                                    ::rpmostreecxx::GVariant const &commit);
+::rpmostreecxx::DeploymentLayeredMeta deployment_layeredmeta_from_commit(::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::GVariant const &commit);
 
-::rpmostreecxx::DeploymentLayeredMeta
-deployment_layeredmeta_load (::rpmostreecxx::OstreeRepo const &repo,
-                             ::rpmostreecxx::OstreeDeployment const &deployment);
+::rpmostreecxx::DeploymentLayeredMeta deployment_layeredmeta_load(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::OstreeDeployment const &deployment);
 
-::rpmostreecxx::OverrideReplacementSource parse_override_source (::rust::Str source);
+::rpmostreecxx::OverrideReplacementSource parse_override_source(::rust::Str source);
 
-::rpmostreecxx::ParsedRevision parse_revision (::rust::Str source);
+::rpmostreecxx::ParsedRevision parse_revision(::rust::Str source);
 
-::rust::String generate_object_path (::rust::Str base, ::rust::Str next_segment);
+::rust::String generate_object_path(::rust::Str base, ::rust::Str next_segment);
 
-void failpoint (::rust::Str p);
+void failpoint(::rust::Str p);
 
-::rust::Box<::rpmostreecxx::RpmImporterFlags> rpm_importer_flags_new_empty () noexcept;
+::rust::Box<::rpmostreecxx::RpmImporterFlags> rpm_importer_flags_new_empty() noexcept;
 
-::rust::Box<::rpmostreecxx::RpmImporter>
-rpm_importer_new (::rust::Str pkg_name, ::rust::Str ostree_branch,
-                  ::rpmostreecxx::RpmImporterFlags const &flags);
+::rust::Box<::rpmostreecxx::RpmImporter> rpm_importer_new(::rust::Str pkg_name, ::rust::Str ostree_branch, ::rpmostreecxx::RpmImporterFlags const &flags);
 
-::rust::String tmpfiles_translate (::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info,
-                                   ::rust::Str username, ::rust::Str groupname);
+::rust::String tmpfiles_translate(::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username, ::rust::Str groupname);
 
-void append_dracut_random_cpio (::std::int32_t fd);
+void append_dracut_random_cpio(::std::int32_t fd);
 
-::std::int32_t initramfs_overlay_generate (::rust::Vec<::rust::String> const &files,
-                                           ::rpmostreecxx::GCancellable &cancellable);
+::std::int32_t initramfs_overlay_generate(::rust::Vec<::rust::String> const &files, ::rpmostreecxx::GCancellable &cancellable);
 
-void journal_print_staging_failure () noexcept;
+void journal_print_staging_failure() noexcept;
 
-void console_progress_begin_task (::rust::Str msg) noexcept;
+void console_progress_begin_task(::rust::Str msg) noexcept;
 
-void console_progress_begin_n_items (::rust::Str msg, ::std::uint64_t n) noexcept;
+void console_progress_begin_n_items(::rust::Str msg, ::std::uint64_t n) noexcept;
 
-void console_progress_begin_percent (::rust::Str msg) noexcept;
+void console_progress_begin_percent(::rust::Str msg) noexcept;
 
-void console_progress_set_message (::rust::Str msg) noexcept;
+void console_progress_set_message(::rust::Str msg) noexcept;
 
-void console_progress_set_sub_message (::rust::Str msg) noexcept;
+void console_progress_set_sub_message(::rust::Str msg) noexcept;
 
-void console_progress_update (::std::uint64_t n) noexcept;
+void console_progress_update(::std::uint64_t n) noexcept;
 
-void console_progress_end (::rust::Str suffix) noexcept;
+void console_progress_end(::rust::Str suffix) noexcept;
 
-::rust::Box<::rpmostreecxx::HistoryCtx> history_ctx_new ();
+::rust::Box<::rpmostreecxx::HistoryCtx> history_ctx_new();
 
-void history_prune ();
+void history_prune();
 
-::rust::Box<::rpmostreecxx::TokioHandle> tokio_handle_get () noexcept;
+::rust::Box<::rpmostreecxx::TokioHandle> tokio_handle_get() noexcept;
 
-bool script_is_ignored (::rust::Str pkg, ::rust::Str script, bool use_kernel_install) noexcept;
+bool script_is_ignored(::rust::Str pkg, ::rust::Str script, bool use_kernel_install) noexcept;
 
-void testutils_entrypoint (::rust::Vec<::rust::String> argv);
+void testutils_entrypoint(::rust::Vec<::rust::String> argv);
 
-::rust::String maybe_shell_quote (::rust::Str input) noexcept;
+::rust::String maybe_shell_quote(::rust::Str input) noexcept;
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new (::rust::Str filename, ::rust::Str basearch);
+::rust::Box<::rpmostreecxx::Treefile> treefile_new(::rust::Str filename, ::rust::Str basearch);
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new_empty ();
+::rust::Box<::rpmostreecxx::Treefile> treefile_new_empty();
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new_from_string (::rust::Str buf, bool client);
+::rust::Box<::rpmostreecxx::Treefile> treefile_new_from_string(::rust::Str buf, bool client);
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new_compose (::rust::Str filename,
-                                                            ::rust::Str basearch);
+::rust::Box<::rpmostreecxx::Treefile> treefile_new_compose(::rust::Str filename, ::rust::Str basearch);
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new_client (::rust::Str filename,
-                                                           ::rust::Str basearch);
+::rust::Box<::rpmostreecxx::Treefile> treefile_new_client(::rust::Str filename, ::rust::Str basearch);
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new_client_from_etc (::rust::Str basearch);
+::rust::Box<::rpmostreecxx::Treefile> treefile_new_client_from_etc(::rust::Str basearch);
 
-::std::uint32_t treefile_delete_client_etc ();
+::std::uint32_t treefile_delete_client_etc();
 
-::rust::String varsubstitute (::rust::Str s,
-                              ::rust::Vec<::rpmostreecxx::StringMapping> const &vars);
+::rust::String varsubstitute(::rust::Str s, ::rust::Vec<::rpmostreecxx::StringMapping> const &vars);
 
-::rust::Vec<::rust::String> get_features () noexcept;
+::rust::Vec<::rust::String> get_features() noexcept;
 
-::rust::String get_rpm_basearch () noexcept;
+::rust::String get_rpm_basearch() noexcept;
 
-::std::int32_t sealed_memfd (::rust::Str description, ::rust::Slice<::std::uint8_t const> content);
+::std::int32_t sealed_memfd(::rust::Str description, ::rust::Slice<::std::uint8_t const> content);
 
-bool running_in_systemd () noexcept;
+bool running_in_systemd() noexcept;
 
-::rpmostreecxx::GVariant *calculate_advisories_diff (::rpmostreecxx::OstreeRepo const &repo,
-                                                     ::rust::Str checksum_from,
-                                                     ::rust::Str checksum_to);
+::rpmostreecxx::GVariant *calculate_advisories_diff(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str checksum_from, ::rust::Str checksum_to);
 
-::rust::String translate_path_for_ostree (::rust::Str path) noexcept;
+::rust::String translate_path_for_ostree(::rust::Str path) noexcept;
 
-::rpmostreecxx::LiveApplyState
-get_live_apply_state (::rpmostreecxx::OstreeSysroot const &sysroot,
-                      ::rpmostreecxx::OstreeDeployment const &deployment);
+::rpmostreecxx::LiveApplyState get_live_apply_state(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment);
 
-bool has_live_apply_state (::rpmostreecxx::OstreeSysroot const &sysroot,
-                           ::rpmostreecxx::OstreeDeployment const &deployment);
+bool has_live_apply_state(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment);
 
-void applylive_sync_ref (::rpmostreecxx::OstreeSysroot const &sysroot);
+void applylive_sync_ref(::rpmostreecxx::OstreeSysroot const &sysroot);
 
-void transaction_apply_live (::rpmostreecxx::OstreeSysroot const &sysroot,
-                             ::rpmostreecxx::GVariant const &target);
+void transaction_apply_live(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::GVariant const &target);
 
-void normalize_etc_shadow (::std::int32_t rootfs_dfd);
+void normalize_etc_shadow(::std::int32_t rootfs_dfd);
 
-bool prepare_rpm_layering (::std::int32_t rootfs, ::std::int32_t merge_passwd_dir);
+bool prepare_rpm_layering(::std::int32_t rootfs, ::std::int32_t merge_passwd_dir);
 
-void complete_rpm_layering (::std::int32_t rootfs);
+void complete_rpm_layering(::std::int32_t rootfs);
 
-void deduplicate_tmpfiles_entries (::std::int32_t rootfs);
+void deduplicate_tmpfiles_entries(::std::int32_t rootfs);
 
-void passwd_cleanup (::std::int32_t rootfs);
+void passwd_cleanup(::std::int32_t rootfs);
 
-void migrate_group_except_root (::std::int32_t rootfs,
-                                ::rust::Vec<::rust::String> const &preserved_groups);
+void migrate_group_except_root(::std::int32_t rootfs, ::rust::Vec<::rust::String> const &preserved_groups);
 
-void migrate_passwd_except_root (::std::int32_t rootfs);
+void migrate_passwd_except_root(::std::int32_t rootfs);
 
-void passwd_compose_prep (::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile);
+void passwd_compose_prep(::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile);
 
-void passwd_compose_prep_repo (::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile,
-                               ::rpmostreecxx::OstreeRepo const &repo,
-                               ::rust::Str previous_checksum, bool unified_core);
+void passwd_compose_prep_repo(::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile, ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str previous_checksum, bool unified_core);
 
-bool dir_contains_uid (::std::int32_t dirfd, ::std::uint32_t id);
+bool dir_contains_uid(::std::int32_t dirfd, ::std::uint32_t id);
 
-bool dir_contains_gid (::std::int32_t dirfd, ::std::uint32_t id);
+bool dir_contains_gid(::std::int32_t dirfd, ::std::uint32_t id);
 
-void check_passwd_group_entries (::rpmostreecxx::OstreeRepo const &ffi_repo,
-                                 ::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile,
-                                 ::rust::Str previous_rev);
+void check_passwd_group_entries(::rpmostreecxx::OstreeRepo const &ffi_repo, ::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile, ::rust::Str previous_rev);
 
-::rust::Box<::rpmostreecxx::PasswdDB> passwddb_open (::std::int32_t rootfs);
+::rust::Box<::rpmostreecxx::PasswdDB> passwddb_open(::std::int32_t rootfs);
 
-::rust::Box<::rpmostreecxx::PasswdEntries> new_passwd_entries () noexcept;
+::rust::Box<::rpmostreecxx::PasswdEntries> new_passwd_entries() noexcept;
 
-::rust::Box<::rpmostreecxx::Extensions>
-extensions_load (::rust::Str path, ::rust::Str basearch,
-                 ::rust::Vec<::rpmostreecxx::StringMapping> const &base_pkgs);
+::rust::Box<::rpmostreecxx::Extensions> extensions_load(::rust::Str path, ::rust::Str basearch, ::rust::Vec<::rpmostreecxx::StringMapping> const &base_pkgs);
 
-::rust::Box<::rpmostreecxx::LockfileConfig>
-lockfile_read (::rust::Vec<::rust::String> const &filenames);
+::rust::Box<::rpmostreecxx::LockfileConfig> lockfile_read(::rust::Vec<::rust::String> const &filenames);
 
-void lockfile_write (::rust::Str filename, ::rpmostreecxx::CxxGObjectArray &packages,
-                     ::rpmostreecxx::CxxGObjectArray &rpmmd_repos);
+void lockfile_write(::rust::Str filename, ::rpmostreecxx::CxxGObjectArray &packages, ::rpmostreecxx::CxxGObjectArray &rpmmd_repos);
 
-::rust::Box<::rpmostreecxx::Treefile> origin_to_treefile (::rpmostreecxx::GKeyFile const &kf);
+::rust::Box<::rpmostreecxx::Treefile> origin_to_treefile(::rpmostreecxx::GKeyFile const &kf);
 
-::rpmostreecxx::GKeyFile *treefile_to_origin (::rpmostreecxx::Treefile const &tf);
+::rpmostreecxx::GKeyFile *treefile_to_origin(::rpmostreecxx::Treefile const &tf);
 
-void origin_validate_roundtrip (::rpmostreecxx::GKeyFile const &kf) noexcept;
+void origin_validate_roundtrip(::rpmostreecxx::GKeyFile const &kf) noexcept;
 
-::rust::String cache_branch_to_nevra (::rust::Str nevra) noexcept;
+::rust::String cache_branch_to_nevra(::rust::Str nevra) noexcept;
 } // namespace rpmostreecxx
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif // __clang__

--- a/rust/cxx.h
+++ b/rust/cxx.h
@@ -20,89 +20,94 @@
 #include <sys/types.h>
 #endif
 
-namespace rust
-{
-inline namespace cxxbridge1
-{
+#if __cplusplus >= 201703L
+#include <string_view>
+#endif
+
+#if __cplusplus >= 202002L
+#include <ranges>
+#endif
+
+namespace rust {
+inline namespace cxxbridge1 {
 
 struct unsafe_bitcopy_t;
 
-namespace
-{
-template <typename T> class impl;
+namespace {
+template <typename T>
+class impl;
 }
 
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
 // https://cxx.rs/binding/string.html
-class String final
-{
+class String final {
 public:
-  String () noexcept;
-  String (const String &) noexcept;
-  String (String &&) noexcept;
-  ~String () noexcept;
+  String() noexcept;
+  String(const String &) noexcept;
+  String(String &&) noexcept;
+  ~String() noexcept;
 
-  String (const std::string &);
-  String (const char *);
-  String (const char *, std::size_t);
-  String (const char16_t *);
-  String (const char16_t *, std::size_t);
+  String(const std::string &);
+  String(const char *);
+  String(const char *, std::size_t);
+  String(const char16_t *);
+  String(const char16_t *, std::size_t);
+#ifdef __cpp_char8_t
+  String(const char8_t *s);
+  String(const char8_t *s, std::size_t len);
+#endif
 
   // Replace invalid Unicode data with the replacement character (U+FFFD).
-  static String lossy (const std::string &) noexcept;
-  static String lossy (const char *) noexcept;
-  static String lossy (const char *, std::size_t) noexcept;
-  static String lossy (const char16_t *) noexcept;
-  static String lossy (const char16_t *, std::size_t) noexcept;
+  static String lossy(const std::string &) noexcept;
+  static String lossy(const char *) noexcept;
+  static String lossy(const char *, std::size_t) noexcept;
+  static String lossy(const char16_t *) noexcept;
+  static String lossy(const char16_t *, std::size_t) noexcept;
 
-  String &operator= (const String &) & noexcept;
-  String &operator= (String &&) & noexcept;
+  String &operator=(const String &) & noexcept;
+  String &operator=(String &&) & noexcept;
 
-  explicit operator std::string () const;
+  explicit operator std::string() const;
 
   // Note: no null terminator.
-  const char *data () const noexcept;
-  std::size_t size () const noexcept;
-  std::size_t length () const noexcept;
-  bool empty () const noexcept;
+  const char *data() const noexcept;
+  std::size_t size() const noexcept;
+  std::size_t length() const noexcept;
+  bool empty() const noexcept;
 
-  const char *c_str () noexcept;
+  const char *c_str() noexcept;
 
-  std::size_t capacity () const noexcept;
-  void reserve (size_t new_cap) noexcept;
+  std::size_t capacity() const noexcept;
+  void reserve(size_t new_cap) noexcept;
 
   using iterator = char *;
-  iterator begin () noexcept;
-  iterator end () noexcept;
+  iterator begin() noexcept;
+  iterator end() noexcept;
 
   using const_iterator = const char *;
-  const_iterator begin () const noexcept;
-  const_iterator end () const noexcept;
-  const_iterator cbegin () const noexcept;
-  const_iterator cend () const noexcept;
+  const_iterator begin() const noexcept;
+  const_iterator end() const noexcept;
+  const_iterator cbegin() const noexcept;
+  const_iterator cend() const noexcept;
 
-  bool operator== (const String &) const noexcept;
-  bool operator!= (const String &) const noexcept;
-  bool operator< (const String &) const noexcept;
-  bool operator<= (const String &) const noexcept;
-  bool operator> (const String &) const noexcept;
-  bool operator>= (const String &) const noexcept;
+  bool operator==(const String &) const noexcept;
+  bool operator!=(const String &) const noexcept;
+  bool operator<(const String &) const noexcept;
+  bool operator<=(const String &) const noexcept;
+  bool operator>(const String &) const noexcept;
+  bool operator>=(const String &) const noexcept;
 
-  void swap (String &) noexcept;
+  void swap(String &) noexcept;
 
   // Internal API only intended for the cxxbridge code generator.
-  String (unsafe_bitcopy_t, const String &) noexcept;
+  String(unsafe_bitcopy_t, const String &) noexcept;
 
 private:
   struct lossy_t;
-  String (lossy_t, const char *, std::size_t) noexcept;
-  String (lossy_t, const char16_t *, std::size_t) noexcept;
-  friend void
-  swap (String &lhs, String &rhs) noexcept
-  {
-    lhs.swap (rhs);
-  }
+  String(lossy_t, const char *, std::size_t) noexcept;
+  String(lossy_t, const char16_t *, std::size_t) noexcept;
+  friend void swap(String &lhs, String &rhs) noexcept { lhs.swap(rhs); }
 
   // Size and alignment statically verified by rust_string.rs.
   std::array<std::uintptr_t, 3> repr;
@@ -112,48 +117,50 @@ private:
 #ifndef CXXBRIDGE1_RUST_STR
 #define CXXBRIDGE1_RUST_STR
 // https://cxx.rs/binding/str.html
-class Str final
-{
+class Str final {
 public:
-  Str () noexcept;
-  Str (const String &) noexcept;
-  Str (const std::string &);
-  Str (const char *);
-  Str (const char *, std::size_t);
+  Str() noexcept;
+  Str(const String &) noexcept;
+  Str(const std::string &);
+  Str(const char *);
+  Str(const char *, std::size_t);
 
-  Str &operator= (const Str &) & noexcept = default;
+  Str &operator=(const Str &) & noexcept = default;
 
-  explicit operator std::string () const;
+  explicit operator std::string() const;
+#if __cplusplus >= 201703L
+  explicit operator std::string_view() const;
+#endif
 
   // Note: no null terminator.
-  const char *data () const noexcept;
-  std::size_t size () const noexcept;
-  std::size_t length () const noexcept;
-  bool empty () const noexcept;
+  const char *data() const noexcept;
+  std::size_t size() const noexcept;
+  std::size_t length() const noexcept;
+  bool empty() const noexcept;
 
   // Important in order for System V ABI to pass in registers.
-  Str (const Str &) noexcept = default;
-  ~Str () noexcept = default;
+  Str(const Str &) noexcept = default;
+  ~Str() noexcept = default;
 
   using iterator = const char *;
   using const_iterator = const char *;
-  const_iterator begin () const noexcept;
-  const_iterator end () const noexcept;
-  const_iterator cbegin () const noexcept;
-  const_iterator cend () const noexcept;
+  const_iterator begin() const noexcept;
+  const_iterator end() const noexcept;
+  const_iterator cbegin() const noexcept;
+  const_iterator cend() const noexcept;
 
-  bool operator== (const Str &) const noexcept;
-  bool operator!= (const Str &) const noexcept;
-  bool operator< (const Str &) const noexcept;
-  bool operator<= (const Str &) const noexcept;
-  bool operator> (const Str &) const noexcept;
-  bool operator>= (const Str &) const noexcept;
+  bool operator==(const Str &) const noexcept;
+  bool operator!=(const Str &) const noexcept;
+  bool operator<(const Str &) const noexcept;
+  bool operator<=(const Str &) const noexcept;
+  bool operator>(const Str &) const noexcept;
+  bool operator>=(const Str &) const noexcept;
 
-  void swap (Str &) noexcept;
+  void swap(Str &) noexcept;
 
 private:
   class uninit;
-  Str (uninit) noexcept;
+  Str(uninit) noexcept;
   friend impl<Str>;
 
   std::array<std::uintptr_t, 2> repr;
@@ -161,149 +168,167 @@ private:
 #endif // CXXBRIDGE1_RUST_STR
 
 #ifndef CXXBRIDGE1_RUST_SLICE
-namespace detail
-{
-template <bool> struct copy_assignable_if
-{
-};
+namespace detail {
+template <bool>
+struct copy_assignable_if {};
 
-template <> struct copy_assignable_if<false>
-{
-  copy_assignable_if () noexcept = default;
-  copy_assignable_if (const copy_assignable_if &) noexcept = default;
-  copy_assignable_if &operator= (const copy_assignable_if &) & noexcept = delete;
-  copy_assignable_if &operator= (copy_assignable_if &&) & noexcept = default;
+template <>
+struct copy_assignable_if<false> {
+  copy_assignable_if() noexcept = default;
+  copy_assignable_if(const copy_assignable_if &) noexcept = default;
+  copy_assignable_if &operator=(const copy_assignable_if &) & noexcept = delete;
+  copy_assignable_if &operator=(copy_assignable_if &&) & noexcept = default;
 };
 } // namespace detail
 
 // https://cxx.rs/binding/slice.html
 template <typename T>
-class Slice final : private detail::copy_assignable_if<std::is_const<T>::value>
-{
+class Slice final
+    : private detail::copy_assignable_if<std::is_const<T>::value> {
 public:
   using value_type = T;
 
-  Slice () noexcept;
-  Slice (T *, std::size_t count) noexcept;
+  Slice() noexcept;
+  Slice(T *, std::size_t count) noexcept;
 
-  Slice &operator= (const Slice<T> &) & noexcept = default;
-  Slice &operator= (Slice<T> &&) & noexcept = default;
+  template <typename C>
+  explicit Slice(C &c) : Slice(c.data(), c.size()) {}
 
-  T *data () const noexcept;
-  std::size_t size () const noexcept;
-  std::size_t length () const noexcept;
-  bool empty () const noexcept;
+  Slice &operator=(const Slice<T> &) & noexcept = default;
+  Slice &operator=(Slice<T> &&) & noexcept = default;
 
-  T &operator[] (std::size_t n) const noexcept;
-  T &at (std::size_t n) const;
-  T &front () const noexcept;
-  T &back () const noexcept;
+  T *data() const noexcept;
+  std::size_t size() const noexcept;
+  std::size_t length() const noexcept;
+  bool empty() const noexcept;
+
+  T &operator[](std::size_t n) const noexcept;
+  T &at(std::size_t n) const;
+  T &front() const noexcept;
+  T &back() const noexcept;
 
   // Important in order for System V ABI to pass in registers.
-  Slice (const Slice<T> &) noexcept = default;
-  ~Slice () noexcept = default;
+  Slice(const Slice<T> &) noexcept = default;
+  ~Slice() noexcept = default;
 
   class iterator;
-  iterator begin () const noexcept;
-  iterator end () const noexcept;
+  iterator begin() const noexcept;
+  iterator end() const noexcept;
 
-  void swap (Slice &) noexcept;
+  void swap(Slice &) noexcept;
 
 private:
   class uninit;
-  Slice (uninit) noexcept;
+  Slice(uninit) noexcept;
   friend impl<Slice>;
-  friend void sliceInit (void *, const void *, std::size_t) noexcept;
-  friend void *slicePtr (const void *) noexcept;
-  friend std::size_t sliceLen (const void *) noexcept;
+  friend void sliceInit(void *, const void *, std::size_t) noexcept;
+  friend void *slicePtr(const void *) noexcept;
+  friend std::size_t sliceLen(const void *) noexcept;
 
   std::array<std::uintptr_t, 2> repr;
 };
 
-template <typename T> class Slice<T>::iterator final
-{
+#ifdef __cpp_deduction_guides
+template <typename C>
+explicit Slice(C &c)
+    -> Slice<std::remove_reference_t<decltype(*std::declval<C>().data())>>;
+#endif // __cpp_deduction_guides
+
+template <typename T>
+class Slice<T>::iterator final {
 public:
+#if __cplusplus >= 202002L
+  using iterator_category = std::contiguous_iterator_tag;
+#else
   using iterator_category = std::random_access_iterator_tag;
+#endif
   using value_type = T;
   using difference_type = std::ptrdiff_t;
   using pointer = typename std::add_pointer<T>::type;
   using reference = typename std::add_lvalue_reference<T>::type;
 
-  reference operator* () const noexcept;
+  reference operator*() const noexcept;
   pointer operator->() const noexcept;
-  reference operator[] (difference_type) const noexcept;
+  reference operator[](difference_type) const noexcept;
 
-  iterator &operator++ () noexcept;
-  iterator operator++ (int) noexcept;
-  iterator &operator-- () noexcept;
-  iterator operator-- (int) noexcept;
+  iterator &operator++() noexcept;
+  iterator operator++(int) noexcept;
+  iterator &operator--() noexcept;
+  iterator operator--(int) noexcept;
 
-  iterator &operator+= (difference_type) noexcept;
-  iterator &operator-= (difference_type) noexcept;
-  iterator operator+ (difference_type) const noexcept;
-  iterator operator- (difference_type) const noexcept;
-  difference_type operator- (const iterator &) const noexcept;
+  iterator &operator+=(difference_type) noexcept;
+  iterator &operator-=(difference_type) noexcept;
+  iterator operator+(difference_type) const noexcept;
+  friend inline iterator operator+(difference_type lhs, iterator rhs) noexcept {
+    return rhs + lhs;
+  }
+  iterator operator-(difference_type) const noexcept;
+  difference_type operator-(const iterator &) const noexcept;
 
-  bool operator== (const iterator &) const noexcept;
-  bool operator!= (const iterator &) const noexcept;
-  bool operator< (const iterator &) const noexcept;
-  bool operator<= (const iterator &) const noexcept;
-  bool operator> (const iterator &) const noexcept;
-  bool operator>= (const iterator &) const noexcept;
+  bool operator==(const iterator &) const noexcept;
+  bool operator!=(const iterator &) const noexcept;
+  bool operator<(const iterator &) const noexcept;
+  bool operator<=(const iterator &) const noexcept;
+  bool operator>(const iterator &) const noexcept;
+  bool operator>=(const iterator &) const noexcept;
 
 private:
   friend class Slice;
   void *pos;
   std::size_t stride;
 };
+
+#if __cplusplus >= 202002L
+static_assert(std::ranges::contiguous_range<rust::Slice<const uint8_t>>);
+static_assert(std::contiguous_iterator<rust::Slice<const uint8_t>::iterator>);
+#endif
+
 #endif // CXXBRIDGE1_RUST_SLICE
 
 #ifndef CXXBRIDGE1_RUST_BOX
 // https://cxx.rs/binding/box.html
-template <typename T> class Box final
-{
+template <typename T>
+class Box final {
 public:
   using element_type = T;
-  using const_pointer = typename std::add_pointer<typename std::add_const<T>::type>::type;
+  using const_pointer =
+      typename std::add_pointer<typename std::add_const<T>::type>::type;
   using pointer = typename std::add_pointer<T>::type;
 
-  Box () = delete;
-  Box (Box &&) noexcept;
-  ~Box () noexcept;
+  Box() = delete;
+  Box(Box &&) noexcept;
+  ~Box() noexcept;
 
-  explicit Box (const T &);
-  explicit Box (T &&);
+  explicit Box(const T &);
+  explicit Box(T &&);
 
-  Box &operator= (Box &&) & noexcept;
+  Box &operator=(Box &&) & noexcept;
 
   const T *operator->() const noexcept;
-  const T &operator* () const noexcept;
+  const T &operator*() const noexcept;
   T *operator->() noexcept;
-  T &operator* () noexcept;
+  T &operator*() noexcept;
 
-  template <typename... Fields> static Box in_place (Fields &&...);
+  template <typename... Fields>
+  static Box in_place(Fields &&...);
 
-  void swap (Box &) noexcept;
+  void swap(Box &) noexcept;
 
   // Important: requires that `raw` came from an into_raw call. Do not pass a
   // pointer from `new` or any other source.
-  static Box from_raw (T *) noexcept;
+  static Box from_raw(T *) noexcept;
 
-  T *into_raw () noexcept;
+  T *into_raw() noexcept;
 
   /* Deprecated */ using value_type = element_type;
 
 private:
   class uninit;
   class allocation;
-  Box (uninit) noexcept;
-  void drop () noexcept;
+  Box(uninit) noexcept;
+  void drop() noexcept;
 
-  friend void
-  swap (Box &lhs, Box &rhs) noexcept
-  {
-    lhs.swap (rhs);
-  }
+  friend void swap(Box &lhs, Box &rhs) noexcept { lhs.swap(rhs); }
 
   T *ptr;
 };
@@ -311,68 +336,65 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_VEC
 // https://cxx.rs/binding/vec.html
-template <typename T> class Vec final
-{
+template <typename T>
+class Vec final {
 public:
   using value_type = T;
 
-  Vec () noexcept;
-  Vec (std::initializer_list<T>);
-  Vec (const Vec &);
-  Vec (Vec &&) noexcept;
-  ~Vec () noexcept;
+  Vec() noexcept;
+  Vec(std::initializer_list<T>);
+  Vec(const Vec &);
+  Vec(Vec &&) noexcept;
+  ~Vec() noexcept;
 
-  Vec &operator= (Vec &&) & noexcept;
-  Vec &operator= (const Vec &) &;
+  Vec &operator=(Vec &&) & noexcept;
+  Vec &operator=(const Vec &) &;
 
-  std::size_t size () const noexcept;
-  bool empty () const noexcept;
-  const T *data () const noexcept;
-  T *data () noexcept;
-  std::size_t capacity () const noexcept;
+  std::size_t size() const noexcept;
+  bool empty() const noexcept;
+  const T *data() const noexcept;
+  T *data() noexcept;
+  std::size_t capacity() const noexcept;
 
-  const T &operator[] (std::size_t n) const noexcept;
-  const T &at (std::size_t n) const;
-  const T &front () const noexcept;
-  const T &back () const noexcept;
+  const T &operator[](std::size_t n) const noexcept;
+  const T &at(std::size_t n) const;
+  const T &front() const noexcept;
+  const T &back() const noexcept;
 
-  T &operator[] (std::size_t n) noexcept;
-  T &at (std::size_t n);
-  T &front () noexcept;
-  T &back () noexcept;
+  T &operator[](std::size_t n) noexcept;
+  T &at(std::size_t n);
+  T &front() noexcept;
+  T &back() noexcept;
 
-  void reserve (std::size_t new_cap);
-  void push_back (const T &value);
-  void push_back (T &&value);
-  template <typename... Args> void emplace_back (Args &&...args);
-  void truncate (std::size_t len);
-  void clear ();
+  void reserve(std::size_t new_cap);
+  void push_back(const T &value);
+  void push_back(T &&value);
+  template <typename... Args>
+  void emplace_back(Args &&...args);
+  void truncate(std::size_t len);
+  void clear();
 
   using iterator = typename Slice<T>::iterator;
-  iterator begin () noexcept;
-  iterator end () noexcept;
+  iterator begin() noexcept;
+  iterator end() noexcept;
 
   using const_iterator = typename Slice<const T>::iterator;
-  const_iterator begin () const noexcept;
-  const_iterator end () const noexcept;
-  const_iterator cbegin () const noexcept;
-  const_iterator cend () const noexcept;
+  const_iterator begin() const noexcept;
+  const_iterator end() const noexcept;
+  const_iterator cbegin() const noexcept;
+  const_iterator cend() const noexcept;
 
-  void swap (Vec &) noexcept;
+  void swap(Vec &) noexcept;
 
   // Internal API only intended for the cxxbridge code generator.
-  Vec (unsafe_bitcopy_t, const Vec &) noexcept;
+  Vec(unsafe_bitcopy_t, const Vec &) noexcept;
 
 private:
-  void reserve_total (std::size_t new_cap) noexcept;
-  void set_len (std::size_t len) noexcept;
-  void drop () noexcept;
+  void reserve_total(std::size_t new_cap) noexcept;
+  void set_len(std::size_t len) noexcept;
+  void drop() noexcept;
 
-  friend void
-  swap (Vec &lhs, Vec &rhs) noexcept
-  {
-    lhs.swap (rhs);
-  }
+  friend void swap(Vec &lhs, Vec &rhs) noexcept { lhs.swap(rhs); }
 
   // Size and alignment statically verified by rust_vec.rs.
   std::array<std::uintptr_t, 3> repr;
@@ -381,16 +403,17 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_FN
 // https://cxx.rs/binding/fn.html
-template <typename Signature> class Fn;
+template <typename Signature>
+class Fn;
 
-template <typename Ret, typename... Args> class Fn<Ret (Args...)> final
-{
+template <typename Ret, typename... Args>
+class Fn<Ret(Args...)> final {
 public:
-  Ret operator() (Args... args) const noexcept;
-  Fn operator* () const noexcept;
+  Ret operator()(Args... args) const noexcept;
+  Fn operator*() const noexcept;
 
 private:
-  Ret (*trampoline) (Args..., void *fn) noexcept;
+  Ret (*trampoline)(Args..., void *fn) noexcept;
   void *fn;
 };
 #endif // CXXBRIDGE1_RUST_FN
@@ -398,20 +421,19 @@ private:
 #ifndef CXXBRIDGE1_RUST_ERROR
 #define CXXBRIDGE1_RUST_ERROR
 // https://cxx.rs/binding/result.html
-class Error final : public std::exception
-{
+class Error final : public std::exception {
 public:
-  Error (const Error &);
-  Error (Error &&) noexcept;
-  ~Error () noexcept override;
+  Error(const Error &);
+  Error(Error &&) noexcept;
+  ~Error() noexcept override;
 
-  Error &operator= (const Error &) &;
-  Error &operator= (Error &&) & noexcept;
+  Error &operator=(const Error &) &;
+  Error &operator=(Error &&) & noexcept;
 
-  const char *what () const noexcept override;
+  const char *what() const noexcept override;
 
 private:
-  Error () noexcept = default;
+  Error() noexcept = default;
   friend impl<Error>;
   const char *msg;
   std::size_t len;
@@ -427,23 +449,24 @@ using isize = ssize_t;
 #endif
 #endif // CXXBRIDGE1_RUST_ISIZE
 
-std::ostream &operator<< (std::ostream &, const String &);
-std::ostream &operator<< (std::ostream &, const Str &);
+std::ostream &operator<<(std::ostream &, const String &);
+std::ostream &operator<<(std::ostream &, const Str &);
 
 #ifndef CXXBRIDGE1_RUST_OPAQUE
 #define CXXBRIDGE1_RUST_OPAQUE
 // Base class of generated opaque Rust types.
-class Opaque
-{
+class Opaque {
 public:
-  Opaque () = delete;
-  Opaque (const Opaque &) = delete;
-  ~Opaque () = delete;
+  Opaque() = delete;
+  Opaque(const Opaque &) = delete;
+  ~Opaque() = delete;
 };
 #endif // CXXBRIDGE1_RUST_OPAQUE
 
-template <typename T> std::size_t size_of ();
-template <typename T> std::size_t align_of ();
+template <typename T>
+std::size_t size_of();
+template <typename T>
+std::size_t align_of();
 
 // IsRelocatable<T> is used in assertions that a C++ type passed by value
 // between Rust and C++ is soundly relocatable by Rust.
@@ -463,7 +486,8 @@ template <typename T> std::size_t align_of ();
 //      --- otherwise:
 //    + template <>
 //    + struct rust::IsRelocatable<MyType> : std::true_type {};
-template <typename T> struct IsRelocatable;
+template <typename T>
+struct IsRelocatable;
 
 using u8 = std::uint8_t;
 using u16 = std::uint16_t;
@@ -480,43 +504,46 @@ using f64 = double;
 // Snake case aliases for use in code that uses this style for type names.
 using string = String;
 using str = Str;
-template <typename T> using slice = Slice<T>;
-template <typename T> using box = Box<T>;
-template <typename T> using vec = Vec<T>;
+template <typename T>
+using slice = Slice<T>;
+template <typename T>
+using box = Box<T>;
+template <typename T>
+using vec = Vec<T>;
 using error = Error;
-template <typename Signature> using fn = Fn<Signature>;
-template <typename T> using is_relocatable = IsRelocatable<T>;
+template <typename Signature>
+using fn = Fn<Signature>;
+template <typename T>
+using is_relocatable = IsRelocatable<T>;
+
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// end public API, begin implementation details
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception> void panic [[noreturn]] (const char *msg);
+template <typename Exception>
+void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 #ifndef CXXBRIDGE1_RUST_FN
 #define CXXBRIDGE1_RUST_FN
 template <typename Ret, typename... Args>
-Ret
-Fn<Ret (Args...)>::operator() (Args... args) const noexcept
-{
-  return (*this->trampoline) (std::forward<Args> (args)..., this->fn);
+Ret Fn<Ret(Args...)>::operator()(Args... args) const noexcept {
+  return (*this->trampoline)(std::forward<Args>(args)..., this->fn);
 }
 
 template <typename Ret, typename... Args>
-Fn<Ret (Args...)>
-Fn<Ret (Args...)>::operator* () const noexcept
-{
+Fn<Ret(Args...)> Fn<Ret(Args...)>::operator*() const noexcept {
   return *this;
 }
 #endif // CXXBRIDGE1_RUST_FN
 
 #ifndef CXXBRIDGE1_RUST_BITCOPY_T
 #define CXXBRIDGE1_RUST_BITCOPY_T
-struct unsafe_bitcopy_t final
-{
-  explicit unsafe_bitcopy_t () = default;
+struct unsafe_bitcopy_t final {
+  explicit unsafe_bitcopy_t() = default;
 };
 #endif // CXXBRIDGE1_RUST_BITCOPY_T
 
@@ -527,717 +554,595 @@ constexpr unsafe_bitcopy_t unsafe_bitcopy{};
 
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
-template <typename T> Slice<T>::Slice () noexcept
-{
-  sliceInit (this, reinterpret_cast<void *> (align_of<T> ()), 0);
-}
-
-template <typename T> Slice<T>::Slice (T *s, std::size_t count) noexcept
-{
-  assert (s != nullptr || count == 0);
-  sliceInit (this,
-             s == nullptr && count == 0 ? reinterpret_cast<void *> (align_of<T> ())
-                                        : const_cast<typename std::remove_const<T>::type *> (s),
-             count);
+template <typename T>
+Slice<T>::Slice() noexcept {
+  sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
 }
 
 template <typename T>
-T *
-Slice<T>::data () const noexcept
-{
-  return reinterpret_cast<T *> (slicePtr (this));
+Slice<T>::Slice(T *s, std::size_t count) noexcept {
+  assert(s != nullptr || count == 0);
+  sliceInit(this,
+            s == nullptr && count == 0
+                ? reinterpret_cast<void *>(align_of<T>())
+                : const_cast<typename std::remove_const<T>::type *>(s),
+            count);
 }
 
 template <typename T>
-std::size_t
-Slice<T>::size () const noexcept
-{
-  return sliceLen (this);
+T *Slice<T>::data() const noexcept {
+  return reinterpret_cast<T *>(slicePtr(this));
 }
 
 template <typename T>
-std::size_t
-Slice<T>::length () const noexcept
-{
-  return this->size ();
+std::size_t Slice<T>::size() const noexcept {
+  return sliceLen(this);
 }
 
 template <typename T>
-bool
-Slice<T>::empty () const noexcept
-{
-  return this->size () == 0;
+std::size_t Slice<T>::length() const noexcept {
+  return this->size();
 }
 
 template <typename T>
-T &
-Slice<T>::operator[] (std::size_t n) const noexcept
-{
-  assert (n < this->size ());
-  auto ptr = static_cast<char *> (slicePtr (this)) + size_of<T> () * n;
-  return *reinterpret_cast<T *> (ptr);
+bool Slice<T>::empty() const noexcept {
+  return this->size() == 0;
 }
 
 template <typename T>
-T &
-Slice<T>::at (std::size_t n) const
-{
-  if (n >= this->size ())
-    {
-      panic<std::out_of_range> ("rust::Slice index out of range");
-    }
+T &Slice<T>::operator[](std::size_t n) const noexcept {
+  assert(n < this->size());
+  auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
+  return *reinterpret_cast<T *>(ptr);
+}
+
+template <typename T>
+T &Slice<T>::at(std::size_t n) const {
+  if (n >= this->size()) {
+    panic<std::out_of_range>("rust::Slice index out of range");
+  }
   return (*this)[n];
 }
 
 template <typename T>
-T &
-Slice<T>::front () const noexcept
-{
-  assert (!this->empty ());
+T &Slice<T>::front() const noexcept {
+  assert(!this->empty());
   return (*this)[0];
 }
 
 template <typename T>
-T &
-Slice<T>::back () const noexcept
-{
-  assert (!this->empty ());
-  return (*this)[this->size () - 1];
+T &Slice<T>::back() const noexcept {
+  assert(!this->empty());
+  return (*this)[this->size() - 1];
 }
 
 template <typename T>
 typename Slice<T>::iterator::reference
-Slice<T>::iterator::operator* () const noexcept
-{
-  return *static_cast<T *> (this->pos);
+Slice<T>::iterator::operator*() const noexcept {
+  return *static_cast<T *>(this->pos);
 }
 
 template <typename T>
 typename Slice<T>::iterator::pointer
-Slice<T>::iterator::operator->() const noexcept
-{
-  return static_cast<T *> (this->pos);
+Slice<T>::iterator::operator->() const noexcept {
+  return static_cast<T *>(this->pos);
 }
 
 template <typename T>
-typename Slice<T>::iterator::reference
-Slice<T>::iterator::operator[] (typename Slice<T>::iterator::difference_type n) const noexcept
-{
-  auto ptr = static_cast<char *> (this->pos) + this->stride * n;
-  return *reinterpret_cast<T *> (ptr);
+typename Slice<T>::iterator::reference Slice<T>::iterator::operator[](
+    typename Slice<T>::iterator::difference_type n) const noexcept {
+  auto ptr = static_cast<char *>(this->pos) + this->stride * n;
+  return *reinterpret_cast<T *>(ptr);
 }
 
 template <typename T>
-typename Slice<T>::iterator &
-Slice<T>::iterator::operator++ () noexcept
-{
-  this->pos = static_cast<char *> (this->pos) + this->stride;
+typename Slice<T>::iterator &Slice<T>::iterator::operator++() noexcept {
+  this->pos = static_cast<char *>(this->pos) + this->stride;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::iterator::operator++ (int) noexcept
-{
-  auto ret = iterator (*this);
-  this->pos = static_cast<char *> (this->pos) + this->stride;
+typename Slice<T>::iterator Slice<T>::iterator::operator++(int) noexcept {
+  auto ret = iterator(*this);
+  this->pos = static_cast<char *>(this->pos) + this->stride;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator &
-Slice<T>::iterator::operator-- () noexcept
-{
-  this->pos = static_cast<char *> (this->pos) - this->stride;
+typename Slice<T>::iterator &Slice<T>::iterator::operator--() noexcept {
+  this->pos = static_cast<char *>(this->pos) - this->stride;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::iterator::operator-- (int) noexcept
-{
-  auto ret = iterator (*this);
-  this->pos = static_cast<char *> (this->pos) - this->stride;
+typename Slice<T>::iterator Slice<T>::iterator::operator--(int) noexcept {
+  auto ret = iterator(*this);
+  this->pos = static_cast<char *>(this->pos) - this->stride;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator &
-Slice<T>::iterator::operator+= (typename Slice<T>::iterator::difference_type n) noexcept
-{
-  this->pos = static_cast<char *> (this->pos) + this->stride * n;
+typename Slice<T>::iterator &Slice<T>::iterator::operator+=(
+    typename Slice<T>::iterator::difference_type n) noexcept {
+  this->pos = static_cast<char *>(this->pos) + this->stride * n;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator &
-Slice<T>::iterator::operator-= (typename Slice<T>::iterator::difference_type n) noexcept
-{
-  this->pos = static_cast<char *> (this->pos) - this->stride * n;
+typename Slice<T>::iterator &Slice<T>::iterator::operator-=(
+    typename Slice<T>::iterator::difference_type n) noexcept {
+  this->pos = static_cast<char *>(this->pos) - this->stride * n;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::iterator::operator+ (typename Slice<T>::iterator::difference_type n) const noexcept
-{
-  auto ret = iterator (*this);
-  ret.pos = static_cast<char *> (this->pos) + this->stride * n;
+typename Slice<T>::iterator Slice<T>::iterator::operator+(
+    typename Slice<T>::iterator::difference_type n) const noexcept {
+  auto ret = iterator(*this);
+  ret.pos = static_cast<char *>(this->pos) + this->stride * n;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::iterator::operator- (typename Slice<T>::iterator::difference_type n) const noexcept
-{
-  auto ret = iterator (*this);
-  ret.pos = static_cast<char *> (this->pos) - this->stride * n;
+typename Slice<T>::iterator Slice<T>::iterator::operator-(
+    typename Slice<T>::iterator::difference_type n) const noexcept {
+  auto ret = iterator(*this);
+  ret.pos = static_cast<char *>(this->pos) - this->stride * n;
   return ret;
 }
 
 template <typename T>
 typename Slice<T>::iterator::difference_type
-Slice<T>::iterator::operator- (const iterator &other) const noexcept
-{
-  auto diff = std::distance (static_cast<char *> (other.pos), static_cast<char *> (this->pos));
-  return diff / this->stride;
+Slice<T>::iterator::operator-(const iterator &other) const noexcept {
+  auto diff = std::distance(static_cast<char *>(other.pos),
+                            static_cast<char *>(this->pos));
+  return diff / static_cast<typename Slice<T>::iterator::difference_type>(
+                    this->stride);
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator== (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator==(const iterator &other) const noexcept {
   return this->pos == other.pos;
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator!= (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator!=(const iterator &other) const noexcept {
   return this->pos != other.pos;
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator< (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator<(const iterator &other) const noexcept {
   return this->pos < other.pos;
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator<= (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator<=(const iterator &other) const noexcept {
   return this->pos <= other.pos;
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator> (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator>(const iterator &other) const noexcept {
   return this->pos > other.pos;
 }
 
 template <typename T>
-bool
-Slice<T>::iterator::operator>= (const iterator &other) const noexcept
-{
+bool Slice<T>::iterator::operator>=(const iterator &other) const noexcept {
   return this->pos >= other.pos;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::begin () const noexcept
-{
+typename Slice<T>::iterator Slice<T>::begin() const noexcept {
   iterator it;
-  it.pos = slicePtr (this);
-  it.stride = size_of<T> ();
+  it.pos = slicePtr(this);
+  it.stride = size_of<T>();
   return it;
 }
 
 template <typename T>
-typename Slice<T>::iterator
-Slice<T>::end () const noexcept
-{
-  iterator it = this->begin ();
-  it.pos = static_cast<char *> (it.pos) + it.stride * this->size ();
+typename Slice<T>::iterator Slice<T>::end() const noexcept {
+  iterator it = this->begin();
+  it.pos = static_cast<char *>(it.pos) + it.stride * this->size();
   return it;
 }
 
 template <typename T>
-void
-Slice<T>::swap (Slice &rhs) noexcept
-{
-  std::swap (*this, rhs);
+void Slice<T>::swap(Slice &rhs) noexcept {
+  std::swap(*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
 
 #ifndef CXXBRIDGE1_RUST_BOX
 #define CXXBRIDGE1_RUST_BOX
-template <typename T> class Box<T>::uninit
-{
-};
+template <typename T>
+class Box<T>::uninit {};
 
-template <typename T> class Box<T>::allocation
-{
-  static T *alloc () noexcept;
-  static void dealloc (T *) noexcept;
+template <typename T>
+class Box<T>::allocation {
+  static T *alloc() noexcept;
+  static void dealloc(T *) noexcept;
 
 public:
-  allocation () noexcept : ptr (alloc ()) {}
-  ~allocation () noexcept
-  {
-    if (this->ptr)
-      {
-        dealloc (this->ptr);
-      }
+  allocation() noexcept : ptr(alloc()) {}
+  ~allocation() noexcept {
+    if (this->ptr) {
+      dealloc(this->ptr);
+    }
   }
   T *ptr;
 };
 
-template <typename T> Box<T>::Box (Box &&other) noexcept : ptr (other.ptr) { other.ptr = nullptr; }
-
-template <typename T> Box<T>::Box (const T &val)
-{
-  allocation alloc;
-  ::new (alloc.ptr) T (val);
-  this->ptr = alloc.ptr;
-  alloc.ptr = nullptr;
-}
-
-template <typename T> Box<T>::Box (T &&val)
-{
-  allocation alloc;
-  ::new (alloc.ptr) T (std::move (val));
-  this->ptr = alloc.ptr;
-  alloc.ptr = nullptr;
-}
-
-template <typename T> Box<T>::~Box () noexcept
-{
-  if (this->ptr)
-    {
-      this->drop ();
-    }
+template <typename T>
+Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
+  other.ptr = nullptr;
 }
 
 template <typename T>
-Box<T> &
-Box<T>::operator= (Box &&other) & noexcept
-{
-  if (this->ptr)
-    {
-      this->drop ();
-    }
+Box<T>::Box(const T &val) {
+  allocation alloc;
+  ::new (alloc.ptr) T(val);
+  this->ptr = alloc.ptr;
+  alloc.ptr = nullptr;
+}
+
+template <typename T>
+Box<T>::Box(T &&val) {
+  allocation alloc;
+  ::new (alloc.ptr) T(std::move(val));
+  this->ptr = alloc.ptr;
+  alloc.ptr = nullptr;
+}
+
+template <typename T>
+Box<T>::~Box() noexcept {
+  if (this->ptr) {
+    this->drop();
+  }
+}
+
+template <typename T>
+Box<T> &Box<T>::operator=(Box &&other) & noexcept {
+  if (this->ptr) {
+    this->drop();
+  }
   this->ptr = other.ptr;
   other.ptr = nullptr;
   return *this;
 }
 
 template <typename T>
-const T *
-Box<T>::operator->() const noexcept
-{
+const T *Box<T>::operator->() const noexcept {
   return this->ptr;
 }
 
 template <typename T>
-const T &
-Box<T>::operator* () const noexcept
-{
+const T &Box<T>::operator*() const noexcept {
   return *this->ptr;
 }
 
 template <typename T>
-T *
-Box<T>::operator->() noexcept
-{
+T *Box<T>::operator->() noexcept {
   return this->ptr;
 }
 
 template <typename T>
-T &
-Box<T>::operator* () noexcept
-{
+T &Box<T>::operator*() noexcept {
   return *this->ptr;
 }
 
 template <typename T>
 template <typename... Fields>
-Box<T>
-Box<T>::in_place (Fields &&...fields)
-{
+Box<T> Box<T>::in_place(Fields &&...fields) {
   allocation alloc;
   auto ptr = alloc.ptr;
-  ::new (ptr) T{ std::forward<Fields> (fields)... };
+  ::new (ptr) T{std::forward<Fields>(fields)...};
   alloc.ptr = nullptr;
-  return from_raw (ptr);
+  return from_raw(ptr);
 }
 
 template <typename T>
-void
-Box<T>::swap (Box &rhs) noexcept
-{
+void Box<T>::swap(Box &rhs) noexcept {
   using std::swap;
-  swap (this->ptr, rhs.ptr);
+  swap(this->ptr, rhs.ptr);
 }
 
 template <typename T>
-Box<T>
-Box<T>::from_raw (T *raw) noexcept
-{
+Box<T> Box<T>::from_raw(T *raw) noexcept {
   Box box = uninit{};
   box.ptr = raw;
   return box;
 }
 
 template <typename T>
-T *
-Box<T>::into_raw () noexcept
-{
+T *Box<T>::into_raw() noexcept {
   T *raw = this->ptr;
   this->ptr = nullptr;
   return raw;
 }
 
-template <typename T> Box<T>::Box (uninit) noexcept {}
+template <typename T>
+Box<T>::Box(uninit) noexcept {}
 #endif // CXXBRIDGE1_RUST_BOX
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T> Vec<T>::Vec (std::initializer_list<T> init) : Vec{}
-{
-  this->reserve_total (init.size ());
-  std::move (init.begin (), init.end (), std::back_inserter (*this));
+template <typename T>
+Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
+  this->reserve_total(init.size());
+  std::move(init.begin(), init.end(), std::back_inserter(*this));
 }
-
-template <typename T> Vec<T>::Vec (const Vec &other) : Vec ()
-{
-  this->reserve_total (other.size ());
-  std::copy (other.begin (), other.end (), std::back_inserter (*this));
-}
-
-template <typename T> Vec<T>::Vec (Vec &&other) noexcept : repr (other.repr)
-{
-  new (&other) Vec ();
-}
-
-template <typename T> Vec<T>::~Vec () noexcept { this->drop (); }
 
 template <typename T>
-Vec<T> &
-Vec<T>::operator= (Vec &&other) & noexcept
-{
-  this->drop ();
+Vec<T>::Vec(const Vec &other) : Vec() {
+  this->reserve_total(other.size());
+  std::copy(other.begin(), other.end(), std::back_inserter(*this));
+}
+
+template <typename T>
+Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
+  new (&other) Vec();
+}
+
+template <typename T>
+Vec<T>::~Vec() noexcept {
+  this->drop();
+}
+
+template <typename T>
+Vec<T> &Vec<T>::operator=(Vec &&other) & noexcept {
+  this->drop();
   this->repr = other.repr;
-  new (&other) Vec ();
+  new (&other) Vec();
   return *this;
 }
 
 template <typename T>
-Vec<T> &
-Vec<T>::operator= (const Vec &other) &
-{
-  if (this != &other)
-    {
-      this->drop ();
-      new (this) Vec (other);
-    }
+Vec<T> &Vec<T>::operator=(const Vec &other) & {
+  if (this != &other) {
+    this->drop();
+    new (this) Vec(other);
+  }
   return *this;
 }
 
 template <typename T>
-bool
-Vec<T>::empty () const noexcept
-{
-  return this->size () == 0;
+bool Vec<T>::empty() const noexcept {
+  return this->size() == 0;
 }
 
 template <typename T>
-T *
-Vec<T>::data () noexcept
-{
-  return const_cast<T *> (const_cast<const Vec<T> *> (this)->data ());
+T *Vec<T>::data() noexcept {
+  return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
 }
 
 template <typename T>
-const T &
-Vec<T>::operator[] (std::size_t n) const noexcept
-{
-  assert (n < this->size ());
-  auto data = reinterpret_cast<const char *> (this->data ());
-  return *reinterpret_cast<const T *> (data + n * size_of<T> ());
+const T &Vec<T>::operator[](std::size_t n) const noexcept {
+  assert(n < this->size());
+  auto data = reinterpret_cast<const char *>(this->data());
+  return *reinterpret_cast<const T *>(data + n * size_of<T>());
 }
 
 template <typename T>
-const T &
-Vec<T>::at (std::size_t n) const
-{
-  if (n >= this->size ())
-    {
-      panic<std::out_of_range> ("rust::Vec index out of range");
-    }
+const T &Vec<T>::at(std::size_t n) const {
+  if (n >= this->size()) {
+    panic<std::out_of_range>("rust::Vec index out of range");
+  }
   return (*this)[n];
 }
 
 template <typename T>
-const T &
-Vec<T>::front () const noexcept
-{
-  assert (!this->empty ());
+const T &Vec<T>::front() const noexcept {
+  assert(!this->empty());
   return (*this)[0];
 }
 
 template <typename T>
-const T &
-Vec<T>::back () const noexcept
-{
-  assert (!this->empty ());
-  return (*this)[this->size () - 1];
+const T &Vec<T>::back() const noexcept {
+  assert(!this->empty());
+  return (*this)[this->size() - 1];
 }
 
 template <typename T>
-T &
-Vec<T>::operator[] (std::size_t n) noexcept
-{
-  assert (n < this->size ());
-  auto data = reinterpret_cast<char *> (this->data ());
-  return *reinterpret_cast<T *> (data + n * size_of<T> ());
+T &Vec<T>::operator[](std::size_t n) noexcept {
+  assert(n < this->size());
+  auto data = reinterpret_cast<char *>(this->data());
+  return *reinterpret_cast<T *>(data + n * size_of<T>());
 }
 
 template <typename T>
-T &
-Vec<T>::at (std::size_t n)
-{
-  if (n >= this->size ())
-    {
-      panic<std::out_of_range> ("rust::Vec index out of range");
-    }
+T &Vec<T>::at(std::size_t n) {
+  if (n >= this->size()) {
+    panic<std::out_of_range>("rust::Vec index out of range");
+  }
   return (*this)[n];
 }
 
 template <typename T>
-T &
-Vec<T>::front () noexcept
-{
-  assert (!this->empty ());
+T &Vec<T>::front() noexcept {
+  assert(!this->empty());
   return (*this)[0];
 }
 
 template <typename T>
-T &
-Vec<T>::back () noexcept
-{
-  assert (!this->empty ());
-  return (*this)[this->size () - 1];
+T &Vec<T>::back() noexcept {
+  assert(!this->empty());
+  return (*this)[this->size() - 1];
 }
 
 template <typename T>
-void
-Vec<T>::reserve (std::size_t new_cap)
-{
-  this->reserve_total (new_cap);
+void Vec<T>::reserve(std::size_t new_cap) {
+  this->reserve_total(new_cap);
 }
 
 template <typename T>
-void
-Vec<T>::push_back (const T &value)
-{
-  this->emplace_back (value);
+void Vec<T>::push_back(const T &value) {
+  this->emplace_back(value);
 }
 
 template <typename T>
-void
-Vec<T>::push_back (T &&value)
-{
-  this->emplace_back (std::move (value));
+void Vec<T>::push_back(T &&value) {
+  this->emplace_back(std::move(value));
 }
 
 template <typename T>
 template <typename... Args>
-void
-Vec<T>::emplace_back (Args &&...args)
-{
-  auto size = this->size ();
-  this->reserve_total (size + 1);
-  ::new (reinterpret_cast<T *> (reinterpret_cast<char *> (this->data ()) + size * size_of<T> ()))
-      T (std::forward<Args> (args)...);
-  this->set_len (size + 1);
+void Vec<T>::emplace_back(Args &&...args) {
+  auto size = this->size();
+  this->reserve_total(size + 1);
+  ::new (reinterpret_cast<T *>(reinterpret_cast<char *>(this->data()) +
+                               size * size_of<T>()))
+      T(std::forward<Args>(args)...);
+  this->set_len(size + 1);
 }
 
 template <typename T>
-void
-Vec<T>::clear ()
-{
-  this->truncate (0);
+void Vec<T>::clear() {
+  this->truncate(0);
 }
 
 template <typename T>
-typename Vec<T>::iterator
-Vec<T>::begin () noexcept
-{
-  return Slice<T> (this->data (), this->size ()).begin ();
+typename Vec<T>::iterator Vec<T>::begin() noexcept {
+  return Slice<T>(this->data(), this->size()).begin();
 }
 
 template <typename T>
-typename Vec<T>::iterator
-Vec<T>::end () noexcept
-{
-  return Slice<T> (this->data (), this->size ()).end ();
+typename Vec<T>::iterator Vec<T>::end() noexcept {
+  return Slice<T>(this->data(), this->size()).end();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator
-Vec<T>::begin () const noexcept
-{
-  return this->cbegin ();
+typename Vec<T>::const_iterator Vec<T>::begin() const noexcept {
+  return this->cbegin();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator
-Vec<T>::end () const noexcept
-{
-  return this->cend ();
+typename Vec<T>::const_iterator Vec<T>::end() const noexcept {
+  return this->cend();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator
-Vec<T>::cbegin () const noexcept
-{
-  return Slice<const T> (this->data (), this->size ()).begin ();
+typename Vec<T>::const_iterator Vec<T>::cbegin() const noexcept {
+  return Slice<const T>(this->data(), this->size()).begin();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator
-Vec<T>::cend () const noexcept
-{
-  return Slice<const T> (this->data (), this->size ()).end ();
+typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
+  return Slice<const T>(this->data(), this->size()).end();
 }
 
 template <typename T>
-void
-Vec<T>::swap (Vec &rhs) noexcept
-{
+void Vec<T>::swap(Vec &rhs) noexcept {
   using std::swap;
-  swap (this->repr, rhs.repr);
+  swap(this->repr, rhs.repr);
 }
 
 // Internal API only intended for the cxxbridge code generator.
-template <typename T> Vec<T>::Vec (unsafe_bitcopy_t, const Vec &bits) noexcept : repr (bits.repr) {}
+template <typename T>
+Vec<T>::Vec(unsafe_bitcopy_t, const Vec &bits) noexcept : repr(bits.repr) {}
 #endif // CXXBRIDGE1_RUST_VEC
 
 #ifndef CXXBRIDGE1_IS_COMPLETE
 #define CXXBRIDGE1_IS_COMPLETE
-namespace detail
-{
-namespace
-{
-template <typename T, typename = std::size_t> struct is_complete : std::false_type
-{
-};
-template <typename T> struct is_complete<T, decltype (sizeof (T))> : std::true_type
-{
-};
+namespace detail {
+namespace {
+template <typename T, typename = std::size_t>
+struct is_complete : std::false_type {};
+template <typename T>
+struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
 } // namespace
 } // namespace detail
 #endif // CXXBRIDGE1_IS_COMPLETE
 
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
-class layout
-{
-  template <typename T> friend std::size_t size_of ();
-  template <typename T> friend std::size_t align_of ();
+class layout {
   template <typename T>
-  static typename std::enable_if<std::is_base_of<Opaque, T>::value, std::size_t>::type
-  do_size_of ()
-  {
-    return T::layout::size ();
+  friend std::size_t size_of();
+  template <typename T>
+  friend std::size_t align_of();
+  template <typename T>
+  static typename std::enable_if<std::is_base_of<Opaque, T>::value,
+                                 std::size_t>::type
+  do_size_of() {
+    return T::layout::size();
   }
   template <typename T>
-  static typename std::enable_if<!std::is_base_of<Opaque, T>::value, std::size_t>::type
-  do_size_of ()
-  {
-    return sizeof (T);
+  static typename std::enable_if<!std::is_base_of<Opaque, T>::value,
+                                 std::size_t>::type
+  do_size_of() {
+    return sizeof(T);
   }
   template <typename T>
-  static typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
-  size_of ()
-  {
-    return do_size_of<T> ();
+  static
+      typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
+      size_of() {
+    return do_size_of<T>();
   }
   template <typename T>
-  static typename std::enable_if<std::is_base_of<Opaque, T>::value, std::size_t>::type
-  do_align_of ()
-  {
-    return T::layout::align ();
+  static typename std::enable_if<std::is_base_of<Opaque, T>::value,
+                                 std::size_t>::type
+  do_align_of() {
+    return T::layout::align();
   }
   template <typename T>
-  static typename std::enable_if<!std::is_base_of<Opaque, T>::value, std::size_t>::type
-  do_align_of ()
-  {
-    return alignof (T);
+  static typename std::enable_if<!std::is_base_of<Opaque, T>::value,
+                                 std::size_t>::type
+  do_align_of() {
+    return alignof(T);
   }
   template <typename T>
-  static typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
-  align_of ()
-  {
-    return do_align_of<T> ();
+  static
+      typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
+      align_of() {
+    return do_align_of<T>();
   }
 };
 
 template <typename T>
-std::size_t
-size_of ()
-{
-  return layout::size_of<T> ();
+std::size_t size_of() {
+  return layout::size_of<T>();
 }
 
 template <typename T>
-std::size_t
-align_of ()
-{
-  return layout::align_of<T> ();
+std::size_t align_of() {
+  return layout::align_of<T>();
 }
 #endif // CXXBRIDGE1_LAYOUT
 
 #ifndef CXXBRIDGE1_RELOCATABLE
 #define CXXBRIDGE1_RELOCATABLE
-namespace detail
-{
-template <typename... Ts> struct make_void
-{
+namespace detail {
+template <typename... Ts>
+struct make_void {
   using type = void;
 };
 
-template <typename... Ts> using void_t = typename make_void<Ts...>::type;
+template <typename... Ts>
+using void_t = typename make_void<Ts...>::type;
 
-template <typename Void, template <typename...> class, typename...> struct detect : std::false_type
-{
-};
+template <typename Void, template <typename...> class, typename...>
+struct detect : std::false_type {};
 template <template <typename...> class T, typename... A>
-struct detect<void_t<T<A...>>, T, A...> : std::true_type
-{
-};
+struct detect<void_t<T<A...>>, T, A...> : std::true_type {};
 
-template <template <typename...> class T, typename... A> using is_detected = detect<void, T, A...>;
-
-template <typename T> using detect_IsRelocatable = typename T::IsRelocatable;
+template <template <typename...> class T, typename... A>
+using is_detected = detect<void, T, A...>;
 
 template <typename T>
-struct get_IsRelocatable : std::is_same<typename T::IsRelocatable, std::true_type>
-{
-};
+using detect_IsRelocatable = typename T::IsRelocatable;
+
+template <typename T>
+struct get_IsRelocatable
+    : std::is_same<typename T::IsRelocatable, std::true_type> {};
 } // namespace detail
 
 template <typename T>
 struct IsRelocatable
     : std::conditional<
-          detail::is_detected<detail::detect_IsRelocatable, T>::value, detail::get_IsRelocatable<T>,
-          std::integral_constant<bool, std::is_trivially_move_constructible<T>::value
-                                           && std::is_trivially_destructible<T>::value>>::type
-{
-};
+          detail::is_detected<detail::detect_IsRelocatable, T>::value,
+          detail::get_IsRelocatable<T>,
+          std::integral_constant<
+              bool, std::is_trivially_move_constructible<T>::value &&
+                        std::is_trivially_destructible<T>::value>>::type {};
 #endif // CXXBRIDGE1_RELOCATABLE
 
 } // namespace cxxbridge1

--- a/rust/cxx.h
+++ b/rust/cxx.h
@@ -28,86 +28,93 @@
 #include <ranges>
 #endif
 
-namespace rust {
-inline namespace cxxbridge1 {
+namespace rust
+{
+inline namespace cxxbridge1
+{
 
 struct unsafe_bitcopy_t;
 
-namespace {
-template <typename T>
-class impl;
+namespace
+{
+template <typename T> class impl;
 }
 
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
 // https://cxx.rs/binding/string.html
-class String final {
+class String final
+{
 public:
-  String() noexcept;
-  String(const String &) noexcept;
-  String(String &&) noexcept;
-  ~String() noexcept;
+  String () noexcept;
+  String (const String &) noexcept;
+  String (String &&) noexcept;
+  ~String () noexcept;
 
-  String(const std::string &);
-  String(const char *);
-  String(const char *, std::size_t);
-  String(const char16_t *);
-  String(const char16_t *, std::size_t);
+  String (const std::string &);
+  String (const char *);
+  String (const char *, std::size_t);
+  String (const char16_t *);
+  String (const char16_t *, std::size_t);
 #ifdef __cpp_char8_t
-  String(const char8_t *s);
-  String(const char8_t *s, std::size_t len);
+  String (const char8_t *s);
+  String (const char8_t *s, std::size_t len);
 #endif
 
   // Replace invalid Unicode data with the replacement character (U+FFFD).
-  static String lossy(const std::string &) noexcept;
-  static String lossy(const char *) noexcept;
-  static String lossy(const char *, std::size_t) noexcept;
-  static String lossy(const char16_t *) noexcept;
-  static String lossy(const char16_t *, std::size_t) noexcept;
+  static String lossy (const std::string &) noexcept;
+  static String lossy (const char *) noexcept;
+  static String lossy (const char *, std::size_t) noexcept;
+  static String lossy (const char16_t *) noexcept;
+  static String lossy (const char16_t *, std::size_t) noexcept;
 
-  String &operator=(const String &) & noexcept;
-  String &operator=(String &&) & noexcept;
+  String &operator= (const String &) & noexcept;
+  String &operator= (String &&) & noexcept;
 
-  explicit operator std::string() const;
+  explicit operator std::string () const;
 
   // Note: no null terminator.
-  const char *data() const noexcept;
-  std::size_t size() const noexcept;
-  std::size_t length() const noexcept;
-  bool empty() const noexcept;
+  const char *data () const noexcept;
+  std::size_t size () const noexcept;
+  std::size_t length () const noexcept;
+  bool empty () const noexcept;
 
-  const char *c_str() noexcept;
+  const char *c_str () noexcept;
 
-  std::size_t capacity() const noexcept;
-  void reserve(size_t new_cap) noexcept;
+  std::size_t capacity () const noexcept;
+  void reserve (size_t new_cap) noexcept;
 
   using iterator = char *;
-  iterator begin() noexcept;
-  iterator end() noexcept;
+  iterator begin () noexcept;
+  iterator end () noexcept;
 
   using const_iterator = const char *;
-  const_iterator begin() const noexcept;
-  const_iterator end() const noexcept;
-  const_iterator cbegin() const noexcept;
-  const_iterator cend() const noexcept;
+  const_iterator begin () const noexcept;
+  const_iterator end () const noexcept;
+  const_iterator cbegin () const noexcept;
+  const_iterator cend () const noexcept;
 
-  bool operator==(const String &) const noexcept;
-  bool operator!=(const String &) const noexcept;
-  bool operator<(const String &) const noexcept;
-  bool operator<=(const String &) const noexcept;
-  bool operator>(const String &) const noexcept;
-  bool operator>=(const String &) const noexcept;
+  bool operator== (const String &) const noexcept;
+  bool operator!= (const String &) const noexcept;
+  bool operator< (const String &) const noexcept;
+  bool operator<= (const String &) const noexcept;
+  bool operator> (const String &) const noexcept;
+  bool operator>= (const String &) const noexcept;
 
-  void swap(String &) noexcept;
+  void swap (String &) noexcept;
 
   // Internal API only intended for the cxxbridge code generator.
-  String(unsafe_bitcopy_t, const String &) noexcept;
+  String (unsafe_bitcopy_t, const String &) noexcept;
 
 private:
   struct lossy_t;
-  String(lossy_t, const char *, std::size_t) noexcept;
-  String(lossy_t, const char16_t *, std::size_t) noexcept;
-  friend void swap(String &lhs, String &rhs) noexcept { lhs.swap(rhs); }
+  String (lossy_t, const char *, std::size_t) noexcept;
+  String (lossy_t, const char16_t *, std::size_t) noexcept;
+  friend void
+  swap (String &lhs, String &rhs) noexcept
+  {
+    lhs.swap (rhs);
+  }
 
   // Size and alignment statically verified by rust_string.rs.
   std::array<std::uintptr_t, 3> repr;
@@ -117,50 +124,51 @@ private:
 #ifndef CXXBRIDGE1_RUST_STR
 #define CXXBRIDGE1_RUST_STR
 // https://cxx.rs/binding/str.html
-class Str final {
+class Str final
+{
 public:
-  Str() noexcept;
-  Str(const String &) noexcept;
-  Str(const std::string &);
-  Str(const char *);
-  Str(const char *, std::size_t);
+  Str () noexcept;
+  Str (const String &) noexcept;
+  Str (const std::string &);
+  Str (const char *);
+  Str (const char *, std::size_t);
 
-  Str &operator=(const Str &) & noexcept = default;
+  Str &operator= (const Str &) & noexcept = default;
 
-  explicit operator std::string() const;
+  explicit operator std::string () const;
 #if __cplusplus >= 201703L
-  explicit operator std::string_view() const;
+  explicit operator std::string_view () const;
 #endif
 
   // Note: no null terminator.
-  const char *data() const noexcept;
-  std::size_t size() const noexcept;
-  std::size_t length() const noexcept;
-  bool empty() const noexcept;
+  const char *data () const noexcept;
+  std::size_t size () const noexcept;
+  std::size_t length () const noexcept;
+  bool empty () const noexcept;
 
   // Important in order for System V ABI to pass in registers.
-  Str(const Str &) noexcept = default;
-  ~Str() noexcept = default;
+  Str (const Str &) noexcept = default;
+  ~Str () noexcept = default;
 
   using iterator = const char *;
   using const_iterator = const char *;
-  const_iterator begin() const noexcept;
-  const_iterator end() const noexcept;
-  const_iterator cbegin() const noexcept;
-  const_iterator cend() const noexcept;
+  const_iterator begin () const noexcept;
+  const_iterator end () const noexcept;
+  const_iterator cbegin () const noexcept;
+  const_iterator cend () const noexcept;
 
-  bool operator==(const Str &) const noexcept;
-  bool operator!=(const Str &) const noexcept;
-  bool operator<(const Str &) const noexcept;
-  bool operator<=(const Str &) const noexcept;
-  bool operator>(const Str &) const noexcept;
-  bool operator>=(const Str &) const noexcept;
+  bool operator== (const Str &) const noexcept;
+  bool operator!= (const Str &) const noexcept;
+  bool operator< (const Str &) const noexcept;
+  bool operator<= (const Str &) const noexcept;
+  bool operator> (const Str &) const noexcept;
+  bool operator>= (const Str &) const noexcept;
 
-  void swap(Str &) noexcept;
+  void swap (Str &) noexcept;
 
 private:
   class uninit;
-  Str(uninit) noexcept;
+  Str (uninit) noexcept;
   friend impl<Str>;
 
   std::array<std::uintptr_t, 2> repr;
@@ -168,74 +176,74 @@ private:
 #endif // CXXBRIDGE1_RUST_STR
 
 #ifndef CXXBRIDGE1_RUST_SLICE
-namespace detail {
-template <bool>
-struct copy_assignable_if {};
+namespace detail
+{
+template <bool> struct copy_assignable_if
+{
+};
 
-template <>
-struct copy_assignable_if<false> {
-  copy_assignable_if() noexcept = default;
-  copy_assignable_if(const copy_assignable_if &) noexcept = default;
-  copy_assignable_if &operator=(const copy_assignable_if &) & noexcept = delete;
-  copy_assignable_if &operator=(copy_assignable_if &&) & noexcept = default;
+template <> struct copy_assignable_if<false>
+{
+  copy_assignable_if () noexcept = default;
+  copy_assignable_if (const copy_assignable_if &) noexcept = default;
+  copy_assignable_if &operator= (const copy_assignable_if &) & noexcept = delete;
+  copy_assignable_if &operator= (copy_assignable_if &&) & noexcept = default;
 };
 } // namespace detail
 
 // https://cxx.rs/binding/slice.html
 template <typename T>
-class Slice final
-    : private detail::copy_assignable_if<std::is_const<T>::value> {
+class Slice final : private detail::copy_assignable_if<std::is_const<T>::value>
+{
 public:
   using value_type = T;
 
-  Slice() noexcept;
-  Slice(T *, std::size_t count) noexcept;
+  Slice () noexcept;
+  Slice (T *, std::size_t count) noexcept;
 
-  template <typename C>
-  explicit Slice(C &c) : Slice(c.data(), c.size()) {}
+  template <typename C> explicit Slice (C &c) : Slice (c.data (), c.size ()) {}
 
-  Slice &operator=(const Slice<T> &) & noexcept = default;
-  Slice &operator=(Slice<T> &&) & noexcept = default;
+  Slice &operator= (const Slice<T> &) & noexcept = default;
+  Slice &operator= (Slice<T> &&) & noexcept = default;
 
-  T *data() const noexcept;
-  std::size_t size() const noexcept;
-  std::size_t length() const noexcept;
-  bool empty() const noexcept;
+  T *data () const noexcept;
+  std::size_t size () const noexcept;
+  std::size_t length () const noexcept;
+  bool empty () const noexcept;
 
-  T &operator[](std::size_t n) const noexcept;
-  T &at(std::size_t n) const;
-  T &front() const noexcept;
-  T &back() const noexcept;
+  T &operator[] (std::size_t n) const noexcept;
+  T &at (std::size_t n) const;
+  T &front () const noexcept;
+  T &back () const noexcept;
 
   // Important in order for System V ABI to pass in registers.
-  Slice(const Slice<T> &) noexcept = default;
-  ~Slice() noexcept = default;
+  Slice (const Slice<T> &) noexcept = default;
+  ~Slice () noexcept = default;
 
   class iterator;
-  iterator begin() const noexcept;
-  iterator end() const noexcept;
+  iterator begin () const noexcept;
+  iterator end () const noexcept;
 
-  void swap(Slice &) noexcept;
+  void swap (Slice &) noexcept;
 
 private:
   class uninit;
-  Slice(uninit) noexcept;
+  Slice (uninit) noexcept;
   friend impl<Slice>;
-  friend void sliceInit(void *, const void *, std::size_t) noexcept;
-  friend void *slicePtr(const void *) noexcept;
-  friend std::size_t sliceLen(const void *) noexcept;
+  friend void sliceInit (void *, const void *, std::size_t) noexcept;
+  friend void *slicePtr (const void *) noexcept;
+  friend std::size_t sliceLen (const void *) noexcept;
 
   std::array<std::uintptr_t, 2> repr;
 };
 
 #ifdef __cpp_deduction_guides
 template <typename C>
-explicit Slice(C &c)
-    -> Slice<std::remove_reference_t<decltype(*std::declval<C>().data())>>;
+explicit Slice (C &c) -> Slice<std::remove_reference_t<decltype (*std::declval<C> ().data ())>>;
 #endif // __cpp_deduction_guides
 
-template <typename T>
-class Slice<T>::iterator final {
+template <typename T> class Slice<T>::iterator final
+{
 public:
 #if __cplusplus >= 202002L
   using iterator_category = std::contiguous_iterator_tag;
@@ -247,30 +255,32 @@ public:
   using pointer = typename std::add_pointer<T>::type;
   using reference = typename std::add_lvalue_reference<T>::type;
 
-  reference operator*() const noexcept;
+  reference operator* () const noexcept;
   pointer operator->() const noexcept;
-  reference operator[](difference_type) const noexcept;
+  reference operator[] (difference_type) const noexcept;
 
-  iterator &operator++() noexcept;
-  iterator operator++(int) noexcept;
-  iterator &operator--() noexcept;
-  iterator operator--(int) noexcept;
+  iterator &operator++ () noexcept;
+  iterator operator++ (int) noexcept;
+  iterator &operator-- () noexcept;
+  iterator operator-- (int) noexcept;
 
-  iterator &operator+=(difference_type) noexcept;
-  iterator &operator-=(difference_type) noexcept;
-  iterator operator+(difference_type) const noexcept;
-  friend inline iterator operator+(difference_type lhs, iterator rhs) noexcept {
+  iterator &operator+= (difference_type) noexcept;
+  iterator &operator-= (difference_type) noexcept;
+  iterator operator+ (difference_type) const noexcept;
+  friend inline iterator
+  operator+ (difference_type lhs, iterator rhs) noexcept
+  {
     return rhs + lhs;
   }
-  iterator operator-(difference_type) const noexcept;
-  difference_type operator-(const iterator &) const noexcept;
+  iterator operator- (difference_type) const noexcept;
+  difference_type operator- (const iterator &) const noexcept;
 
-  bool operator==(const iterator &) const noexcept;
-  bool operator!=(const iterator &) const noexcept;
-  bool operator<(const iterator &) const noexcept;
-  bool operator<=(const iterator &) const noexcept;
-  bool operator>(const iterator &) const noexcept;
-  bool operator>=(const iterator &) const noexcept;
+  bool operator== (const iterator &) const noexcept;
+  bool operator!= (const iterator &) const noexcept;
+  bool operator< (const iterator &) const noexcept;
+  bool operator<= (const iterator &) const noexcept;
+  bool operator> (const iterator &) const noexcept;
+  bool operator>= (const iterator &) const noexcept;
 
 private:
   friend class Slice;
@@ -279,56 +289,58 @@ private:
 };
 
 #if __cplusplus >= 202002L
-static_assert(std::ranges::contiguous_range<rust::Slice<const uint8_t>>);
-static_assert(std::contiguous_iterator<rust::Slice<const uint8_t>::iterator>);
+static_assert (std::ranges::contiguous_range<rust::Slice<const uint8_t>>);
+static_assert (std::contiguous_iterator<rust::Slice<const uint8_t>::iterator>);
 #endif
 
 #endif // CXXBRIDGE1_RUST_SLICE
 
 #ifndef CXXBRIDGE1_RUST_BOX
 // https://cxx.rs/binding/box.html
-template <typename T>
-class Box final {
+template <typename T> class Box final
+{
 public:
   using element_type = T;
-  using const_pointer =
-      typename std::add_pointer<typename std::add_const<T>::type>::type;
+  using const_pointer = typename std::add_pointer<typename std::add_const<T>::type>::type;
   using pointer = typename std::add_pointer<T>::type;
 
-  Box() = delete;
-  Box(Box &&) noexcept;
-  ~Box() noexcept;
+  Box () = delete;
+  Box (Box &&) noexcept;
+  ~Box () noexcept;
 
-  explicit Box(const T &);
-  explicit Box(T &&);
+  explicit Box (const T &);
+  explicit Box (T &&);
 
-  Box &operator=(Box &&) & noexcept;
+  Box &operator= (Box &&) & noexcept;
 
   const T *operator->() const noexcept;
-  const T &operator*() const noexcept;
+  const T &operator* () const noexcept;
   T *operator->() noexcept;
-  T &operator*() noexcept;
+  T &operator* () noexcept;
 
-  template <typename... Fields>
-  static Box in_place(Fields &&...);
+  template <typename... Fields> static Box in_place (Fields &&...);
 
-  void swap(Box &) noexcept;
+  void swap (Box &) noexcept;
 
   // Important: requires that `raw` came from an into_raw call. Do not pass a
   // pointer from `new` or any other source.
-  static Box from_raw(T *) noexcept;
+  static Box from_raw (T *) noexcept;
 
-  T *into_raw() noexcept;
+  T *into_raw () noexcept;
 
   /* Deprecated */ using value_type = element_type;
 
 private:
   class uninit;
   class allocation;
-  Box(uninit) noexcept;
-  void drop() noexcept;
+  Box (uninit) noexcept;
+  void drop () noexcept;
 
-  friend void swap(Box &lhs, Box &rhs) noexcept { lhs.swap(rhs); }
+  friend void
+  swap (Box &lhs, Box &rhs) noexcept
+  {
+    lhs.swap (rhs);
+  }
 
   T *ptr;
 };
@@ -336,65 +348,68 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_VEC
 // https://cxx.rs/binding/vec.html
-template <typename T>
-class Vec final {
+template <typename T> class Vec final
+{
 public:
   using value_type = T;
 
-  Vec() noexcept;
-  Vec(std::initializer_list<T>);
-  Vec(const Vec &);
-  Vec(Vec &&) noexcept;
-  ~Vec() noexcept;
+  Vec () noexcept;
+  Vec (std::initializer_list<T>);
+  Vec (const Vec &);
+  Vec (Vec &&) noexcept;
+  ~Vec () noexcept;
 
-  Vec &operator=(Vec &&) & noexcept;
-  Vec &operator=(const Vec &) &;
+  Vec &operator= (Vec &&) & noexcept;
+  Vec &operator= (const Vec &) &;
 
-  std::size_t size() const noexcept;
-  bool empty() const noexcept;
-  const T *data() const noexcept;
-  T *data() noexcept;
-  std::size_t capacity() const noexcept;
+  std::size_t size () const noexcept;
+  bool empty () const noexcept;
+  const T *data () const noexcept;
+  T *data () noexcept;
+  std::size_t capacity () const noexcept;
 
-  const T &operator[](std::size_t n) const noexcept;
-  const T &at(std::size_t n) const;
-  const T &front() const noexcept;
-  const T &back() const noexcept;
+  const T &operator[] (std::size_t n) const noexcept;
+  const T &at (std::size_t n) const;
+  const T &front () const noexcept;
+  const T &back () const noexcept;
 
-  T &operator[](std::size_t n) noexcept;
-  T &at(std::size_t n);
-  T &front() noexcept;
-  T &back() noexcept;
+  T &operator[] (std::size_t n) noexcept;
+  T &at (std::size_t n);
+  T &front () noexcept;
+  T &back () noexcept;
 
-  void reserve(std::size_t new_cap);
-  void push_back(const T &value);
-  void push_back(T &&value);
-  template <typename... Args>
-  void emplace_back(Args &&...args);
-  void truncate(std::size_t len);
-  void clear();
+  void reserve (std::size_t new_cap);
+  void push_back (const T &value);
+  void push_back (T &&value);
+  template <typename... Args> void emplace_back (Args &&...args);
+  void truncate (std::size_t len);
+  void clear ();
 
   using iterator = typename Slice<T>::iterator;
-  iterator begin() noexcept;
-  iterator end() noexcept;
+  iterator begin () noexcept;
+  iterator end () noexcept;
 
   using const_iterator = typename Slice<const T>::iterator;
-  const_iterator begin() const noexcept;
-  const_iterator end() const noexcept;
-  const_iterator cbegin() const noexcept;
-  const_iterator cend() const noexcept;
+  const_iterator begin () const noexcept;
+  const_iterator end () const noexcept;
+  const_iterator cbegin () const noexcept;
+  const_iterator cend () const noexcept;
 
-  void swap(Vec &) noexcept;
+  void swap (Vec &) noexcept;
 
   // Internal API only intended for the cxxbridge code generator.
-  Vec(unsafe_bitcopy_t, const Vec &) noexcept;
+  Vec (unsafe_bitcopy_t, const Vec &) noexcept;
 
 private:
-  void reserve_total(std::size_t new_cap) noexcept;
-  void set_len(std::size_t len) noexcept;
-  void drop() noexcept;
+  void reserve_total (std::size_t new_cap) noexcept;
+  void set_len (std::size_t len) noexcept;
+  void drop () noexcept;
 
-  friend void swap(Vec &lhs, Vec &rhs) noexcept { lhs.swap(rhs); }
+  friend void
+  swap (Vec &lhs, Vec &rhs) noexcept
+  {
+    lhs.swap (rhs);
+  }
 
   // Size and alignment statically verified by rust_vec.rs.
   std::array<std::uintptr_t, 3> repr;
@@ -403,17 +418,16 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_FN
 // https://cxx.rs/binding/fn.html
-template <typename Signature>
-class Fn;
+template <typename Signature> class Fn;
 
-template <typename Ret, typename... Args>
-class Fn<Ret(Args...)> final {
+template <typename Ret, typename... Args> class Fn<Ret (Args...)> final
+{
 public:
-  Ret operator()(Args... args) const noexcept;
-  Fn operator*() const noexcept;
+  Ret operator() (Args... args) const noexcept;
+  Fn operator* () const noexcept;
 
 private:
-  Ret (*trampoline)(Args..., void *fn) noexcept;
+  Ret (*trampoline) (Args..., void *fn) noexcept;
   void *fn;
 };
 #endif // CXXBRIDGE1_RUST_FN
@@ -421,19 +435,20 @@ private:
 #ifndef CXXBRIDGE1_RUST_ERROR
 #define CXXBRIDGE1_RUST_ERROR
 // https://cxx.rs/binding/result.html
-class Error final : public std::exception {
+class Error final : public std::exception
+{
 public:
-  Error(const Error &);
-  Error(Error &&) noexcept;
-  ~Error() noexcept override;
+  Error (const Error &);
+  Error (Error &&) noexcept;
+  ~Error () noexcept override;
 
-  Error &operator=(const Error &) &;
-  Error &operator=(Error &&) & noexcept;
+  Error &operator= (const Error &) &;
+  Error &operator= (Error &&) & noexcept;
 
-  const char *what() const noexcept override;
+  const char *what () const noexcept override;
 
 private:
-  Error() noexcept = default;
+  Error () noexcept = default;
   friend impl<Error>;
   const char *msg;
   std::size_t len;
@@ -449,24 +464,23 @@ using isize = ssize_t;
 #endif
 #endif // CXXBRIDGE1_RUST_ISIZE
 
-std::ostream &operator<<(std::ostream &, const String &);
-std::ostream &operator<<(std::ostream &, const Str &);
+std::ostream &operator<< (std::ostream &, const String &);
+std::ostream &operator<< (std::ostream &, const Str &);
 
 #ifndef CXXBRIDGE1_RUST_OPAQUE
 #define CXXBRIDGE1_RUST_OPAQUE
 // Base class of generated opaque Rust types.
-class Opaque {
+class Opaque
+{
 public:
-  Opaque() = delete;
-  Opaque(const Opaque &) = delete;
-  ~Opaque() = delete;
+  Opaque () = delete;
+  Opaque (const Opaque &) = delete;
+  ~Opaque () = delete;
 };
 #endif // CXXBRIDGE1_RUST_OPAQUE
 
-template <typename T>
-std::size_t size_of();
-template <typename T>
-std::size_t align_of();
+template <typename T> std::size_t size_of ();
+template <typename T> std::size_t align_of ();
 
 // IsRelocatable<T> is used in assertions that a C++ type passed by value
 // between Rust and C++ is soundly relocatable by Rust.
@@ -486,8 +500,7 @@ std::size_t align_of();
 //      --- otherwise:
 //    + template <>
 //    + struct rust::IsRelocatable<MyType> : std::true_type {};
-template <typename T>
-struct IsRelocatable;
+template <typename T> struct IsRelocatable;
 
 using u8 = std::uint8_t;
 using u16 = std::uint16_t;
@@ -504,46 +517,43 @@ using f64 = double;
 // Snake case aliases for use in code that uses this style for type names.
 using string = String;
 using str = Str;
-template <typename T>
-using slice = Slice<T>;
-template <typename T>
-using box = Box<T>;
-template <typename T>
-using vec = Vec<T>;
+template <typename T> using slice = Slice<T>;
+template <typename T> using box = Box<T>;
+template <typename T> using vec = Vec<T>;
 using error = Error;
-template <typename Signature>
-using fn = Fn<Signature>;
-template <typename T>
-using is_relocatable = IsRelocatable<T>;
-
-
+template <typename Signature> using fn = Fn<Signature>;
+template <typename T> using is_relocatable = IsRelocatable<T>;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// end public API, begin implementation details
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception>
-void panic [[noreturn]] (const char *msg);
+template <typename Exception> void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 #ifndef CXXBRIDGE1_RUST_FN
 #define CXXBRIDGE1_RUST_FN
 template <typename Ret, typename... Args>
-Ret Fn<Ret(Args...)>::operator()(Args... args) const noexcept {
-  return (*this->trampoline)(std::forward<Args>(args)..., this->fn);
+Ret
+Fn<Ret (Args...)>::operator() (Args... args) const noexcept
+{
+  return (*this->trampoline) (std::forward<Args> (args)..., this->fn);
 }
 
 template <typename Ret, typename... Args>
-Fn<Ret(Args...)> Fn<Ret(Args...)>::operator*() const noexcept {
+Fn<Ret (Args...)>
+Fn<Ret (Args...)>::operator* () const noexcept
+{
   return *this;
 }
 #endif // CXXBRIDGE1_RUST_FN
 
 #ifndef CXXBRIDGE1_RUST_BITCOPY_T
 #define CXXBRIDGE1_RUST_BITCOPY_T
-struct unsafe_bitcopy_t final {
-  explicit unsafe_bitcopy_t() = default;
+struct unsafe_bitcopy_t final
+{
+  explicit unsafe_bitcopy_t () = default;
 };
 #endif // CXXBRIDGE1_RUST_BITCOPY_T
 
@@ -554,595 +564,717 @@ constexpr unsafe_bitcopy_t unsafe_bitcopy{};
 
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
-template <typename T>
-Slice<T>::Slice() noexcept {
-  sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
+template <typename T> Slice<T>::Slice () noexcept
+{
+  sliceInit (this, reinterpret_cast<void *> (align_of<T> ()), 0);
+}
+
+template <typename T> Slice<T>::Slice (T *s, std::size_t count) noexcept
+{
+  assert (s != nullptr || count == 0);
+  sliceInit (this,
+             s == nullptr && count == 0 ? reinterpret_cast<void *> (align_of<T> ())
+                                        : const_cast<typename std::remove_const<T>::type *> (s),
+             count);
 }
 
 template <typename T>
-Slice<T>::Slice(T *s, std::size_t count) noexcept {
-  assert(s != nullptr || count == 0);
-  sliceInit(this,
-            s == nullptr && count == 0
-                ? reinterpret_cast<void *>(align_of<T>())
-                : const_cast<typename std::remove_const<T>::type *>(s),
-            count);
+T *
+Slice<T>::data () const noexcept
+{
+  return reinterpret_cast<T *> (slicePtr (this));
 }
 
 template <typename T>
-T *Slice<T>::data() const noexcept {
-  return reinterpret_cast<T *>(slicePtr(this));
+std::size_t
+Slice<T>::size () const noexcept
+{
+  return sliceLen (this);
 }
 
 template <typename T>
-std::size_t Slice<T>::size() const noexcept {
-  return sliceLen(this);
+std::size_t
+Slice<T>::length () const noexcept
+{
+  return this->size ();
 }
 
 template <typename T>
-std::size_t Slice<T>::length() const noexcept {
-  return this->size();
+bool
+Slice<T>::empty () const noexcept
+{
+  return this->size () == 0;
 }
 
 template <typename T>
-bool Slice<T>::empty() const noexcept {
-  return this->size() == 0;
+T &
+Slice<T>::operator[] (std::size_t n) const noexcept
+{
+  assert (n < this->size ());
+  auto ptr = static_cast<char *> (slicePtr (this)) + size_of<T> () * n;
+  return *reinterpret_cast<T *> (ptr);
 }
 
 template <typename T>
-T &Slice<T>::operator[](std::size_t n) const noexcept {
-  assert(n < this->size());
-  auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
-  return *reinterpret_cast<T *>(ptr);
-}
-
-template <typename T>
-T &Slice<T>::at(std::size_t n) const {
-  if (n >= this->size()) {
-    panic<std::out_of_range>("rust::Slice index out of range");
-  }
+T &
+Slice<T>::at (std::size_t n) const
+{
+  if (n >= this->size ())
+    {
+      panic<std::out_of_range> ("rust::Slice index out of range");
+    }
   return (*this)[n];
 }
 
 template <typename T>
-T &Slice<T>::front() const noexcept {
-  assert(!this->empty());
+T &
+Slice<T>::front () const noexcept
+{
+  assert (!this->empty ());
   return (*this)[0];
 }
 
 template <typename T>
-T &Slice<T>::back() const noexcept {
-  assert(!this->empty());
-  return (*this)[this->size() - 1];
+T &
+Slice<T>::back () const noexcept
+{
+  assert (!this->empty ());
+  return (*this)[this->size () - 1];
 }
 
 template <typename T>
 typename Slice<T>::iterator::reference
-Slice<T>::iterator::operator*() const noexcept {
-  return *static_cast<T *>(this->pos);
+Slice<T>::iterator::operator* () const noexcept
+{
+  return *static_cast<T *> (this->pos);
 }
 
 template <typename T>
 typename Slice<T>::iterator::pointer
-Slice<T>::iterator::operator->() const noexcept {
-  return static_cast<T *>(this->pos);
+Slice<T>::iterator::operator->() const noexcept
+{
+  return static_cast<T *> (this->pos);
 }
 
 template <typename T>
-typename Slice<T>::iterator::reference Slice<T>::iterator::operator[](
-    typename Slice<T>::iterator::difference_type n) const noexcept {
-  auto ptr = static_cast<char *>(this->pos) + this->stride * n;
-  return *reinterpret_cast<T *>(ptr);
+typename Slice<T>::iterator::reference
+Slice<T>::iterator::operator[] (typename Slice<T>::iterator::difference_type n) const noexcept
+{
+  auto ptr = static_cast<char *> (this->pos) + this->stride * n;
+  return *reinterpret_cast<T *> (ptr);
 }
 
 template <typename T>
-typename Slice<T>::iterator &Slice<T>::iterator::operator++() noexcept {
-  this->pos = static_cast<char *>(this->pos) + this->stride;
+typename Slice<T>::iterator &
+Slice<T>::iterator::operator++ () noexcept
+{
+  this->pos = static_cast<char *> (this->pos) + this->stride;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::iterator::operator++(int) noexcept {
-  auto ret = iterator(*this);
-  this->pos = static_cast<char *>(this->pos) + this->stride;
+typename Slice<T>::iterator
+Slice<T>::iterator::operator++ (int) noexcept
+{
+  auto ret = iterator (*this);
+  this->pos = static_cast<char *> (this->pos) + this->stride;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator &Slice<T>::iterator::operator--() noexcept {
-  this->pos = static_cast<char *>(this->pos) - this->stride;
+typename Slice<T>::iterator &
+Slice<T>::iterator::operator-- () noexcept
+{
+  this->pos = static_cast<char *> (this->pos) - this->stride;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::iterator::operator--(int) noexcept {
-  auto ret = iterator(*this);
-  this->pos = static_cast<char *>(this->pos) - this->stride;
+typename Slice<T>::iterator
+Slice<T>::iterator::operator-- (int) noexcept
+{
+  auto ret = iterator (*this);
+  this->pos = static_cast<char *> (this->pos) - this->stride;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator &Slice<T>::iterator::operator+=(
-    typename Slice<T>::iterator::difference_type n) noexcept {
-  this->pos = static_cast<char *>(this->pos) + this->stride * n;
+typename Slice<T>::iterator &
+Slice<T>::iterator::operator+= (typename Slice<T>::iterator::difference_type n) noexcept
+{
+  this->pos = static_cast<char *> (this->pos) + this->stride * n;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator &Slice<T>::iterator::operator-=(
-    typename Slice<T>::iterator::difference_type n) noexcept {
-  this->pos = static_cast<char *>(this->pos) - this->stride * n;
+typename Slice<T>::iterator &
+Slice<T>::iterator::operator-= (typename Slice<T>::iterator::difference_type n) noexcept
+{
+  this->pos = static_cast<char *> (this->pos) - this->stride * n;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::iterator::operator+(
-    typename Slice<T>::iterator::difference_type n) const noexcept {
-  auto ret = iterator(*this);
-  ret.pos = static_cast<char *>(this->pos) + this->stride * n;
+typename Slice<T>::iterator
+Slice<T>::iterator::operator+ (typename Slice<T>::iterator::difference_type n) const noexcept
+{
+  auto ret = iterator (*this);
+  ret.pos = static_cast<char *> (this->pos) + this->stride * n;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::iterator::operator-(
-    typename Slice<T>::iterator::difference_type n) const noexcept {
-  auto ret = iterator(*this);
-  ret.pos = static_cast<char *>(this->pos) - this->stride * n;
+typename Slice<T>::iterator
+Slice<T>::iterator::operator- (typename Slice<T>::iterator::difference_type n) const noexcept
+{
+  auto ret = iterator (*this);
+  ret.pos = static_cast<char *> (this->pos) - this->stride * n;
   return ret;
 }
 
 template <typename T>
 typename Slice<T>::iterator::difference_type
-Slice<T>::iterator::operator-(const iterator &other) const noexcept {
-  auto diff = std::distance(static_cast<char *>(other.pos),
-                            static_cast<char *>(this->pos));
-  return diff / static_cast<typename Slice<T>::iterator::difference_type>(
-                    this->stride);
+Slice<T>::iterator::operator- (const iterator &other) const noexcept
+{
+  auto diff = std::distance (static_cast<char *> (other.pos), static_cast<char *> (this->pos));
+  return diff / static_cast<typename Slice<T>::iterator::difference_type> (this->stride);
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator==(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator== (const iterator &other) const noexcept
+{
   return this->pos == other.pos;
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator!=(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator!= (const iterator &other) const noexcept
+{
   return this->pos != other.pos;
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator<(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator< (const iterator &other) const noexcept
+{
   return this->pos < other.pos;
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator<=(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator<= (const iterator &other) const noexcept
+{
   return this->pos <= other.pos;
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator>(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator> (const iterator &other) const noexcept
+{
   return this->pos > other.pos;
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator>=(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator>= (const iterator &other) const noexcept
+{
   return this->pos >= other.pos;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::begin() const noexcept {
+typename Slice<T>::iterator
+Slice<T>::begin () const noexcept
+{
   iterator it;
-  it.pos = slicePtr(this);
-  it.stride = size_of<T>();
+  it.pos = slicePtr (this);
+  it.stride = size_of<T> ();
   return it;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::end() const noexcept {
-  iterator it = this->begin();
-  it.pos = static_cast<char *>(it.pos) + it.stride * this->size();
+typename Slice<T>::iterator
+Slice<T>::end () const noexcept
+{
+  iterator it = this->begin ();
+  it.pos = static_cast<char *> (it.pos) + it.stride * this->size ();
   return it;
 }
 
 template <typename T>
-void Slice<T>::swap(Slice &rhs) noexcept {
-  std::swap(*this, rhs);
+void
+Slice<T>::swap (Slice &rhs) noexcept
+{
+  std::swap (*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
 
 #ifndef CXXBRIDGE1_RUST_BOX
 #define CXXBRIDGE1_RUST_BOX
-template <typename T>
-class Box<T>::uninit {};
+template <typename T> class Box<T>::uninit
+{
+};
 
-template <typename T>
-class Box<T>::allocation {
-  static T *alloc() noexcept;
-  static void dealloc(T *) noexcept;
+template <typename T> class Box<T>::allocation
+{
+  static T *alloc () noexcept;
+  static void dealloc (T *) noexcept;
 
 public:
-  allocation() noexcept : ptr(alloc()) {}
-  ~allocation() noexcept {
-    if (this->ptr) {
-      dealloc(this->ptr);
-    }
+  allocation () noexcept : ptr (alloc ()) {}
+  ~allocation () noexcept
+  {
+    if (this->ptr)
+      {
+        dealloc (this->ptr);
+      }
   }
   T *ptr;
 };
 
-template <typename T>
-Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
-  other.ptr = nullptr;
-}
+template <typename T> Box<T>::Box (Box &&other) noexcept : ptr (other.ptr) { other.ptr = nullptr; }
 
-template <typename T>
-Box<T>::Box(const T &val) {
+template <typename T> Box<T>::Box (const T &val)
+{
   allocation alloc;
-  ::new (alloc.ptr) T(val);
+  ::new (alloc.ptr) T (val);
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(T &&val) {
+template <typename T> Box<T>::Box (T &&val)
+{
   allocation alloc;
-  ::new (alloc.ptr) T(std::move(val));
+  ::new (alloc.ptr) T (std::move (val));
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::~Box() noexcept {
-  if (this->ptr) {
-    this->drop();
-  }
+template <typename T> Box<T>::~Box () noexcept
+{
+  if (this->ptr)
+    {
+      this->drop ();
+    }
 }
 
 template <typename T>
-Box<T> &Box<T>::operator=(Box &&other) & noexcept {
-  if (this->ptr) {
-    this->drop();
-  }
+Box<T> &
+Box<T>::operator= (Box &&other) & noexcept
+{
+  if (this->ptr)
+    {
+      this->drop ();
+    }
   this->ptr = other.ptr;
   other.ptr = nullptr;
   return *this;
 }
 
 template <typename T>
-const T *Box<T>::operator->() const noexcept {
+const T *
+Box<T>::operator->() const noexcept
+{
   return this->ptr;
 }
 
 template <typename T>
-const T &Box<T>::operator*() const noexcept {
+const T &
+Box<T>::operator* () const noexcept
+{
   return *this->ptr;
 }
 
 template <typename T>
-T *Box<T>::operator->() noexcept {
+T *
+Box<T>::operator->() noexcept
+{
   return this->ptr;
 }
 
 template <typename T>
-T &Box<T>::operator*() noexcept {
+T &
+Box<T>::operator* () noexcept
+{
   return *this->ptr;
 }
 
 template <typename T>
 template <typename... Fields>
-Box<T> Box<T>::in_place(Fields &&...fields) {
+Box<T>
+Box<T>::in_place (Fields &&...fields)
+{
   allocation alloc;
   auto ptr = alloc.ptr;
-  ::new (ptr) T{std::forward<Fields>(fields)...};
+  ::new (ptr) T{ std::forward<Fields> (fields)... };
   alloc.ptr = nullptr;
-  return from_raw(ptr);
+  return from_raw (ptr);
 }
 
 template <typename T>
-void Box<T>::swap(Box &rhs) noexcept {
+void
+Box<T>::swap (Box &rhs) noexcept
+{
   using std::swap;
-  swap(this->ptr, rhs.ptr);
+  swap (this->ptr, rhs.ptr);
 }
 
 template <typename T>
-Box<T> Box<T>::from_raw(T *raw) noexcept {
+Box<T>
+Box<T>::from_raw (T *raw) noexcept
+{
   Box box = uninit{};
   box.ptr = raw;
   return box;
 }
 
 template <typename T>
-T *Box<T>::into_raw() noexcept {
+T *
+Box<T>::into_raw () noexcept
+{
   T *raw = this->ptr;
   this->ptr = nullptr;
   return raw;
 }
 
-template <typename T>
-Box<T>::Box(uninit) noexcept {}
+template <typename T> Box<T>::Box (uninit) noexcept {}
 #endif // CXXBRIDGE1_RUST_BOX
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T>
-Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
-  this->reserve_total(init.size());
-  std::move(init.begin(), init.end(), std::back_inserter(*this));
+template <typename T> Vec<T>::Vec (std::initializer_list<T> init) : Vec{}
+{
+  this->reserve_total (init.size ());
+  std::move (init.begin (), init.end (), std::back_inserter (*this));
 }
 
-template <typename T>
-Vec<T>::Vec(const Vec &other) : Vec() {
-  this->reserve_total(other.size());
-  std::copy(other.begin(), other.end(), std::back_inserter(*this));
+template <typename T> Vec<T>::Vec (const Vec &other) : Vec ()
+{
+  this->reserve_total (other.size ());
+  std::copy (other.begin (), other.end (), std::back_inserter (*this));
 }
 
-template <typename T>
-Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
-  new (&other) Vec();
+template <typename T> Vec<T>::Vec (Vec &&other) noexcept : repr (other.repr)
+{
+  new (&other) Vec ();
 }
 
-template <typename T>
-Vec<T>::~Vec() noexcept {
-  this->drop();
-}
+template <typename T> Vec<T>::~Vec () noexcept { this->drop (); }
 
 template <typename T>
-Vec<T> &Vec<T>::operator=(Vec &&other) & noexcept {
-  this->drop();
+Vec<T> &
+Vec<T>::operator= (Vec &&other) & noexcept
+{
+  this->drop ();
   this->repr = other.repr;
-  new (&other) Vec();
+  new (&other) Vec ();
   return *this;
 }
 
 template <typename T>
-Vec<T> &Vec<T>::operator=(const Vec &other) & {
-  if (this != &other) {
-    this->drop();
-    new (this) Vec(other);
-  }
+Vec<T> &
+Vec<T>::operator= (const Vec &other) &
+{
+  if (this != &other)
+    {
+      this->drop ();
+      new (this) Vec (other);
+    }
   return *this;
 }
 
 template <typename T>
-bool Vec<T>::empty() const noexcept {
-  return this->size() == 0;
+bool
+Vec<T>::empty () const noexcept
+{
+  return this->size () == 0;
 }
 
 template <typename T>
-T *Vec<T>::data() noexcept {
-  return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
+T *
+Vec<T>::data () noexcept
+{
+  return const_cast<T *> (const_cast<const Vec<T> *> (this)->data ());
 }
 
 template <typename T>
-const T &Vec<T>::operator[](std::size_t n) const noexcept {
-  assert(n < this->size());
-  auto data = reinterpret_cast<const char *>(this->data());
-  return *reinterpret_cast<const T *>(data + n * size_of<T>());
+const T &
+Vec<T>::operator[] (std::size_t n) const noexcept
+{
+  assert (n < this->size ());
+  auto data = reinterpret_cast<const char *> (this->data ());
+  return *reinterpret_cast<const T *> (data + n * size_of<T> ());
 }
 
 template <typename T>
-const T &Vec<T>::at(std::size_t n) const {
-  if (n >= this->size()) {
-    panic<std::out_of_range>("rust::Vec index out of range");
-  }
+const T &
+Vec<T>::at (std::size_t n) const
+{
+  if (n >= this->size ())
+    {
+      panic<std::out_of_range> ("rust::Vec index out of range");
+    }
   return (*this)[n];
 }
 
 template <typename T>
-const T &Vec<T>::front() const noexcept {
-  assert(!this->empty());
+const T &
+Vec<T>::front () const noexcept
+{
+  assert (!this->empty ());
   return (*this)[0];
 }
 
 template <typename T>
-const T &Vec<T>::back() const noexcept {
-  assert(!this->empty());
-  return (*this)[this->size() - 1];
+const T &
+Vec<T>::back () const noexcept
+{
+  assert (!this->empty ());
+  return (*this)[this->size () - 1];
 }
 
 template <typename T>
-T &Vec<T>::operator[](std::size_t n) noexcept {
-  assert(n < this->size());
-  auto data = reinterpret_cast<char *>(this->data());
-  return *reinterpret_cast<T *>(data + n * size_of<T>());
+T &
+Vec<T>::operator[] (std::size_t n) noexcept
+{
+  assert (n < this->size ());
+  auto data = reinterpret_cast<char *> (this->data ());
+  return *reinterpret_cast<T *> (data + n * size_of<T> ());
 }
 
 template <typename T>
-T &Vec<T>::at(std::size_t n) {
-  if (n >= this->size()) {
-    panic<std::out_of_range>("rust::Vec index out of range");
-  }
+T &
+Vec<T>::at (std::size_t n)
+{
+  if (n >= this->size ())
+    {
+      panic<std::out_of_range> ("rust::Vec index out of range");
+    }
   return (*this)[n];
 }
 
 template <typename T>
-T &Vec<T>::front() noexcept {
-  assert(!this->empty());
+T &
+Vec<T>::front () noexcept
+{
+  assert (!this->empty ());
   return (*this)[0];
 }
 
 template <typename T>
-T &Vec<T>::back() noexcept {
-  assert(!this->empty());
-  return (*this)[this->size() - 1];
+T &
+Vec<T>::back () noexcept
+{
+  assert (!this->empty ());
+  return (*this)[this->size () - 1];
 }
 
 template <typename T>
-void Vec<T>::reserve(std::size_t new_cap) {
-  this->reserve_total(new_cap);
+void
+Vec<T>::reserve (std::size_t new_cap)
+{
+  this->reserve_total (new_cap);
 }
 
 template <typename T>
-void Vec<T>::push_back(const T &value) {
-  this->emplace_back(value);
+void
+Vec<T>::push_back (const T &value)
+{
+  this->emplace_back (value);
 }
 
 template <typename T>
-void Vec<T>::push_back(T &&value) {
-  this->emplace_back(std::move(value));
+void
+Vec<T>::push_back (T &&value)
+{
+  this->emplace_back (std::move (value));
 }
 
 template <typename T>
 template <typename... Args>
-void Vec<T>::emplace_back(Args &&...args) {
-  auto size = this->size();
-  this->reserve_total(size + 1);
-  ::new (reinterpret_cast<T *>(reinterpret_cast<char *>(this->data()) +
-                               size * size_of<T>()))
-      T(std::forward<Args>(args)...);
-  this->set_len(size + 1);
+void
+Vec<T>::emplace_back (Args &&...args)
+{
+  auto size = this->size ();
+  this->reserve_total (size + 1);
+  ::new (reinterpret_cast<T *> (reinterpret_cast<char *> (this->data ()) + size * size_of<T> ()))
+      T (std::forward<Args> (args)...);
+  this->set_len (size + 1);
 }
 
 template <typename T>
-void Vec<T>::clear() {
-  this->truncate(0);
+void
+Vec<T>::clear ()
+{
+  this->truncate (0);
 }
 
 template <typename T>
-typename Vec<T>::iterator Vec<T>::begin() noexcept {
-  return Slice<T>(this->data(), this->size()).begin();
+typename Vec<T>::iterator
+Vec<T>::begin () noexcept
+{
+  return Slice<T> (this->data (), this->size ()).begin ();
 }
 
 template <typename T>
-typename Vec<T>::iterator Vec<T>::end() noexcept {
-  return Slice<T>(this->data(), this->size()).end();
+typename Vec<T>::iterator
+Vec<T>::end () noexcept
+{
+  return Slice<T> (this->data (), this->size ()).end ();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator Vec<T>::begin() const noexcept {
-  return this->cbegin();
+typename Vec<T>::const_iterator
+Vec<T>::begin () const noexcept
+{
+  return this->cbegin ();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator Vec<T>::end() const noexcept {
-  return this->cend();
+typename Vec<T>::const_iterator
+Vec<T>::end () const noexcept
+{
+  return this->cend ();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator Vec<T>::cbegin() const noexcept {
-  return Slice<const T>(this->data(), this->size()).begin();
+typename Vec<T>::const_iterator
+Vec<T>::cbegin () const noexcept
+{
+  return Slice<const T> (this->data (), this->size ()).begin ();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
-  return Slice<const T>(this->data(), this->size()).end();
+typename Vec<T>::const_iterator
+Vec<T>::cend () const noexcept
+{
+  return Slice<const T> (this->data (), this->size ()).end ();
 }
 
 template <typename T>
-void Vec<T>::swap(Vec &rhs) noexcept {
+void
+Vec<T>::swap (Vec &rhs) noexcept
+{
   using std::swap;
-  swap(this->repr, rhs.repr);
+  swap (this->repr, rhs.repr);
 }
 
 // Internal API only intended for the cxxbridge code generator.
-template <typename T>
-Vec<T>::Vec(unsafe_bitcopy_t, const Vec &bits) noexcept : repr(bits.repr) {}
+template <typename T> Vec<T>::Vec (unsafe_bitcopy_t, const Vec &bits) noexcept : repr (bits.repr) {}
 #endif // CXXBRIDGE1_RUST_VEC
 
 #ifndef CXXBRIDGE1_IS_COMPLETE
 #define CXXBRIDGE1_IS_COMPLETE
-namespace detail {
-namespace {
-template <typename T, typename = std::size_t>
-struct is_complete : std::false_type {};
-template <typename T>
-struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
+namespace detail
+{
+namespace
+{
+template <typename T, typename = std::size_t> struct is_complete : std::false_type
+{
+};
+template <typename T> struct is_complete<T, decltype (sizeof (T))> : std::true_type
+{
+};
 } // namespace
 } // namespace detail
 #endif // CXXBRIDGE1_IS_COMPLETE
 
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
-class layout {
+class layout
+{
+  template <typename T> friend std::size_t size_of ();
+  template <typename T> friend std::size_t align_of ();
   template <typename T>
-  friend std::size_t size_of();
-  template <typename T>
-  friend std::size_t align_of();
-  template <typename T>
-  static typename std::enable_if<std::is_base_of<Opaque, T>::value,
-                                 std::size_t>::type
-  do_size_of() {
-    return T::layout::size();
+  static typename std::enable_if<std::is_base_of<Opaque, T>::value, std::size_t>::type
+  do_size_of ()
+  {
+    return T::layout::size ();
   }
   template <typename T>
-  static typename std::enable_if<!std::is_base_of<Opaque, T>::value,
-                                 std::size_t>::type
-  do_size_of() {
-    return sizeof(T);
+  static typename std::enable_if<!std::is_base_of<Opaque, T>::value, std::size_t>::type
+  do_size_of ()
+  {
+    return sizeof (T);
   }
   template <typename T>
-  static
-      typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
-      size_of() {
-    return do_size_of<T>();
+  static typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
+  size_of ()
+  {
+    return do_size_of<T> ();
   }
   template <typename T>
-  static typename std::enable_if<std::is_base_of<Opaque, T>::value,
-                                 std::size_t>::type
-  do_align_of() {
-    return T::layout::align();
+  static typename std::enable_if<std::is_base_of<Opaque, T>::value, std::size_t>::type
+  do_align_of ()
+  {
+    return T::layout::align ();
   }
   template <typename T>
-  static typename std::enable_if<!std::is_base_of<Opaque, T>::value,
-                                 std::size_t>::type
-  do_align_of() {
-    return alignof(T);
+  static typename std::enable_if<!std::is_base_of<Opaque, T>::value, std::size_t>::type
+  do_align_of ()
+  {
+    return alignof (T);
   }
   template <typename T>
-  static
-      typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
-      align_of() {
-    return do_align_of<T>();
+  static typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
+  align_of ()
+  {
+    return do_align_of<T> ();
   }
 };
 
 template <typename T>
-std::size_t size_of() {
-  return layout::size_of<T>();
+std::size_t
+size_of ()
+{
+  return layout::size_of<T> ();
 }
 
 template <typename T>
-std::size_t align_of() {
-  return layout::align_of<T>();
+std::size_t
+align_of ()
+{
+  return layout::align_of<T> ();
 }
 #endif // CXXBRIDGE1_LAYOUT
 
 #ifndef CXXBRIDGE1_RELOCATABLE
 #define CXXBRIDGE1_RELOCATABLE
-namespace detail {
-template <typename... Ts>
-struct make_void {
+namespace detail
+{
+template <typename... Ts> struct make_void
+{
   using type = void;
 };
 
-template <typename... Ts>
-using void_t = typename make_void<Ts...>::type;
+template <typename... Ts> using void_t = typename make_void<Ts...>::type;
 
-template <typename Void, template <typename...> class, typename...>
-struct detect : std::false_type {};
+template <typename Void, template <typename...> class, typename...> struct detect : std::false_type
+{
+};
 template <template <typename...> class T, typename... A>
-struct detect<void_t<T<A...>>, T, A...> : std::true_type {};
+struct detect<void_t<T<A...>>, T, A...> : std::true_type
+{
+};
 
-template <template <typename...> class T, typename... A>
-using is_detected = detect<void, T, A...>;
+template <template <typename...> class T, typename... A> using is_detected = detect<void, T, A...>;
+
+template <typename T> using detect_IsRelocatable = typename T::IsRelocatable;
 
 template <typename T>
-using detect_IsRelocatable = typename T::IsRelocatable;
-
-template <typename T>
-struct get_IsRelocatable
-    : std::is_same<typename T::IsRelocatable, std::true_type> {};
+struct get_IsRelocatable : std::is_same<typename T::IsRelocatable, std::true_type>
+{
+};
 } // namespace detail
 
 template <typename T>
 struct IsRelocatable
     : std::conditional<
-          detail::is_detected<detail::detect_IsRelocatable, T>::value,
-          detail::get_IsRelocatable<T>,
-          std::integral_constant<
-              bool, std::is_trivially_move_constructible<T>::value &&
-                        std::is_trivially_destructible<T>::value>>::type {};
+          detail::is_detected<detail::detect_IsRelocatable, T>::value, detail::get_IsRelocatable<T>,
+          std::integral_constant<bool, std::is_trivially_move_constructible<T>::value
+                                           && std::is_trivially_destructible<T>::value>>::type
+{
+};
 #endif // CXXBRIDGE1_RELOCATABLE
 
 } // namespace cxxbridge1

--- a/rust/libdnf-sys/Cargo.toml
+++ b/rust/libdnf-sys/Cargo.toml
@@ -7,17 +7,17 @@ links = "dnf"
 publish = false
 
 [dependencies]
-cxx = "1.0.158"
+cxx = "1.0.180"
 
 [lib]
 name = "libdnf_sys"
 path = "lib.rs"
 
 [build-dependencies]
-cmake = "0.1.54"
+cmake = "0.1.58"
 system-deps = "7.0"
 anyhow = "1.0"
-cxx-build = "1.0.158"
+cxx-build = "1.0.194"
 pkg-config = "0.3"
 
 # This currently needs to duplicate the libraries from libdnf

--- a/rust/rpmostree-client/Cargo.toml
+++ b/rust/rpmostree-client/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.102"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_derive = "1.0.118"
-serde_json = "1.0.140"
+serde_json = "1.0.150"

--- a/rust/src/containers_storage.rs
+++ b/rust/src/containers_storage.rs
@@ -13,9 +13,9 @@ use crate::cmdutils::CommandRunExt;
 /// and container storage operations will work reliably.
 /// https://github.com/containers/buildah/issues/5976
 pub(crate) fn reexec_if_needed() -> Result<()> {
-    use rustix::thread::{capability_is_in_bounding_set, Capability};
+    use rustix::thread::{capability_is_in_bounding_set, CapabilitySet};
     if crate::client::running_in_container()
-        && !capability_is_in_bounding_set(Capability::SystemAdmin)?
+        && !capability_is_in_bounding_set(CapabilitySet::SYS_ADMIN)?
     {
         crate::reexec::reexec_with_guardenv(
             "_RPMOSTREE_REEXEC_USERNS",

--- a/tests/build-chunked-oci/Containerfile.test
+++ b/tests/build-chunked-oci/Containerfile.test
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-bootc:41
+FROM quay.io/fedora/fedora-bootc:44
 RUN <<EORUN
 set -xeuo pipefail
 mkdir -p /var/lib/rpm-state

--- a/tests/encapsulate.sh
+++ b/tests/encapsulate.sh
@@ -9,12 +9,20 @@ rpm-ostree container-encapsulate --help >/dev/null
 tmpdir=$(mktemp -d)
 cd ${tmpdir}
 ostree --repo=repo init --mode=bare-user
-cat /etc/ostree/remotes.d/fedora.conf >> repo/config
-# Pull the ostree commit directly from the remote. We use ostree pull
-# rather than container unencapsulate because FCOS stable now ships
-# non-ostree layers for bootc compatibility.
-testref=fedora:fedora/x86_64/coreos/stable
-ostree --repo=repo pull "${testref}"
+
+# Create a minimal ostree commit to test encapsulation. The commit needs
+# a populated rpmdb (container-encapsulate uses package data to generate
+# chunked layers) and /usr/lib/modules.
+mkdir -p rootfs/usr/bin rootfs/usr/lib/modules rootfs/usr/share/rpm
+echo '#!/bin/sh' > rootfs/usr/bin/test-encapsulate
+chmod +x rootfs/usr/bin/test-encapsulate
+# Copy host rpmdb - location varies across systems
+cp /usr/share/rpm/rpmdb.sqlite rootfs/usr/share/rpm/ 2>/dev/null || \
+  cp /usr/lib/sysimage/rpm/rpmdb.sqlite rootfs/usr/share/rpm/
+testref=testref
+ostree --repo=repo commit -b "${testref}" --tree=dir=rootfs \
+  --add-metadata-string=version=1.0 \
+  --add-metadata-string=fedora-coreos.stream=stable
 # Re-pack it as a (chunked) container
 
 cat > config.json << 'EOF'


### PR DESCRIPTION
Cargo dependency updates (combines dependabot PRs #5600, #5590, #5559):

- rustix 1.0 -> 1.1, cxx 1.0.158 -> 1.0.180, tokio 1.46 -> 1.52,
anyhow, bitflags, camino, chrono, rayon, serde_json, tempfile, rand,
bytes, and others

Submodule updates (dependabot PR #5587):

- libglnx de29c5f -> ff64d52

Build fixes:

- configure.ac: Add AC_CHECK_DECLS for name_to_handle_at and
AC_CHECK_FUNCS for open_tree/openat2 needed by newer libglnx
- Regenerate cxxbridge bindings for cxx 1.0.194
- Use CapabilitySet::SYS_ADMIN for rustix 1.1 API change
- Bump GLIB_VERSION_MAX_ALLOWED to 2_76 for g_autofd warnings
- Run clang-format on regenerated rust/cxx.h

CI fixes:

- Re-enable treefile-apply tests (versionlock is a built-in dnf5
command, not a plugin — the --enableplugin=versionlock flag is a
harmless no-op)
- Switch test containers from coreos-assembler:latest (f43/glibc 2.42)
to fcos-buildroot:testing-devel (f44/glibc 2.43) to match the build
environment — updated deps require glibc 2.43 symbols
- Update compose-image test matrix from f40/f41/f42 to f43/f44
- Update build-chunked-oci Containerfile from fedora-bootc:41 to :44
- Use local ostree commit in encapsulate test instead of pulling from
remote (removes network dependency and cosa container requirement)
- Add skopeo to test dependencies

Closes #5600
Closes #5590
Closes #5587
Closes #5559