### PR TITLE
Release 2026.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl
 dnl SEE RELEASE.md FOR INSTRUCTIONS ON HOW TO DO A RELEASE.
 dnl
 m4_define([year_version], [2026])
-m4_define([release_version], [1])
+m4_define([release_version], [2])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [coreos@lists.fedoraproject.org])
 AC_CONFIG_HEADER([config.h])

--- a/packaging/rpm-ostree.spec
+++ b/packaging/rpm-ostree.spec
@@ -3,7 +3,7 @@
 
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2026.1
+Version: 2026.2
 Release: 1%{?dist}
 License: LGPL-2.0-or-later
 URL: https://github.com/coreos/rpm-ostree


### PR DESCRIPTION
```
Daniel Hast (1):
      build-chunked-oci: Add --previous-build option

Jonathan Lebon (1):
      importer: Add `/var/lib/selinux` compatibility symlink via tmpfiles.d

Joseph Marrero Corchado (21):
      rpmostreed-transaction-types: fix override reset
      sysroot_upgrade: fix off-by-one in layer pull progress display
      Fix silent upgrade failure on container systems
      deploy: Print status message on container early-return path
      packaging: Mark rpm-ostreed.conf as %config(noreplace)
      Cargo.lock: Update openssl to 0.10.79
      Update submodule: libdnf to dnf-4-master
      ci: Port test infrastructure to Fedora 44
      tests/encapsulate: Pull ostree commit directly from remote
      tests/compose: Drop lockfile args and add retry to curl
      tests/kolainst: Fix broken sysusers.d in rpmostree-openvpn test RPM
      tests/kolainst: Make misc.sh resilient to FCOS package changes
      deps: Update openssl, rustls-webpki, tar for security fixes
      tests/vmcheck: Fix override-replace-2 and layering-non-root-caps for f44
      deps: Update Cargo dependencies; Update submodule: libglnx
      deps: Fix build for libglnx + cxx updates
      deps: Fix warnings from rustix 1.1 and libglnx update
      ci: Re-enable treefile-apply tests
      deps: Run clang-format on regenerated rust/cxx.h
      ci: Switch test containers to fcos-buildroot for glibc compat
      Release 2026.2

Xiaofeng Wang (2):
      spec: Fix CentOS Stream 9 Copr build failure
      Fix "ostree-container: symlinkat: File exists" on cs9 copr build

dependabot[bot] (1):
      build(deps): bump tar from 0.4.44 to 0.4.46

renner (1):
      docs: fix typo in build-chunked-oci
```