### PR TITLE
composepost: Add subs_dist equivalency for /var/lib/selinux

### DIFF
--- a/packaging/Containerfile
+++ b/packaging/Containerfile
@@ -1,7 +1,7 @@
 # Build RPMs for rpm-ostree
 # This containerfile builds RPMs in a containerized environment.
 
-ARG base=quay.io/fedora/fedora-bootc:42
+ARG base=quay.io/fedora/fedora-bootc:44
 
 FROM scratch as src
 # For RPM builds, we need the git repository

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -419,6 +419,14 @@ fn postprocess_subs_dist(rootfs_dfd: &Dir) -> Result<()> {
                 }
                 writeln!(w, "# https://github.com/coreos/rpm-ostree/pull/1795")?;
                 writeln!(w, "/usr/lib/opt /opt")?;
+                // The SELinux policy store is moved from /var/lib/selinux to
+                // /etc/selinux (see postprocess_selinux_policy_store_location),
+                // and a compatibility symlink is created via tmpfiles.d. Add an
+                // equivalency rule so that label lookups through the old path
+                // resolve correctly.
+                // https://github.com/coreos/rpm-ostree/issues/5616
+                writeln!(w, "# https://github.com/coreos/rpm-ostree/issues/5616")?;
+                writeln!(w, "/var/lib/selinux /etc/selinux")?;
                 Ok(())
             })?;
         }

--- a/tests/compose.sh
+++ b/tests/compose.sh
@@ -50,7 +50,7 @@ if [ ! -d compose-cache ]; then
   # default; we'll want it to test `install-langs`. This also means that we have
   # to add updates-archive to the repo list.
   # Also neuter OSTree layers; we don't re-implement cosa's auto-layering sugar
-  curl -Lf --retry 3 -O https://src.fedoraproject.org/rpms/fedora-repos/raw/f42/f/fedora-updates-archive.repo
+  curl -Lf --retry 3 -O https://src.fedoraproject.org/rpms/fedora-repos/raw/f44/f/fedora-updates-archive.repo
   python3 -c '
 import sys, json
 y = json.load(sys.stdin)

--- a/tests/compose/libbasic-test.sh
+++ b/tests/compose/libbasic-test.sh
@@ -38,6 +38,8 @@ ostree --repo=${repo} cat ${treeref} \
   /usr/etc/selinux/targeted/contexts/files/file_contexts.subs_dist > subs_dist.txt
 assert_not_file_has_content subs_dist.txt '^/var/home \+'
 assert_file_has_content subs_dist.txt '^/home \+/var/home$'
+# https://github.com/coreos/rpm-ostree/issues/5616
+assert_file_has_content subs_dist.txt '^/var/lib/selinux \+/etc/selinux$'
 echo "ok etc/default/useradd"
 
 for path in /usr/share/rpm /usr/lib/sysimage/rpm-ostree-base-db; do


### PR DESCRIPTION
Since PR #5572, a tmpfiles.d symlink /var/lib/selinux -> ../../etc/selinux is created at boot. Without a corresponding file_contexts.subs_dist entry, SELinux label lookups through the old /var/lib/selinux path hit the catch-all rule (/var/lib/selinux(/.*)? -> semanage_store_t) instead of the more specific /etc/selinux rules. This causes AVC denials when daemons like dbus-broker-launch traverse the symlink to access contexts/dbus_contexts.

Add /var/lib/selinux /etc/selinux to subs_dist so that label lookups through the symlink path are substituted to the canonical /etc/selinux path, matching the correct file_contexts rules.

Closes: https://github.com/coreos/rpm-ostree/issues/5616

Assisted by: AI.
