### PR TITLE
Support relocated repo configs and GPG keys (Fedora 45+)

### DIFF
--- a/docs/treefile.md
+++ b/docs/treefile.md
@@ -36,8 +36,9 @@ It supports the following parameters:
    use, from any files that end in `.repo`, in the same directory as
    the treefile. If missing, all yum repos enabled by default are used.
    `rpm-ostree compose tree` does not use the system
-   `/etc/yum.repos.d`, because it's common to want to compose a target
-   system distinct from the one the host sytem is running.
+   repository configuration directories, because it's common to want
+   to compose a target system distinct from the one the host sytem
+   is running.
 
  * `selinux`: boolean, optional: Defaults to `true`.  If `false`, then
    no SELinux labeling will be performed on the server side.

--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -222,8 +222,8 @@ Boston, MA 02111-1307, USA.
         <listitem>
           <para>
             Takes one or more packages as arguments. The packages are
-            fetched from the enabled repositories in
-            <filename>/etc/yum.repos.d/</filename> and are overlayed on
+            fetched from the enabled repositories in the system
+            repository configuration directories and are overlayed on
             top of a new deployment.  It is also possible to specify a
             local RPM package that resides on the host. Overlayed
             packages can later be removed with the
@@ -310,8 +310,8 @@ Boston, MA 02111-1307, USA.
             Takes one or more packages as arguments. The packages are
             removed from the set of packages that are currently
             overlayed. The remaining packages in the set (if any) are
-            fetched from the enabled repositories in
-            <filename>/etc/yum.repos.d/</filename> and are overlayed on
+            fetched from the enabled repositories in the system
+            repository configuration directories and are overlayed on
             top of a new deployment.
           </para>
 
@@ -334,8 +334,8 @@ Boston, MA 02111-1307, USA.
         <listitem>
           <para>
             Takes one or more query terms as arguments. The packages are
-            searched within the enabled repositories in
-            <filename>/etc/yum.repos.d/</filename>. Packages can be
+            searched within the enabled repositories in the system
+            repository configuration directories. Packages can be
             overlayed and removed using the <command>install</command>
             and <command>uninstall</command> commands.
           </para>
@@ -519,8 +519,8 @@ Boston, MA 02111-1307, USA.
             <option>--check</option> to just check if an upgrade is
             available, without downloading it or performing a
             package-level diff.  Using this flag will force an update
-            of the RPM metadata from the enabled repos in
-            <filename>/etc/yum.repos.d/</filename>, if there are any
+            of the RPM metadata from the enabled repos in the system
+            repository configuration directories, if there are any
             layered packages.
           </para>
 
@@ -911,14 +911,17 @@ $ systemctl start postgresql  # Some setup required
     <title>Repository configuration and GPG keys</title>
 
     <para>
-      rpm-ostree uses the libdnf shared library, which honors <literal>/etc/yum.repos.d</literal>.
+      rpm-ostree uses the libdnf shared library, which honors both
+      <literal>/etc/yum.repos.d</literal> (for user configuration) and
+      <literal>/usr/share/dnf5/repos.d</literal> (for distribution-provided configuration).
       Note that rpm-md (yum/dnf) repositories are only checked if client-side package layering is
       enabled.
     </para>
 
     <para>
       However, the behavior for GPG keys is slightly different from a traditional <command>rpm</command>
-      system.  Essentially, all GPG keys in <literal>/etc/pki/rpm-gpg</literal> are loaded and trusted.
+      system.  Essentially, all GPG keys in <literal>/etc/pki/rpm-gpg</literal> and
+      <literal>/usr/share/pki/rpm-gpg</literal> are loaded and trusted.
       The <literal>.repo</literal> file should reference the file path in there.
     </para>
     <para>

--- a/rpmostree-cxxrs.cxx
+++ b/rpmostree-cxxrs.cxx
@@ -1,16 +1,15 @@
-#include "src/libpriv/rpmostree-cxxrs-prelude.h"
+#include "rpmostree-cxxrs.h"
+#include "rpmostree-clientlib.h"
 #include "rpmostree-container.hpp"
 #include "rpmostree-cxxrsutil.hpp"
-#include "rpmostree-util.h"
-#include "rpmostreemain.h"
-#include "rpmostree-clientlib.h"
 #include "rpmostree-diff.hpp"
 #include "rpmostree-libbuiltin.h"
-#include "rpmostree-util.h"
 #include "rpmostree-output.h"
-#include "rpmostree-rpm-util.h"
 #include "rpmostree-package-variants.h"
-#include "rpmostree-cxxrs.h"
+#include "rpmostree-rpm-util.h"
+#include "rpmostree-util.h"
+#include "rpmostreemain.h"
+#include "src/libpriv/rpmostree-cxxrs-prelude.h"
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -40,94 +39,98 @@
 #endif // __clang__
 #endif // __GNUC__
 
-namespace rust {
-inline namespace cxxbridge1 {
+namespace rust
+{
+inline namespace cxxbridge1
+{
 // #include "rust/cxx.h"
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception>
-void panic [[noreturn]] (const char *msg);
+template <typename Exception> void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 struct unsafe_bitcopy_t;
 
-namespace {
-template <typename T>
-class impl;
+namespace
+{
+template <typename T> class impl;
 } // namespace
 
-template <typename T>
-::std::size_t size_of();
-template <typename T>
-::std::size_t align_of();
+template <typename T>::std::size_t size_of ();
+template <typename T>::std::size_t align_of ();
 
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
-class String final {
+class String final
+{
 public:
-  String() noexcept;
-  String(const String &) noexcept;
-  String(String &&) noexcept;
-  ~String() noexcept;
+  String () noexcept;
+  String (const String &) noexcept;
+  String (String &&) noexcept;
+  ~String () noexcept;
 
-  String(const std::string &);
-  String(const char *);
-  String(const char *, std::size_t);
-  String(const char16_t *);
-  String(const char16_t *, std::size_t);
+  String (const std::string &);
+  String (const char *);
+  String (const char *, std::size_t);
+  String (const char16_t *);
+  String (const char16_t *, std::size_t);
 #ifdef __cpp_char8_t
-  String(const char8_t *s);
-  String(const char8_t *s, std::size_t len);
+  String (const char8_t *s);
+  String (const char8_t *s, std::size_t len);
 #endif
 
-  static String lossy(const std::string &) noexcept;
-  static String lossy(const char *) noexcept;
-  static String lossy(const char *, std::size_t) noexcept;
-  static String lossy(const char16_t *) noexcept;
-  static String lossy(const char16_t *, std::size_t) noexcept;
+  static String lossy (const std::string &) noexcept;
+  static String lossy (const char *) noexcept;
+  static String lossy (const char *, std::size_t) noexcept;
+  static String lossy (const char16_t *) noexcept;
+  static String lossy (const char16_t *, std::size_t) noexcept;
 
-  String &operator=(const String &) & noexcept;
-  String &operator=(String &&) & noexcept;
+  String &operator= (const String &) & noexcept;
+  String &operator= (String &&) & noexcept;
 
-  explicit operator std::string() const;
+  explicit operator std::string () const;
 
-  const char *data() const noexcept;
-  std::size_t size() const noexcept;
-  std::size_t length() const noexcept;
-  bool empty() const noexcept;
+  const char *data () const noexcept;
+  std::size_t size () const noexcept;
+  std::size_t length () const noexcept;
+  bool empty () const noexcept;
 
-  const char *c_str() noexcept;
+  const char *c_str () noexcept;
 
-  std::size_t capacity() const noexcept;
-  void reserve(size_t new_cap) noexcept;
+  std::size_t capacity () const noexcept;
+  void reserve (size_t new_cap) noexcept;
 
   using iterator = char *;
-  iterator begin() noexcept;
-  iterator end() noexcept;
+  iterator begin () noexcept;
+  iterator end () noexcept;
 
   using const_iterator = const char *;
-  const_iterator begin() const noexcept;
-  const_iterator end() const noexcept;
-  const_iterator cbegin() const noexcept;
-  const_iterator cend() const noexcept;
+  const_iterator begin () const noexcept;
+  const_iterator end () const noexcept;
+  const_iterator cbegin () const noexcept;
+  const_iterator cend () const noexcept;
 
-  bool operator==(const String &) const noexcept;
-  bool operator!=(const String &) const noexcept;
-  bool operator<(const String &) const noexcept;
-  bool operator<=(const String &) const noexcept;
-  bool operator>(const String &) const noexcept;
-  bool operator>=(const String &) const noexcept;
+  bool operator== (const String &) const noexcept;
+  bool operator!= (const String &) const noexcept;
+  bool operator< (const String &) const noexcept;
+  bool operator<= (const String &) const noexcept;
+  bool operator> (const String &) const noexcept;
+  bool operator>= (const String &) const noexcept;
 
-  void swap(String &) noexcept;
+  void swap (String &) noexcept;
 
-  String(unsafe_bitcopy_t, const String &) noexcept;
+  String (unsafe_bitcopy_t, const String &) noexcept;
 
 private:
   struct lossy_t;
-  String(lossy_t, const char *, std::size_t) noexcept;
-  String(lossy_t, const char16_t *, std::size_t) noexcept;
-  friend void swap(String &lhs, String &rhs) noexcept { lhs.swap(rhs); }
+  String (lossy_t, const char *, std::size_t) noexcept;
+  String (lossy_t, const char16_t *, std::size_t) noexcept;
+  friend void
+  swap (String &lhs, String &rhs) noexcept
+  {
+    lhs.swap (rhs);
+  }
 
   std::array<std::uintptr_t, 3> repr;
 };
@@ -135,48 +138,49 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_STR
 #define CXXBRIDGE1_RUST_STR
-class Str final {
+class Str final
+{
 public:
-  Str() noexcept;
-  Str(const String &) noexcept;
-  Str(const std::string &);
-  Str(const char *);
-  Str(const char *, std::size_t);
+  Str () noexcept;
+  Str (const String &) noexcept;
+  Str (const std::string &);
+  Str (const char *);
+  Str (const char *, std::size_t);
 
-  Str &operator=(const Str &) & noexcept = default;
+  Str &operator= (const Str &) & noexcept = default;
 
-  explicit operator std::string() const;
+  explicit operator std::string () const;
 #if __cplusplus >= 201703L
-  explicit operator std::string_view() const;
+  explicit operator std::string_view () const;
 #endif
 
-  const char *data() const noexcept;
-  std::size_t size() const noexcept;
-  std::size_t length() const noexcept;
-  bool empty() const noexcept;
+  const char *data () const noexcept;
+  std::size_t size () const noexcept;
+  std::size_t length () const noexcept;
+  bool empty () const noexcept;
 
-  Str(const Str &) noexcept = default;
-  ~Str() noexcept = default;
+  Str (const Str &) noexcept = default;
+  ~Str () noexcept = default;
 
   using iterator = const char *;
   using const_iterator = const char *;
-  const_iterator begin() const noexcept;
-  const_iterator end() const noexcept;
-  const_iterator cbegin() const noexcept;
-  const_iterator cend() const noexcept;
+  const_iterator begin () const noexcept;
+  const_iterator end () const noexcept;
+  const_iterator cbegin () const noexcept;
+  const_iterator cend () const noexcept;
 
-  bool operator==(const Str &) const noexcept;
-  bool operator!=(const Str &) const noexcept;
-  bool operator<(const Str &) const noexcept;
-  bool operator<=(const Str &) const noexcept;
-  bool operator>(const Str &) const noexcept;
-  bool operator>=(const Str &) const noexcept;
+  bool operator== (const Str &) const noexcept;
+  bool operator!= (const Str &) const noexcept;
+  bool operator< (const Str &) const noexcept;
+  bool operator<= (const Str &) const noexcept;
+  bool operator> (const Str &) const noexcept;
+  bool operator>= (const Str &) const noexcept;
 
-  void swap(Str &) noexcept;
+  void swap (Str &) noexcept;
 
 private:
   class uninit;
-  Str(uninit) noexcept;
+  Str (uninit) noexcept;
   friend impl<Str>;
 
   std::array<std::uintptr_t, 2> repr;
@@ -185,72 +189,72 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
-namespace detail {
-template <bool>
-struct copy_assignable_if {};
+namespace detail
+{
+template <bool> struct copy_assignable_if
+{
+};
 
-template <>
-struct copy_assignable_if<false> {
-  copy_assignable_if() noexcept = default;
-  copy_assignable_if(const copy_assignable_if &) noexcept = default;
-  copy_assignable_if &operator=(const copy_assignable_if &) & noexcept = delete;
-  copy_assignable_if &operator=(copy_assignable_if &&) & noexcept = default;
+template <> struct copy_assignable_if<false>
+{
+  copy_assignable_if () noexcept = default;
+  copy_assignable_if (const copy_assignable_if &) noexcept = default;
+  copy_assignable_if &operator= (const copy_assignable_if &) & noexcept = delete;
+  copy_assignable_if &operator= (copy_assignable_if &&) & noexcept = default;
 };
 } // namespace detail
 
 template <typename T>
-class Slice final
-    : private detail::copy_assignable_if<std::is_const<T>::value> {
+class Slice final : private detail::copy_assignable_if<std::is_const<T>::value>
+{
 public:
   using value_type = T;
 
-  Slice() noexcept;
-  Slice(T *, std::size_t count) noexcept;
+  Slice () noexcept;
+  Slice (T *, std::size_t count) noexcept;
 
-  template <typename C>
-  explicit Slice(C &c) : Slice(c.data(), c.size()) {}
+  template <typename C> explicit Slice (C &c) : Slice (c.data (), c.size ()) {}
 
-  Slice &operator=(const Slice<T> &) & noexcept = default;
-  Slice &operator=(Slice<T> &&) & noexcept = default;
+  Slice &operator= (const Slice<T> &) & noexcept = default;
+  Slice &operator= (Slice<T> &&) & noexcept = default;
 
-  T *data() const noexcept;
-  std::size_t size() const noexcept;
-  std::size_t length() const noexcept;
-  bool empty() const noexcept;
+  T *data () const noexcept;
+  std::size_t size () const noexcept;
+  std::size_t length () const noexcept;
+  bool empty () const noexcept;
 
-  T &operator[](std::size_t n) const noexcept;
-  T &at(std::size_t n) const;
-  T &front() const noexcept;
-  T &back() const noexcept;
+  T &operator[] (std::size_t n) const noexcept;
+  T &at (std::size_t n) const;
+  T &front () const noexcept;
+  T &back () const noexcept;
 
-  Slice(const Slice<T> &) noexcept = default;
-  ~Slice() noexcept = default;
+  Slice (const Slice<T> &) noexcept = default;
+  ~Slice () noexcept = default;
 
   class iterator;
-  iterator begin() const noexcept;
-  iterator end() const noexcept;
+  iterator begin () const noexcept;
+  iterator end () const noexcept;
 
-  void swap(Slice &) noexcept;
+  void swap (Slice &) noexcept;
 
 private:
   class uninit;
-  Slice(uninit) noexcept;
+  Slice (uninit) noexcept;
   friend impl<Slice>;
-  friend void sliceInit(void *, const void *, std::size_t) noexcept;
-  friend void *slicePtr(const void *) noexcept;
-  friend std::size_t sliceLen(const void *) noexcept;
+  friend void sliceInit (void *, const void *, std::size_t) noexcept;
+  friend void *slicePtr (const void *) noexcept;
+  friend std::size_t sliceLen (const void *) noexcept;
 
   std::array<std::uintptr_t, 2> repr;
 };
 
 #ifdef __cpp_deduction_guides
 template <typename C>
-explicit Slice(C &c)
-    -> Slice<std::remove_reference_t<decltype(*std::declval<C>().data())>>;
+explicit Slice (C &c) -> Slice<std::remove_reference_t<decltype (*std::declval<C> ().data ())>>;
 #endif // __cpp_deduction_guides
 
-template <typename T>
-class Slice<T>::iterator final {
+template <typename T> class Slice<T>::iterator final
+{
 public:
 #if __cplusplus >= 202002L
   using iterator_category = std::contiguous_iterator_tag;
@@ -262,30 +266,32 @@ public:
   using pointer = typename std::add_pointer<T>::type;
   using reference = typename std::add_lvalue_reference<T>::type;
 
-  reference operator*() const noexcept;
+  reference operator* () const noexcept;
   pointer operator->() const noexcept;
-  reference operator[](difference_type) const noexcept;
+  reference operator[] (difference_type) const noexcept;
 
-  iterator &operator++() noexcept;
-  iterator operator++(int) noexcept;
-  iterator &operator--() noexcept;
-  iterator operator--(int) noexcept;
+  iterator &operator++ () noexcept;
+  iterator operator++ (int) noexcept;
+  iterator &operator-- () noexcept;
+  iterator operator-- (int) noexcept;
 
-  iterator &operator+=(difference_type) noexcept;
-  iterator &operator-=(difference_type) noexcept;
-  iterator operator+(difference_type) const noexcept;
-  friend inline iterator operator+(difference_type lhs, iterator rhs) noexcept {
+  iterator &operator+= (difference_type) noexcept;
+  iterator &operator-= (difference_type) noexcept;
+  iterator operator+ (difference_type) const noexcept;
+  friend inline iterator
+  operator+ (difference_type lhs, iterator rhs) noexcept
+  {
     return rhs + lhs;
   }
-  iterator operator-(difference_type) const noexcept;
-  difference_type operator-(const iterator &) const noexcept;
+  iterator operator- (difference_type) const noexcept;
+  difference_type operator- (const iterator &) const noexcept;
 
-  bool operator==(const iterator &) const noexcept;
-  bool operator!=(const iterator &) const noexcept;
-  bool operator<(const iterator &) const noexcept;
-  bool operator<=(const iterator &) const noexcept;
-  bool operator>(const iterator &) const noexcept;
-  bool operator>=(const iterator &) const noexcept;
+  bool operator== (const iterator &) const noexcept;
+  bool operator!= (const iterator &) const noexcept;
+  bool operator< (const iterator &) const noexcept;
+  bool operator<= (const iterator &) const noexcept;
+  bool operator> (const iterator &) const noexcept;
+  bool operator>= (const iterator &) const noexcept;
 
 private:
   friend class Slice;
@@ -294,367 +300,437 @@ private:
 };
 
 #if __cplusplus >= 202002L
-static_assert(std::ranges::contiguous_range<rust::Slice<const uint8_t>>);
-static_assert(std::contiguous_iterator<rust::Slice<const uint8_t>::iterator>);
+static_assert (std::ranges::contiguous_range<rust::Slice<const uint8_t>>);
+static_assert (std::contiguous_iterator<rust::Slice<const uint8_t>::iterator>);
 #endif
 
-template <typename T>
-Slice<T>::Slice() noexcept {
-  sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
+template <typename T> Slice<T>::Slice () noexcept
+{
+  sliceInit (this, reinterpret_cast<void *> (align_of<T> ()), 0);
+}
+
+template <typename T> Slice<T>::Slice (T *s, std::size_t count) noexcept
+{
+  assert (s != nullptr || count == 0);
+  sliceInit (this,
+             s == nullptr && count == 0 ? reinterpret_cast<void *> (align_of<T> ())
+                                        : const_cast<typename std::remove_const<T>::type *> (s),
+             count);
 }
 
 template <typename T>
-Slice<T>::Slice(T *s, std::size_t count) noexcept {
-  assert(s != nullptr || count == 0);
-  sliceInit(this,
-            s == nullptr && count == 0
-                ? reinterpret_cast<void *>(align_of<T>())
-                : const_cast<typename std::remove_const<T>::type *>(s),
-            count);
+T *
+Slice<T>::data () const noexcept
+{
+  return reinterpret_cast<T *> (slicePtr (this));
 }
 
 template <typename T>
-T *Slice<T>::data() const noexcept {
-  return reinterpret_cast<T *>(slicePtr(this));
+std::size_t
+Slice<T>::size () const noexcept
+{
+  return sliceLen (this);
 }
 
 template <typename T>
-std::size_t Slice<T>::size() const noexcept {
-  return sliceLen(this);
+std::size_t
+Slice<T>::length () const noexcept
+{
+  return this->size ();
 }
 
 template <typename T>
-std::size_t Slice<T>::length() const noexcept {
-  return this->size();
+bool
+Slice<T>::empty () const noexcept
+{
+  return this->size () == 0;
 }
 
 template <typename T>
-bool Slice<T>::empty() const noexcept {
-  return this->size() == 0;
+T &
+Slice<T>::operator[] (std::size_t n) const noexcept
+{
+  assert (n < this->size ());
+  auto ptr = static_cast<char *> (slicePtr (this)) + size_of<T> () * n;
+  return *reinterpret_cast<T *> (ptr);
 }
 
 template <typename T>
-T &Slice<T>::operator[](std::size_t n) const noexcept {
-  assert(n < this->size());
-  auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
-  return *reinterpret_cast<T *>(ptr);
-}
-
-template <typename T>
-T &Slice<T>::at(std::size_t n) const {
-  if (n >= this->size()) {
-    panic<std::out_of_range>("rust::Slice index out of range");
-  }
+T &
+Slice<T>::at (std::size_t n) const
+{
+  if (n >= this->size ())
+    {
+      panic<std::out_of_range> ("rust::Slice index out of range");
+    }
   return (*this)[n];
 }
 
 template <typename T>
-T &Slice<T>::front() const noexcept {
-  assert(!this->empty());
+T &
+Slice<T>::front () const noexcept
+{
+  assert (!this->empty ());
   return (*this)[0];
 }
 
 template <typename T>
-T &Slice<T>::back() const noexcept {
-  assert(!this->empty());
-  return (*this)[this->size() - 1];
+T &
+Slice<T>::back () const noexcept
+{
+  assert (!this->empty ());
+  return (*this)[this->size () - 1];
 }
 
 template <typename T>
 typename Slice<T>::iterator::reference
-Slice<T>::iterator::operator*() const noexcept {
-  return *static_cast<T *>(this->pos);
+Slice<T>::iterator::operator* () const noexcept
+{
+  return *static_cast<T *> (this->pos);
 }
 
 template <typename T>
 typename Slice<T>::iterator::pointer
-Slice<T>::iterator::operator->() const noexcept {
-  return static_cast<T *>(this->pos);
+Slice<T>::iterator::operator->() const noexcept
+{
+  return static_cast<T *> (this->pos);
 }
 
 template <typename T>
-typename Slice<T>::iterator::reference Slice<T>::iterator::operator[](
-    typename Slice<T>::iterator::difference_type n) const noexcept {
-  auto ptr = static_cast<char *>(this->pos) + this->stride * n;
-  return *reinterpret_cast<T *>(ptr);
+typename Slice<T>::iterator::reference
+Slice<T>::iterator::operator[] (typename Slice<T>::iterator::difference_type n) const noexcept
+{
+  auto ptr = static_cast<char *> (this->pos) + this->stride * n;
+  return *reinterpret_cast<T *> (ptr);
 }
 
 template <typename T>
-typename Slice<T>::iterator &Slice<T>::iterator::operator++() noexcept {
-  this->pos = static_cast<char *>(this->pos) + this->stride;
+typename Slice<T>::iterator &
+Slice<T>::iterator::operator++ () noexcept
+{
+  this->pos = static_cast<char *> (this->pos) + this->stride;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::iterator::operator++(int) noexcept {
-  auto ret = iterator(*this);
-  this->pos = static_cast<char *>(this->pos) + this->stride;
+typename Slice<T>::iterator
+Slice<T>::iterator::operator++ (int) noexcept
+{
+  auto ret = iterator (*this);
+  this->pos = static_cast<char *> (this->pos) + this->stride;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator &Slice<T>::iterator::operator--() noexcept {
-  this->pos = static_cast<char *>(this->pos) - this->stride;
+typename Slice<T>::iterator &
+Slice<T>::iterator::operator-- () noexcept
+{
+  this->pos = static_cast<char *> (this->pos) - this->stride;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::iterator::operator--(int) noexcept {
-  auto ret = iterator(*this);
-  this->pos = static_cast<char *>(this->pos) - this->stride;
+typename Slice<T>::iterator
+Slice<T>::iterator::operator-- (int) noexcept
+{
+  auto ret = iterator (*this);
+  this->pos = static_cast<char *> (this->pos) - this->stride;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator &Slice<T>::iterator::operator+=(
-    typename Slice<T>::iterator::difference_type n) noexcept {
-  this->pos = static_cast<char *>(this->pos) + this->stride * n;
+typename Slice<T>::iterator &
+Slice<T>::iterator::operator+= (typename Slice<T>::iterator::difference_type n) noexcept
+{
+  this->pos = static_cast<char *> (this->pos) + this->stride * n;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator &Slice<T>::iterator::operator-=(
-    typename Slice<T>::iterator::difference_type n) noexcept {
-  this->pos = static_cast<char *>(this->pos) - this->stride * n;
+typename Slice<T>::iterator &
+Slice<T>::iterator::operator-= (typename Slice<T>::iterator::difference_type n) noexcept
+{
+  this->pos = static_cast<char *> (this->pos) - this->stride * n;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::iterator::operator+(
-    typename Slice<T>::iterator::difference_type n) const noexcept {
-  auto ret = iterator(*this);
-  ret.pos = static_cast<char *>(this->pos) + this->stride * n;
+typename Slice<T>::iterator
+Slice<T>::iterator::operator+ (typename Slice<T>::iterator::difference_type n) const noexcept
+{
+  auto ret = iterator (*this);
+  ret.pos = static_cast<char *> (this->pos) + this->stride * n;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::iterator::operator-(
-    typename Slice<T>::iterator::difference_type n) const noexcept {
-  auto ret = iterator(*this);
-  ret.pos = static_cast<char *>(this->pos) - this->stride * n;
+typename Slice<T>::iterator
+Slice<T>::iterator::operator- (typename Slice<T>::iterator::difference_type n) const noexcept
+{
+  auto ret = iterator (*this);
+  ret.pos = static_cast<char *> (this->pos) - this->stride * n;
   return ret;
 }
 
 template <typename T>
 typename Slice<T>::iterator::difference_type
-Slice<T>::iterator::operator-(const iterator &other) const noexcept {
-  auto diff = std::distance(static_cast<char *>(other.pos),
-                            static_cast<char *>(this->pos));
-  return diff / static_cast<typename Slice<T>::iterator::difference_type>(
-                    this->stride);
+Slice<T>::iterator::operator- (const iterator &other) const noexcept
+{
+  auto diff = std::distance (static_cast<char *> (other.pos), static_cast<char *> (this->pos));
+  return diff / static_cast<typename Slice<T>::iterator::difference_type> (this->stride);
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator==(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator== (const iterator &other) const noexcept
+{
   return this->pos == other.pos;
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator!=(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator!= (const iterator &other) const noexcept
+{
   return this->pos != other.pos;
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator<(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator< (const iterator &other) const noexcept
+{
   return this->pos < other.pos;
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator<=(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator<= (const iterator &other) const noexcept
+{
   return this->pos <= other.pos;
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator>(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator> (const iterator &other) const noexcept
+{
   return this->pos > other.pos;
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator>=(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator>= (const iterator &other) const noexcept
+{
   return this->pos >= other.pos;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::begin() const noexcept {
+typename Slice<T>::iterator
+Slice<T>::begin () const noexcept
+{
   iterator it;
-  it.pos = slicePtr(this);
-  it.stride = size_of<T>();
+  it.pos = slicePtr (this);
+  it.stride = size_of<T> ();
   return it;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::end() const noexcept {
-  iterator it = this->begin();
-  it.pos = static_cast<char *>(it.pos) + it.stride * this->size();
+typename Slice<T>::iterator
+Slice<T>::end () const noexcept
+{
+  iterator it = this->begin ();
+  it.pos = static_cast<char *> (it.pos) + it.stride * this->size ();
   return it;
 }
 
 template <typename T>
-void Slice<T>::swap(Slice &rhs) noexcept {
-  std::swap(*this, rhs);
+void
+Slice<T>::swap (Slice &rhs) noexcept
+{
+  std::swap (*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
 
 #ifndef CXXBRIDGE1_RUST_BOX
 #define CXXBRIDGE1_RUST_BOX
-template <typename T>
-class Box final {
+template <typename T> class Box final
+{
 public:
   using element_type = T;
-  using const_pointer =
-      typename std::add_pointer<typename std::add_const<T>::type>::type;
+  using const_pointer = typename std::add_pointer<typename std::add_const<T>::type>::type;
   using pointer = typename std::add_pointer<T>::type;
 
-  Box() = delete;
-  Box(Box &&) noexcept;
-  ~Box() noexcept;
+  Box () = delete;
+  Box (Box &&) noexcept;
+  ~Box () noexcept;
 
-  explicit Box(const T &);
-  explicit Box(T &&);
+  explicit Box (const T &);
+  explicit Box (T &&);
 
-  Box &operator=(Box &&) & noexcept;
+  Box &operator= (Box &&) & noexcept;
 
   const T *operator->() const noexcept;
-  const T &operator*() const noexcept;
+  const T &operator* () const noexcept;
   T *operator->() noexcept;
-  T &operator*() noexcept;
+  T &operator* () noexcept;
 
-  template <typename... Fields>
-  static Box in_place(Fields &&...);
+  template <typename... Fields> static Box in_place (Fields &&...);
 
-  void swap(Box &) noexcept;
+  void swap (Box &) noexcept;
 
-  static Box from_raw(T *) noexcept;
+  static Box from_raw (T *) noexcept;
 
-  T *into_raw() noexcept;
+  T *into_raw () noexcept;
 
   /* Deprecated */ using value_type = element_type;
 
 private:
   class uninit;
   class allocation;
-  Box(uninit) noexcept;
-  void drop() noexcept;
+  Box (uninit) noexcept;
+  void drop () noexcept;
 
-  friend void swap(Box &lhs, Box &rhs) noexcept { lhs.swap(rhs); }
+  friend void
+  swap (Box &lhs, Box &rhs) noexcept
+  {
+    lhs.swap (rhs);
+  }
 
   T *ptr;
 };
 
-template <typename T>
-class Box<T>::uninit {};
+template <typename T> class Box<T>::uninit
+{
+};
 
-template <typename T>
-class Box<T>::allocation {
-  static T *alloc() noexcept;
-  static void dealloc(T *) noexcept;
+template <typename T> class Box<T>::allocation
+{
+  static T *alloc () noexcept;
+  static void dealloc (T *) noexcept;
 
 public:
-  allocation() noexcept : ptr(alloc()) {}
-  ~allocation() noexcept {
-    if (this->ptr) {
-      dealloc(this->ptr);
-    }
+  allocation () noexcept : ptr (alloc ()) {}
+  ~allocation () noexcept
+  {
+    if (this->ptr)
+      {
+        dealloc (this->ptr);
+      }
   }
   T *ptr;
 };
 
-template <typename T>
-Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
-  other.ptr = nullptr;
-}
+template <typename T> Box<T>::Box (Box &&other) noexcept : ptr (other.ptr) { other.ptr = nullptr; }
 
-template <typename T>
-Box<T>::Box(const T &val) {
+template <typename T> Box<T>::Box (const T &val)
+{
   allocation alloc;
-  ::new (alloc.ptr) T(val);
+  ::new (alloc.ptr) T (val);
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(T &&val) {
+template <typename T> Box<T>::Box (T &&val)
+{
   allocation alloc;
-  ::new (alloc.ptr) T(std::move(val));
+  ::new (alloc.ptr) T (std::move (val));
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::~Box() noexcept {
-  if (this->ptr) {
-    this->drop();
-  }
+template <typename T> Box<T>::~Box () noexcept
+{
+  if (this->ptr)
+    {
+      this->drop ();
+    }
 }
 
 template <typename T>
-Box<T> &Box<T>::operator=(Box &&other) & noexcept {
-  if (this->ptr) {
-    this->drop();
-  }
+Box<T> &
+Box<T>::operator= (Box &&other) & noexcept
+{
+  if (this->ptr)
+    {
+      this->drop ();
+    }
   this->ptr = other.ptr;
   other.ptr = nullptr;
   return *this;
 }
 
 template <typename T>
-const T *Box<T>::operator->() const noexcept {
+const T *
+Box<T>::operator->() const noexcept
+{
   return this->ptr;
 }
 
 template <typename T>
-const T &Box<T>::operator*() const noexcept {
+const T &
+Box<T>::operator* () const noexcept
+{
   return *this->ptr;
 }
 
 template <typename T>
-T *Box<T>::operator->() noexcept {
+T *
+Box<T>::operator->() noexcept
+{
   return this->ptr;
 }
 
 template <typename T>
-T &Box<T>::operator*() noexcept {
+T &
+Box<T>::operator* () noexcept
+{
   return *this->ptr;
 }
 
 template <typename T>
 template <typename... Fields>
-Box<T> Box<T>::in_place(Fields &&...fields) {
+Box<T>
+Box<T>::in_place (Fields &&...fields)
+{
   allocation alloc;
   auto ptr = alloc.ptr;
-  ::new (ptr) T{std::forward<Fields>(fields)...};
+  ::new (ptr) T{ std::forward<Fields> (fields)... };
   alloc.ptr = nullptr;
-  return from_raw(ptr);
+  return from_raw (ptr);
 }
 
 template <typename T>
-void Box<T>::swap(Box &rhs) noexcept {
+void
+Box<T>::swap (Box &rhs) noexcept
+{
   using std::swap;
-  swap(this->ptr, rhs.ptr);
+  swap (this->ptr, rhs.ptr);
 }
 
 template <typename T>
-Box<T> Box<T>::from_raw(T *raw) noexcept {
+Box<T>
+Box<T>::from_raw (T *raw) noexcept
+{
   Box box = uninit{};
   box.ptr = raw;
   return box;
 }
 
 template <typename T>
-T *Box<T>::into_raw() noexcept {
+T *
+Box<T>::into_raw () noexcept
+{
   T *raw = this->ptr;
   this->ptr = nullptr;
   return raw;
 }
 
-template <typename T>
-Box<T>::Box(uninit) noexcept {}
+template <typename T> Box<T>::Box (uninit) noexcept {}
 #endif // CXXBRIDGE1_RUST_BOX
 
 #ifndef CXXBRIDGE1_RUST_BITCOPY_T
 #define CXXBRIDGE1_RUST_BITCOPY_T
-struct unsafe_bitcopy_t final {
-  explicit unsafe_bitcopy_t() = default;
+struct unsafe_bitcopy_t final
+{
+  explicit unsafe_bitcopy_t () = default;
 };
 #endif // CXXBRIDGE1_RUST_BITCOPY_T
 
@@ -665,257 +741,307 @@ constexpr unsafe_bitcopy_t unsafe_bitcopy{};
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T>
-class Vec final {
+template <typename T> class Vec final
+{
 public:
   using value_type = T;
 
-  Vec() noexcept;
-  Vec(std::initializer_list<T>);
-  Vec(const Vec &);
-  Vec(Vec &&) noexcept;
-  ~Vec() noexcept;
+  Vec () noexcept;
+  Vec (std::initializer_list<T>);
+  Vec (const Vec &);
+  Vec (Vec &&) noexcept;
+  ~Vec () noexcept;
 
-  Vec &operator=(Vec &&) & noexcept;
-  Vec &operator=(const Vec &) &;
+  Vec &operator= (Vec &&) & noexcept;
+  Vec &operator= (const Vec &) &;
 
-  std::size_t size() const noexcept;
-  bool empty() const noexcept;
-  const T *data() const noexcept;
-  T *data() noexcept;
-  std::size_t capacity() const noexcept;
+  std::size_t size () const noexcept;
+  bool empty () const noexcept;
+  const T *data () const noexcept;
+  T *data () noexcept;
+  std::size_t capacity () const noexcept;
 
-  const T &operator[](std::size_t n) const noexcept;
-  const T &at(std::size_t n) const;
-  const T &front() const noexcept;
-  const T &back() const noexcept;
+  const T &operator[] (std::size_t n) const noexcept;
+  const T &at (std::size_t n) const;
+  const T &front () const noexcept;
+  const T &back () const noexcept;
 
-  T &operator[](std::size_t n) noexcept;
-  T &at(std::size_t n);
-  T &front() noexcept;
-  T &back() noexcept;
+  T &operator[] (std::size_t n) noexcept;
+  T &at (std::size_t n);
+  T &front () noexcept;
+  T &back () noexcept;
 
-  void reserve(std::size_t new_cap);
-  void push_back(const T &value);
-  void push_back(T &&value);
-  template <typename... Args>
-  void emplace_back(Args &&...args);
-  void truncate(std::size_t len);
-  void clear();
+  void reserve (std::size_t new_cap);
+  void push_back (const T &value);
+  void push_back (T &&value);
+  template <typename... Args> void emplace_back (Args &&...args);
+  void truncate (std::size_t len);
+  void clear ();
 
   using iterator = typename Slice<T>::iterator;
-  iterator begin() noexcept;
-  iterator end() noexcept;
+  iterator begin () noexcept;
+  iterator end () noexcept;
 
   using const_iterator = typename Slice<const T>::iterator;
-  const_iterator begin() const noexcept;
-  const_iterator end() const noexcept;
-  const_iterator cbegin() const noexcept;
-  const_iterator cend() const noexcept;
+  const_iterator begin () const noexcept;
+  const_iterator end () const noexcept;
+  const_iterator cbegin () const noexcept;
+  const_iterator cend () const noexcept;
 
-  void swap(Vec &) noexcept;
+  void swap (Vec &) noexcept;
 
-  Vec(unsafe_bitcopy_t, const Vec &) noexcept;
+  Vec (unsafe_bitcopy_t, const Vec &) noexcept;
 
 private:
-  void reserve_total(std::size_t new_cap) noexcept;
-  void set_len(std::size_t len) noexcept;
-  void drop() noexcept;
+  void reserve_total (std::size_t new_cap) noexcept;
+  void set_len (std::size_t len) noexcept;
+  void drop () noexcept;
 
-  friend void swap(Vec &lhs, Vec &rhs) noexcept { lhs.swap(rhs); }
+  friend void
+  swap (Vec &lhs, Vec &rhs) noexcept
+  {
+    lhs.swap (rhs);
+  }
 
   std::array<std::uintptr_t, 3> repr;
 };
 
-template <typename T>
-Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
-  this->reserve_total(init.size());
-  std::move(init.begin(), init.end(), std::back_inserter(*this));
+template <typename T> Vec<T>::Vec (std::initializer_list<T> init) : Vec{}
+{
+  this->reserve_total (init.size ());
+  std::move (init.begin (), init.end (), std::back_inserter (*this));
 }
 
-template <typename T>
-Vec<T>::Vec(const Vec &other) : Vec() {
-  this->reserve_total(other.size());
-  std::copy(other.begin(), other.end(), std::back_inserter(*this));
+template <typename T> Vec<T>::Vec (const Vec &other) : Vec ()
+{
+  this->reserve_total (other.size ());
+  std::copy (other.begin (), other.end (), std::back_inserter (*this));
 }
 
-template <typename T>
-Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
-  new (&other) Vec();
+template <typename T> Vec<T>::Vec (Vec &&other) noexcept : repr (other.repr)
+{
+  new (&other) Vec ();
 }
 
-template <typename T>
-Vec<T>::~Vec() noexcept {
-  this->drop();
-}
+template <typename T> Vec<T>::~Vec () noexcept { this->drop (); }
 
 template <typename T>
-Vec<T> &Vec<T>::operator=(Vec &&other) & noexcept {
-  this->drop();
+Vec<T> &
+Vec<T>::operator= (Vec &&other) & noexcept
+{
+  this->drop ();
   this->repr = other.repr;
-  new (&other) Vec();
+  new (&other) Vec ();
   return *this;
 }
 
 template <typename T>
-Vec<T> &Vec<T>::operator=(const Vec &other) & {
-  if (this != &other) {
-    this->drop();
-    new (this) Vec(other);
-  }
+Vec<T> &
+Vec<T>::operator= (const Vec &other) &
+{
+  if (this != &other)
+    {
+      this->drop ();
+      new (this) Vec (other);
+    }
   return *this;
 }
 
 template <typename T>
-bool Vec<T>::empty() const noexcept {
-  return this->size() == 0;
+bool
+Vec<T>::empty () const noexcept
+{
+  return this->size () == 0;
 }
 
 template <typename T>
-T *Vec<T>::data() noexcept {
-  return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
+T *
+Vec<T>::data () noexcept
+{
+  return const_cast<T *> (const_cast<const Vec<T> *> (this)->data ());
 }
 
 template <typename T>
-const T &Vec<T>::operator[](std::size_t n) const noexcept {
-  assert(n < this->size());
-  auto data = reinterpret_cast<const char *>(this->data());
-  return *reinterpret_cast<const T *>(data + n * size_of<T>());
+const T &
+Vec<T>::operator[] (std::size_t n) const noexcept
+{
+  assert (n < this->size ());
+  auto data = reinterpret_cast<const char *> (this->data ());
+  return *reinterpret_cast<const T *> (data + n * size_of<T> ());
 }
 
 template <typename T>
-const T &Vec<T>::at(std::size_t n) const {
-  if (n >= this->size()) {
-    panic<std::out_of_range>("rust::Vec index out of range");
-  }
+const T &
+Vec<T>::at (std::size_t n) const
+{
+  if (n >= this->size ())
+    {
+      panic<std::out_of_range> ("rust::Vec index out of range");
+    }
   return (*this)[n];
 }
 
 template <typename T>
-const T &Vec<T>::front() const noexcept {
-  assert(!this->empty());
+const T &
+Vec<T>::front () const noexcept
+{
+  assert (!this->empty ());
   return (*this)[0];
 }
 
 template <typename T>
-const T &Vec<T>::back() const noexcept {
-  assert(!this->empty());
-  return (*this)[this->size() - 1];
+const T &
+Vec<T>::back () const noexcept
+{
+  assert (!this->empty ());
+  return (*this)[this->size () - 1];
 }
 
 template <typename T>
-T &Vec<T>::operator[](std::size_t n) noexcept {
-  assert(n < this->size());
-  auto data = reinterpret_cast<char *>(this->data());
-  return *reinterpret_cast<T *>(data + n * size_of<T>());
+T &
+Vec<T>::operator[] (std::size_t n) noexcept
+{
+  assert (n < this->size ());
+  auto data = reinterpret_cast<char *> (this->data ());
+  return *reinterpret_cast<T *> (data + n * size_of<T> ());
 }
 
 template <typename T>
-T &Vec<T>::at(std::size_t n) {
-  if (n >= this->size()) {
-    panic<std::out_of_range>("rust::Vec index out of range");
-  }
+T &
+Vec<T>::at (std::size_t n)
+{
+  if (n >= this->size ())
+    {
+      panic<std::out_of_range> ("rust::Vec index out of range");
+    }
   return (*this)[n];
 }
 
 template <typename T>
-T &Vec<T>::front() noexcept {
-  assert(!this->empty());
+T &
+Vec<T>::front () noexcept
+{
+  assert (!this->empty ());
   return (*this)[0];
 }
 
 template <typename T>
-T &Vec<T>::back() noexcept {
-  assert(!this->empty());
-  return (*this)[this->size() - 1];
+T &
+Vec<T>::back () noexcept
+{
+  assert (!this->empty ());
+  return (*this)[this->size () - 1];
 }
 
 template <typename T>
-void Vec<T>::reserve(std::size_t new_cap) {
-  this->reserve_total(new_cap);
+void
+Vec<T>::reserve (std::size_t new_cap)
+{
+  this->reserve_total (new_cap);
 }
 
 template <typename T>
-void Vec<T>::push_back(const T &value) {
-  this->emplace_back(value);
+void
+Vec<T>::push_back (const T &value)
+{
+  this->emplace_back (value);
 }
 
 template <typename T>
-void Vec<T>::push_back(T &&value) {
-  this->emplace_back(std::move(value));
+void
+Vec<T>::push_back (T &&value)
+{
+  this->emplace_back (std::move (value));
 }
 
 template <typename T>
 template <typename... Args>
-void Vec<T>::emplace_back(Args &&...args) {
-  auto size = this->size();
-  this->reserve_total(size + 1);
-  ::new (reinterpret_cast<T *>(reinterpret_cast<char *>(this->data()) +
-                               size * size_of<T>()))
-      T(std::forward<Args>(args)...);
-  this->set_len(size + 1);
+void
+Vec<T>::emplace_back (Args &&...args)
+{
+  auto size = this->size ();
+  this->reserve_total (size + 1);
+  ::new (reinterpret_cast<T *> (reinterpret_cast<char *> (this->data ()) + size * size_of<T> ()))
+      T (std::forward<Args> (args)...);
+  this->set_len (size + 1);
 }
 
 template <typename T>
-void Vec<T>::clear() {
-  this->truncate(0);
+void
+Vec<T>::clear ()
+{
+  this->truncate (0);
 }
 
 template <typename T>
-typename Vec<T>::iterator Vec<T>::begin() noexcept {
-  return Slice<T>(this->data(), this->size()).begin();
+typename Vec<T>::iterator
+Vec<T>::begin () noexcept
+{
+  return Slice<T> (this->data (), this->size ()).begin ();
 }
 
 template <typename T>
-typename Vec<T>::iterator Vec<T>::end() noexcept {
-  return Slice<T>(this->data(), this->size()).end();
+typename Vec<T>::iterator
+Vec<T>::end () noexcept
+{
+  return Slice<T> (this->data (), this->size ()).end ();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator Vec<T>::begin() const noexcept {
-  return this->cbegin();
+typename Vec<T>::const_iterator
+Vec<T>::begin () const noexcept
+{
+  return this->cbegin ();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator Vec<T>::end() const noexcept {
-  return this->cend();
+typename Vec<T>::const_iterator
+Vec<T>::end () const noexcept
+{
+  return this->cend ();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator Vec<T>::cbegin() const noexcept {
-  return Slice<const T>(this->data(), this->size()).begin();
+typename Vec<T>::const_iterator
+Vec<T>::cbegin () const noexcept
+{
+  return Slice<const T> (this->data (), this->size ()).begin ();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
-  return Slice<const T>(this->data(), this->size()).end();
+typename Vec<T>::const_iterator
+Vec<T>::cend () const noexcept
+{
+  return Slice<const T> (this->data (), this->size ()).end ();
 }
 
 template <typename T>
-void Vec<T>::swap(Vec &rhs) noexcept {
+void
+Vec<T>::swap (Vec &rhs) noexcept
+{
   using std::swap;
-  swap(this->repr, rhs.repr);
+  swap (this->repr, rhs.repr);
 }
 
-template <typename T>
-Vec<T>::Vec(unsafe_bitcopy_t, const Vec &bits) noexcept : repr(bits.repr) {}
+template <typename T> Vec<T>::Vec (unsafe_bitcopy_t, const Vec &bits) noexcept : repr (bits.repr) {}
 #endif // CXXBRIDGE1_RUST_VEC
 
 #ifndef CXXBRIDGE1_RUST_ERROR
 #define CXXBRIDGE1_RUST_ERROR
-class Error final : public std::exception {
+class Error final : public std::exception
+{
 public:
-  Error(const Error &);
-  Error(Error &&) noexcept;
-  ~Error() noexcept override;
+  Error (const Error &);
+  Error (Error &&) noexcept;
+  ~Error () noexcept override;
 
-  Error &operator=(const Error &) &;
-  Error &operator=(Error &&) & noexcept;
+  Error &operator= (const Error &) &;
+  Error &operator= (Error &&) & noexcept;
 
-  const char *what() const noexcept override;
+  const char *what () const noexcept override;
 
 private:
-  Error() noexcept = default;
+  Error () noexcept = default;
   friend impl<Error>;
   const char *msg;
   std::size_t len;
@@ -924,188 +1050,239 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_OPAQUE
 #define CXXBRIDGE1_RUST_OPAQUE
-class Opaque {
+class Opaque
+{
 public:
-  Opaque() = delete;
-  Opaque(const Opaque &) = delete;
-  ~Opaque() = delete;
+  Opaque () = delete;
+  Opaque (const Opaque &) = delete;
+  ~Opaque () = delete;
 };
 #endif // CXXBRIDGE1_RUST_OPAQUE
 
 #ifndef CXXBRIDGE1_IS_COMPLETE
 #define CXXBRIDGE1_IS_COMPLETE
-namespace detail {
-namespace {
-template <typename T, typename = std::size_t>
-struct is_complete : std::false_type {};
-template <typename T>
-struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
+namespace detail
+{
+namespace
+{
+template <typename T, typename = std::size_t> struct is_complete : std::false_type
+{
+};
+template <typename T> struct is_complete<T, decltype (sizeof (T))> : std::true_type
+{
+};
 } // namespace
 } // namespace detail
 #endif // CXXBRIDGE1_IS_COMPLETE
 
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
-class layout {
+class layout
+{
+  template <typename T> friend std::size_t size_of ();
+  template <typename T> friend std::size_t align_of ();
   template <typename T>
-  friend std::size_t size_of();
-  template <typename T>
-  friend std::size_t align_of();
-  template <typename T>
-  static typename std::enable_if<std::is_base_of<Opaque, T>::value,
-                                 std::size_t>::type
-  do_size_of() {
-    return T::layout::size();
+  static typename std::enable_if<std::is_base_of<Opaque, T>::value, std::size_t>::type
+  do_size_of ()
+  {
+    return T::layout::size ();
   }
   template <typename T>
-  static typename std::enable_if<!std::is_base_of<Opaque, T>::value,
-                                 std::size_t>::type
-  do_size_of() {
-    return sizeof(T);
+  static typename std::enable_if<!std::is_base_of<Opaque, T>::value, std::size_t>::type
+  do_size_of ()
+  {
+    return sizeof (T);
   }
   template <typename T>
-  static
-      typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
-      size_of() {
-    return do_size_of<T>();
+  static typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
+  size_of ()
+  {
+    return do_size_of<T> ();
   }
   template <typename T>
-  static typename std::enable_if<std::is_base_of<Opaque, T>::value,
-                                 std::size_t>::type
-  do_align_of() {
-    return T::layout::align();
+  static typename std::enable_if<std::is_base_of<Opaque, T>::value, std::size_t>::type
+  do_align_of ()
+  {
+    return T::layout::align ();
   }
   template <typename T>
-  static typename std::enable_if<!std::is_base_of<Opaque, T>::value,
-                                 std::size_t>::type
-  do_align_of() {
-    return alignof(T);
+  static typename std::enable_if<!std::is_base_of<Opaque, T>::value, std::size_t>::type
+  do_align_of ()
+  {
+    return alignof (T);
   }
   template <typename T>
-  static
-      typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
-      align_of() {
-    return do_align_of<T>();
+  static typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
+  align_of ()
+  {
+    return do_align_of<T> ();
   }
 };
 
 template <typename T>
-std::size_t size_of() {
-  return layout::size_of<T>();
+std::size_t
+size_of ()
+{
+  return layout::size_of<T> ();
 }
 
 template <typename T>
-std::size_t align_of() {
-  return layout::align_of<T>();
+std::size_t
+align_of ()
+{
+  return layout::align_of<T> ();
 }
 #endif // CXXBRIDGE1_LAYOUT
 
-class Str::uninit {};
-inline Str::Str(uninit) noexcept {}
+class Str::uninit
+{
+};
+inline Str::Str (uninit) noexcept {}
 
-template <typename T>
-class Slice<T>::uninit {};
-template <typename T>
-inline Slice<T>::Slice(uninit) noexcept {}
+template <typename T> class Slice<T>::uninit
+{
+};
+template <typename T> inline Slice<T>::Slice (uninit) noexcept {}
 
-namespace repr {
+namespace repr
+{
 using Fat = ::std::array<::std::uintptr_t, 2>;
 
-struct PtrLen final {
+struct PtrLen final
+{
   void *ptr;
   ::std::size_t len;
 };
 } // namespace repr
 
-namespace detail {
-template <typename T, typename = void *>
-struct operator_new {
-  void *operator()(::std::size_t sz) { return ::operator new(sz); }
+namespace detail
+{
+template <typename T, typename = void *> struct operator_new
+{
+  void *
+  operator() (::std::size_t sz)
+  {
+    return ::operator new (sz);
+  }
 };
 
-template <typename T>
-struct operator_new<T, decltype(T::operator new(sizeof(T)))> {
-  void *operator()(::std::size_t sz) { return T::operator new(sz); }
+template <typename T> struct operator_new<T, decltype (T::operator new (sizeof (T)))>
+{
+  void *
+  operator() (::std::size_t sz)
+  {
+    return T::operator new (sz);
+  }
 };
 
-class Fail final {
+class Fail final
+{
   ::rust::repr::PtrLen &throw$;
+
 public:
-  Fail(::rust::repr::PtrLen &throw$) noexcept : throw$(throw$) {}
-  void operator()(char const *) noexcept;
-  void operator()(std::string const &) noexcept;
+  Fail (::rust::repr::PtrLen &throw$) noexcept : throw$ (throw$) {}
+  void operator() (char const *) noexcept;
+  void operator() (std::string const &) noexcept;
 };
 } // namespace detail
 
-template <typename T>
-union ManuallyDrop {
+template <typename T> union ManuallyDrop
+{
   T value;
-  ManuallyDrop(T &&value) : value(::std::move(value)) {}
-  ~ManuallyDrop() {}
+  ManuallyDrop (T &&value) : value (::std::move (value)) {}
+  ~ManuallyDrop () {}
 };
 
-template <typename T>
-union MaybeUninit {
+template <typename T> union MaybeUninit
+{
   T value;
-  void *operator new(::std::size_t sz) { return detail::operator_new<T>{}(sz); }
-  MaybeUninit() {}
-  ~MaybeUninit() {}
+  void *
+  operator new (::std::size_t sz)
+  {
+    return detail::operator_new<T>{}(sz);
+  }
+  MaybeUninit () {}
+  ~MaybeUninit () {}
 };
 
-namespace {
-template <>
-class impl<Str> final {
+namespace
+{
+template <> class impl<Str> final
+{
 public:
-  static Str new_unchecked(repr::Fat repr) noexcept {
+  static Str
+  new_unchecked (repr::Fat repr) noexcept
+  {
     Str str = Str::uninit{};
     str.repr = repr;
     return str;
   }
 };
 
-template <typename T>
-class impl<Slice<T>> final {
+template <typename T> class impl<Slice<T>> final
+{
 public:
-  static Slice<T> slice(repr::Fat repr) noexcept {
+  static Slice<T>
+  slice (repr::Fat repr) noexcept
+  {
     Slice<T> slice = typename Slice<T>::uninit{};
     slice.repr = repr;
     return slice;
   }
 };
 
-template <>
-class impl<Error> final {
+template <> class impl<Error> final
+{
 public:
-  static Error error(repr::PtrLen repr) noexcept {
+  static Error
+  error (repr::PtrLen repr) noexcept
+  {
     Error error;
-    error.msg = static_cast<char const *>(repr.ptr);
+    error.msg = static_cast<char const *> (repr.ptr);
     error.len = repr.len;
     return error;
   }
 };
 
-template <bool> struct deleter_if {
-  template <typename T> void operator()(T *) {}
+template <bool> struct deleter_if
+{
+  template <typename T>
+  void
+  operator() (T *)
+  {
+  }
 };
-template <> struct deleter_if<true> {
-  template <typename T> void operator()(T *ptr) { ptr->~T(); }
+template <> struct deleter_if<true>
+{
+  template <typename T>
+  void
+  operator() (T *ptr)
+  {
+    ptr->~T ();
+  }
 };
 } // namespace
 } // namespace cxxbridge1
 
-namespace behavior {
-class missing {};
-missing trycatch(...);
+namespace behavior
+{
+class missing
+{
+};
+missing trycatch (...);
 
 template <typename Try, typename Fail>
 static typename ::std::enable_if<::std::is_same<
-    decltype(trycatch(::std::declval<Try>(), ::std::declval<Fail>())),
-    missing>::value>::type
-trycatch(Try &&func, Fail &&fail) noexcept try {
-  func();
-} catch (::std::exception const &e) {
-  fail(e.what());
-}
+    decltype (trycatch (::std::declval<Try> (), ::std::declval<Fail> ())), missing>::value>::type
+trycatch (Try &&func, Fail &&fail) noexcept
+try
+  {
+    func ();
+  }
+catch (::std::exception const &e)
+  {
+    fail (e.what ());
+  }
 } // namespace behavior
 } // namespace rust
 
@@ -1115,51 +1292,53 @@ trycatch(Try &&func, Fail &&fail) noexcept try {
 #define CXX_DEFAULT_VALUE(value)
 #endif
 
-namespace rpmostreecxx {
-  struct StringMapping;
-  enum class SystemHostType : ::std::uint8_t;
-  enum class BubblewrapMutability : ::std::uint8_t;
-  struct Bubblewrap;
-  struct ContainerImageState;
-  struct ExportedManifestDiff;
-  struct PrunedContainerInfo;
-  enum class RefspecType : ::std::uint8_t;
-  struct TempEtcGuard;
-  struct FilesystemScriptPrep;
-  struct DeploymentLayeredMeta;
-  struct OverrideReplacementSource;
-  enum class ParsedRevisionKind : ::std::uint8_t;
-  struct ParsedRevision;
-  struct RpmImporterFlags;
-  struct RpmImporter;
-  struct HistoryEntry;
-  struct HistoryCtx;
-  struct TokioHandle;
-  struct TokioEnterGuard;
-  enum class RepoMetadataTarget : ::std::uint8_t;
-  enum class AdvisoriesMetadataTarget : ::std::uint8_t;
-  struct Refspec;
-  enum class OverrideReplacementType : ::std::uint8_t;
-  struct OverrideReplacement;
-  enum class OptUsrLocal : ::std::uint8_t;
-  struct Treefile;
-  struct RepoPackage;
-  struct LiveApplyState;
-  struct PasswdDB;
-  struct PasswdEntries;
-  struct Extensions;
-  struct LockedPackage;
-  struct LockfileConfig;
-  using CxxGObjectArray = ::rpmostreecxx::CxxGObjectArray;
-  using ClientConnection = ::rpmostreecxx::ClientConnection;
-  using RPMDiff = ::rpmostreecxx::RPMDiff;
-  using RpmOstreeDiffPrintFormat = ::rpmostreecxx::RpmOstreeDiffPrintFormat;
-  using Progress = ::rpmostreecxx::Progress;
-  using RpmTs = ::rpmostreecxx::RpmTs;
-  using PackageMeta = ::rpmostreecxx::PackageMeta;
+namespace rpmostreecxx
+{
+struct StringMapping;
+enum class SystemHostType : ::std::uint8_t;
+enum class BubblewrapMutability : ::std::uint8_t;
+struct Bubblewrap;
+struct ContainerImageState;
+struct ExportedManifestDiff;
+struct PrunedContainerInfo;
+enum class RefspecType : ::std::uint8_t;
+struct TempEtcGuard;
+struct FilesystemScriptPrep;
+struct DeploymentLayeredMeta;
+struct OverrideReplacementSource;
+enum class ParsedRevisionKind : ::std::uint8_t;
+struct ParsedRevision;
+struct RpmImporterFlags;
+struct RpmImporter;
+struct HistoryEntry;
+struct HistoryCtx;
+struct TokioHandle;
+struct TokioEnterGuard;
+enum class RepoMetadataTarget : ::std::uint8_t;
+enum class AdvisoriesMetadataTarget : ::std::uint8_t;
+struct Refspec;
+enum class OverrideReplacementType : ::std::uint8_t;
+struct OverrideReplacement;
+enum class OptUsrLocal : ::std::uint8_t;
+struct Treefile;
+struct RepoPackage;
+struct LiveApplyState;
+struct PasswdDB;
+struct PasswdEntries;
+struct Extensions;
+struct LockedPackage;
+struct LockfileConfig;
+using CxxGObjectArray = ::rpmostreecxx::CxxGObjectArray;
+using ClientConnection = ::rpmostreecxx::ClientConnection;
+using RPMDiff = ::rpmostreecxx::RPMDiff;
+using RpmOstreeDiffPrintFormat = ::rpmostreecxx::RpmOstreeDiffPrintFormat;
+using Progress = ::rpmostreecxx::Progress;
+using RpmTs = ::rpmostreecxx::RpmTs;
+using PackageMeta = ::rpmostreecxx::PackageMeta;
 }
 
-namespace rpmostreecxx {
+namespace rpmostreecxx
+{
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$StringMapping
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$StringMapping
 // Currently cxx-rs doesn't support mappings; like probably most projects,
@@ -1167,7 +1346,8 @@ namespace rpmostreecxx {
 // our data sizes aren't large, we serialize this as a vector of strings pairs.
 // In the future it's also likely that cxx-rs will support a C++ string_view
 // so we could avoid duplicating in that direction.
-struct StringMapping final {
+struct StringMapping final
+{
   ::rust::String k;
   ::rust::String v;
 
@@ -1178,7 +1358,8 @@ struct StringMapping final {
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$SystemHostType
 #define CXXBRIDGE1_ENUM_rpmostreecxx$SystemHostType
 // Classify the running system.
-enum class SystemHostType : ::std::uint8_t {
+enum class SystemHostType : ::std::uint8_t
+{
   OstreeContainer = 0,
   OstreeHost = 1,
   Unknown = 2,
@@ -1187,7 +1368,8 @@ enum class SystemHostType : ::std::uint8_t {
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$BubblewrapMutability
 #define CXXBRIDGE1_ENUM_rpmostreecxx$BubblewrapMutability
-enum class BubblewrapMutability : ::std::uint8_t {
+enum class BubblewrapMutability : ::std::uint8_t
+{
   Immutable = 0,
   RoFiles = 1,
   MutateFreely = 2,
@@ -1196,49 +1378,52 @@ enum class BubblewrapMutability : ::std::uint8_t {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Bubblewrap
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Bubblewrap
-struct Bubblewrap final : public ::rust::Opaque {
-  ::std::int32_t get_rootfs_fd() const noexcept;
-  void append_bwrap_arg(::rust::Str arg) noexcept;
-  void append_child_arg(::rust::Str arg) noexcept;
-  void setenv(::rust::Str k, ::rust::Str v) noexcept;
-  void take_fd(::std::int32_t source_fd, ::std::int32_t target_fd) noexcept;
-  void set_inherit_stdin() noexcept;
-  void take_stdin_fd(::std::int32_t source_fd) noexcept;
-  void take_stdout_fd(::std::int32_t source_fd) noexcept;
-  void take_stderr_fd(::std::int32_t source_fd) noexcept;
-  void take_stdout_and_stderr_fd(::std::int32_t source_fd) noexcept;
-  void bind_read(::rust::Str src, ::rust::Str dest) noexcept;
-  void bind_readwrite(::rust::Str src, ::rust::Str dest) noexcept;
-  void setup_compat_var();
-  void run(::rpmostreecxx::GCancellable const &cancellable);
-  ~Bubblewrap() = delete;
+struct Bubblewrap final : public ::rust::Opaque
+{
+  ::std::int32_t get_rootfs_fd () const noexcept;
+  void append_bwrap_arg (::rust::Str arg) noexcept;
+  void append_child_arg (::rust::Str arg) noexcept;
+  void setenv (::rust::Str k, ::rust::Str v) noexcept;
+  void take_fd (::std::int32_t source_fd, ::std::int32_t target_fd) noexcept;
+  void set_inherit_stdin () noexcept;
+  void take_stdin_fd (::std::int32_t source_fd) noexcept;
+  void take_stdout_fd (::std::int32_t source_fd) noexcept;
+  void take_stderr_fd (::std::int32_t source_fd) noexcept;
+  void take_stdout_and_stderr_fd (::std::int32_t source_fd) noexcept;
+  void bind_read (::rust::Str src, ::rust::Str dest) noexcept;
+  void bind_readwrite (::rust::Str src, ::rust::Str dest) noexcept;
+  void setup_compat_var ();
+  void run (::rpmostreecxx::GCancellable const &cancellable);
+  ~Bubblewrap () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$Bubblewrap
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$ExportedManifestDiff
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$ExportedManifestDiff
-struct ExportedManifestDiff final {
+struct ExportedManifestDiff final
+{
   // Check if the struct is initialized
-  bool initialized CXX_DEFAULT_VALUE(false);
+  bool initialized CXX_DEFAULT_VALUE (false);
   // The total number of packages in the next upgrade
-  ::std::uint64_t total CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t total CXX_DEFAULT_VALUE (0);
   // The size of the total number of packages in the next upgrade
-  ::std::uint64_t total_size CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t total_size CXX_DEFAULT_VALUE (0);
   // The total number of removed packages in the next upgrade
-  ::std::uint64_t n_removed CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t n_removed CXX_DEFAULT_VALUE (0);
   // The size of total number of removed packages in the next upgrade
-  ::std::uint64_t removed_size CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t removed_size CXX_DEFAULT_VALUE (0);
   // The total number of added packages in the next upgrade
-  ::std::uint64_t n_added CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t n_added CXX_DEFAULT_VALUE (0);
   // The size of total number of added packages in the next upgrade
-  ::std::uint64_t added_size CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t added_size CXX_DEFAULT_VALUE (0);
   // The version of the next upgrade
   ::rust::String version;
 
@@ -1248,10 +1433,11 @@ struct ExportedManifestDiff final {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$ContainerImageState
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$ContainerImageState
-// `ContainerImageState` is currently identical to ostree-rs-ext's `LayeredImageState` struct, because
-// cxx.rs currently requires types used as extern Rust types to be defined by the same crate
+// `ContainerImageState` is currently identical to ostree-rs-ext's `LayeredImageState` struct,
+// because cxx.rs currently requires types used as extern Rust types to be defined by the same crate
 // that contains the bridge using them, so we redefine an `ContainerImport` struct here.
-struct ContainerImageState final {
+struct ContainerImageState final
+{
   ::rust::String base_commit;
   ::rust::String merge_commit;
   ::rust::String image_digest;
@@ -1265,19 +1451,21 @@ struct ContainerImageState final {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$PrunedContainerInfo
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$PrunedContainerInfo
-struct PrunedContainerInfo final {
-  ::std::uint32_t images CXX_DEFAULT_VALUE(0);
-  ::std::uint32_t layers CXX_DEFAULT_VALUE(0);
+struct PrunedContainerInfo final
+{
+  ::std::uint32_t images CXX_DEFAULT_VALUE (0);
+  ::std::uint32_t layers CXX_DEFAULT_VALUE (0);
 
-  bool operator==(PrunedContainerInfo const &) const noexcept;
-  bool operator!=(PrunedContainerInfo const &) const noexcept;
+  bool operator== (PrunedContainerInfo const &) const noexcept;
+  bool operator!= (PrunedContainerInfo const &) const noexcept;
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$PrunedContainerInfo
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$RefspecType
 #define CXXBRIDGE1_ENUM_rpmostreecxx$RefspecType
-enum class RefspecType : ::std::uint8_t {
+enum class RefspecType : ::std::uint8_t
+{
   Ostree = 0,
   Checksum = 1,
   Container = 2,
@@ -1286,40 +1474,45 @@ enum class RefspecType : ::std::uint8_t {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$TempEtcGuard
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$TempEtcGuard
-struct TempEtcGuard final : public ::rust::Opaque {
-  void undo() const;
-  ~TempEtcGuard() = delete;
+struct TempEtcGuard final : public ::rust::Opaque
+{
+  void undo () const;
+  ~TempEtcGuard () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$TempEtcGuard
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$FilesystemScriptPrep
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$FilesystemScriptPrep
-struct FilesystemScriptPrep final : public ::rust::Opaque {
-  void undo();
-  ~FilesystemScriptPrep() = delete;
+struct FilesystemScriptPrep final : public ::rust::Opaque
+{
+  void undo ();
+  ~FilesystemScriptPrep () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$FilesystemScriptPrep
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$DeploymentLayeredMeta
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$DeploymentLayeredMeta
-struct DeploymentLayeredMeta final {
-  bool is_layered CXX_DEFAULT_VALUE(false);
+struct DeploymentLayeredMeta final
+{
+  bool is_layered CXX_DEFAULT_VALUE (false);
   ::rust::String base_commit;
-  ::std::uint32_t clientlayer_version CXX_DEFAULT_VALUE(0);
+  ::std::uint32_t clientlayer_version CXX_DEFAULT_VALUE (0);
 
   using IsRelocatable = ::std::true_type;
 };
@@ -1327,7 +1520,8 @@ struct DeploymentLayeredMeta final {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacementSource
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacementSource
-struct OverrideReplacementSource final {
+struct OverrideReplacementSource final
+{
   ::rpmostreecxx::OverrideReplacementType kind;
   ::rust::String name;
 
@@ -1337,7 +1531,8 @@ struct OverrideReplacementSource final {
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$ParsedRevisionKind
 #define CXXBRIDGE1_ENUM_rpmostreecxx$ParsedRevisionKind
-enum class ParsedRevisionKind : ::std::uint8_t {
+enum class ParsedRevisionKind : ::std::uint8_t
+{
   Version = 0,
   Checksum = 1,
 };
@@ -1345,7 +1540,8 @@ enum class ParsedRevisionKind : ::std::uint8_t {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$ParsedRevision
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$ParsedRevision
-struct ParsedRevision final {
+struct ParsedRevision final
+{
   ::rpmostreecxx::ParsedRevisionKind kind;
   ::rust::String value;
 
@@ -1355,44 +1551,50 @@ struct ParsedRevision final {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporterFlags
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporterFlags
-struct RpmImporterFlags final : public ::rust::Opaque {
-  bool is_ima_enabled() const noexcept;
-  ~RpmImporterFlags() = delete;
+struct RpmImporterFlags final : public ::rust::Opaque
+{
+  bool is_ima_enabled () const noexcept;
+  ~RpmImporterFlags () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporterFlags
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporter
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporter
-struct RpmImporter final : public ::rust::Opaque {
-  ::rust::String handle_translate_pathname(::rust::Str path) noexcept;
-  ::rust::String ostree_branch() const noexcept;
-  ::rust::String pkg_name() const noexcept;
-  bool doc_files_are_filtered() const noexcept;
-  void doc_files_insert(::rust::Str path) noexcept;
-  bool doc_files_contains(::rust::Str path) const noexcept;
-  void rpmfi_overrides_insert(::rust::Str path, ::std::uint64_t index) noexcept;
-  bool rpmfi_overrides_contains(::rust::Str path) const noexcept;
-  ::std::uint64_t rpmfi_overrides_get(::rust::Str path) const noexcept;
-  bool is_ima_enabled() const noexcept;
-  void tweak_imported_file_info(::rpmostreecxx::GFileInfo const &file_info) const noexcept;
-  bool is_file_filtered(::rust::Str path, ::rpmostreecxx::GFileInfo const &file_info) const;
-  void translate_to_tmpfiles_entry(::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username, ::rust::Str groupname);
-  bool has_tmpfiles_entries() const noexcept;
-  ::rust::String serialize_tmpfiles_content() const noexcept;
-  ~RpmImporter() = delete;
+struct RpmImporter final : public ::rust::Opaque
+{
+  ::rust::String handle_translate_pathname (::rust::Str path) noexcept;
+  ::rust::String ostree_branch () const noexcept;
+  ::rust::String pkg_name () const noexcept;
+  bool doc_files_are_filtered () const noexcept;
+  void doc_files_insert (::rust::Str path) noexcept;
+  bool doc_files_contains (::rust::Str path) const noexcept;
+  void rpmfi_overrides_insert (::rust::Str path, ::std::uint64_t index) noexcept;
+  bool rpmfi_overrides_contains (::rust::Str path) const noexcept;
+  ::std::uint64_t rpmfi_overrides_get (::rust::Str path) const noexcept;
+  bool is_ima_enabled () const noexcept;
+  void tweak_imported_file_info (::rpmostreecxx::GFileInfo const &file_info) const noexcept;
+  bool is_file_filtered (::rust::Str path, ::rpmostreecxx::GFileInfo const &file_info) const;
+  void translate_to_tmpfiles_entry (::rust::Str abs_path,
+                                    ::rpmostreecxx::GFileInfo const &file_info,
+                                    ::rust::Str username, ::rust::Str groupname);
+  bool has_tmpfiles_entries () const noexcept;
+  ::rust::String serialize_tmpfiles_content () const noexcept;
+  ~RpmImporter () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporter
@@ -1401,73 +1603,81 @@ private:
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryEntry
 // A history entry in the journal. It may represent multiple consecutive boots
 // into the same deployment. This struct is exposed directly via FFI to C.
-struct HistoryEntry final {
+struct HistoryEntry final
+{
   // The deployment root timestamp.
-  ::std::uint64_t deploy_timestamp CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t deploy_timestamp CXX_DEFAULT_VALUE (0);
   // The command-line that was used to create the deployment, if any.
   ::rust::String deploy_cmdline;
   // The number of consecutive times the deployment was booted.
-  ::std::uint64_t boot_count CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t boot_count CXX_DEFAULT_VALUE (0);
   // The first time the deployment was booted if multiple consecutive times.
-  ::std::uint64_t first_boot_timestamp CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t first_boot_timestamp CXX_DEFAULT_VALUE (0);
   // The last time the deployment was booted if multiple consecutive times.
-  ::std::uint64_t last_boot_timestamp CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t last_boot_timestamp CXX_DEFAULT_VALUE (0);
   // `true` if there are no more entries.
-  bool eof CXX_DEFAULT_VALUE(false);
+  bool eof CXX_DEFAULT_VALUE (false);
 
-  bool operator==(HistoryEntry const &) const noexcept;
-  bool operator!=(HistoryEntry const &) const noexcept;
+  bool operator== (HistoryEntry const &) const noexcept;
+  bool operator!= (HistoryEntry const &) const noexcept;
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryEntry
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryCtx
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryCtx
-struct HistoryCtx final : public ::rust::Opaque {
-  ::rpmostreecxx::HistoryEntry next_entry();
-  ~HistoryCtx() = delete;
+struct HistoryCtx final : public ::rust::Opaque
+{
+  ::rpmostreecxx::HistoryEntry next_entry ();
+  ~HistoryCtx () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryCtx
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$TokioHandle
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$TokioHandle
-struct TokioHandle final : public ::rust::Opaque {
-  ::rust::Box<::rpmostreecxx::TokioEnterGuard> enter() const noexcept;
-  ~TokioHandle() = delete;
+struct TokioHandle final : public ::rust::Opaque
+{
+  ::rust::Box<::rpmostreecxx::TokioEnterGuard> enter () const noexcept;
+  ~TokioHandle () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$TokioHandle
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$TokioEnterGuard
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$TokioEnterGuard
-struct TokioEnterGuard final : public ::rust::Opaque {
-  ~TokioEnterGuard() = delete;
+struct TokioEnterGuard final : public ::rust::Opaque
+{
+  ~TokioEnterGuard () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$TokioEnterGuard
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$RepoMetadataTarget
 #define CXXBRIDGE1_ENUM_rpmostreecxx$RepoMetadataTarget
-enum class RepoMetadataTarget : ::std::uint8_t {
+enum class RepoMetadataTarget : ::std::uint8_t
+{
   Inline = 0,
   Detached = 1,
   Disabled = 2,
@@ -1476,7 +1686,8 @@ enum class RepoMetadataTarget : ::std::uint8_t {
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$AdvisoriesMetadataTarget
 #define CXXBRIDGE1_ENUM_rpmostreecxx$AdvisoriesMetadataTarget
-enum class AdvisoriesMetadataTarget : ::std::uint8_t {
+enum class AdvisoriesMetadataTarget : ::std::uint8_t
+{
   Inline = 0,
   Detached = 1,
   Disabled = 2,
@@ -1485,39 +1696,43 @@ enum class AdvisoriesMetadataTarget : ::std::uint8_t {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Refspec
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Refspec
-struct Refspec final {
+struct Refspec final
+{
   ::rpmostreecxx::RefspecType kind;
   ::rust::String refspec;
 
-  bool operator==(Refspec const &) const noexcept;
-  bool operator!=(Refspec const &) const noexcept;
+  bool operator== (Refspec const &) const noexcept;
+  bool operator!= (Refspec const &) const noexcept;
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$Refspec
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$OverrideReplacementType
 #define CXXBRIDGE1_ENUM_rpmostreecxx$OverrideReplacementType
-enum class OverrideReplacementType : ::std::uint8_t {
+enum class OverrideReplacementType : ::std::uint8_t
+{
   Repo = 0,
 };
 #endif // CXXBRIDGE1_ENUM_rpmostreecxx$OverrideReplacementType
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacement
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacement
-struct OverrideReplacement final {
+struct OverrideReplacement final
+{
   ::rust::String from;
   ::rpmostreecxx::OverrideReplacementType from_kind;
   ::rust::Vec<::rust::String> packages;
 
-  bool operator==(OverrideReplacement const &) const noexcept;
-  bool operator!=(OverrideReplacement const &) const noexcept;
+  bool operator== (OverrideReplacement const &) const noexcept;
+  bool operator!= (OverrideReplacement const &) const noexcept;
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacement
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$OptUsrLocal
 #define CXXBRIDGE1_ENUM_rpmostreecxx$OptUsrLocal
-enum class OptUsrLocal : ::std::uint8_t {
+enum class OptUsrLocal : ::std::uint8_t
+{
   Var = 0,
   Root = 1,
   StateOverlay = 2,
@@ -1526,125 +1741,131 @@ enum class OptUsrLocal : ::std::uint8_t {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Treefile
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Treefile
-struct Treefile final : public ::rust::Opaque {
-  ::rust::Str get_workdir() const noexcept;
-  ::std::int32_t get_passwd_fd() noexcept;
-  ::std::int32_t get_group_fd() noexcept;
-  ::rust::String get_json_string() const noexcept;
-  ::rust::Vec<::rust::String> get_ostree_layers() const noexcept;
-  ::rust::Vec<::rust::String> get_ostree_override_layers() const noexcept;
-  ::rust::Vec<::rust::String> get_all_ostree_layers() const noexcept;
-  ::rust::Vec<::rust::String> get_repos() const noexcept;
-  ::rust::Vec<::rust::String> get_packages() const noexcept;
-  ::rust::String require_automatic_version_prefix() const;
-  bool add_packages(::rust::Vec<::rust::String> packages, bool allow_existing);
-  bool has_packages() const noexcept;
-  ::rust::Vec<::rust::String> get_local_packages() const noexcept;
-  bool add_local_packages(::rust::Vec<::rust::String> packages, bool allow_existing);
-  ::rust::Vec<::rust::String> get_local_fileoverride_packages() const noexcept;
-  bool add_local_fileoverride_packages(::rust::Vec<::rust::String> packages, bool allow_existing);
-  bool remove_packages(::rust::Vec<::rust::String> packages, bool allow_noent);
-  ::rust::Vec<::rpmostreecxx::OverrideReplacement> get_packages_override_replace() const noexcept;
-  bool has_packages_override_replace() const noexcept;
-  bool add_packages_override_replace(::rpmostreecxx::OverrideReplacement replacement) noexcept;
-  bool remove_package_override_replace(::rust::Str package) noexcept;
-  ::rust::Vec<::rust::String> get_packages_override_replace_local() const noexcept;
-  void add_packages_override_replace_local(::rust::Vec<::rust::String> packages);
-  bool remove_package_override_replace_local(::rust::Str package) noexcept;
-  ::rust::Vec<::rust::String> get_packages_override_remove() const noexcept;
-  void add_packages_override_remove(::rust::Vec<::rust::String> packages);
-  bool remove_package_override_remove(::rust::Str package) noexcept;
-  bool has_packages_override_remove_name(::rust::Str name) const noexcept;
-  bool remove_all_overrides() noexcept;
-  bool remove_all_packages() noexcept;
-  ::rust::Vec<::rust::String> get_exclude_packages() const noexcept;
-  ::rust::String get_platform_module() const noexcept;
-  ::rust::Vec<::rust::String> get_install_langs() const noexcept;
-  ::rust::String format_install_langs_macro() const noexcept;
-  ::rust::Vec<::rust::String> get_lockfile_repos() const noexcept;
-  ::rust::Str get_ref() const noexcept;
-  bool get_cliwrap() const noexcept;
-  ::rust::Vec<::rust::String> get_cliwrap_binaries() const noexcept;
-  void set_cliwrap(bool enabled) noexcept;
-  ::rust::Vec<::rust::String> get_container_cmd() const noexcept;
-  bool get_readonly_executables() const noexcept;
-  bool get_documentation() const noexcept;
-  bool get_recommends() const noexcept;
-  bool get_selinux() const noexcept;
-  bool get_sysusers_is_forced() const noexcept;
-  ::std::uint32_t get_selinux_label_version() const noexcept;
-  ::rust::String get_gpg_key() const noexcept;
-  ::rust::String get_automatic_version_suffix() const noexcept;
-  bool get_container() const noexcept;
-  bool get_machineid_compat() const noexcept;
-  ::rust::Vec<::rust::String> get_etc_group_members() const noexcept;
-  bool get_boot_location_is_modules() const noexcept;
-  bool use_kernel_install() const noexcept;
-  bool get_ima() const noexcept;
-  ::rust::String get_releasever() const noexcept;
-  ::rpmostreecxx::RepoMetadataTarget get_repo_metadata_target() const noexcept;
-  ::rpmostreecxx::AdvisoriesMetadataTarget get_advisories_metadata_target() const noexcept;
-  bool rpmdb_backend_is_target() const noexcept;
-  bool should_normalize_rpmdb() const noexcept;
-  ::rpmostreecxx::OptUsrLocal get_opt_usrlocal() const noexcept;
-  ::rust::Vec<::rust::String> get_files_remove_regex(::rust::Str package) const noexcept;
-  ::rust::String get_checksum(::rpmostreecxx::OstreeRepo const &repo) const;
-  ::rust::String get_ostree_ref() const noexcept;
-  ::rust::Slice<::rpmostreecxx::RepoPackage const> get_repo_packages() const noexcept;
-  void clear_repo_packages() noexcept;
-  void prettyprint_json_stdout() const noexcept;
-  void print_deprecation_warnings() const noexcept;
-  void print_experimental_notices() const noexcept;
-  void sanitycheck_externals() const;
-  ::rust::Box<::rpmostreecxx::RpmImporterFlags> importer_flags(::rust::Str pkg_name) const noexcept;
-  ::rust::String write_repovars(::std::int32_t workdir_dfd_raw) const;
-  void set_releasever(::rust::Str releasever);
-  void set_recommends(bool val);
-  void enable_repo(::rust::Str repo);
-  void disable_repo(::rust::Str repo);
-  void validate_for_container() const;
-  ::rpmostreecxx::Refspec get_base_refspec() const noexcept;
-  void rebase(::rust::Str new_refspec, ::rust::Str custom_origin_url, ::rust::Str custom_origin_description) noexcept;
-  ::rust::String get_origin_custom_url() const noexcept;
-  ::rust::String get_origin_custom_description() const noexcept;
-  ::rust::String get_override_commit() const noexcept;
-  void set_override_commit(::rust::Str checksum) noexcept;
-  ::rust::Vec<::rust::String> get_initramfs_etc_files() const noexcept;
-  bool has_initramfs_etc_files() const noexcept;
-  bool initramfs_etc_files_track(::rust::Vec<::rust::String> files) noexcept;
-  bool initramfs_etc_files_untrack(::rust::Vec<::rust::String> files) noexcept;
-  bool initramfs_etc_files_untrack_all() noexcept;
-  bool get_initramfs_regenerate() const noexcept;
-  ::rust::Vec<::rust::String> get_initramfs_args() const noexcept;
-  void set_initramfs_regenerate(bool enabled, ::rust::Vec<::rust::String> args) noexcept;
-  ::rust::String get_unconfigured_state() const noexcept;
-  bool may_require_local_assembly() const noexcept;
-  bool has_any_packages() const noexcept;
-  bool merge_treefile(::rust::Str treefile);
-  bool get_no_initramfs() const noexcept;
-  ~Treefile() = delete;
+struct Treefile final : public ::rust::Opaque
+{
+  ::rust::Str get_workdir () const noexcept;
+  ::std::int32_t get_passwd_fd () noexcept;
+  ::std::int32_t get_group_fd () noexcept;
+  ::rust::String get_json_string () const noexcept;
+  ::rust::Vec<::rust::String> get_ostree_layers () const noexcept;
+  ::rust::Vec<::rust::String> get_ostree_override_layers () const noexcept;
+  ::rust::Vec<::rust::String> get_all_ostree_layers () const noexcept;
+  ::rust::Vec<::rust::String> get_repos () const noexcept;
+  ::rust::Vec<::rust::String> get_packages () const noexcept;
+  ::rust::String require_automatic_version_prefix () const;
+  bool add_packages (::rust::Vec<::rust::String> packages, bool allow_existing);
+  bool has_packages () const noexcept;
+  ::rust::Vec<::rust::String> get_local_packages () const noexcept;
+  bool add_local_packages (::rust::Vec<::rust::String> packages, bool allow_existing);
+  ::rust::Vec<::rust::String> get_local_fileoverride_packages () const noexcept;
+  bool add_local_fileoverride_packages (::rust::Vec<::rust::String> packages, bool allow_existing);
+  bool remove_packages (::rust::Vec<::rust::String> packages, bool allow_noent);
+  ::rust::Vec<::rpmostreecxx::OverrideReplacement> get_packages_override_replace () const noexcept;
+  bool has_packages_override_replace () const noexcept;
+  bool add_packages_override_replace (::rpmostreecxx::OverrideReplacement replacement) noexcept;
+  bool remove_package_override_replace (::rust::Str package) noexcept;
+  ::rust::Vec<::rust::String> get_packages_override_replace_local () const noexcept;
+  void add_packages_override_replace_local (::rust::Vec<::rust::String> packages);
+  bool remove_package_override_replace_local (::rust::Str package) noexcept;
+  ::rust::Vec<::rust::String> get_packages_override_remove () const noexcept;
+  void add_packages_override_remove (::rust::Vec<::rust::String> packages);
+  bool remove_package_override_remove (::rust::Str package) noexcept;
+  bool has_packages_override_remove_name (::rust::Str name) const noexcept;
+  bool remove_all_overrides () noexcept;
+  bool remove_all_packages () noexcept;
+  ::rust::Vec<::rust::String> get_exclude_packages () const noexcept;
+  ::rust::String get_platform_module () const noexcept;
+  ::rust::Vec<::rust::String> get_install_langs () const noexcept;
+  ::rust::String format_install_langs_macro () const noexcept;
+  ::rust::Vec<::rust::String> get_lockfile_repos () const noexcept;
+  ::rust::Str get_ref () const noexcept;
+  bool get_cliwrap () const noexcept;
+  ::rust::Vec<::rust::String> get_cliwrap_binaries () const noexcept;
+  void set_cliwrap (bool enabled) noexcept;
+  ::rust::Vec<::rust::String> get_container_cmd () const noexcept;
+  bool get_readonly_executables () const noexcept;
+  bool get_documentation () const noexcept;
+  bool get_recommends () const noexcept;
+  bool get_selinux () const noexcept;
+  bool get_sysusers_is_forced () const noexcept;
+  ::std::uint32_t get_selinux_label_version () const noexcept;
+  ::rust::String get_gpg_key () const noexcept;
+  ::rust::String get_automatic_version_suffix () const noexcept;
+  bool get_container () const noexcept;
+  bool get_machineid_compat () const noexcept;
+  ::rust::Vec<::rust::String> get_etc_group_members () const noexcept;
+  bool get_boot_location_is_modules () const noexcept;
+  bool use_kernel_install () const noexcept;
+  bool get_ima () const noexcept;
+  ::rust::String get_releasever () const noexcept;
+  ::rpmostreecxx::RepoMetadataTarget get_repo_metadata_target () const noexcept;
+  ::rpmostreecxx::AdvisoriesMetadataTarget get_advisories_metadata_target () const noexcept;
+  bool rpmdb_backend_is_target () const noexcept;
+  bool should_normalize_rpmdb () const noexcept;
+  ::rpmostreecxx::OptUsrLocal get_opt_usrlocal () const noexcept;
+  ::rust::Vec<::rust::String> get_files_remove_regex (::rust::Str package) const noexcept;
+  ::rust::String get_checksum (::rpmostreecxx::OstreeRepo const &repo) const;
+  ::rust::String get_ostree_ref () const noexcept;
+  ::rust::Slice<::rpmostreecxx::RepoPackage const> get_repo_packages () const noexcept;
+  void clear_repo_packages () noexcept;
+  void prettyprint_json_stdout () const noexcept;
+  void print_deprecation_warnings () const noexcept;
+  void print_experimental_notices () const noexcept;
+  void sanitycheck_externals () const;
+  ::rust::Box<::rpmostreecxx::RpmImporterFlags>
+  importer_flags (::rust::Str pkg_name) const noexcept;
+  ::rust::String write_repovars (::std::int32_t workdir_dfd_raw) const;
+  void set_releasever (::rust::Str releasever);
+  void set_recommends (bool val);
+  void enable_repo (::rust::Str repo);
+  void disable_repo (::rust::Str repo);
+  void validate_for_container () const;
+  ::rpmostreecxx::Refspec get_base_refspec () const noexcept;
+  void rebase (::rust::Str new_refspec, ::rust::Str custom_origin_url,
+               ::rust::Str custom_origin_description) noexcept;
+  ::rust::String get_origin_custom_url () const noexcept;
+  ::rust::String get_origin_custom_description () const noexcept;
+  ::rust::String get_override_commit () const noexcept;
+  void set_override_commit (::rust::Str checksum) noexcept;
+  ::rust::Vec<::rust::String> get_initramfs_etc_files () const noexcept;
+  bool has_initramfs_etc_files () const noexcept;
+  bool initramfs_etc_files_track (::rust::Vec<::rust::String> files) noexcept;
+  bool initramfs_etc_files_untrack (::rust::Vec<::rust::String> files) noexcept;
+  bool initramfs_etc_files_untrack_all () noexcept;
+  bool get_initramfs_regenerate () const noexcept;
+  ::rust::Vec<::rust::String> get_initramfs_args () const noexcept;
+  void set_initramfs_regenerate (bool enabled, ::rust::Vec<::rust::String> args) noexcept;
+  ::rust::String get_unconfigured_state () const noexcept;
+  bool may_require_local_assembly () const noexcept;
+  bool has_any_packages () const noexcept;
+  bool merge_treefile (::rust::Str treefile);
+  bool get_no_initramfs () const noexcept;
+  ~Treefile () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$Treefile
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$RepoPackage
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$RepoPackage
-struct RepoPackage final : public ::rust::Opaque {
-  ::rust::Str get_repo() const noexcept;
-  ::rust::Vec<::rust::String> get_packages() const noexcept;
-  ~RepoPackage() = delete;
+struct RepoPackage final : public ::rust::Opaque
+{
+  ::rust::Str get_repo () const noexcept;
+  ::rust::Vec<::rust::String> get_packages () const noexcept;
+  ~RepoPackage () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$RepoPackage
@@ -1654,7 +1875,8 @@ private:
 // A copy of LiveFsState that is bridged to C++; the main
 // change here is we can't use Option<> yet, so empty values
 // are represented by the empty string.
-struct LiveApplyState final {
+struct LiveApplyState final
+{
   ::rust::String inprogress;
   ::rust::String commit;
 
@@ -1664,64 +1886,72 @@ struct LiveApplyState final {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdDB
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdDB
-struct PasswdDB final : public ::rust::Opaque {
-  ::rust::String lookup_user(::std::uint32_t uid) const;
-  ::rust::String lookup_group(::std::uint32_t gid) const;
-  ~PasswdDB() = delete;
+struct PasswdDB final : public ::rust::Opaque
+{
+  ::rust::String lookup_user (::std::uint32_t uid) const;
+  ::rust::String lookup_group (::std::uint32_t gid) const;
+  ~PasswdDB () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdDB
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdEntries
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdEntries
-struct PasswdEntries final : public ::rust::Opaque {
-  void add_group_content(::std::int32_t rootfs, ::rust::Str path);
-  void add_passwd_content(::std::int32_t rootfs, ::rust::Str path);
-  bool contains_group(::rust::Str user) const noexcept;
-  bool contains_user(::rust::Str user) const noexcept;
-  ::std::uint32_t lookup_user_id(::rust::Str user) const;
-  ::std::uint32_t lookup_group_id(::rust::Str group) const;
-  ~PasswdEntries() = delete;
+struct PasswdEntries final : public ::rust::Opaque
+{
+  void add_group_content (::std::int32_t rootfs, ::rust::Str path);
+  void add_passwd_content (::std::int32_t rootfs, ::rust::Str path);
+  bool contains_group (::rust::Str user) const noexcept;
+  bool contains_user (::rust::Str user) const noexcept;
+  ::std::uint32_t lookup_user_id (::rust::Str user) const;
+  ::std::uint32_t lookup_group_id (::rust::Str group) const;
+  ~PasswdEntries () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdEntries
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Extensions
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Extensions
-struct Extensions final : public ::rust::Opaque {
-  ::rust::Vec<::rust::String> get_repos() const noexcept;
-  ::rust::Vec<::rust::String> get_os_extension_packages() const noexcept;
-  ::rust::Vec<::rust::String> get_development_packages() const noexcept;
-  bool state_checksum_changed(::rust::Str chksum, ::rust::Str output_dir) const;
-  void update_state_checksum(::rust::Str chksum, ::rust::Str output_dir) const;
-  void serialize_to_dir(::rust::Str output_dir) const;
-  ::rust::Box<::rpmostreecxx::Treefile> generate_treefile(::rpmostreecxx::Treefile const &src) const;
-  ~Extensions() = delete;
+struct Extensions final : public ::rust::Opaque
+{
+  ::rust::Vec<::rust::String> get_repos () const noexcept;
+  ::rust::Vec<::rust::String> get_os_extension_packages () const noexcept;
+  ::rust::Vec<::rust::String> get_development_packages () const noexcept;
+  bool state_checksum_changed (::rust::Str chksum, ::rust::Str output_dir) const;
+  void update_state_checksum (::rust::Str chksum, ::rust::Str output_dir) const;
+  void serialize_to_dir (::rust::Str output_dir) const;
+  ::rust::Box<::rpmostreecxx::Treefile>
+  generate_treefile (::rpmostreecxx::Treefile const &src) const;
+  ~Extensions () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$Extensions
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$LockedPackage
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$LockedPackage
-struct LockedPackage final {
+struct LockedPackage final
+{
   ::rust::String name;
   ::rust::String evr;
   ::rust::String arch;
@@ -1733,3262 +1963,4985 @@ struct LockedPackage final {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$LockfileConfig
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$LockfileConfig
-struct LockfileConfig final : public ::rust::Opaque {
-  ::rust::Vec<::rpmostreecxx::LockedPackage> get_locked_packages() const;
-  ~LockfileConfig() = delete;
+struct LockfileConfig final : public ::rust::Opaque
+{
+  ::rust::Vec<::rpmostreecxx::LockedPackage> get_locked_packages () const;
+  ~LockfileConfig () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$LockfileConfig
 
-static_assert(::std::is_enum<RpmOstreeDiffPrintFormat>::value, "expected enum");
-static_assert(sizeof(RpmOstreeDiffPrintFormat) == sizeof(::std::uint8_t), "incorrect size");
-static_assert(static_cast<::std::uint8_t>(RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_SUMMARY) == 0, "disagrees with the value in #[cxx::bridge]");
-static_assert(static_cast<::std::uint8_t>(RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_ALIGNED) == 1, "disagrees with the value in #[cxx::bridge]");
-static_assert(static_cast<::std::uint8_t>(RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE) == 2, "disagrees with the value in #[cxx::bridge]");
+static_assert (::std::is_enum<RpmOstreeDiffPrintFormat>::value, "expected enum");
+static_assert (sizeof (RpmOstreeDiffPrintFormat) == sizeof (::std::uint8_t), "incorrect size");
+static_assert (
+    static_cast<::std::uint8_t> (RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_SUMMARY)
+        == 0,
+    "disagrees with the value in #[cxx::bridge]");
+static_assert (
+    static_cast<::std::uint8_t> (RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_ALIGNED)
+        == 1,
+    "disagrees with the value in #[cxx::bridge]");
+static_assert (static_cast<::std::uint8_t> (
+                   RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE)
+                   == 2,
+               "disagrees with the value in #[cxx::bridge]");
 
-extern "C" {
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$is_bare_split_xattrs(bool *return$) noexcept;
+extern "C"
+{
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$is_bare_split_xattrs (bool *return$) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$is_http_arg(::rust::Str arg) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$is_http_arg (::rust::Str arg) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$is_ostree_container(bool *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$is_ostree_container (bool *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$get_system_host_type(::rpmostreecxx::SystemHostType *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$get_system_host_type (
+      ::rpmostreecxx::SystemHostType *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$require_system_host_type(::rpmostreecxx::SystemHostType t) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$require_system_host_type (::rpmostreecxx::SystemHostType t) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$is_rpm_arg(::rust::Str arg) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$is_rpm_arg (::rust::Str arg) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$client_start_daemon() noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$client_start_daemon () noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$client_handle_fd_argument(::rust::Str arg, ::rust::Str arch, bool is_replace, ::rust::Vec<::std::int32_t> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$client_handle_fd_argument (
+      ::rust::Str arg, ::rust::Str arch, bool is_replace,
+      ::rust::Vec<::std::int32_t> *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$client_render_download_progress(::rpmostreecxx::GVariant const &progress, ::rust::String *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$client_render_download_progress (
+      ::rpmostreecxx::GVariant const &progress, ::rust::String *return$) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$running_in_container() noexcept;
+  bool rpmostreecxx$cxxbridge1$194$running_in_container () noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$confirm(bool *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$confirm (bool *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$confirm_or_abort() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$Bubblewrap$operator$sizeof() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$Bubblewrap$operator$alignof() noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$confirm_or_abort () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$Bubblewrap$operator$sizeof () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$Bubblewrap$operator$alignof () noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$bubblewrap_selftest() noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$bubblewrap_selftest () noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$bubblewrap_run_sync(::std::int32_t rootfs_dfd, ::rust::Vec<::rust::String> const &args, bool capture_stdout, ::rpmostreecxx::BubblewrapMutability mutability, ::rust::Vec<::std::uint8_t> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$bubblewrap_run_sync (
+      ::std::int32_t rootfs_dfd, ::rust::Vec<::rust::String> const &args, bool capture_stdout,
+      ::rpmostreecxx::BubblewrapMutability mutability,
+      ::rust::Vec<::std::uint8_t> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$bubblewrap_new(::std::int32_t rootfs_fd, ::rust::Box<::rpmostreecxx::Bubblewrap> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$bubblewrap_new (
+      ::std::int32_t rootfs_fd, ::rust::Box<::rpmostreecxx::Bubblewrap> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$bubblewrap_new_with_mutability(::std::int32_t rootfs_fd, ::rpmostreecxx::BubblewrapMutability mutability, ::rust::Box<::rpmostreecxx::Bubblewrap> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$bubblewrap_new_with_mutability (
+      ::std::int32_t rootfs_fd, ::rpmostreecxx::BubblewrapMutability mutability,
+      ::rust::Box<::rpmostreecxx::Bubblewrap> *return$) noexcept;
 
-::std::int32_t rpmostreecxx$cxxbridge1$194$Bubblewrap$get_rootfs_fd(::rpmostreecxx::Bubblewrap const &self) noexcept;
+  ::std::int32_t rpmostreecxx$cxxbridge1$194$Bubblewrap$get_rootfs_fd (
+      ::rpmostreecxx::Bubblewrap const &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Bubblewrap$append_bwrap_arg(::rpmostreecxx::Bubblewrap &self, ::rust::Str arg) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Bubblewrap$append_bwrap_arg (::rpmostreecxx::Bubblewrap &self,
+                                                                ::rust::Str arg) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Bubblewrap$append_child_arg(::rpmostreecxx::Bubblewrap &self, ::rust::Str arg) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Bubblewrap$append_child_arg (::rpmostreecxx::Bubblewrap &self,
+                                                                ::rust::Str arg) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Bubblewrap$setenv(::rpmostreecxx::Bubblewrap &self, ::rust::Str k, ::rust::Str v) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Bubblewrap$setenv (::rpmostreecxx::Bubblewrap &self,
+                                                      ::rust::Str k, ::rust::Str v) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Bubblewrap$take_fd(::rpmostreecxx::Bubblewrap &self, ::std::int32_t source_fd, ::std::int32_t target_fd) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Bubblewrap$take_fd (::rpmostreecxx::Bubblewrap &self,
+                                                       ::std::int32_t source_fd,
+                                                       ::std::int32_t target_fd) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Bubblewrap$set_inherit_stdin(::rpmostreecxx::Bubblewrap &self) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Bubblewrap$set_inherit_stdin (
+      ::rpmostreecxx::Bubblewrap &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdin_fd(::rpmostreecxx::Bubblewrap &self, ::std::int32_t source_fd) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdin_fd (::rpmostreecxx::Bubblewrap &self,
+                                                             ::std::int32_t source_fd) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdout_fd(::rpmostreecxx::Bubblewrap &self, ::std::int32_t source_fd) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdout_fd (::rpmostreecxx::Bubblewrap &self,
+                                                              ::std::int32_t source_fd) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stderr_fd(::rpmostreecxx::Bubblewrap &self, ::std::int32_t source_fd) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stderr_fd (::rpmostreecxx::Bubblewrap &self,
+                                                              ::std::int32_t source_fd) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdout_and_stderr_fd(::rpmostreecxx::Bubblewrap &self, ::std::int32_t source_fd) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdout_and_stderr_fd (
+      ::rpmostreecxx::Bubblewrap &self, ::std::int32_t source_fd) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Bubblewrap$bind_read(::rpmostreecxx::Bubblewrap &self, ::rust::Str src, ::rust::Str dest) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Bubblewrap$bind_read (::rpmostreecxx::Bubblewrap &self,
+                                                         ::rust::Str src,
+                                                         ::rust::Str dest) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Bubblewrap$bind_readwrite(::rpmostreecxx::Bubblewrap &self, ::rust::Str src, ::rust::Str dest) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Bubblewrap$bind_readwrite (::rpmostreecxx::Bubblewrap &self,
+                                                              ::rust::Str src,
+                                                              ::rust::Str dest) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Bubblewrap$setup_compat_var(::rpmostreecxx::Bubblewrap &self) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Bubblewrap$setup_compat_var (
+      ::rpmostreecxx::Bubblewrap &self) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Bubblewrap$run(::rpmostreecxx::Bubblewrap &self, ::rpmostreecxx::GCancellable const &cancellable) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Bubblewrap$run (
+      ::rpmostreecxx::Bubblewrap &self, ::rpmostreecxx::GCancellable const &cancellable) noexcept;
 
-::rpmostreecxx::BubblewrapMutability rpmostreecxx$cxxbridge1$194$mutability_for_unified_core(bool unified_core) noexcept;
+  ::rpmostreecxx::BubblewrapMutability
+  rpmostreecxx$cxxbridge1$194$mutability_for_unified_core (bool unified_core) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$usroverlay_entrypoint(::rust::Vec<::rust::String> const &args) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$usroverlay_entrypoint (
+      ::rust::Vec<::rust::String> const &args) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$applylive_entrypoint(::rust::Vec<::rust::String> const &args) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$applylive_entrypoint (
+      ::rust::Vec<::rust::String> const &args) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$applylive_finish(::rpmostreecxx::OstreeSysroot const &sysroot) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$applylive_finish (
+      ::rpmostreecxx::OstreeSysroot const &sysroot) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$composeutil_legacy_prep_dev_and_run(::std::int32_t rootfs_dfd) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$composeutil_legacy_prep_dev_and_run (
+      ::std::int32_t rootfs_dfd) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$print_ostree_txn_stats(::rpmostreecxx::OstreeRepoTransactionStats &stats) noexcept;
+  void rpmostreecxx$cxxbridge1$194$print_ostree_txn_stats (
+      ::rpmostreecxx::OstreeRepoTransactionStats &stats) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$write_commit_id(::rust::Str target_path, ::rust::Str revision) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$write_commit_id (::rust::Str target_path,
+                                                                    ::rust::Str revision) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$cliwrap_write_wrappers(::std::int32_t rootfs) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$cliwrap_write_wrappers (::std::int32_t rootfs) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$cliwrap_write_some_wrappers(::std::int32_t rootfs, ::rust::Vec<::rust::String> const &args) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$cliwrap_write_some_wrappers (
+      ::std::int32_t rootfs, ::rust::Vec<::rust::String> const &args) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$cliwrap_destdir(::rust::String *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$cliwrap_destdir (::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$container_encapsulate(::rust::Vec<::rust::String> *args) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$container_encapsulate (::rust::Vec<::rust::String> *args) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deploy_from_self_entrypoint(::rust::Vec<::rust::String> *args) noexcept;
-bool rpmostreecxx$cxxbridge1$194$PrunedContainerInfo$operator$eq(PrunedContainerInfo const &, PrunedContainerInfo const &) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deploy_from_self_entrypoint (
+      ::rust::Vec<::rust::String> *args) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$PrunedContainerInfo$operator$eq (
+      PrunedContainerInfo const &, PrunedContainerInfo const &) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$pull_container(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref, ::rust::Str digest_override, ::rust::Box<::rpmostreecxx::ContainerImageState> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$pull_container (
+      ::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable,
+      ::rust::Str imgref, ::rust::Str digest_override,
+      ::rust::Box<::rpmostreecxx::ContainerImageState> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$container_prune(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::PrunedContainerInfo *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$container_prune (
+      ::rpmostreecxx::OstreeSysroot const &sysroot,
+      ::rpmostreecxx::PrunedContainerInfo *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$query_container_image_commit(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str c, ::rust::Box<::rpmostreecxx::ContainerImageState> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$query_container_image_commit (
+      ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str c,
+      ::rust::Box<::rpmostreecxx::ContainerImageState> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$purge_refspec(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$purge_refspec (::rpmostreecxx::OstreeRepo const &repo,
+                                             ::rust::Str refspec) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$check_container_update(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref, bool *return$) noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$TempEtcGuard$operator$sizeof() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$TempEtcGuard$operator$alignof() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$operator$sizeof() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$operator$alignof() noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$check_container_update (
+      ::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable,
+      ::rust::Str imgref, bool *return$) noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$TempEtcGuard$operator$sizeof () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$TempEtcGuard$operator$alignof () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$operator$sizeof () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$operator$alignof () noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$prepare_tempetc_guard(::std::int32_t rootfs, ::rust::Box<::rpmostreecxx::TempEtcGuard> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$prepare_tempetc_guard (
+      ::std::int32_t rootfs, ::rust::Box<::rpmostreecxx::TempEtcGuard> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$TempEtcGuard$undo(::rpmostreecxx::TempEtcGuard const &self) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$TempEtcGuard$undo (::rpmostreecxx::TempEtcGuard const &self) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$prepare_filesystem_script_prep(::std::int32_t rootfs, ::rust::Box<::rpmostreecxx::FilesystemScriptPrep> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$prepare_filesystem_script_prep (
+      ::std::int32_t rootfs, ::rust::Box<::rpmostreecxx::FilesystemScriptPrep> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$undo(::rpmostreecxx::FilesystemScriptPrep &self) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$undo (
+      ::rpmostreecxx::FilesystemScriptPrep &self) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$run_depmod(::std::int32_t rootfs_dfd, ::rust::Str kver, bool unified_core) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$run_depmod (::std::int32_t rootfs_dfd,
+                                                               ::rust::Str kver,
+                                                               bool unified_core) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$run_sysusers(::std::int32_t rootfs_dfd, bool force) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$run_sysusers (::std::int32_t rootfs_dfd,
+                                                                 bool force) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$log_treefile(::rpmostreecxx::Treefile const &tf) noexcept;
+  void rpmostreecxx$cxxbridge1$194$log_treefile (::rpmostreecxx::Treefile const &tf) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$is_container_image_reference(::rust::Str refspec) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$is_container_image_reference (::rust::Str refspec) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$is_container_image_digest_reference(::rust::Str refspec) noexcept;
+  bool
+  rpmostreecxx$cxxbridge1$194$is_container_image_digest_reference (::rust::Str refspec) noexcept;
 
-::rpmostreecxx::RefspecType rpmostreecxx$cxxbridge1$194$refspec_classify(::rust::Str refspec) noexcept;
+  ::rpmostreecxx::RefspecType
+  rpmostreecxx$cxxbridge1$194$refspec_classify (::rust::Str refspec) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$verify_kernel_hmac(::std::int32_t rootfs, ::rust::Str moddir) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$verify_kernel_hmac (::std::int32_t rootfs,
+                                                                       ::rust::Str moddir) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$stage_container_rpms(::rust::Vec<::rust::String> *rpms, ::rust::Vec<::rust::String> *return$) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$stage_container_rpms (::rust::Vec<::rust::String> *rpms,
+                                                    ::rust::Vec<::rust::String> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$stage_container_rpm_raw_fds(::rust::Vec<::std::int32_t> *fds, ::rust::Vec<::rust::String> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$stage_container_rpm_raw_fds (
+      ::rust::Vec<::std::int32_t> *fds, ::rust::Vec<::rust::String> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$commit_has_matching_sepolicy(::rpmostreecxx::GVariant const &commit, ::rpmostreecxx::OstreeSePolicy const &policy, bool *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$commit_has_matching_sepolicy (
+      ::rpmostreecxx::GVariant const &commit, ::rpmostreecxx::OstreeSePolicy const &policy,
+      bool *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$get_header_variant(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str cachebranch, ::rpmostreecxx::GVariant **return$) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$get_header_variant (::rpmostreecxx::OstreeRepo const &repo,
+                                                  ::rust::Str cachebranch,
+                                                  ::rpmostreecxx::GVariant **return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_build_chunked_oci_entrypoint(::rust::Vec<::rust::String> *args) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_build_chunked_oci_entrypoint (
+      ::rust::Vec<::rust::String> *args) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_image(::rust::Vec<::rust::String> *args) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$compose_image (::rust::Vec<::rust::String> *args) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_rootfs_entrypoint(::rust::Vec<::rust::String> *args) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_rootfs_entrypoint (
+      ::rust::Vec<::rust::String> *args) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$configure_build_repo_from_target(::rpmostreecxx::OstreeRepo const &build_repo, ::rpmostreecxx::OstreeRepo const &target_repo) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$configure_build_repo_from_target (
+      ::rpmostreecxx::OstreeRepo const &build_repo,
+      ::rpmostreecxx::OstreeRepo const &target_repo) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_prepare_rootfs(::std::int32_t src_rootfs_dfd, ::std::int32_t dest_rootfs_dfd, ::rpmostreecxx::Treefile &treefile) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$compose_prepare_rootfs (::std::int32_t src_rootfs_dfd,
+                                                      ::std::int32_t dest_rootfs_dfd,
+                                                      ::rpmostreecxx::Treefile &treefile) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$composepost_nsswitch_altfiles(::std::int32_t rootfs_dfd) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$composepost_nsswitch_altfiles (::std::int32_t rootfs_dfd) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_postprocess(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile, ::rust::Str next_version, bool unified_core) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_postprocess (
+      ::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile, ::rust::Str next_version,
+      bool unified_core) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_postprocess_final_pre(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_postprocess_final_pre (
+      ::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_postprocess_final(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$compose_postprocess_final (
+      ::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$convert_var_to_tmpfiles_d(::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable const &cancellable) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$convert_var_to_tmpfiles_d (
+      ::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable const &cancellable) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$rootfs_prepare_links(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile, bool skip_usrlocal) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$rootfs_prepare_links (::std::int32_t rootfs_dfd,
+                                                    ::rpmostreecxx::Treefile const &treefile,
+                                                    bool skip_usrlocal) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$workaround_selinux_cross_labeling(::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable &cancellable) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$workaround_selinux_cross_labeling (
+      ::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable &cancellable) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$postprocess_cleanup_rpmdb(::std::int32_t rootfs_dfd) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$postprocess_cleanup_rpmdb (::std::int32_t rootfs_dfd) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$rewrite_rpmdb_for_target(::std::int32_t rootfs_dfd, bool normalize) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$rewrite_rpmdb_for_target (::std::int32_t rootfs_dfd,
+                                                        bool normalize) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$directory_size(::std::int32_t dfd, ::rpmostreecxx::GCancellable const &cancellable, ::std::uint64_t *return$) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$directory_size (::std::int32_t dfd,
+                                              ::rpmostreecxx::GCancellable const &cancellable,
+                                              ::std::uint64_t *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$container_rebuild(::rust::Str treefile) noexcept {
-  void (*container_rebuild$)(::rust::Str) = ::rpmostreecxx::container_rebuild;
-  ::rust::repr::PtrLen throw$;
-  ::rust::behavior::trycatch(
-      [&] {
-        container_rebuild$(treefile);
-        throw$.ptr = nullptr;
-      },
-      ::rust::detail::Fail(throw$));
-  return throw$;
-}
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$container_rebuild (::rust::Str treefile) noexcept
+  {
+    void (*container_rebuild$) (::rust::Str) = ::rpmostreecxx::container_rebuild;
+    ::rust::repr::PtrLen throw$;
+    ::rust::behavior::trycatch (
+        [&]
+          {
+            container_rebuild$ (treefile);
+            throw$.ptr = nullptr;
+          },
+        ::rust::detail::Fail (throw$));
+    return throw$;
+  }
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_for_id(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id, ::rpmostreecxx::OstreeDeployment **return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_for_id (
+      ::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id,
+      ::rpmostreecxx::OstreeDeployment **return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_checksum_for_id(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id, ::rust::String *return$) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$deployment_checksum_for_id (::rpmostreecxx::OstreeSysroot &sysroot,
+                                                          ::rust::Str deploy_id,
+                                                          ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_get_base(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str opt_deploy_id, ::rust::Str opt_os_name, ::rpmostreecxx::OstreeDeployment **return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_get_base (
+      ::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str opt_deploy_id, ::rust::Str opt_os_name,
+      ::rpmostreecxx::OstreeDeployment **return$) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$deployment_add_manifest_diff(::rpmostreecxx::GVariantDict const &dict, ::rpmostreecxx::ExportedManifestDiff const &diff) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$deployment_add_manifest_diff (
+      ::rpmostreecxx::GVariantDict const &dict,
+      ::rpmostreecxx::ExportedManifestDiff const &diff) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$daemon_sanitycheck_environment(::rpmostreecxx::OstreeSysroot const &sysroot) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$daemon_sanitycheck_environment (
+      ::rpmostreecxx::OstreeSysroot const &sysroot) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$deployment_generate_id(::rpmostreecxx::OstreeDeployment const &deployment, ::rust::String *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$deployment_generate_id (
+      ::rpmostreecxx::OstreeDeployment const &deployment, ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_populate_variant(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::GVariantDict const &dict) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_populate_variant (
+      ::rpmostreecxx::OstreeSysroot const &sysroot,
+      ::rpmostreecxx::OstreeDeployment const &deployment,
+      ::rpmostreecxx::GVariantDict const &dict) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$generate_baselayer_refs(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$generate_baselayer_refs (
+      ::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeRepo const &repo,
+      ::rpmostreecxx::GCancellable const &cancellable) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$variant_add_remote_status(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec, ::rust::Str base_checksum, ::rpmostreecxx::GVariantDict const &dict) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$variant_add_remote_status (
+      ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec, ::rust::Str base_checksum,
+      ::rpmostreecxx::GVariantDict const &dict) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_layeredmeta_from_commit(::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::GVariant const &commit, ::rpmostreecxx::DeploymentLayeredMeta *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_layeredmeta_from_commit (
+      ::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::GVariant const &commit,
+      ::rpmostreecxx::DeploymentLayeredMeta *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_layeredmeta_load(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::DeploymentLayeredMeta *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deployment_layeredmeta_load (
+      ::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::OstreeDeployment const &deployment,
+      ::rpmostreecxx::DeploymentLayeredMeta *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$parse_override_source(::rust::Str source, ::rpmostreecxx::OverrideReplacementSource *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$parse_override_source (
+      ::rust::Str source, ::rpmostreecxx::OverrideReplacementSource *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$parse_revision(::rust::Str source, ::rpmostreecxx::ParsedRevision *return$) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$parse_revision (::rust::Str source,
+                                              ::rpmostreecxx::ParsedRevision *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$generate_object_path(::rust::Str base, ::rust::Str next_segment, ::rust::String *return$) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$generate_object_path (::rust::Str base, ::rust::Str next_segment,
+                                                    ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$failpoint(::rust::Str p) noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$RpmImporterFlags$operator$sizeof() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$RpmImporterFlags$operator$alignof() noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$failpoint (::rust::Str p) noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$RpmImporterFlags$operator$sizeof () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$RpmImporterFlags$operator$alignof () noexcept;
 
-::rpmostreecxx::RpmImporterFlags *rpmostreecxx$cxxbridge1$194$rpm_importer_flags_new_empty() noexcept;
+  ::rpmostreecxx::RpmImporterFlags *
+  rpmostreecxx$cxxbridge1$194$rpm_importer_flags_new_empty () noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$RpmImporterFlags$is_ima_enabled(::rpmostreecxx::RpmImporterFlags const &self) noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$RpmImporter$operator$sizeof() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$RpmImporter$operator$alignof() noexcept;
+  bool rpmostreecxx$cxxbridge1$194$RpmImporterFlags$is_ima_enabled (
+      ::rpmostreecxx::RpmImporterFlags const &self) noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$RpmImporter$operator$sizeof () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$RpmImporter$operator$alignof () noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$rpm_importer_new(::rust::Str pkg_name, ::rust::Str ostree_branch, ::rpmostreecxx::RpmImporterFlags const &flags, ::rust::Box<::rpmostreecxx::RpmImporter> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$rpm_importer_new (
+      ::rust::Str pkg_name, ::rust::Str ostree_branch,
+      ::rpmostreecxx::RpmImporterFlags const &flags,
+      ::rust::Box<::rpmostreecxx::RpmImporter> *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$RpmImporter$handle_translate_pathname(::rpmostreecxx::RpmImporter &self, ::rust::Str path, ::rust::String *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$RpmImporter$handle_translate_pathname (
+      ::rpmostreecxx::RpmImporter &self, ::rust::Str path, ::rust::String *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$RpmImporter$ostree_branch(::rpmostreecxx::RpmImporter const &self, ::rust::String *return$) noexcept;
+  void
+  rpmostreecxx$cxxbridge1$194$RpmImporter$ostree_branch (::rpmostreecxx::RpmImporter const &self,
+                                                         ::rust::String *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$RpmImporter$pkg_name(::rpmostreecxx::RpmImporter const &self, ::rust::String *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$RpmImporter$pkg_name (::rpmostreecxx::RpmImporter const &self,
+                                                         ::rust::String *return$) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_are_filtered(::rpmostreecxx::RpmImporter const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_are_filtered (
+      ::rpmostreecxx::RpmImporter const &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_insert(::rpmostreecxx::RpmImporter &self, ::rust::Str path) noexcept;
+  void rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_insert (::rpmostreecxx::RpmImporter &self,
+                                                                 ::rust::Str path) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_contains(::rpmostreecxx::RpmImporter const &self, ::rust::Str path) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_contains (
+      ::rpmostreecxx::RpmImporter const &self, ::rust::Str path) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_insert(::rpmostreecxx::RpmImporter &self, ::rust::Str path, ::std::uint64_t index) noexcept;
+  void rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_insert (
+      ::rpmostreecxx::RpmImporter &self, ::rust::Str path, ::std::uint64_t index) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_contains(::rpmostreecxx::RpmImporter const &self, ::rust::Str path) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_contains (
+      ::rpmostreecxx::RpmImporter const &self, ::rust::Str path) noexcept;
 
-::std::uint64_t rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_get(::rpmostreecxx::RpmImporter const &self, ::rust::Str path) noexcept;
+  ::std::uint64_t rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_get (
+      ::rpmostreecxx::RpmImporter const &self, ::rust::Str path) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$RpmImporter$is_ima_enabled(::rpmostreecxx::RpmImporter const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$RpmImporter$is_ima_enabled (
+      ::rpmostreecxx::RpmImporter const &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$RpmImporter$tweak_imported_file_info(::rpmostreecxx::RpmImporter const &self, ::rpmostreecxx::GFileInfo const &file_info) noexcept;
+  void rpmostreecxx$cxxbridge1$194$RpmImporter$tweak_imported_file_info (
+      ::rpmostreecxx::RpmImporter const &self, ::rpmostreecxx::GFileInfo const &file_info) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$RpmImporter$is_file_filtered(::rpmostreecxx::RpmImporter const &self, ::rust::Str path, ::rpmostreecxx::GFileInfo const &file_info, bool *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$RpmImporter$is_file_filtered (
+      ::rpmostreecxx::RpmImporter const &self, ::rust::Str path,
+      ::rpmostreecxx::GFileInfo const &file_info, bool *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$RpmImporter$translate_to_tmpfiles_entry(::rpmostreecxx::RpmImporter &self, ::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username, ::rust::Str groupname) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$RpmImporter$translate_to_tmpfiles_entry (
+      ::rpmostreecxx::RpmImporter &self, ::rust::Str abs_path,
+      ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username,
+      ::rust::Str groupname) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$RpmImporter$has_tmpfiles_entries(::rpmostreecxx::RpmImporter const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$RpmImporter$has_tmpfiles_entries (
+      ::rpmostreecxx::RpmImporter const &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$RpmImporter$serialize_tmpfiles_content(::rpmostreecxx::RpmImporter const &self, ::rust::String *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$RpmImporter$serialize_tmpfiles_content (
+      ::rpmostreecxx::RpmImporter const &self, ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$tmpfiles_translate(::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username, ::rust::Str groupname, ::rust::String *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$tmpfiles_translate (
+      ::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username,
+      ::rust::Str groupname, ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$append_dracut_random_cpio(::std::int32_t fd) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$append_dracut_random_cpio (::std::int32_t fd) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$initramfs_overlay_generate(::rust::Vec<::rust::String> const &files, ::rpmostreecxx::GCancellable &cancellable, ::std::int32_t *return$) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$initramfs_overlay_generate (::rust::Vec<::rust::String> const &files,
+                                                          ::rpmostreecxx::GCancellable &cancellable,
+                                                          ::std::int32_t *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$journal_print_staging_failure() noexcept;
+  void rpmostreecxx$cxxbridge1$194$journal_print_staging_failure () noexcept;
 
-void rpmostreecxx$cxxbridge1$194$console_progress_begin_task(::rust::Str msg) noexcept;
+  void rpmostreecxx$cxxbridge1$194$console_progress_begin_task (::rust::Str msg) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$console_progress_begin_n_items(::rust::Str msg, ::std::uint64_t n) noexcept;
+  void rpmostreecxx$cxxbridge1$194$console_progress_begin_n_items (::rust::Str msg,
+                                                                   ::std::uint64_t n) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$console_progress_begin_percent(::rust::Str msg) noexcept;
+  void rpmostreecxx$cxxbridge1$194$console_progress_begin_percent (::rust::Str msg) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$console_progress_set_message(::rust::Str msg) noexcept;
+  void rpmostreecxx$cxxbridge1$194$console_progress_set_message (::rust::Str msg) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$console_progress_set_sub_message(::rust::Str msg) noexcept;
+  void rpmostreecxx$cxxbridge1$194$console_progress_set_sub_message (::rust::Str msg) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$console_progress_update(::std::uint64_t n) noexcept;
+  void rpmostreecxx$cxxbridge1$194$console_progress_update (::std::uint64_t n) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$console_progress_end(::rust::Str suffix) noexcept;
-bool rpmostreecxx$cxxbridge1$194$HistoryEntry$operator$eq(HistoryEntry const &, HistoryEntry const &) noexcept;
-bool rpmostreecxx$cxxbridge1$194$HistoryEntry$operator$ne(HistoryEntry const &, HistoryEntry const &) noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$HistoryCtx$operator$sizeof() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$HistoryCtx$operator$alignof() noexcept;
+  void rpmostreecxx$cxxbridge1$194$console_progress_end (::rust::Str suffix) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$HistoryEntry$operator$eq (HistoryEntry const &,
+                                                             HistoryEntry const &) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$HistoryEntry$operator$ne (HistoryEntry const &,
+                                                             HistoryEntry const &) noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$HistoryCtx$operator$sizeof () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$HistoryCtx$operator$alignof () noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$history_ctx_new(::rust::Box<::rpmostreecxx::HistoryCtx> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$history_ctx_new (
+      ::rust::Box<::rpmostreecxx::HistoryCtx> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$HistoryCtx$next_entry(::rpmostreecxx::HistoryCtx &self, ::rpmostreecxx::HistoryEntry *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$HistoryCtx$next_entry (
+      ::rpmostreecxx::HistoryCtx &self, ::rpmostreecxx::HistoryEntry *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$history_prune() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$TokioHandle$operator$sizeof() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$TokioHandle$operator$alignof() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$TokioEnterGuard$operator$sizeof() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$TokioEnterGuard$operator$alignof() noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$history_prune () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$TokioHandle$operator$sizeof () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$TokioHandle$operator$alignof () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$TokioEnterGuard$operator$sizeof () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$TokioEnterGuard$operator$alignof () noexcept;
 
-::rpmostreecxx::TokioHandle *rpmostreecxx$cxxbridge1$194$tokio_handle_get() noexcept;
+  ::rpmostreecxx::TokioHandle *rpmostreecxx$cxxbridge1$194$tokio_handle_get () noexcept;
 
-::rpmostreecxx::TokioEnterGuard *rpmostreecxx$cxxbridge1$194$TokioHandle$enter(::rpmostreecxx::TokioHandle const &self) noexcept;
+  ::rpmostreecxx::TokioEnterGuard *
+  rpmostreecxx$cxxbridge1$194$TokioHandle$enter (::rpmostreecxx::TokioHandle const &self) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$script_is_ignored(::rust::Str pkg, ::rust::Str script, bool use_kernel_install) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$script_is_ignored (::rust::Str pkg, ::rust::Str script,
+                                                      bool use_kernel_install) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$testutils_entrypoint(::rust::Vec<::rust::String> *argv) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$testutils_entrypoint (::rust::Vec<::rust::String> *argv) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$maybe_shell_quote(::rust::Str input, ::rust::String *return$) noexcept;
-bool rpmostreecxx$cxxbridge1$194$Refspec$operator$eq(Refspec const &, Refspec const &) noexcept;
-bool rpmostreecxx$cxxbridge1$194$OverrideReplacement$operator$eq(OverrideReplacement const &, OverrideReplacement const &) noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$Treefile$operator$sizeof() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$Treefile$operator$alignof() noexcept;
+  void rpmostreecxx$cxxbridge1$194$maybe_shell_quote (::rust::Str input,
+                                                      ::rust::String *return$) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Refspec$operator$eq (Refspec const &, Refspec const &) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$OverrideReplacement$operator$eq (
+      OverrideReplacement const &, OverrideReplacement const &) noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$Treefile$operator$sizeof () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$Treefile$operator$alignof () noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new(::rust::Str filename, ::rust::Str basearch, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new (
+      ::rust::Str filename, ::rust::Str basearch,
+      ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new_empty(::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new_empty (
+      ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new_from_string(::rust::Str buf, bool client, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new_from_string (
+      ::rust::Str buf, bool client, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new_compose(::rust::Str filename, ::rust::Str basearch, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new_compose (
+      ::rust::Str filename, ::rust::Str basearch,
+      ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new_client(::rust::Str filename, ::rust::Str basearch, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new_client (
+      ::rust::Str filename, ::rust::Str basearch,
+      ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new_client_from_etc(::rust::Str basearch, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_new_client_from_etc (
+      ::rust::Str basearch, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_delete_client_etc(::std::uint32_t *return$) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$treefile_delete_client_etc (::std::uint32_t *return$) noexcept;
 
-::rust::repr::Fat rpmostreecxx$cxxbridge1$194$Treefile$get_workdir(::rpmostreecxx::Treefile const &self) noexcept;
+  ::rust::repr::Fat
+  rpmostreecxx$cxxbridge1$194$Treefile$get_workdir (::rpmostreecxx::Treefile const &self) noexcept;
 
-::std::int32_t rpmostreecxx$cxxbridge1$194$Treefile$get_passwd_fd(::rpmostreecxx::Treefile &self) noexcept;
+  ::std::int32_t
+  rpmostreecxx$cxxbridge1$194$Treefile$get_passwd_fd (::rpmostreecxx::Treefile &self) noexcept;
 
-::std::int32_t rpmostreecxx$cxxbridge1$194$Treefile$get_group_fd(::rpmostreecxx::Treefile &self) noexcept;
+  ::std::int32_t
+  rpmostreecxx$cxxbridge1$194$Treefile$get_group_fd (::rpmostreecxx::Treefile &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_json_string(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_json_string (::rpmostreecxx::Treefile const &self,
+                                                             ::rust::String *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_layers(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_layers (
+      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_override_layers(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_override_layers (
+      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_all_ostree_layers(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_all_ostree_layers (
+      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_repos(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void
+  rpmostreecxx$cxxbridge1$194$Treefile$get_repos (::rpmostreecxx::Treefile const &self,
+                                                  ::rust::Vec<::rust::String> *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_packages(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void
+  rpmostreecxx$cxxbridge1$194$Treefile$get_packages (::rpmostreecxx::Treefile const &self,
+                                                     ::rust::Vec<::rust::String> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$require_automatic_version_prefix(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$require_automatic_version_prefix (
+      ::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$add_packages(::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages, bool allow_existing, bool *return$) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$Treefile$add_packages (::rpmostreecxx::Treefile &self,
+                                                     ::rust::Vec<::rust::String> *packages,
+                                                     bool allow_existing, bool *return$) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$has_packages(::rpmostreecxx::Treefile const &self) noexcept;
+  bool
+  rpmostreecxx$cxxbridge1$194$Treefile$has_packages (::rpmostreecxx::Treefile const &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_local_packages(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_local_packages (
+      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$add_local_packages(::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages, bool allow_existing, bool *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$add_local_packages (
+      ::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages, bool allow_existing,
+      bool *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_local_fileoverride_packages(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_local_fileoverride_packages (
+      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$add_local_fileoverride_packages(::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages, bool allow_existing, bool *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$add_local_fileoverride_packages (
+      ::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages, bool allow_existing,
+      bool *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$remove_packages(::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages, bool allow_noent, bool *return$) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$Treefile$remove_packages (::rpmostreecxx::Treefile &self,
+                                                        ::rust::Vec<::rust::String> *packages,
+                                                        bool allow_noent, bool *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_replace(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rpmostreecxx::OverrideReplacement> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_replace (
+      ::rpmostreecxx::Treefile const &self,
+      ::rust::Vec<::rpmostreecxx::OverrideReplacement> *return$) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$has_packages_override_replace(::rpmostreecxx::Treefile const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$has_packages_override_replace (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_replace(::rpmostreecxx::Treefile &self, ::rpmostreecxx::OverrideReplacement *replacement) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_replace (
+      ::rpmostreecxx::Treefile &self, ::rpmostreecxx::OverrideReplacement *replacement) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_replace(::rpmostreecxx::Treefile &self, ::rust::Str package) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_replace (
+      ::rpmostreecxx::Treefile &self, ::rust::Str package) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_replace_local(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_replace_local (
+      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_replace_local(::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_replace_local (
+      ::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_replace_local(::rpmostreecxx::Treefile &self, ::rust::Str package) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_replace_local (
+      ::rpmostreecxx::Treefile &self, ::rust::Str package) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_remove(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_remove (
+      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_remove(::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_remove (
+      ::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *packages) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_remove(::rpmostreecxx::Treefile &self, ::rust::Str package) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_remove (
+      ::rpmostreecxx::Treefile &self, ::rust::Str package) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$has_packages_override_remove_name(::rpmostreecxx::Treefile const &self, ::rust::Str name) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$has_packages_override_remove_name (
+      ::rpmostreecxx::Treefile const &self, ::rust::Str name) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$remove_all_overrides(::rpmostreecxx::Treefile &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$remove_all_overrides (
+      ::rpmostreecxx::Treefile &self) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$remove_all_packages(::rpmostreecxx::Treefile &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$remove_all_packages (
+      ::rpmostreecxx::Treefile &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_exclude_packages(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_exclude_packages (
+      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_platform_module(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
+  void
+  rpmostreecxx$cxxbridge1$194$Treefile$get_platform_module (::rpmostreecxx::Treefile const &self,
+                                                            ::rust::String *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_install_langs(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_install_langs (
+      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$format_install_langs_macro(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$format_install_langs_macro (
+      ::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_lockfile_repos(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_lockfile_repos (
+      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-::rust::repr::Fat rpmostreecxx$cxxbridge1$194$Treefile$get_ref(::rpmostreecxx::Treefile const &self) noexcept;
+  ::rust::repr::Fat
+  rpmostreecxx$cxxbridge1$194$Treefile$get_ref (::rpmostreecxx::Treefile const &self) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$get_cliwrap(::rpmostreecxx::Treefile const &self) noexcept;
+  bool
+  rpmostreecxx$cxxbridge1$194$Treefile$get_cliwrap (::rpmostreecxx::Treefile const &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_cliwrap_binaries(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_cliwrap_binaries (
+      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$set_cliwrap(::rpmostreecxx::Treefile &self, bool enabled) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$set_cliwrap (::rpmostreecxx::Treefile &self,
+                                                         bool enabled) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_container_cmd(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_container_cmd (
+      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$get_readonly_executables(::rpmostreecxx::Treefile const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$get_readonly_executables (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$get_documentation(::rpmostreecxx::Treefile const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$get_documentation (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$get_recommends(::rpmostreecxx::Treefile const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$get_recommends (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$get_selinux(::rpmostreecxx::Treefile const &self) noexcept;
+  bool
+  rpmostreecxx$cxxbridge1$194$Treefile$get_selinux (::rpmostreecxx::Treefile const &self) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$get_sysusers_is_forced(::rpmostreecxx::Treefile const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$get_sysusers_is_forced (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-::std::uint32_t rpmostreecxx$cxxbridge1$194$Treefile$get_selinux_label_version(::rpmostreecxx::Treefile const &self) noexcept;
+  ::std::uint32_t rpmostreecxx$cxxbridge1$194$Treefile$get_selinux_label_version (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_gpg_key(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_gpg_key (::rpmostreecxx::Treefile const &self,
+                                                         ::rust::String *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_automatic_version_suffix(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_automatic_version_suffix (
+      ::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$get_container(::rpmostreecxx::Treefile const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$get_container (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$get_machineid_compat(::rpmostreecxx::Treefile const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$get_machineid_compat (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_etc_group_members(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_etc_group_members (
+      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$get_boot_location_is_modules(::rpmostreecxx::Treefile const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$get_boot_location_is_modules (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$use_kernel_install(::rpmostreecxx::Treefile const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$use_kernel_install (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$get_ima(::rpmostreecxx::Treefile const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$get_ima (::rpmostreecxx::Treefile const &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_releasever(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_releasever (::rpmostreecxx::Treefile const &self,
+                                                            ::rust::String *return$) noexcept;
 
-::rpmostreecxx::RepoMetadataTarget rpmostreecxx$cxxbridge1$194$Treefile$get_repo_metadata_target(::rpmostreecxx::Treefile const &self) noexcept;
+  ::rpmostreecxx::RepoMetadataTarget rpmostreecxx$cxxbridge1$194$Treefile$get_repo_metadata_target (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-::rpmostreecxx::AdvisoriesMetadataTarget rpmostreecxx$cxxbridge1$194$Treefile$get_advisories_metadata_target(::rpmostreecxx::Treefile const &self) noexcept;
+  ::rpmostreecxx::AdvisoriesMetadataTarget
+  rpmostreecxx$cxxbridge1$194$Treefile$get_advisories_metadata_target (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$rpmdb_backend_is_target(::rpmostreecxx::Treefile const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$rpmdb_backend_is_target (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$should_normalize_rpmdb(::rpmostreecxx::Treefile const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$should_normalize_rpmdb (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-::rpmostreecxx::OptUsrLocal rpmostreecxx$cxxbridge1$194$Treefile$get_opt_usrlocal(::rpmostreecxx::Treefile const &self) noexcept;
+  ::rpmostreecxx::OptUsrLocal rpmostreecxx$cxxbridge1$194$Treefile$get_opt_usrlocal (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_files_remove_regex(::rpmostreecxx::Treefile const &self, ::rust::Str package, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_files_remove_regex (
+      ::rpmostreecxx::Treefile const &self, ::rust::Str package,
+      ::rust::Vec<::rust::String> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$get_checksum(::rpmostreecxx::Treefile const &self, ::rpmostreecxx::OstreeRepo const &repo, ::rust::String *return$) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$Treefile$get_checksum (::rpmostreecxx::Treefile const &self,
+                                                     ::rpmostreecxx::OstreeRepo const &repo,
+                                                     ::rust::String *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_ref(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_ref (::rpmostreecxx::Treefile const &self,
+                                                            ::rust::String *return$) noexcept;
 
-::rust::repr::Fat rpmostreecxx$cxxbridge1$194$Treefile$get_repo_packages(::rpmostreecxx::Treefile const &self) noexcept;
+  ::rust::repr::Fat rpmostreecxx$cxxbridge1$194$Treefile$get_repo_packages (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$clear_repo_packages(::rpmostreecxx::Treefile &self) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$clear_repo_packages (
+      ::rpmostreecxx::Treefile &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$prettyprint_json_stdout(::rpmostreecxx::Treefile const &self) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$prettyprint_json_stdout (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$print_deprecation_warnings(::rpmostreecxx::Treefile const &self) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$print_deprecation_warnings (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$print_experimental_notices(::rpmostreecxx::Treefile const &self) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$print_experimental_notices (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$sanitycheck_externals(::rpmostreecxx::Treefile const &self) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$sanitycheck_externals (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-::rpmostreecxx::RpmImporterFlags *rpmostreecxx$cxxbridge1$194$Treefile$importer_flags(::rpmostreecxx::Treefile const &self, ::rust::Str pkg_name) noexcept;
+  ::rpmostreecxx::RpmImporterFlags *
+  rpmostreecxx$cxxbridge1$194$Treefile$importer_flags (::rpmostreecxx::Treefile const &self,
+                                                       ::rust::Str pkg_name) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$write_repovars(::rpmostreecxx::Treefile const &self, ::std::int32_t workdir_dfd_raw, ::rust::String *return$) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$Treefile$write_repovars (::rpmostreecxx::Treefile const &self,
+                                                       ::std::int32_t workdir_dfd_raw,
+                                                       ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$set_releasever(::rpmostreecxx::Treefile &self, ::rust::Str releasever) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$Treefile$set_releasever (::rpmostreecxx::Treefile &self,
+                                                       ::rust::Str releasever) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$set_recommends(::rpmostreecxx::Treefile &self, bool val) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$Treefile$set_recommends (::rpmostreecxx::Treefile &self,
+                                                       bool val) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$enable_repo(::rpmostreecxx::Treefile &self, ::rust::Str repo) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$Treefile$enable_repo (::rpmostreecxx::Treefile &self,
+                                                    ::rust::Str repo) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$disable_repo(::rpmostreecxx::Treefile &self, ::rust::Str repo) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$Treefile$disable_repo (::rpmostreecxx::Treefile &self,
+                                                     ::rust::Str repo) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$validate_for_container(::rpmostreecxx::Treefile const &self) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$validate_for_container (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_base_refspec(::rpmostreecxx::Treefile const &self, ::rpmostreecxx::Refspec *return$) noexcept;
+  void
+  rpmostreecxx$cxxbridge1$194$Treefile$get_base_refspec (::rpmostreecxx::Treefile const &self,
+                                                         ::rpmostreecxx::Refspec *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$rebase(::rpmostreecxx::Treefile &self, ::rust::Str new_refspec, ::rust::Str custom_origin_url, ::rust::Str custom_origin_description) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$rebase (::rpmostreecxx::Treefile &self,
+                                                    ::rust::Str new_refspec,
+                                                    ::rust::Str custom_origin_url,
+                                                    ::rust::Str custom_origin_description) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_origin_custom_url(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
+  void
+  rpmostreecxx$cxxbridge1$194$Treefile$get_origin_custom_url (::rpmostreecxx::Treefile const &self,
+                                                              ::rust::String *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_origin_custom_description(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_origin_custom_description (
+      ::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_override_commit(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
+  void
+  rpmostreecxx$cxxbridge1$194$Treefile$get_override_commit (::rpmostreecxx::Treefile const &self,
+                                                            ::rust::String *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$set_override_commit(::rpmostreecxx::Treefile &self, ::rust::Str checksum) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$set_override_commit (::rpmostreecxx::Treefile &self,
+                                                                 ::rust::Str checksum) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_etc_files(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_etc_files (
+      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$has_initramfs_etc_files(::rpmostreecxx::Treefile const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$has_initramfs_etc_files (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_track(::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *files) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_track (
+      ::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *files) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_untrack(::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *files) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_untrack (
+      ::rpmostreecxx::Treefile &self, ::rust::Vec<::rust::String> *files) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_untrack_all(::rpmostreecxx::Treefile &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_untrack_all (
+      ::rpmostreecxx::Treefile &self) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_regenerate(::rpmostreecxx::Treefile const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_regenerate (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_args(::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_args (
+      ::rpmostreecxx::Treefile const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$set_initramfs_regenerate(::rpmostreecxx::Treefile &self, bool enabled, ::rust::Vec<::rust::String> *args) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Treefile$set_initramfs_regenerate (
+      ::rpmostreecxx::Treefile &self, bool enabled, ::rust::Vec<::rust::String> *args) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Treefile$get_unconfigured_state(::rpmostreecxx::Treefile const &self, ::rust::String *return$) noexcept;
+  void
+  rpmostreecxx$cxxbridge1$194$Treefile$get_unconfigured_state (::rpmostreecxx::Treefile const &self,
+                                                               ::rust::String *return$) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$may_require_local_assembly(::rpmostreecxx::Treefile const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$may_require_local_assembly (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$has_any_packages(::rpmostreecxx::Treefile const &self) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$has_any_packages (
+      ::rpmostreecxx::Treefile const &self) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$merge_treefile(::rpmostreecxx::Treefile &self, ::rust::Str treefile, bool *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Treefile$merge_treefile (
+      ::rpmostreecxx::Treefile &self, ::rust::Str treefile, bool *return$) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$Treefile$get_no_initramfs(::rpmostreecxx::Treefile const &self) noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$RepoPackage$operator$sizeof() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$RepoPackage$operator$alignof() noexcept;
+  bool rpmostreecxx$cxxbridge1$194$Treefile$get_no_initramfs (
+      ::rpmostreecxx::Treefile const &self) noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$RepoPackage$operator$sizeof () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$RepoPackage$operator$alignof () noexcept;
 
-::rust::repr::Fat rpmostreecxx$cxxbridge1$194$RepoPackage$get_repo(::rpmostreecxx::RepoPackage const &self) noexcept;
+  ::rust::repr::Fat rpmostreecxx$cxxbridge1$194$RepoPackage$get_repo (
+      ::rpmostreecxx::RepoPackage const &self) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$RepoPackage$get_packages(::rpmostreecxx::RepoPackage const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$RepoPackage$get_packages (
+      ::rpmostreecxx::RepoPackage const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$varsubstitute(::rust::Str s, ::rust::Vec<::rpmostreecxx::StringMapping> const &vars, ::rust::String *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$get_repos_dirs (::rust::Vec<::rust::String> *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$get_features(::rust::Vec<::rust::String> *return$) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$varsubstitute (::rust::Str s,
+                                             ::rust::Vec<::rpmostreecxx::StringMapping> const &vars,
+                                             ::rust::String *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$get_rpm_basearch(::rust::String *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$get_features (::rust::Vec<::rust::String> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$sealed_memfd(::rust::Str description, ::rust::Slice<::std::uint8_t const> content, ::std::int32_t *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$get_rpm_basearch (::rust::String *return$) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$running_in_systemd() noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$sealed_memfd (::rust::Str description,
+                                            ::rust::Slice<::std::uint8_t const> content,
+                                            ::std::int32_t *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$calculate_advisories_diff(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str checksum_from, ::rust::Str checksum_to, ::rpmostreecxx::GVariant **return$) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$running_in_systemd () noexcept;
 
-void rpmostreecxx$cxxbridge1$194$translate_path_for_ostree(::rust::Str path, ::rust::String *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$calculate_advisories_diff (
+      ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str checksum_from, ::rust::Str checksum_to,
+      ::rpmostreecxx::GVariant **return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$get_live_apply_state(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::LiveApplyState *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$translate_path_for_ostree (::rust::Str path,
+                                                              ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$has_live_apply_state(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment, bool *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$get_live_apply_state (
+      ::rpmostreecxx::OstreeSysroot const &sysroot,
+      ::rpmostreecxx::OstreeDeployment const &deployment,
+      ::rpmostreecxx::LiveApplyState *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$applylive_sync_ref(::rpmostreecxx::OstreeSysroot const &sysroot) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$has_live_apply_state (
+      ::rpmostreecxx::OstreeSysroot const &sysroot,
+      ::rpmostreecxx::OstreeDeployment const &deployment, bool *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$transaction_apply_live(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::GVariant const &target) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$applylive_sync_ref (
+      ::rpmostreecxx::OstreeSysroot const &sysroot) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$normalize_etc_shadow(::std::int32_t rootfs_dfd) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$transaction_apply_live (
+      ::rpmostreecxx::OstreeSysroot const &sysroot,
+      ::rpmostreecxx::GVariant const &target) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$prepare_rpm_layering(::std::int32_t rootfs, ::std::int32_t merge_passwd_dir, bool *return$) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$normalize_etc_shadow (::std::int32_t rootfs_dfd) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$complete_rpm_layering(::std::int32_t rootfs) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$prepare_rpm_layering (
+      ::std::int32_t rootfs, ::std::int32_t merge_passwd_dir, bool *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$deduplicate_tmpfiles_entries(::std::int32_t rootfs) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$complete_rpm_layering (::std::int32_t rootfs) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$passwd_cleanup(::std::int32_t rootfs) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$deduplicate_tmpfiles_entries (::std::int32_t rootfs) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$migrate_group_except_root(::std::int32_t rootfs, ::rust::Vec<::rust::String> const &preserved_groups) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$passwd_cleanup (::std::int32_t rootfs) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$migrate_passwd_except_root(::std::int32_t rootfs) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$migrate_group_except_root (
+      ::std::int32_t rootfs, ::rust::Vec<::rust::String> const &preserved_groups) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$passwd_compose_prep(::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$migrate_passwd_except_root (::std::int32_t rootfs) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$passwd_compose_prep_repo(::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile, ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str previous_checksum, bool unified_core) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$passwd_compose_prep (::std::int32_t rootfs,
+                                                   ::rpmostreecxx::Treefile &treefile) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$dir_contains_uid(::std::int32_t dirfd, ::std::uint32_t id, bool *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$passwd_compose_prep_repo (
+      ::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile,
+      ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str previous_checksum,
+      bool unified_core) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$dir_contains_gid(::std::int32_t dirfd, ::std::uint32_t id, bool *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$dir_contains_uid (::std::int32_t dirfd,
+                                                                     ::std::uint32_t id,
+                                                                     bool *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$check_passwd_group_entries(::rpmostreecxx::OstreeRepo const &ffi_repo, ::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile, ::rust::Str previous_rev) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$dir_contains_gid (::std::int32_t dirfd,
+                                                                     ::std::uint32_t id,
+                                                                     bool *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$passwddb_open(::std::int32_t rootfs, ::rust::Box<::rpmostreecxx::PasswdDB> *return$) noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$PasswdDB$operator$sizeof() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$PasswdDB$operator$alignof() noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$check_passwd_group_entries (
+      ::rpmostreecxx::OstreeRepo const &ffi_repo, ::std::int32_t rootfs_dfd,
+      ::rpmostreecxx::Treefile &treefile, ::rust::Str previous_rev) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdDB$lookup_user(::rpmostreecxx::PasswdDB const &self, ::std::uint32_t uid, ::rust::String *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$passwddb_open (
+      ::std::int32_t rootfs, ::rust::Box<::rpmostreecxx::PasswdDB> *return$) noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$PasswdDB$operator$sizeof () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$PasswdDB$operator$alignof () noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdDB$lookup_group(::rpmostreecxx::PasswdDB const &self, ::std::uint32_t gid, ::rust::String *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdDB$lookup_user (
+      ::rpmostreecxx::PasswdDB const &self, ::std::uint32_t uid, ::rust::String *return$) noexcept;
 
-::rpmostreecxx::PasswdEntries *rpmostreecxx$cxxbridge1$194$new_passwd_entries() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$PasswdEntries$operator$sizeof() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$PasswdEntries$operator$alignof() noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdDB$lookup_group (
+      ::rpmostreecxx::PasswdDB const &self, ::std::uint32_t gid, ::rust::String *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdEntries$add_group_content(::rpmostreecxx::PasswdEntries &self, ::std::int32_t rootfs, ::rust::Str path) noexcept;
+  ::rpmostreecxx::PasswdEntries *rpmostreecxx$cxxbridge1$194$new_passwd_entries () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$PasswdEntries$operator$sizeof () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$PasswdEntries$operator$alignof () noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdEntries$add_passwd_content(::rpmostreecxx::PasswdEntries &self, ::std::int32_t rootfs, ::rust::Str path) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdEntries$add_group_content (
+      ::rpmostreecxx::PasswdEntries &self, ::std::int32_t rootfs, ::rust::Str path) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$PasswdEntries$contains_group(::rpmostreecxx::PasswdEntries const &self, ::rust::Str user) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdEntries$add_passwd_content (
+      ::rpmostreecxx::PasswdEntries &self, ::std::int32_t rootfs, ::rust::Str path) noexcept;
 
-bool rpmostreecxx$cxxbridge1$194$PasswdEntries$contains_user(::rpmostreecxx::PasswdEntries const &self, ::rust::Str user) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$PasswdEntries$contains_group (
+      ::rpmostreecxx::PasswdEntries const &self, ::rust::Str user) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdEntries$lookup_user_id(::rpmostreecxx::PasswdEntries const &self, ::rust::Str user, ::std::uint32_t *return$) noexcept;
+  bool rpmostreecxx$cxxbridge1$194$PasswdEntries$contains_user (
+      ::rpmostreecxx::PasswdEntries const &self, ::rust::Str user) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdEntries$lookup_group_id(::rpmostreecxx::PasswdEntries const &self, ::rust::Str group, ::std::uint32_t *return$) noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$Extensions$operator$sizeof() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$Extensions$operator$alignof() noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdEntries$lookup_user_id (
+      ::rpmostreecxx::PasswdEntries const &self, ::rust::Str user,
+      ::std::uint32_t *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$extensions_load(::rust::Str path, ::rust::Str basearch, ::rust::Vec<::rpmostreecxx::StringMapping> const &base_pkgs, ::rust::Box<::rpmostreecxx::Extensions> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PasswdEntries$lookup_group_id (
+      ::rpmostreecxx::PasswdEntries const &self, ::rust::Str group,
+      ::std::uint32_t *return$) noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$Extensions$operator$sizeof () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$Extensions$operator$alignof () noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Extensions$get_repos(::rpmostreecxx::Extensions const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$extensions_load (
+      ::rust::Str path, ::rust::Str basearch,
+      ::rust::Vec<::rpmostreecxx::StringMapping> const &base_pkgs,
+      ::rust::Box<::rpmostreecxx::Extensions> *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Extensions$get_os_extension_packages(::rpmostreecxx::Extensions const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void
+  rpmostreecxx$cxxbridge1$194$Extensions$get_repos (::rpmostreecxx::Extensions const &self,
+                                                    ::rust::Vec<::rust::String> *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$Extensions$get_development_packages(::rpmostreecxx::Extensions const &self, ::rust::Vec<::rust::String> *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Extensions$get_os_extension_packages (
+      ::rpmostreecxx::Extensions const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Extensions$state_checksum_changed(::rpmostreecxx::Extensions const &self, ::rust::Str chksum, ::rust::Str output_dir, bool *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$Extensions$get_development_packages (
+      ::rpmostreecxx::Extensions const &self, ::rust::Vec<::rust::String> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Extensions$update_state_checksum(::rpmostreecxx::Extensions const &self, ::rust::Str chksum, ::rust::Str output_dir) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Extensions$state_checksum_changed (
+      ::rpmostreecxx::Extensions const &self, ::rust::Str chksum, ::rust::Str output_dir,
+      bool *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Extensions$serialize_to_dir(::rpmostreecxx::Extensions const &self, ::rust::Str output_dir) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Extensions$update_state_checksum (
+      ::rpmostreecxx::Extensions const &self, ::rust::Str chksum, ::rust::Str output_dir) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Extensions$generate_treefile(::rpmostreecxx::Extensions const &self, ::rpmostreecxx::Treefile const &src, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$LockfileConfig$operator$sizeof() noexcept;
-::std::size_t rpmostreecxx$cxxbridge1$194$LockfileConfig$operator$alignof() noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$Extensions$serialize_to_dir (::rpmostreecxx::Extensions const &self,
+                                                           ::rust::Str output_dir) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$lockfile_read(::rust::Vec<::rust::String> const &filenames, ::rust::Box<::rpmostreecxx::LockfileConfig> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$Extensions$generate_treefile (
+      ::rpmostreecxx::Extensions const &self, ::rpmostreecxx::Treefile const &src,
+      ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$LockfileConfig$operator$sizeof () noexcept;
+  ::std::size_t rpmostreecxx$cxxbridge1$194$LockfileConfig$operator$alignof () noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$lockfile_write(::rust::Str filename, ::rpmostreecxx::CxxGObjectArray &packages, ::rpmostreecxx::CxxGObjectArray &rpmmd_repos) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$lockfile_read (
+      ::rust::Vec<::rust::String> const &filenames,
+      ::rust::Box<::rpmostreecxx::LockfileConfig> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$LockfileConfig$get_locked_packages(::rpmostreecxx::LockfileConfig const &self, ::rust::Vec<::rpmostreecxx::LockedPackage> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$lockfile_write (
+      ::rust::Str filename, ::rpmostreecxx::CxxGObjectArray &packages,
+      ::rpmostreecxx::CxxGObjectArray &rpmmd_repos) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$origin_to_treefile(::rpmostreecxx::GKeyFile const &kf, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$LockfileConfig$get_locked_packages (
+      ::rpmostreecxx::LockfileConfig const &self,
+      ::rust::Vec<::rpmostreecxx::LockedPackage> *return$) noexcept;
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$treefile_to_origin(::rpmostreecxx::Treefile const &tf, ::rpmostreecxx::GKeyFile **return$) noexcept;
+  ::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$origin_to_treefile (
+      ::rpmostreecxx::GKeyFile const &kf, ::rust::Box<::rpmostreecxx::Treefile> *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$origin_validate_roundtrip(::rpmostreecxx::GKeyFile const &kf) noexcept;
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$treefile_to_origin (::rpmostreecxx::Treefile const &tf,
+                                                  ::rpmostreecxx::GKeyFile **return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$cache_branch_to_nevra(::rust::Str nevra, ::rust::String *return$) noexcept;
+  void rpmostreecxx$cxxbridge1$194$origin_validate_roundtrip (
+      ::rpmostreecxx::GKeyFile const &kf) noexcept;
 
-::std::uint32_t rpmostreecxx$cxxbridge1$194$CxxGObjectArray$length(::rpmostreecxx::CxxGObjectArray &self) noexcept {
-  ::std::uint32_t (::rpmostreecxx::CxxGObjectArray::*length$)() = &::rpmostreecxx::CxxGObjectArray::length;
-  return (self.*length$)();
-}
+  void rpmostreecxx$cxxbridge1$194$cache_branch_to_nevra (::rust::Str nevra,
+                                                          ::rust::String *return$) noexcept;
 
-void rpmostreecxx$cxxbridge1$194$CxxGObjectArray$get(::rpmostreecxx::CxxGObjectArray &self, ::std::uint32_t i, ::rpmostreecxx::GObject **return$) noexcept {
-  ::rpmostreecxx::GObject &(::rpmostreecxx::CxxGObjectArray::*get$)(::std::uint32_t) = &::rpmostreecxx::CxxGObjectArray::get;
-  new (return$) ::rpmostreecxx::GObject *(&(self.*get$)(i));
-}
+  ::std::uint32_t
+  rpmostreecxx$cxxbridge1$194$CxxGObjectArray$length (
+      ::rpmostreecxx::CxxGObjectArray &self) noexcept
+  {
+    ::std::uint32_t (::rpmostreecxx::CxxGObjectArray::*length$) ()
+        = &::rpmostreecxx::CxxGObjectArray::length;
+    return (self.*length$) ();
+  }
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$util_next_version(::rust::Str auto_version_prefix, ::rust::Str version_suffix, ::rust::Str last_version, ::rust::String *return$) noexcept {
-  ::rust::String (*util_next_version$)(::rust::Str, ::rust::Str, ::rust::Str) = ::rpmostreecxx::util_next_version;
-  ::rust::repr::PtrLen throw$;
-  ::rust::behavior::trycatch(
-      [&] {
-        new (return$) ::rust::String(util_next_version$(auto_version_prefix, version_suffix, last_version));
-        throw$.ptr = nullptr;
-      },
-      ::rust::detail::Fail(throw$));
-  return throw$;
-}
+  void
+  rpmostreecxx$cxxbridge1$194$CxxGObjectArray$get (::rpmostreecxx::CxxGObjectArray &self,
+                                                   ::std::uint32_t i,
+                                                   ::rpmostreecxx::GObject **return$) noexcept
+  {
+    ::rpmostreecxx::GObject &(::rpmostreecxx::CxxGObjectArray::*get$) (::std::uint32_t)
+        = &::rpmostreecxx::CxxGObjectArray::get;
+    new (return$)::rpmostreecxx::GObject *(&(self.*get$) (i));
+  }
 
-::std::int32_t rpmostreecxx$cxxbridge1$194$testutil_validate_cxxrs_passthrough(::rpmostreecxx::OstreeRepo const &repo) noexcept {
-  ::std::int32_t (*testutil_validate_cxxrs_passthrough$)(::rpmostreecxx::OstreeRepo const &) = ::rpmostreecxx::testutil_validate_cxxrs_passthrough;
-  return testutil_validate_cxxrs_passthrough$(repo);
-}
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$util_next_version (::rust::Str auto_version_prefix,
+                                                 ::rust::Str version_suffix,
+                                                 ::rust::Str last_version,
+                                                 ::rust::String *return$) noexcept
+  {
+    ::rust::String (*util_next_version$) (::rust::Str, ::rust::Str, ::rust::Str)
+        = ::rpmostreecxx::util_next_version;
+    ::rust::repr::PtrLen throw$;
+    ::rust::behavior::trycatch (
+        [&]
+          {
+            new (return$)::rust::String (
+                util_next_version$ (auto_version_prefix, version_suffix, last_version));
+            throw$.ptr = nullptr;
+          },
+        ::rust::detail::Fail (throw$));
+    return throw$;
+  }
 
-void rpmostreecxx$cxxbridge1$194$early_main() noexcept {
-  void (*early_main$)() = ::rpmostreecxx::early_main;
-  early_main$();
-}
+  ::std::int32_t
+  rpmostreecxx$cxxbridge1$194$testutil_validate_cxxrs_passthrough (
+      ::rpmostreecxx::OstreeRepo const &repo) noexcept
+  {
+    ::std::int32_t (*testutil_validate_cxxrs_passthrough$) (::rpmostreecxx::OstreeRepo const &)
+        = ::rpmostreecxx::testutil_validate_cxxrs_passthrough;
+    return testutil_validate_cxxrs_passthrough$ (repo);
+  }
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$rpmostree_main(::rust::Slice<::rust::Str const> args, ::std::int32_t *return$) noexcept {
-  ::std::int32_t (*rpmostree_main$)(::rust::Slice<::rust::Str const>) = ::rpmostreecxx::rpmostree_main;
-  ::rust::repr::PtrLen throw$;
-  ::rust::behavior::trycatch(
-      [&] {
-        new (return$) ::std::int32_t(rpmostree_main$(args));
-        throw$.ptr = nullptr;
-      },
-      ::rust::detail::Fail(throw$));
-  return throw$;
-}
+  void
+  rpmostreecxx$cxxbridge1$194$early_main () noexcept
+  {
+    void (*early_main$) () = ::rpmostreecxx::early_main;
+    early_main$ ();
+  }
 
-void rpmostreecxx$cxxbridge1$194$rpmostree_process_global_teardown() noexcept {
-  void (*rpmostree_process_global_teardown$)() = ::rpmostreecxx::rpmostree_process_global_teardown;
-  rpmostree_process_global_teardown$();
-}
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$rpmostree_main (::rust::Slice<::rust::Str const> args,
+                                              ::std::int32_t *return$) noexcept
+  {
+    ::std::int32_t (*rpmostree_main$) (::rust::Slice<::rust::Str const>)
+        = ::rpmostreecxx::rpmostree_main;
+    ::rust::repr::PtrLen throw$;
+    ::rust::behavior::trycatch (
+        [&]
+          {
+            new (return$)::std::int32_t (rpmostree_main$ (args));
+            throw$.ptr = nullptr;
+          },
+        ::rust::detail::Fail (throw$));
+    return throw$;
+  }
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$c_unit_tests() noexcept {
-  void (*c_unit_tests$)() = ::rpmostreecxx::c_unit_tests;
-  ::rust::repr::PtrLen throw$;
-  ::rust::behavior::trycatch(
-      [&] {
-        c_unit_tests$();
-        throw$.ptr = nullptr;
-      },
-      ::rust::detail::Fail(throw$));
-  return throw$;
-}
+  void
+  rpmostreecxx$cxxbridge1$194$rpmostree_process_global_teardown () noexcept
+  {
+    void (*rpmostree_process_global_teardown$) ()
+        = ::rpmostreecxx::rpmostree_process_global_teardown;
+    rpmostree_process_global_teardown$ ();
+  }
 
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$client_require_root() noexcept {
-  void (*client_require_root$)() = ::rpmostreecxx::client_require_root;
-  ::rust::repr::PtrLen throw$;
-  ::rust::behavior::trycatch(
-      [&] {
-        client_require_root$();
-        throw$.ptr = nullptr;
-      },
-      ::rust::detail::Fail(throw$));
-  return throw$;
-}
-
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$new_client_connection(::rpmostreecxx::ClientConnection **return$) noexcept {
-  ::std::unique_ptr<::rpmostreecxx::ClientConnection> (*new_client_connection$)() = ::rpmostreecxx::new_client_connection;
-  ::rust::repr::PtrLen throw$;
-  ::rust::behavior::trycatch(
-      [&] {
-        new (return$) ::rpmostreecxx::ClientConnection *(new_client_connection$().release());
-        throw$.ptr = nullptr;
-      },
-      ::rust::detail::Fail(throw$));
-  return throw$;
-}
-
-::rpmostreecxx::GDBusConnection const *rpmostreecxx$cxxbridge1$194$ClientConnection$get_connection(::rpmostreecxx::ClientConnection &self) noexcept {
-  ::rpmostreecxx::GDBusConnection const &(::rpmostreecxx::ClientConnection::*get_connection$)() = &::rpmostreecxx::ClientConnection::get_connection;
-  return &(self.*get_connection$)();
-}
-
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$ClientConnection$transaction_connect_progress_sync(::rpmostreecxx::ClientConnection const &self, ::rust::Str address) noexcept {
-  void (::rpmostreecxx::ClientConnection::*transaction_connect_progress_sync$)(::rust::Str) const = &::rpmostreecxx::ClientConnection::transaction_connect_progress_sync;
-  ::rust::repr::PtrLen throw$;
-  ::rust::behavior::trycatch(
-      [&] {
-        (self.*transaction_connect_progress_sync$)(address);
-        throw$.ptr = nullptr;
-      },
-      ::rust::detail::Fail(throw$));
-  return throw$;
-}
-
-::std::int32_t rpmostreecxx$cxxbridge1$194$RPMDiff$n_removed(::rpmostreecxx::RPMDiff const &self) noexcept {
-  ::std::int32_t (::rpmostreecxx::RPMDiff::*n_removed$)() const = &::rpmostreecxx::RPMDiff::n_removed;
-  return (self.*n_removed$)();
-}
-
-::std::int32_t rpmostreecxx$cxxbridge1$194$RPMDiff$n_added(::rpmostreecxx::RPMDiff const &self) noexcept {
-  ::std::int32_t (::rpmostreecxx::RPMDiff::*n_added$)() const = &::rpmostreecxx::RPMDiff::n_added;
-  return (self.*n_added$)();
-}
-
-::std::int32_t rpmostreecxx$cxxbridge1$194$RPMDiff$n_modified(::rpmostreecxx::RPMDiff const &self) noexcept {
-  ::std::int32_t (::rpmostreecxx::RPMDiff::*n_modified$)() const = &::rpmostreecxx::RPMDiff::n_modified;
-  return (self.*n_modified$)();
-}
-
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$rpmdb_diff(::rpmostreecxx::OstreeRepo const &repo, ::std::string const &src, ::std::string const &dest, bool allow_noent, ::rpmostreecxx::RPMDiff **return$) noexcept {
-  ::std::unique_ptr<::rpmostreecxx::RPMDiff> (*rpmdb_diff$)(::rpmostreecxx::OstreeRepo const &, ::std::string const &, ::std::string const &, bool) = ::rpmostreecxx::rpmdb_diff;
-  ::rust::repr::PtrLen throw$;
-  ::rust::behavior::trycatch(
-      [&] {
-        new (return$) ::rpmostreecxx::RPMDiff *(rpmdb_diff$(repo, src, dest, allow_noent).release());
-        throw$.ptr = nullptr;
-      },
-      ::rust::detail::Fail(throw$));
-  return throw$;
-}
-
-void rpmostreecxx$cxxbridge1$194$RPMDiff$print(::rpmostreecxx::RPMDiff const &self) noexcept {
-  void (::rpmostreecxx::RPMDiff::*print$)() const = &::rpmostreecxx::RPMDiff::print;
-  (self.*print$)();
-}
-
-void rpmostreecxx$cxxbridge1$194$print_treepkg_diff_from_sysroot_path(::rust::Str sysroot_path, ::rpmostreecxx::RpmOstreeDiffPrintFormat format, ::std::uint32_t max_key_len, ::rpmostreecxx::GCancellable *cancellable) noexcept {
-  void (*print_treepkg_diff_from_sysroot_path$)(::rust::Str, ::rpmostreecxx::RpmOstreeDiffPrintFormat, ::std::uint32_t, ::rpmostreecxx::GCancellable *) = ::rpmostreecxx::print_treepkg_diff_from_sysroot_path;
-  print_treepkg_diff_from_sysroot_path$(sysroot_path, format, max_key_len, cancellable);
-}
-
-::rpmostreecxx::Progress *rpmostreecxx$cxxbridge1$194$progress_begin_task(::rust::Str msg) noexcept {
-  ::std::unique_ptr<::rpmostreecxx::Progress> (*progress_begin_task$)(::rust::Str) = ::rpmostreecxx::progress_begin_task;
-  return progress_begin_task$(msg).release();
-}
-
-void rpmostreecxx$cxxbridge1$194$Progress$end(::rpmostreecxx::Progress &self, ::rust::Str msg) noexcept {
-  void (::rpmostreecxx::Progress::*end$)(::rust::Str) = &::rpmostreecxx::Progress::end;
-  (self.*end$)(msg);
-}
-
-void rpmostreecxx$cxxbridge1$194$output_message(::rust::Str msg) noexcept {
-  void (*output_message$)(::rust::Str) = ::rpmostreecxx::output_message;
-  output_message$(msg);
-}
-
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$nevra_to_cache_branch(::std::string const &nevra, ::rust::String *return$) noexcept {
-  ::rust::String (*nevra_to_cache_branch$)(::std::string const &) = ::rpmostreecxx::nevra_to_cache_branch;
-  ::rust::repr::PtrLen throw$;
-  ::rust::behavior::trycatch(
-      [&] {
-        new (return$) ::rust::String(nevra_to_cache_branch$(nevra));
-        throw$.ptr = nullptr;
-      },
-      ::rust::detail::Fail(throw$));
-  return throw$;
-}
-
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$get_repodata_chksum_repr(::dnfcxx::FFIDnfPackage &pkg, ::rust::String *return$) noexcept {
-  ::rust::String (*get_repodata_chksum_repr$)(::dnfcxx::FFIDnfPackage &) = ::rpmostreecxx::get_repodata_chksum_repr;
-  ::rust::repr::PtrLen throw$;
-  ::rust::behavior::trycatch(
-      [&] {
-        new (return$) ::rust::String(get_repodata_chksum_repr$(pkg));
-        throw$.ptr = nullptr;
-      },
-      ::rust::detail::Fail(throw$));
-  return throw$;
-}
-
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$rpmts_for_commit(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str rev, ::rpmostreecxx::RpmTs **return$) noexcept {
-  ::std::unique_ptr<::rpmostreecxx::RpmTs> (*rpmts_for_commit$)(::rpmostreecxx::OstreeRepo const &, ::rust::Str) = ::rpmostreecxx::rpmts_for_commit;
-  ::rust::repr::PtrLen throw$;
-  ::rust::behavior::trycatch(
-      [&] {
-        new (return$) ::rpmostreecxx::RpmTs *(rpmts_for_commit$(repo, rev).release());
-        throw$.ptr = nullptr;
-      },
-      ::rust::detail::Fail(throw$));
-  return throw$;
-}
-
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$rpmdb_package_name_list(::std::int32_t dfd, ::rust::String const *path, ::rust::Vec<::rust::String> *return$) noexcept {
-  ::rust::Vec<::rust::String> (*rpmdb_package_name_list$)(::std::int32_t, ::rust::String) = ::rpmostreecxx::rpmdb_package_name_list;
-  ::rust::repr::PtrLen throw$;
-  ::rust::behavior::trycatch(
-      [&] {
-        new (return$) ::rust::Vec<::rust::String>(rpmdb_package_name_list$(dfd, ::rust::String(::rust::unsafe_bitcopy, *path)));
-        throw$.ptr = nullptr;
-      },
-      ::rust::detail::Fail(throw$));
-  return throw$;
-}
-
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$RpmTs$package_meta(::rpmostreecxx::RpmTs const &self, ::rust::Str name, ::rust::Str arch, ::rpmostreecxx::PackageMeta **return$) noexcept {
-  ::std::unique_ptr<::rpmostreecxx::PackageMeta> (::rpmostreecxx::RpmTs::*package_meta$)(::rust::Str, ::rust::Str) const = &::rpmostreecxx::RpmTs::package_meta;
-  ::rust::repr::PtrLen throw$;
-  ::rust::behavior::trycatch(
-      [&] {
-        new (return$) ::rpmostreecxx::PackageMeta *((self.*package_meta$)(name, arch).release());
-        throw$.ptr = nullptr;
-      },
-      ::rust::detail::Fail(throw$));
-  return throw$;
-}
-
-::std::uint64_t rpmostreecxx$cxxbridge1$194$PackageMeta$size(::rpmostreecxx::PackageMeta const &self) noexcept {
-  ::std::uint64_t (::rpmostreecxx::PackageMeta::*size$)() const = &::rpmostreecxx::PackageMeta::size;
-  return (self.*size$)();
-}
-
-::std::uint64_t rpmostreecxx$cxxbridge1$194$PackageMeta$buildtime(::rpmostreecxx::PackageMeta const &self) noexcept {
-  ::std::uint64_t (::rpmostreecxx::PackageMeta::*buildtime$)() const = &::rpmostreecxx::PackageMeta::buildtime;
-  return (self.*buildtime$)();
-}
-
-void rpmostreecxx$cxxbridge1$194$PackageMeta$changelogs(::rpmostreecxx::PackageMeta const &self, ::rust::Vec<::std::uint64_t> *return$) noexcept {
-  ::rust::Vec<::std::uint64_t> (::rpmostreecxx::PackageMeta::*changelogs$)() const = &::rpmostreecxx::PackageMeta::changelogs;
-  new (return$) ::rust::Vec<::std::uint64_t>((self.*changelogs$)());
-}
-
-void rpmostreecxx$cxxbridge1$194$PackageMeta$src_pkg(::rpmostreecxx::PackageMeta const &self, ::rust::Str *return$) noexcept {
-  ::rust::Str (::rpmostreecxx::PackageMeta::*src_pkg$)() const = &::rpmostreecxx::PackageMeta::src_pkg;
-  new (return$) ::rust::Str((self.*src_pkg$)());
-}
-
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$PackageMeta$provided_paths(::rpmostreecxx::PackageMeta const &self, ::rust::Vec<::rust::String> *return$) noexcept {
-  ::rust::Vec<::rust::String> (::rpmostreecxx::PackageMeta::*provided_paths$)() const = &::rpmostreecxx::PackageMeta::provided_paths;
-  ::rust::repr::PtrLen throw$;
-  ::rust::behavior::trycatch(
-      [&] {
-        new (return$) ::rust::Vec<::rust::String>((self.*provided_paths$)());
-        throw$.ptr = nullptr;
-      },
-      ::rust::detail::Fail(throw$));
-  return throw$;
-}
-
-::rust::repr::PtrLen rpmostreecxx$cxxbridge1$194$package_variant_list_for_commit(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str rev, ::rpmostreecxx::GCancellable const &cancellable, ::rpmostreecxx::GVariant **return$) noexcept {
-  ::rpmostreecxx::GVariant *(*package_variant_list_for_commit$)(::rpmostreecxx::OstreeRepo const &, ::rust::Str, ::rpmostreecxx::GCancellable const &) = ::rpmostreecxx::package_variant_list_for_commit;
-  ::rust::repr::PtrLen throw$;
-  ::rust::behavior::trycatch(
-      [&] {
-        new (return$) ::rpmostreecxx::GVariant *(package_variant_list_for_commit$(repo, rev, cancellable));
-        throw$.ptr = nullptr;
-      },
-      ::rust::detail::Fail(throw$));
-  return throw$;
-}
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$c_unit_tests () noexcept
+  {
+    void (*c_unit_tests$) () = ::rpmostreecxx::c_unit_tests;
+    ::rust::repr::PtrLen throw$;
+    ::rust::behavior::trycatch (
+        [&]
+          {
+            c_unit_tests$ ();
+            throw$.ptr = nullptr;
+          },
+        ::rust::detail::Fail (throw$));
+    return throw$;
+  }
+
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$client_require_root () noexcept
+  {
+    void (*client_require_root$) () = ::rpmostreecxx::client_require_root;
+    ::rust::repr::PtrLen throw$;
+    ::rust::behavior::trycatch (
+        [&]
+          {
+            client_require_root$ ();
+            throw$.ptr = nullptr;
+          },
+        ::rust::detail::Fail (throw$));
+    return throw$;
+  }
+
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$new_client_connection (
+      ::rpmostreecxx::ClientConnection **return$) noexcept
+  {
+    ::std::unique_ptr<::rpmostreecxx::ClientConnection> (*new_client_connection$) ()
+        = ::rpmostreecxx::new_client_connection;
+    ::rust::repr::PtrLen throw$;
+    ::rust::behavior::trycatch (
+        [&]
+          {
+            new (return$)::rpmostreecxx::ClientConnection *(new_client_connection$ ().release ());
+            throw$.ptr = nullptr;
+          },
+        ::rust::detail::Fail (throw$));
+    return throw$;
+  }
+
+  ::rpmostreecxx::GDBusConnection const *
+  rpmostreecxx$cxxbridge1$194$ClientConnection$get_connection (
+      ::rpmostreecxx::ClientConnection &self) noexcept
+  {
+    ::rpmostreecxx::GDBusConnection const &(::rpmostreecxx::ClientConnection::*get_connection$) ()
+        = &::rpmostreecxx::ClientConnection::get_connection;
+    return &(self.*get_connection$) ();
+  }
+
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$ClientConnection$transaction_connect_progress_sync (
+      ::rpmostreecxx::ClientConnection const &self, ::rust::Str address) noexcept
+  {
+    void (::rpmostreecxx::ClientConnection::*transaction_connect_progress_sync$) (::rust::Str) const
+        = &::rpmostreecxx::ClientConnection::transaction_connect_progress_sync;
+    ::rust::repr::PtrLen throw$;
+    ::rust::behavior::trycatch (
+        [&]
+          {
+            (self.*transaction_connect_progress_sync$) (address);
+            throw$.ptr = nullptr;
+          },
+        ::rust::detail::Fail (throw$));
+    return throw$;
+  }
+
+  ::std::int32_t
+  rpmostreecxx$cxxbridge1$194$RPMDiff$n_removed (::rpmostreecxx::RPMDiff const &self) noexcept
+  {
+    ::std::int32_t (::rpmostreecxx::RPMDiff::*n_removed$) () const
+        = &::rpmostreecxx::RPMDiff::n_removed;
+    return (self.*n_removed$) ();
+  }
+
+  ::std::int32_t
+  rpmostreecxx$cxxbridge1$194$RPMDiff$n_added (::rpmostreecxx::RPMDiff const &self) noexcept
+  {
+    ::std::int32_t (::rpmostreecxx::RPMDiff::*n_added$) () const
+        = &::rpmostreecxx::RPMDiff::n_added;
+    return (self.*n_added$) ();
+  }
+
+  ::std::int32_t
+  rpmostreecxx$cxxbridge1$194$RPMDiff$n_modified (::rpmostreecxx::RPMDiff const &self) noexcept
+  {
+    ::std::int32_t (::rpmostreecxx::RPMDiff::*n_modified$) () const
+        = &::rpmostreecxx::RPMDiff::n_modified;
+    return (self.*n_modified$) ();
+  }
+
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$rpmdb_diff (::rpmostreecxx::OstreeRepo const &repo,
+                                          ::std::string const &src, ::std::string const &dest,
+                                          bool allow_noent,
+                                          ::rpmostreecxx::RPMDiff **return$) noexcept
+  {
+    ::std::unique_ptr<::rpmostreecxx::RPMDiff> (*rpmdb_diff$) (
+        ::rpmostreecxx::OstreeRepo const &, ::std::string const &, ::std::string const &, bool)
+        = ::rpmostreecxx::rpmdb_diff;
+    ::rust::repr::PtrLen throw$;
+    ::rust::behavior::trycatch (
+        [&]
+          {
+            new (return$)::rpmostreecxx::RPMDiff *(
+                rpmdb_diff$ (repo, src, dest, allow_noent).release ());
+            throw$.ptr = nullptr;
+          },
+        ::rust::detail::Fail (throw$));
+    return throw$;
+  }
+
+  void
+  rpmostreecxx$cxxbridge1$194$RPMDiff$print (::rpmostreecxx::RPMDiff const &self) noexcept
+  {
+    void (::rpmostreecxx::RPMDiff::*print$) () const = &::rpmostreecxx::RPMDiff::print;
+    (self.*print$) ();
+  }
+
+  void
+  rpmostreecxx$cxxbridge1$194$print_treepkg_diff_from_sysroot_path (
+      ::rust::Str sysroot_path, ::rpmostreecxx::RpmOstreeDiffPrintFormat format,
+      ::std::uint32_t max_key_len, ::rpmostreecxx::GCancellable *cancellable) noexcept
+  {
+    void (*print_treepkg_diff_from_sysroot_path$) (::rust::Str,
+                                                   ::rpmostreecxx::RpmOstreeDiffPrintFormat,
+                                                   ::std::uint32_t, ::rpmostreecxx::GCancellable *)
+        = ::rpmostreecxx::print_treepkg_diff_from_sysroot_path;
+    print_treepkg_diff_from_sysroot_path$ (sysroot_path, format, max_key_len, cancellable);
+  }
+
+  ::rpmostreecxx::Progress *
+  rpmostreecxx$cxxbridge1$194$progress_begin_task (::rust::Str msg) noexcept
+  {
+    ::std::unique_ptr<::rpmostreecxx::Progress> (*progress_begin_task$) (::rust::Str)
+        = ::rpmostreecxx::progress_begin_task;
+    return progress_begin_task$ (msg).release ();
+  }
+
+  void
+  rpmostreecxx$cxxbridge1$194$Progress$end (::rpmostreecxx::Progress &self,
+                                            ::rust::Str msg) noexcept
+  {
+    void (::rpmostreecxx::Progress::*end$) (::rust::Str) = &::rpmostreecxx::Progress::end;
+    (self.*end$) (msg);
+  }
+
+  void
+  rpmostreecxx$cxxbridge1$194$output_message (::rust::Str msg) noexcept
+  {
+    void (*output_message$) (::rust::Str) = ::rpmostreecxx::output_message;
+    output_message$ (msg);
+  }
+
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$nevra_to_cache_branch (::std::string const &nevra,
+                                                     ::rust::String *return$) noexcept
+  {
+    ::rust::String (*nevra_to_cache_branch$) (::std::string const &)
+        = ::rpmostreecxx::nevra_to_cache_branch;
+    ::rust::repr::PtrLen throw$;
+    ::rust::behavior::trycatch (
+        [&]
+          {
+            new (return$)::rust::String (nevra_to_cache_branch$ (nevra));
+            throw$.ptr = nullptr;
+          },
+        ::rust::detail::Fail (throw$));
+    return throw$;
+  }
+
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$get_repodata_chksum_repr (::dnfcxx::FFIDnfPackage &pkg,
+                                                        ::rust::String *return$) noexcept
+  {
+    ::rust::String (*get_repodata_chksum_repr$) (::dnfcxx::FFIDnfPackage &)
+        = ::rpmostreecxx::get_repodata_chksum_repr;
+    ::rust::repr::PtrLen throw$;
+    ::rust::behavior::trycatch (
+        [&]
+          {
+            new (return$)::rust::String (get_repodata_chksum_repr$ (pkg));
+            throw$.ptr = nullptr;
+          },
+        ::rust::detail::Fail (throw$));
+    return throw$;
+  }
+
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$rpmts_for_commit (::rpmostreecxx::OstreeRepo const &repo,
+                                                ::rust::Str rev,
+                                                ::rpmostreecxx::RpmTs **return$) noexcept
+  {
+    ::std::unique_ptr<::rpmostreecxx::RpmTs> (*rpmts_for_commit$) (
+        ::rpmostreecxx::OstreeRepo const &, ::rust::Str)
+        = ::rpmostreecxx::rpmts_for_commit;
+    ::rust::repr::PtrLen throw$;
+    ::rust::behavior::trycatch (
+        [&]
+          {
+            new (return$)::rpmostreecxx::RpmTs *(rpmts_for_commit$ (repo, rev).release ());
+            throw$.ptr = nullptr;
+          },
+        ::rust::detail::Fail (throw$));
+    return throw$;
+  }
+
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$rpmdb_package_name_list (
+      ::std::int32_t dfd, ::rust::String const *path, ::rust::Vec<::rust::String> *return$) noexcept
+  {
+    ::rust::Vec<::rust::String> (*rpmdb_package_name_list$) (::std::int32_t, ::rust::String)
+        = ::rpmostreecxx::rpmdb_package_name_list;
+    ::rust::repr::PtrLen throw$;
+    ::rust::behavior::trycatch (
+        [&]
+          {
+            new (return$)::rust::Vec<::rust::String> (
+                rpmdb_package_name_list$ (dfd, ::rust::String (::rust::unsafe_bitcopy, *path)));
+            throw$.ptr = nullptr;
+          },
+        ::rust::detail::Fail (throw$));
+    return throw$;
+  }
+
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$RpmTs$package_meta (::rpmostreecxx::RpmTs const &self,
+                                                  ::rust::Str name, ::rust::Str arch,
+                                                  ::rpmostreecxx::PackageMeta **return$) noexcept
+  {
+    ::std::unique_ptr<::rpmostreecxx::PackageMeta> (::rpmostreecxx::RpmTs::*package_meta$) (
+        ::rust::Str, ::rust::Str) const
+        = &::rpmostreecxx::RpmTs::package_meta;
+    ::rust::repr::PtrLen throw$;
+    ::rust::behavior::trycatch (
+        [&]
+          {
+            new (return$)::rpmostreecxx::PackageMeta *(
+                (self.*package_meta$) (name, arch).release ());
+            throw$.ptr = nullptr;
+          },
+        ::rust::detail::Fail (throw$));
+    return throw$;
+  }
+
+  ::std::uint64_t
+  rpmostreecxx$cxxbridge1$194$PackageMeta$size (::rpmostreecxx::PackageMeta const &self) noexcept
+  {
+    ::std::uint64_t (::rpmostreecxx::PackageMeta::*size$) () const
+        = &::rpmostreecxx::PackageMeta::size;
+    return (self.*size$) ();
+  }
+
+  ::std::uint64_t
+  rpmostreecxx$cxxbridge1$194$PackageMeta$buildtime (
+      ::rpmostreecxx::PackageMeta const &self) noexcept
+  {
+    ::std::uint64_t (::rpmostreecxx::PackageMeta::*buildtime$) () const
+        = &::rpmostreecxx::PackageMeta::buildtime;
+    return (self.*buildtime$) ();
+  }
+
+  void
+  rpmostreecxx$cxxbridge1$194$PackageMeta$changelogs (
+      ::rpmostreecxx::PackageMeta const &self, ::rust::Vec<::std::uint64_t> *return$) noexcept
+  {
+    ::rust::Vec<::std::uint64_t> (::rpmostreecxx::PackageMeta::*changelogs$) () const
+        = &::rpmostreecxx::PackageMeta::changelogs;
+    new (return$)::rust::Vec<::std::uint64_t> ((self.*changelogs$) ());
+  }
+
+  void
+  rpmostreecxx$cxxbridge1$194$PackageMeta$src_pkg (::rpmostreecxx::PackageMeta const &self,
+                                                   ::rust::Str *return$) noexcept
+  {
+    ::rust::Str (::rpmostreecxx::PackageMeta::*src_pkg$) () const
+        = &::rpmostreecxx::PackageMeta::src_pkg;
+    new (return$)::rust::Str ((self.*src_pkg$) ());
+  }
+
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$PackageMeta$provided_paths (
+      ::rpmostreecxx::PackageMeta const &self, ::rust::Vec<::rust::String> *return$) noexcept
+  {
+    ::rust::Vec<::rust::String> (::rpmostreecxx::PackageMeta::*provided_paths$) () const
+        = &::rpmostreecxx::PackageMeta::provided_paths;
+    ::rust::repr::PtrLen throw$;
+    ::rust::behavior::trycatch (
+        [&]
+          {
+            new (return$)::rust::Vec<::rust::String> ((self.*provided_paths$) ());
+            throw$.ptr = nullptr;
+          },
+        ::rust::detail::Fail (throw$));
+    return throw$;
+  }
+
+  ::rust::repr::PtrLen
+  rpmostreecxx$cxxbridge1$194$package_variant_list_for_commit (
+      ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str rev,
+      ::rpmostreecxx::GCancellable const &cancellable, ::rpmostreecxx::GVariant **return$) noexcept
+  {
+    ::rpmostreecxx::GVariant *(*package_variant_list_for_commit$) (
+        ::rpmostreecxx::OstreeRepo const &, ::rust::Str, ::rpmostreecxx::GCancellable const &)
+        = ::rpmostreecxx::package_variant_list_for_commit;
+    ::rust::repr::PtrLen throw$;
+    ::rust::behavior::trycatch (
+        [&]
+          {
+            new (return$)::rpmostreecxx::GVariant *(
+                package_variant_list_for_commit$ (repo, rev, cancellable));
+            throw$.ptr = nullptr;
+          },
+        ::rust::detail::Fail (throw$));
+    return throw$;
+  }
 } // extern "C"
 
-bool is_bare_split_xattrs() {
+bool
+is_bare_split_xattrs ()
+{
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$is_bare_split_xattrs(&return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$is_bare_split_xattrs (&return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-bool is_http_arg(::rust::Str arg) noexcept {
-  return rpmostreecxx$cxxbridge1$194$is_http_arg(arg);
+bool
+is_http_arg (::rust::Str arg) noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$is_http_arg (arg);
 }
 
-bool is_ostree_container() {
+bool
+is_ostree_container ()
+{
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$is_ostree_container(&return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$is_ostree_container (&return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rpmostreecxx::SystemHostType get_system_host_type() {
+::rpmostreecxx::SystemHostType
+get_system_host_type ()
+{
   ::rust::MaybeUninit<::rpmostreecxx::SystemHostType> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$get_system_host_type(&return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$get_system_host_type (&return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void require_system_host_type(::rpmostreecxx::SystemHostType t) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$require_system_host_type(t);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+require_system_host_type (::rpmostreecxx::SystemHostType t)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$require_system_host_type (t);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-bool is_rpm_arg(::rust::Str arg) noexcept {
-  return rpmostreecxx$cxxbridge1$194$is_rpm_arg(arg);
+bool
+is_rpm_arg (::rust::Str arg) noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$is_rpm_arg (arg);
 }
 
-void client_start_daemon() {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$client_start_daemon();
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+client_start_daemon ()
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$client_start_daemon ();
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::rust::Vec<::std::int32_t> client_handle_fd_argument(::rust::Str arg, ::rust::Str arch, bool is_replace) {
+::rust::Vec<::std::int32_t>
+client_handle_fd_argument (::rust::Str arg, ::rust::Str arch, bool is_replace)
+{
   ::rust::MaybeUninit<::rust::Vec<::std::int32_t>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$client_handle_fd_argument(arg, arch, is_replace, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$client_handle_fd_argument (
+      arg, arch, is_replace, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::String client_render_download_progress(::rpmostreecxx::GVariant const &progress) noexcept {
+::rust::String
+client_render_download_progress (::rpmostreecxx::GVariant const &progress) noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$client_render_download_progress(progress, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$client_render_download_progress (progress, &return$.value);
+  return ::std::move (return$.value);
 }
 
-bool running_in_container() noexcept {
-  return rpmostreecxx$cxxbridge1$194$running_in_container();
+bool
+running_in_container () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$running_in_container ();
 }
 
-bool confirm() {
+bool
+confirm ()
+{
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$confirm(&return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$confirm (&return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void confirm_or_abort() {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$confirm_or_abort();
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+confirm_or_abort ()
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$confirm_or_abort ();
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::std::size_t Bubblewrap::layout::size() noexcept {
-  return rpmostreecxx$cxxbridge1$194$Bubblewrap$operator$sizeof();
+::std::size_t
+Bubblewrap::layout::size () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Bubblewrap$operator$sizeof ();
 }
 
-::std::size_t Bubblewrap::layout::align() noexcept {
-  return rpmostreecxx$cxxbridge1$194$Bubblewrap$operator$alignof();
+::std::size_t
+Bubblewrap::layout::align () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Bubblewrap$operator$alignof ();
 }
 
-void bubblewrap_selftest() {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$bubblewrap_selftest();
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+bubblewrap_selftest ()
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$bubblewrap_selftest ();
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::rust::Vec<::std::uint8_t> bubblewrap_run_sync(::std::int32_t rootfs_dfd, ::rust::Vec<::rust::String> const &args, bool capture_stdout, ::rpmostreecxx::BubblewrapMutability mutability) {
+::rust::Vec<::std::uint8_t>
+bubblewrap_run_sync (::std::int32_t rootfs_dfd, ::rust::Vec<::rust::String> const &args,
+                     bool capture_stdout, ::rpmostreecxx::BubblewrapMutability mutability)
+{
   ::rust::MaybeUninit<::rust::Vec<::std::uint8_t>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$bubblewrap_run_sync(rootfs_dfd, args, capture_stdout, mutability, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$bubblewrap_run_sync (
+      rootfs_dfd, args, capture_stdout, mutability, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::Box<::rpmostreecxx::Bubblewrap> bubblewrap_new(::std::int32_t rootfs_fd) {
+::rust::Box<::rpmostreecxx::Bubblewrap>
+bubblewrap_new (::std::int32_t rootfs_fd)
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Bubblewrap>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$bubblewrap_new(rootfs_fd, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$bubblewrap_new (rootfs_fd, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::Box<::rpmostreecxx::Bubblewrap> bubblewrap_new_with_mutability(::std::int32_t rootfs_fd, ::rpmostreecxx::BubblewrapMutability mutability) {
+::rust::Box<::rpmostreecxx::Bubblewrap>
+bubblewrap_new_with_mutability (::std::int32_t rootfs_fd,
+                                ::rpmostreecxx::BubblewrapMutability mutability)
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Bubblewrap>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$bubblewrap_new_with_mutability(rootfs_fd, mutability, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$bubblewrap_new_with_mutability (
+      rootfs_fd, mutability, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::std::int32_t Bubblewrap::get_rootfs_fd() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Bubblewrap$get_rootfs_fd(*this);
+::std::int32_t
+Bubblewrap::get_rootfs_fd () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Bubblewrap$get_rootfs_fd (*this);
 }
 
-void Bubblewrap::append_bwrap_arg(::rust::Str arg) noexcept {
-  rpmostreecxx$cxxbridge1$194$Bubblewrap$append_bwrap_arg(*this, arg);
+void
+Bubblewrap::append_bwrap_arg (::rust::Str arg) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$append_bwrap_arg (*this, arg);
 }
 
-void Bubblewrap::append_child_arg(::rust::Str arg) noexcept {
-  rpmostreecxx$cxxbridge1$194$Bubblewrap$append_child_arg(*this, arg);
+void
+Bubblewrap::append_child_arg (::rust::Str arg) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$append_child_arg (*this, arg);
 }
 
-void Bubblewrap::setenv(::rust::Str k, ::rust::Str v) noexcept {
-  rpmostreecxx$cxxbridge1$194$Bubblewrap$setenv(*this, k, v);
+void
+Bubblewrap::setenv (::rust::Str k, ::rust::Str v) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$setenv (*this, k, v);
 }
 
-void Bubblewrap::take_fd(::std::int32_t source_fd, ::std::int32_t target_fd) noexcept {
-  rpmostreecxx$cxxbridge1$194$Bubblewrap$take_fd(*this, source_fd, target_fd);
+void
+Bubblewrap::take_fd (::std::int32_t source_fd, ::std::int32_t target_fd) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$take_fd (*this, source_fd, target_fd);
 }
 
-void Bubblewrap::set_inherit_stdin() noexcept {
-  rpmostreecxx$cxxbridge1$194$Bubblewrap$set_inherit_stdin(*this);
+void
+Bubblewrap::set_inherit_stdin () noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$set_inherit_stdin (*this);
 }
 
-void Bubblewrap::take_stdin_fd(::std::int32_t source_fd) noexcept {
-  rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdin_fd(*this, source_fd);
+void
+Bubblewrap::take_stdin_fd (::std::int32_t source_fd) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdin_fd (*this, source_fd);
 }
 
-void Bubblewrap::take_stdout_fd(::std::int32_t source_fd) noexcept {
-  rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdout_fd(*this, source_fd);
+void
+Bubblewrap::take_stdout_fd (::std::int32_t source_fd) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdout_fd (*this, source_fd);
 }
 
-void Bubblewrap::take_stderr_fd(::std::int32_t source_fd) noexcept {
-  rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stderr_fd(*this, source_fd);
+void
+Bubblewrap::take_stderr_fd (::std::int32_t source_fd) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stderr_fd (*this, source_fd);
 }
 
-void Bubblewrap::take_stdout_and_stderr_fd(::std::int32_t source_fd) noexcept {
-  rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdout_and_stderr_fd(*this, source_fd);
+void
+Bubblewrap::take_stdout_and_stderr_fd (::std::int32_t source_fd) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$take_stdout_and_stderr_fd (*this, source_fd);
 }
 
-void Bubblewrap::bind_read(::rust::Str src, ::rust::Str dest) noexcept {
-  rpmostreecxx$cxxbridge1$194$Bubblewrap$bind_read(*this, src, dest);
+void
+Bubblewrap::bind_read (::rust::Str src, ::rust::Str dest) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$bind_read (*this, src, dest);
 }
 
-void Bubblewrap::bind_readwrite(::rust::Str src, ::rust::Str dest) noexcept {
-  rpmostreecxx$cxxbridge1$194$Bubblewrap$bind_readwrite(*this, src, dest);
+void
+Bubblewrap::bind_readwrite (::rust::Str src, ::rust::Str dest) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Bubblewrap$bind_readwrite (*this, src, dest);
 }
 
-void Bubblewrap::setup_compat_var() {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Bubblewrap$setup_compat_var(*this);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+Bubblewrap::setup_compat_var ()
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Bubblewrap$setup_compat_var (*this);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void Bubblewrap::run(::rpmostreecxx::GCancellable const &cancellable) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Bubblewrap$run(*this, cancellable);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+Bubblewrap::run (::rpmostreecxx::GCancellable const &cancellable)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Bubblewrap$run (*this, cancellable);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::rpmostreecxx::BubblewrapMutability mutability_for_unified_core(bool unified_core) noexcept {
-  return rpmostreecxx$cxxbridge1$194$mutability_for_unified_core(unified_core);
+::rpmostreecxx::BubblewrapMutability
+mutability_for_unified_core (bool unified_core) noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$mutability_for_unified_core (unified_core);
 }
 
-void usroverlay_entrypoint(::rust::Vec<::rust::String> const &args) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$usroverlay_entrypoint(args);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+usroverlay_entrypoint (::rust::Vec<::rust::String> const &args)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$usroverlay_entrypoint (args);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void applylive_entrypoint(::rust::Vec<::rust::String> const &args) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$applylive_entrypoint(args);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+applylive_entrypoint (::rust::Vec<::rust::String> const &args)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$applylive_entrypoint (args);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void applylive_finish(::rpmostreecxx::OstreeSysroot const &sysroot) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$applylive_finish(sysroot);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+applylive_finish (::rpmostreecxx::OstreeSysroot const &sysroot)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$applylive_finish (sysroot);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void composeutil_legacy_prep_dev_and_run(::std::int32_t rootfs_dfd) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$composeutil_legacy_prep_dev_and_run(rootfs_dfd);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+composeutil_legacy_prep_dev_and_run (::std::int32_t rootfs_dfd)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$composeutil_legacy_prep_dev_and_run (rootfs_dfd);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void print_ostree_txn_stats(::rpmostreecxx::OstreeRepoTransactionStats &stats) noexcept {
-  rpmostreecxx$cxxbridge1$194$print_ostree_txn_stats(stats);
+void
+print_ostree_txn_stats (::rpmostreecxx::OstreeRepoTransactionStats &stats) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$print_ostree_txn_stats (stats);
 }
 
-void write_commit_id(::rust::Str target_path, ::rust::Str revision) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$write_commit_id(target_path, revision);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+write_commit_id (::rust::Str target_path, ::rust::Str revision)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$write_commit_id (target_path, revision);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void cliwrap_write_wrappers(::std::int32_t rootfs) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$cliwrap_write_wrappers(rootfs);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+cliwrap_write_wrappers (::std::int32_t rootfs)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$cliwrap_write_wrappers (rootfs);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void cliwrap_write_some_wrappers(::std::int32_t rootfs, ::rust::Vec<::rust::String> const &args) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$cliwrap_write_some_wrappers(rootfs, args);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+cliwrap_write_some_wrappers (::std::int32_t rootfs, ::rust::Vec<::rust::String> const &args)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$cliwrap_write_some_wrappers (rootfs, args);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::rust::String cliwrap_destdir() noexcept {
+::rust::String
+cliwrap_destdir () noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$cliwrap_destdir(&return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$cliwrap_destdir (&return$.value);
+  return ::std::move (return$.value);
 }
 
-void container_encapsulate(::rust::Vec<::rust::String> args) {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$(::std::move(args));
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$container_encapsulate(&args$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+container_encapsulate (::rust::Vec<::rust::String> args)
+{
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$ (::std::move (args));
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$container_encapsulate (&args$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void deploy_from_self_entrypoint(::rust::Vec<::rust::String> args) {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$(::std::move(args));
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deploy_from_self_entrypoint(&args$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+deploy_from_self_entrypoint (::rust::Vec<::rust::String> args)
+{
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$ (::std::move (args));
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$deploy_from_self_entrypoint (&args$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-bool PrunedContainerInfo::operator==(PrunedContainerInfo const &rhs) const noexcept {
-  return rpmostreecxx$cxxbridge1$194$PrunedContainerInfo$operator$eq(*this, rhs);
+bool
+PrunedContainerInfo::operator== (PrunedContainerInfo const &rhs) const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$PrunedContainerInfo$operator$eq (*this, rhs);
 }
 
-bool PrunedContainerInfo::operator!=(PrunedContainerInfo const &rhs) const noexcept {
+bool
+PrunedContainerInfo::operator!= (PrunedContainerInfo const &rhs) const noexcept
+{
   return !(*this == rhs);
 }
 
-::rust::Box<::rpmostreecxx::ContainerImageState> pull_container(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref, ::rust::Str digest_override) {
+::rust::Box<::rpmostreecxx::ContainerImageState>
+pull_container (::rpmostreecxx::OstreeRepo const &repo,
+                ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref,
+                ::rust::Str digest_override)
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::ContainerImageState>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$pull_container(repo, cancellable, imgref, digest_override, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$pull_container (
+      repo, cancellable, imgref, digest_override, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rpmostreecxx::PrunedContainerInfo container_prune(::rpmostreecxx::OstreeSysroot const &sysroot) {
+::rpmostreecxx::PrunedContainerInfo
+container_prune (::rpmostreecxx::OstreeSysroot const &sysroot)
+{
   ::rust::MaybeUninit<::rpmostreecxx::PrunedContainerInfo> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$container_prune(sysroot, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$container_prune (sysroot, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::Box<::rpmostreecxx::ContainerImageState> query_container_image_commit(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str c) {
+::rust::Box<::rpmostreecxx::ContainerImageState>
+query_container_image_commit (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str c)
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::ContainerImageState>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$query_container_image_commit(repo, c, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$query_container_image_commit (repo, c, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void purge_refspec(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$purge_refspec(repo, refspec);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+purge_refspec (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$purge_refspec (repo, refspec);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-bool check_container_update(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref) {
+bool
+check_container_update (::rpmostreecxx::OstreeRepo const &repo,
+                        ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref)
+{
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$check_container_update(repo, cancellable, imgref, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$check_container_update (
+      repo, cancellable, imgref, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::std::size_t TempEtcGuard::layout::size() noexcept {
-  return rpmostreecxx$cxxbridge1$194$TempEtcGuard$operator$sizeof();
+::std::size_t
+TempEtcGuard::layout::size () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$TempEtcGuard$operator$sizeof ();
 }
 
-::std::size_t TempEtcGuard::layout::align() noexcept {
-  return rpmostreecxx$cxxbridge1$194$TempEtcGuard$operator$alignof();
+::std::size_t
+TempEtcGuard::layout::align () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$TempEtcGuard$operator$alignof ();
 }
 
-::std::size_t FilesystemScriptPrep::layout::size() noexcept {
-  return rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$operator$sizeof();
+::std::size_t
+FilesystemScriptPrep::layout::size () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$operator$sizeof ();
 }
 
-::std::size_t FilesystemScriptPrep::layout::align() noexcept {
-  return rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$operator$alignof();
+::std::size_t
+FilesystemScriptPrep::layout::align () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$operator$alignof ();
 }
 
-::rust::Box<::rpmostreecxx::TempEtcGuard> prepare_tempetc_guard(::std::int32_t rootfs) {
+::rust::Box<::rpmostreecxx::TempEtcGuard>
+prepare_tempetc_guard (::std::int32_t rootfs)
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::TempEtcGuard>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$prepare_tempetc_guard(rootfs, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$prepare_tempetc_guard (rootfs, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void TempEtcGuard::undo() const {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$TempEtcGuard$undo(*this);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+TempEtcGuard::undo () const
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$TempEtcGuard$undo (*this);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::rust::Box<::rpmostreecxx::FilesystemScriptPrep> prepare_filesystem_script_prep(::std::int32_t rootfs) {
+::rust::Box<::rpmostreecxx::FilesystemScriptPrep>
+prepare_filesystem_script_prep (::std::int32_t rootfs)
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::FilesystemScriptPrep>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$prepare_filesystem_script_prep(rootfs, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$prepare_filesystem_script_prep (rootfs, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void FilesystemScriptPrep::undo() {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$undo(*this);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+FilesystemScriptPrep::undo ()
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$FilesystemScriptPrep$undo (*this);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void run_depmod(::std::int32_t rootfs_dfd, ::rust::Str kver, bool unified_core) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$run_depmod(rootfs_dfd, kver, unified_core);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+run_depmod (::std::int32_t rootfs_dfd, ::rust::Str kver, bool unified_core)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$run_depmod (rootfs_dfd, kver, unified_core);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void run_sysusers(::std::int32_t rootfs_dfd, bool force) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$run_sysusers(rootfs_dfd, force);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+run_sysusers (::std::int32_t rootfs_dfd, bool force)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$run_sysusers (rootfs_dfd, force);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void log_treefile(::rpmostreecxx::Treefile const &tf) noexcept {
-  rpmostreecxx$cxxbridge1$194$log_treefile(tf);
+void
+log_treefile (::rpmostreecxx::Treefile const &tf) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$log_treefile (tf);
 }
 
-bool is_container_image_reference(::rust::Str refspec) noexcept {
-  return rpmostreecxx$cxxbridge1$194$is_container_image_reference(refspec);
+bool
+is_container_image_reference (::rust::Str refspec) noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$is_container_image_reference (refspec);
 }
 
-bool is_container_image_digest_reference(::rust::Str refspec) noexcept {
-  return rpmostreecxx$cxxbridge1$194$is_container_image_digest_reference(refspec);
+bool
+is_container_image_digest_reference (::rust::Str refspec) noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$is_container_image_digest_reference (refspec);
 }
 
-::rpmostreecxx::RefspecType refspec_classify(::rust::Str refspec) noexcept {
-  return rpmostreecxx$cxxbridge1$194$refspec_classify(refspec);
+::rpmostreecxx::RefspecType
+refspec_classify (::rust::Str refspec) noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$refspec_classify (refspec);
 }
 
-void verify_kernel_hmac(::std::int32_t rootfs, ::rust::Str moddir) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$verify_kernel_hmac(rootfs, moddir);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+verify_kernel_hmac (::std::int32_t rootfs, ::rust::Str moddir)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$verify_kernel_hmac (rootfs, moddir);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::rust::Vec<::rust::String> stage_container_rpms(::rust::Vec<::rust::String> rpms) {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> rpms$(::std::move(rpms));
+::rust::Vec<::rust::String>
+stage_container_rpms (::rust::Vec<::rust::String> rpms)
+{
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> rpms$ (::std::move (rpms));
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$stage_container_rpms(&rpms$.value, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$stage_container_rpms (&rpms$.value, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::Vec<::rust::String> stage_container_rpm_raw_fds(::rust::Vec<::std::int32_t> fds) {
-  ::rust::ManuallyDrop<::rust::Vec<::std::int32_t>> fds$(::std::move(fds));
+::rust::Vec<::rust::String>
+stage_container_rpm_raw_fds (::rust::Vec<::std::int32_t> fds)
+{
+  ::rust::ManuallyDrop<::rust::Vec<::std::int32_t>> fds$ (::std::move (fds));
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$stage_container_rpm_raw_fds(&fds$.value, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$stage_container_rpm_raw_fds (&fds$.value, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-bool commit_has_matching_sepolicy(::rpmostreecxx::GVariant const &commit, ::rpmostreecxx::OstreeSePolicy const &policy) {
+bool
+commit_has_matching_sepolicy (::rpmostreecxx::GVariant const &commit,
+                              ::rpmostreecxx::OstreeSePolicy const &policy)
+{
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$commit_has_matching_sepolicy(commit, policy, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$commit_has_matching_sepolicy (commit, policy, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rpmostreecxx::GVariant *get_header_variant(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str cachebranch) {
+::rpmostreecxx::GVariant *
+get_header_variant (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str cachebranch)
+{
   ::rust::MaybeUninit<::rpmostreecxx::GVariant *> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$get_header_variant(repo, cachebranch, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$get_header_variant (repo, cachebranch, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void compose_build_chunked_oci_entrypoint(::rust::Vec<::rust::String> args) {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$(::std::move(args));
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_build_chunked_oci_entrypoint(&args$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+compose_build_chunked_oci_entrypoint (::rust::Vec<::rust::String> args)
+{
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$ (::std::move (args));
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$compose_build_chunked_oci_entrypoint (&args$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void compose_image(::rust::Vec<::rust::String> args) {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$(::std::move(args));
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_image(&args$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+compose_image (::rust::Vec<::rust::String> args)
+{
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$ (::std::move (args));
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_image (&args$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void compose_rootfs_entrypoint(::rust::Vec<::rust::String> args) {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$(::std::move(args));
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_rootfs_entrypoint(&args$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+compose_rootfs_entrypoint (::rust::Vec<::rust::String> args)
+{
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$ (::std::move (args));
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$compose_rootfs_entrypoint (&args$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void configure_build_repo_from_target(::rpmostreecxx::OstreeRepo const &build_repo, ::rpmostreecxx::OstreeRepo const &target_repo) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$configure_build_repo_from_target(build_repo, target_repo);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+configure_build_repo_from_target (::rpmostreecxx::OstreeRepo const &build_repo,
+                                  ::rpmostreecxx::OstreeRepo const &target_repo)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$configure_build_repo_from_target (build_repo, target_repo);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void compose_prepare_rootfs(::std::int32_t src_rootfs_dfd, ::std::int32_t dest_rootfs_dfd, ::rpmostreecxx::Treefile &treefile) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_prepare_rootfs(src_rootfs_dfd, dest_rootfs_dfd, treefile);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+compose_prepare_rootfs (::std::int32_t src_rootfs_dfd, ::std::int32_t dest_rootfs_dfd,
+                        ::rpmostreecxx::Treefile &treefile)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_prepare_rootfs (
+      src_rootfs_dfd, dest_rootfs_dfd, treefile);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void composepost_nsswitch_altfiles(::std::int32_t rootfs_dfd) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$composepost_nsswitch_altfiles(rootfs_dfd);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+composepost_nsswitch_altfiles (::std::int32_t rootfs_dfd)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$composepost_nsswitch_altfiles (rootfs_dfd);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void compose_postprocess(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile, ::rust::Str next_version, bool unified_core) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_postprocess(rootfs_dfd, treefile, next_version, unified_core);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+compose_postprocess (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile,
+                     ::rust::Str next_version, bool unified_core)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_postprocess (
+      rootfs_dfd, treefile, next_version, unified_core);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void compose_postprocess_final_pre(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_postprocess_final_pre(rootfs_dfd, treefile);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+compose_postprocess_final_pre (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$compose_postprocess_final_pre (rootfs_dfd, treefile);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void compose_postprocess_final(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$compose_postprocess_final(rootfs_dfd, treefile);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+compose_postprocess_final (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$compose_postprocess_final (rootfs_dfd, treefile);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void convert_var_to_tmpfiles_d(::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable const &cancellable) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$convert_var_to_tmpfiles_d(rootfs_dfd, cancellable);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+convert_var_to_tmpfiles_d (::std::int32_t rootfs_dfd,
+                           ::rpmostreecxx::GCancellable const &cancellable)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$convert_var_to_tmpfiles_d (rootfs_dfd, cancellable);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void rootfs_prepare_links(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile, bool skip_usrlocal) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$rootfs_prepare_links(rootfs_dfd, treefile, skip_usrlocal);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+rootfs_prepare_links (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile,
+                      bool skip_usrlocal)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$rootfs_prepare_links (rootfs_dfd, treefile, skip_usrlocal);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void workaround_selinux_cross_labeling(::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable &cancellable) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$workaround_selinux_cross_labeling(rootfs_dfd, cancellable);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+workaround_selinux_cross_labeling (::std::int32_t rootfs_dfd,
+                                   ::rpmostreecxx::GCancellable &cancellable)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$workaround_selinux_cross_labeling (rootfs_dfd, cancellable);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void postprocess_cleanup_rpmdb(::std::int32_t rootfs_dfd) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$postprocess_cleanup_rpmdb(rootfs_dfd);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+postprocess_cleanup_rpmdb (::std::int32_t rootfs_dfd)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$postprocess_cleanup_rpmdb (rootfs_dfd);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void rewrite_rpmdb_for_target(::std::int32_t rootfs_dfd, bool normalize) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$rewrite_rpmdb_for_target(rootfs_dfd, normalize);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+rewrite_rpmdb_for_target (::std::int32_t rootfs_dfd, bool normalize)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$rewrite_rpmdb_for_target (rootfs_dfd, normalize);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::std::uint64_t directory_size(::std::int32_t dfd, ::rpmostreecxx::GCancellable const &cancellable) {
+::std::uint64_t
+directory_size (::std::int32_t dfd, ::rpmostreecxx::GCancellable const &cancellable)
+{
   ::rust::MaybeUninit<::std::uint64_t> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$directory_size(dfd, cancellable, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$directory_size (dfd, cancellable, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rpmostreecxx::OstreeDeployment *deployment_for_id(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id) {
+::rpmostreecxx::OstreeDeployment *
+deployment_for_id (::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id)
+{
   ::rust::MaybeUninit<::rpmostreecxx::OstreeDeployment *> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deployment_for_id(sysroot, deploy_id, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$deployment_for_id (sysroot, deploy_id, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::String deployment_checksum_for_id(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id) {
+::rust::String
+deployment_checksum_for_id (::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id)
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deployment_checksum_for_id(sysroot, deploy_id, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$deployment_checksum_for_id (sysroot, deploy_id, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rpmostreecxx::OstreeDeployment *deployment_get_base(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str opt_deploy_id, ::rust::Str opt_os_name) {
+::rpmostreecxx::OstreeDeployment *
+deployment_get_base (::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str opt_deploy_id,
+                     ::rust::Str opt_os_name)
+{
   ::rust::MaybeUninit<::rpmostreecxx::OstreeDeployment *> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deployment_get_base(sysroot, opt_deploy_id, opt_os_name, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deployment_get_base (
+      sysroot, opt_deploy_id, opt_os_name, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-bool deployment_add_manifest_diff(::rpmostreecxx::GVariantDict const &dict, ::rpmostreecxx::ExportedManifestDiff const &diff) noexcept {
-  return rpmostreecxx$cxxbridge1$194$deployment_add_manifest_diff(dict, diff);
+bool
+deployment_add_manifest_diff (::rpmostreecxx::GVariantDict const &dict,
+                              ::rpmostreecxx::ExportedManifestDiff const &diff) noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$deployment_add_manifest_diff (dict, diff);
 }
 
-void daemon_sanitycheck_environment(::rpmostreecxx::OstreeSysroot const &sysroot) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$daemon_sanitycheck_environment(sysroot);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+daemon_sanitycheck_environment (::rpmostreecxx::OstreeSysroot const &sysroot)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$daemon_sanitycheck_environment (sysroot);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::rust::String deployment_generate_id(::rpmostreecxx::OstreeDeployment const &deployment) noexcept {
+::rust::String
+deployment_generate_id (::rpmostreecxx::OstreeDeployment const &deployment) noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$deployment_generate_id(deployment, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$deployment_generate_id (deployment, &return$.value);
+  return ::std::move (return$.value);
 }
 
-void deployment_populate_variant(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::GVariantDict const &dict) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deployment_populate_variant(sysroot, deployment, dict);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+deployment_populate_variant (::rpmostreecxx::OstreeSysroot const &sysroot,
+                             ::rpmostreecxx::OstreeDeployment const &deployment,
+                             ::rpmostreecxx::GVariantDict const &dict)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$deployment_populate_variant (sysroot, deployment, dict);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void generate_baselayer_refs(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$generate_baselayer_refs(sysroot, repo, cancellable);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+generate_baselayer_refs (::rpmostreecxx::OstreeSysroot const &sysroot,
+                         ::rpmostreecxx::OstreeRepo const &repo,
+                         ::rpmostreecxx::GCancellable const &cancellable)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$generate_baselayer_refs (sysroot, repo, cancellable);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void variant_add_remote_status(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec, ::rust::Str base_checksum, ::rpmostreecxx::GVariantDict const &dict) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$variant_add_remote_status(repo, refspec, base_checksum, dict);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+variant_add_remote_status (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec,
+                           ::rust::Str base_checksum, ::rpmostreecxx::GVariantDict const &dict)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$variant_add_remote_status (repo, refspec, base_checksum, dict);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::rpmostreecxx::DeploymentLayeredMeta deployment_layeredmeta_from_commit(::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::GVariant const &commit) {
+::rpmostreecxx::DeploymentLayeredMeta
+deployment_layeredmeta_from_commit (::rpmostreecxx::OstreeDeployment const &deployment,
+                                    ::rpmostreecxx::GVariant const &commit)
+{
   ::rust::MaybeUninit<::rpmostreecxx::DeploymentLayeredMeta> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deployment_layeredmeta_from_commit(deployment, commit, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deployment_layeredmeta_from_commit (
+      deployment, commit, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rpmostreecxx::DeploymentLayeredMeta deployment_layeredmeta_load(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::OstreeDeployment const &deployment) {
+::rpmostreecxx::DeploymentLayeredMeta
+deployment_layeredmeta_load (::rpmostreecxx::OstreeRepo const &repo,
+                             ::rpmostreecxx::OstreeDeployment const &deployment)
+{
   ::rust::MaybeUninit<::rpmostreecxx::DeploymentLayeredMeta> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deployment_layeredmeta_load(repo, deployment, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$deployment_layeredmeta_load (repo, deployment, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rpmostreecxx::OverrideReplacementSource parse_override_source(::rust::Str source) {
+::rpmostreecxx::OverrideReplacementSource
+parse_override_source (::rust::Str source)
+{
   ::rust::MaybeUninit<::rpmostreecxx::OverrideReplacementSource> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$parse_override_source(source, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$parse_override_source (source, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rpmostreecxx::ParsedRevision parse_revision(::rust::Str source) {
+::rpmostreecxx::ParsedRevision
+parse_revision (::rust::Str source)
+{
   ::rust::MaybeUninit<::rpmostreecxx::ParsedRevision> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$parse_revision(source, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$parse_revision (source, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::String generate_object_path(::rust::Str base, ::rust::Str next_segment) {
+::rust::String
+generate_object_path (::rust::Str base, ::rust::Str next_segment)
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$generate_object_path(base, next_segment, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$generate_object_path (base, next_segment, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void failpoint(::rust::Str p) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$failpoint(p);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+failpoint (::rust::Str p)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$failpoint (p);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::std::size_t RpmImporterFlags::layout::size() noexcept {
-  return rpmostreecxx$cxxbridge1$194$RpmImporterFlags$operator$sizeof();
+::std::size_t
+RpmImporterFlags::layout::size () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$RpmImporterFlags$operator$sizeof ();
 }
 
-::std::size_t RpmImporterFlags::layout::align() noexcept {
-  return rpmostreecxx$cxxbridge1$194$RpmImporterFlags$operator$alignof();
+::std::size_t
+RpmImporterFlags::layout::align () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$RpmImporterFlags$operator$alignof ();
 }
 
-::rust::Box<::rpmostreecxx::RpmImporterFlags> rpm_importer_flags_new_empty() noexcept {
-  return ::rust::Box<::rpmostreecxx::RpmImporterFlags>::from_raw(rpmostreecxx$cxxbridge1$194$rpm_importer_flags_new_empty());
+::rust::Box<::rpmostreecxx::RpmImporterFlags>
+rpm_importer_flags_new_empty () noexcept
+{
+  return ::rust::Box<::rpmostreecxx::RpmImporterFlags>::from_raw (
+      rpmostreecxx$cxxbridge1$194$rpm_importer_flags_new_empty ());
 }
 
-bool RpmImporterFlags::is_ima_enabled() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$RpmImporterFlags$is_ima_enabled(*this);
+bool
+RpmImporterFlags::is_ima_enabled () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$RpmImporterFlags$is_ima_enabled (*this);
 }
 
-::std::size_t RpmImporter::layout::size() noexcept {
-  return rpmostreecxx$cxxbridge1$194$RpmImporter$operator$sizeof();
+::std::size_t
+RpmImporter::layout::size () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$RpmImporter$operator$sizeof ();
 }
 
-::std::size_t RpmImporter::layout::align() noexcept {
-  return rpmostreecxx$cxxbridge1$194$RpmImporter$operator$alignof();
+::std::size_t
+RpmImporter::layout::align () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$RpmImporter$operator$alignof ();
 }
 
-::rust::Box<::rpmostreecxx::RpmImporter> rpm_importer_new(::rust::Str pkg_name, ::rust::Str ostree_branch, ::rpmostreecxx::RpmImporterFlags const &flags) {
+::rust::Box<::rpmostreecxx::RpmImporter>
+rpm_importer_new (::rust::Str pkg_name, ::rust::Str ostree_branch,
+                  ::rpmostreecxx::RpmImporterFlags const &flags)
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::RpmImporter>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$rpm_importer_new(pkg_name, ostree_branch, flags, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$rpm_importer_new (
+      pkg_name, ostree_branch, flags, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::String RpmImporter::handle_translate_pathname(::rust::Str path) noexcept {
+::rust::String
+RpmImporter::handle_translate_pathname (::rust::Str path) noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$RpmImporter$handle_translate_pathname(*this, path, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$RpmImporter$handle_translate_pathname (*this, path, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::String RpmImporter::ostree_branch() const noexcept {
+::rust::String
+RpmImporter::ostree_branch () const noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$RpmImporter$ostree_branch(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$RpmImporter$ostree_branch (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::String RpmImporter::pkg_name() const noexcept {
+::rust::String
+RpmImporter::pkg_name () const noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$RpmImporter$pkg_name(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$RpmImporter$pkg_name (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-bool RpmImporter::doc_files_are_filtered() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_are_filtered(*this);
+bool
+RpmImporter::doc_files_are_filtered () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_are_filtered (*this);
 }
 
-void RpmImporter::doc_files_insert(::rust::Str path) noexcept {
-  rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_insert(*this, path);
+void
+RpmImporter::doc_files_insert (::rust::Str path) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_insert (*this, path);
 }
 
-bool RpmImporter::doc_files_contains(::rust::Str path) const noexcept {
-  return rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_contains(*this, path);
+bool
+RpmImporter::doc_files_contains (::rust::Str path) const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$RpmImporter$doc_files_contains (*this, path);
 }
 
-void RpmImporter::rpmfi_overrides_insert(::rust::Str path, ::std::uint64_t index) noexcept {
-  rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_insert(*this, path, index);
+void
+RpmImporter::rpmfi_overrides_insert (::rust::Str path, ::std::uint64_t index) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_insert (*this, path, index);
 }
 
-bool RpmImporter::rpmfi_overrides_contains(::rust::Str path) const noexcept {
-  return rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_contains(*this, path);
+bool
+RpmImporter::rpmfi_overrides_contains (::rust::Str path) const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_contains (*this, path);
 }
 
-::std::uint64_t RpmImporter::rpmfi_overrides_get(::rust::Str path) const noexcept {
-  return rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_get(*this, path);
+::std::uint64_t
+RpmImporter::rpmfi_overrides_get (::rust::Str path) const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$RpmImporter$rpmfi_overrides_get (*this, path);
 }
 
-bool RpmImporter::is_ima_enabled() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$RpmImporter$is_ima_enabled(*this);
+bool
+RpmImporter::is_ima_enabled () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$RpmImporter$is_ima_enabled (*this);
 }
 
-void RpmImporter::tweak_imported_file_info(::rpmostreecxx::GFileInfo const &file_info) const noexcept {
-  rpmostreecxx$cxxbridge1$194$RpmImporter$tweak_imported_file_info(*this, file_info);
+void
+RpmImporter::tweak_imported_file_info (::rpmostreecxx::GFileInfo const &file_info) const noexcept
+{
+  rpmostreecxx$cxxbridge1$194$RpmImporter$tweak_imported_file_info (*this, file_info);
 }
 
-bool RpmImporter::is_file_filtered(::rust::Str path, ::rpmostreecxx::GFileInfo const &file_info) const {
+bool
+RpmImporter::is_file_filtered (::rust::Str path, ::rpmostreecxx::GFileInfo const &file_info) const
+{
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$RpmImporter$is_file_filtered(*this, path, file_info, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$RpmImporter$is_file_filtered (
+      *this, path, file_info, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void RpmImporter::translate_to_tmpfiles_entry(::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username, ::rust::Str groupname) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$RpmImporter$translate_to_tmpfiles_entry(*this, abs_path, file_info, username, groupname);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+RpmImporter::translate_to_tmpfiles_entry (::rust::Str abs_path,
+                                          ::rpmostreecxx::GFileInfo const &file_info,
+                                          ::rust::Str username, ::rust::Str groupname)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$RpmImporter$translate_to_tmpfiles_entry (
+          *this, abs_path, file_info, username, groupname);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-bool RpmImporter::has_tmpfiles_entries() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$RpmImporter$has_tmpfiles_entries(*this);
+bool
+RpmImporter::has_tmpfiles_entries () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$RpmImporter$has_tmpfiles_entries (*this);
 }
 
-::rust::String RpmImporter::serialize_tmpfiles_content() const noexcept {
+::rust::String
+RpmImporter::serialize_tmpfiles_content () const noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$RpmImporter$serialize_tmpfiles_content(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$RpmImporter$serialize_tmpfiles_content (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::String tmpfiles_translate(::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username, ::rust::Str groupname) {
+::rust::String
+tmpfiles_translate (::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info,
+                    ::rust::Str username, ::rust::Str groupname)
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$tmpfiles_translate(abs_path, file_info, username, groupname, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$tmpfiles_translate (
+      abs_path, file_info, username, groupname, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void append_dracut_random_cpio(::std::int32_t fd) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$append_dracut_random_cpio(fd);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+append_dracut_random_cpio (::std::int32_t fd)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$append_dracut_random_cpio (fd);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::std::int32_t initramfs_overlay_generate(::rust::Vec<::rust::String> const &files, ::rpmostreecxx::GCancellable &cancellable) {
+::std::int32_t
+initramfs_overlay_generate (::rust::Vec<::rust::String> const &files,
+                            ::rpmostreecxx::GCancellable &cancellable)
+{
   ::rust::MaybeUninit<::std::int32_t> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$initramfs_overlay_generate(files, cancellable, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$initramfs_overlay_generate (files, cancellable, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void journal_print_staging_failure() noexcept {
-  rpmostreecxx$cxxbridge1$194$journal_print_staging_failure();
+void
+journal_print_staging_failure () noexcept
+{
+  rpmostreecxx$cxxbridge1$194$journal_print_staging_failure ();
 }
 
-void console_progress_begin_task(::rust::Str msg) noexcept {
-  rpmostreecxx$cxxbridge1$194$console_progress_begin_task(msg);
+void
+console_progress_begin_task (::rust::Str msg) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$console_progress_begin_task (msg);
 }
 
-void console_progress_begin_n_items(::rust::Str msg, ::std::uint64_t n) noexcept {
-  rpmostreecxx$cxxbridge1$194$console_progress_begin_n_items(msg, n);
+void
+console_progress_begin_n_items (::rust::Str msg, ::std::uint64_t n) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$console_progress_begin_n_items (msg, n);
 }
 
-void console_progress_begin_percent(::rust::Str msg) noexcept {
-  rpmostreecxx$cxxbridge1$194$console_progress_begin_percent(msg);
+void
+console_progress_begin_percent (::rust::Str msg) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$console_progress_begin_percent (msg);
 }
 
-void console_progress_set_message(::rust::Str msg) noexcept {
-  rpmostreecxx$cxxbridge1$194$console_progress_set_message(msg);
+void
+console_progress_set_message (::rust::Str msg) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$console_progress_set_message (msg);
 }
 
-void console_progress_set_sub_message(::rust::Str msg) noexcept {
-  rpmostreecxx$cxxbridge1$194$console_progress_set_sub_message(msg);
+void
+console_progress_set_sub_message (::rust::Str msg) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$console_progress_set_sub_message (msg);
 }
 
-void console_progress_update(::std::uint64_t n) noexcept {
-  rpmostreecxx$cxxbridge1$194$console_progress_update(n);
+void
+console_progress_update (::std::uint64_t n) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$console_progress_update (n);
 }
 
-void console_progress_end(::rust::Str suffix) noexcept {
-  rpmostreecxx$cxxbridge1$194$console_progress_end(suffix);
+void
+console_progress_end (::rust::Str suffix) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$console_progress_end (suffix);
 }
 
-bool HistoryEntry::operator==(HistoryEntry const &rhs) const noexcept {
-  return rpmostreecxx$cxxbridge1$194$HistoryEntry$operator$eq(*this, rhs);
+bool
+HistoryEntry::operator== (HistoryEntry const &rhs) const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$HistoryEntry$operator$eq (*this, rhs);
 }
 
-bool HistoryEntry::operator!=(HistoryEntry const &rhs) const noexcept {
-  return rpmostreecxx$cxxbridge1$194$HistoryEntry$operator$ne(*this, rhs);
+bool
+HistoryEntry::operator!= (HistoryEntry const &rhs) const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$HistoryEntry$operator$ne (*this, rhs);
 }
 
-::std::size_t HistoryCtx::layout::size() noexcept {
-  return rpmostreecxx$cxxbridge1$194$HistoryCtx$operator$sizeof();
+::std::size_t
+HistoryCtx::layout::size () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$HistoryCtx$operator$sizeof ();
 }
 
-::std::size_t HistoryCtx::layout::align() noexcept {
-  return rpmostreecxx$cxxbridge1$194$HistoryCtx$operator$alignof();
+::std::size_t
+HistoryCtx::layout::align () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$HistoryCtx$operator$alignof ();
 }
 
-::rust::Box<::rpmostreecxx::HistoryCtx> history_ctx_new() {
+::rust::Box<::rpmostreecxx::HistoryCtx>
+history_ctx_new ()
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::HistoryCtx>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$history_ctx_new(&return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$history_ctx_new (&return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rpmostreecxx::HistoryEntry HistoryCtx::next_entry() {
+::rpmostreecxx::HistoryEntry
+HistoryCtx::next_entry ()
+{
   ::rust::MaybeUninit<::rpmostreecxx::HistoryEntry> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$HistoryCtx$next_entry(*this, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$HistoryCtx$next_entry (*this, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void history_prune() {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$history_prune();
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+history_prune ()
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$history_prune ();
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::std::size_t TokioHandle::layout::size() noexcept {
-  return rpmostreecxx$cxxbridge1$194$TokioHandle$operator$sizeof();
+::std::size_t
+TokioHandle::layout::size () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$TokioHandle$operator$sizeof ();
 }
 
-::std::size_t TokioHandle::layout::align() noexcept {
-  return rpmostreecxx$cxxbridge1$194$TokioHandle$operator$alignof();
+::std::size_t
+TokioHandle::layout::align () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$TokioHandle$operator$alignof ();
 }
 
-::std::size_t TokioEnterGuard::layout::size() noexcept {
-  return rpmostreecxx$cxxbridge1$194$TokioEnterGuard$operator$sizeof();
+::std::size_t
+TokioEnterGuard::layout::size () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$TokioEnterGuard$operator$sizeof ();
 }
 
-::std::size_t TokioEnterGuard::layout::align() noexcept {
-  return rpmostreecxx$cxxbridge1$194$TokioEnterGuard$operator$alignof();
+::std::size_t
+TokioEnterGuard::layout::align () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$TokioEnterGuard$operator$alignof ();
 }
 
-::rust::Box<::rpmostreecxx::TokioHandle> tokio_handle_get() noexcept {
-  return ::rust::Box<::rpmostreecxx::TokioHandle>::from_raw(rpmostreecxx$cxxbridge1$194$tokio_handle_get());
+::rust::Box<::rpmostreecxx::TokioHandle>
+tokio_handle_get () noexcept
+{
+  return ::rust::Box<::rpmostreecxx::TokioHandle>::from_raw (
+      rpmostreecxx$cxxbridge1$194$tokio_handle_get ());
 }
 
-::rust::Box<::rpmostreecxx::TokioEnterGuard> TokioHandle::enter() const noexcept {
-  return ::rust::Box<::rpmostreecxx::TokioEnterGuard>::from_raw(rpmostreecxx$cxxbridge1$194$TokioHandle$enter(*this));
+::rust::Box<::rpmostreecxx::TokioEnterGuard>
+TokioHandle::enter () const noexcept
+{
+  return ::rust::Box<::rpmostreecxx::TokioEnterGuard>::from_raw (
+      rpmostreecxx$cxxbridge1$194$TokioHandle$enter (*this));
 }
 
-bool script_is_ignored(::rust::Str pkg, ::rust::Str script, bool use_kernel_install) noexcept {
-  return rpmostreecxx$cxxbridge1$194$script_is_ignored(pkg, script, use_kernel_install);
+bool
+script_is_ignored (::rust::Str pkg, ::rust::Str script, bool use_kernel_install) noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$script_is_ignored (pkg, script, use_kernel_install);
 }
 
-void testutils_entrypoint(::rust::Vec<::rust::String> argv) {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> argv$(::std::move(argv));
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$testutils_entrypoint(&argv$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+testutils_entrypoint (::rust::Vec<::rust::String> argv)
+{
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> argv$ (::std::move (argv));
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$testutils_entrypoint (&argv$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::rust::String maybe_shell_quote(::rust::Str input) noexcept {
+::rust::String
+maybe_shell_quote (::rust::Str input) noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$maybe_shell_quote(input, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$maybe_shell_quote (input, &return$.value);
+  return ::std::move (return$.value);
 }
 
-bool Refspec::operator==(Refspec const &rhs) const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Refspec$operator$eq(*this, rhs);
+bool
+Refspec::operator== (Refspec const &rhs) const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Refspec$operator$eq (*this, rhs);
 }
 
-bool Refspec::operator!=(Refspec const &rhs) const noexcept {
+bool
+Refspec::operator!= (Refspec const &rhs) const noexcept
+{
   return !(*this == rhs);
 }
 
-bool OverrideReplacement::operator==(OverrideReplacement const &rhs) const noexcept {
-  return rpmostreecxx$cxxbridge1$194$OverrideReplacement$operator$eq(*this, rhs);
+bool
+OverrideReplacement::operator== (OverrideReplacement const &rhs) const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$OverrideReplacement$operator$eq (*this, rhs);
 }
 
-bool OverrideReplacement::operator!=(OverrideReplacement const &rhs) const noexcept {
+bool
+OverrideReplacement::operator!= (OverrideReplacement const &rhs) const noexcept
+{
   return !(*this == rhs);
 }
 
-::std::size_t Treefile::layout::size() noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$operator$sizeof();
+::std::size_t
+Treefile::layout::size () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$operator$sizeof ();
 }
 
-::std::size_t Treefile::layout::align() noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$operator$alignof();
+::std::size_t
+Treefile::layout::align () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$operator$alignof ();
 }
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new(::rust::Str filename, ::rust::Str basearch) {
+::rust::Box<::rpmostreecxx::Treefile>
+treefile_new (::rust::Str filename, ::rust::Str basearch)
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Treefile>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_new(filename, basearch, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$treefile_new (filename, basearch, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new_empty() {
+::rust::Box<::rpmostreecxx::Treefile>
+treefile_new_empty ()
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Treefile>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_new_empty(&return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_new_empty (&return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new_from_string(::rust::Str buf, bool client) {
+::rust::Box<::rpmostreecxx::Treefile>
+treefile_new_from_string (::rust::Str buf, bool client)
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Treefile>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_new_from_string(buf, client, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$treefile_new_from_string (buf, client, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new_compose(::rust::Str filename, ::rust::Str basearch) {
+::rust::Box<::rpmostreecxx::Treefile>
+treefile_new_compose (::rust::Str filename, ::rust::Str basearch)
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Treefile>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_new_compose(filename, basearch, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$treefile_new_compose (filename, basearch, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new_client(::rust::Str filename, ::rust::Str basearch) {
+::rust::Box<::rpmostreecxx::Treefile>
+treefile_new_client (::rust::Str filename, ::rust::Str basearch)
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Treefile>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_new_client(filename, basearch, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$treefile_new_client (filename, basearch, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new_client_from_etc(::rust::Str basearch) {
+::rust::Box<::rpmostreecxx::Treefile>
+treefile_new_client_from_etc (::rust::Str basearch)
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Treefile>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_new_client_from_etc(basearch, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$treefile_new_client_from_etc (basearch, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::std::uint32_t treefile_delete_client_etc() {
+::std::uint32_t
+treefile_delete_client_etc ()
+{
   ::rust::MaybeUninit<::std::uint32_t> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_delete_client_etc(&return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$treefile_delete_client_etc (&return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::Str Treefile::get_workdir() const noexcept {
-  return ::rust::impl<::rust::Str>::new_unchecked(rpmostreecxx$cxxbridge1$194$Treefile$get_workdir(*this));
+::rust::Str
+Treefile::get_workdir () const noexcept
+{
+  return ::rust::impl<::rust::Str>::new_unchecked (
+      rpmostreecxx$cxxbridge1$194$Treefile$get_workdir (*this));
 }
 
-::std::int32_t Treefile::get_passwd_fd() noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_passwd_fd(*this);
+::std::int32_t
+Treefile::get_passwd_fd () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_passwd_fd (*this);
 }
 
-::std::int32_t Treefile::get_group_fd() noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_group_fd(*this);
+::std::int32_t
+Treefile::get_group_fd () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_group_fd (*this);
 }
 
-::rust::String Treefile::get_json_string() const noexcept {
+::rust::String
+Treefile::get_json_string () const noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_json_string(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_json_string (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::Vec<::rust::String> Treefile::get_ostree_layers() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_ostree_layers () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_layers(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_layers (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::Vec<::rust::String> Treefile::get_ostree_override_layers() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_ostree_override_layers () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_override_layers(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_override_layers (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::Vec<::rust::String> Treefile::get_all_ostree_layers() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_all_ostree_layers () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_all_ostree_layers(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_all_ostree_layers (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::Vec<::rust::String> Treefile::get_repos() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_repos () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_repos(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_repos (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::Vec<::rust::String> Treefile::get_packages() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_packages () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_packages(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_packages (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::String Treefile::require_automatic_version_prefix() const {
+::rust::String
+Treefile::require_automatic_version_prefix () const
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$require_automatic_version_prefix(*this, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$Treefile$require_automatic_version_prefix (*this,
+                                                                               &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-bool Treefile::add_packages(::rust::Vec<::rust::String> packages, bool allow_existing) {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$(::std::move(packages));
+bool
+Treefile::add_packages (::rust::Vec<::rust::String> packages, bool allow_existing)
+{
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$ (::std::move (packages));
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$add_packages(*this, &packages$.value, allow_existing, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$add_packages (
+      *this, &packages$.value, allow_existing, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-bool Treefile::has_packages() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$has_packages(*this);
+bool
+Treefile::has_packages () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$has_packages (*this);
 }
 
-::rust::Vec<::rust::String> Treefile::get_local_packages() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_local_packages () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_local_packages(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_local_packages (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-bool Treefile::add_local_packages(::rust::Vec<::rust::String> packages, bool allow_existing) {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$(::std::move(packages));
+bool
+Treefile::add_local_packages (::rust::Vec<::rust::String> packages, bool allow_existing)
+{
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$ (::std::move (packages));
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$add_local_packages(*this, &packages$.value, allow_existing, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$add_local_packages (
+      *this, &packages$.value, allow_existing, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::Vec<::rust::String> Treefile::get_local_fileoverride_packages() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_local_fileoverride_packages () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_local_fileoverride_packages(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_local_fileoverride_packages (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-bool Treefile::add_local_fileoverride_packages(::rust::Vec<::rust::String> packages, bool allow_existing) {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$(::std::move(packages));
+bool
+Treefile::add_local_fileoverride_packages (::rust::Vec<::rust::String> packages,
+                                           bool allow_existing)
+{
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$ (::std::move (packages));
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$add_local_fileoverride_packages(*this, &packages$.value, allow_existing, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$Treefile$add_local_fileoverride_packages (
+          *this, &packages$.value, allow_existing, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-bool Treefile::remove_packages(::rust::Vec<::rust::String> packages, bool allow_noent) {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$(::std::move(packages));
+bool
+Treefile::remove_packages (::rust::Vec<::rust::String> packages, bool allow_noent)
+{
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$ (::std::move (packages));
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$remove_packages(*this, &packages$.value, allow_noent, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$remove_packages (
+      *this, &packages$.value, allow_noent, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::Vec<::rpmostreecxx::OverrideReplacement> Treefile::get_packages_override_replace() const noexcept {
+::rust::Vec<::rpmostreecxx::OverrideReplacement>
+Treefile::get_packages_override_replace () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rpmostreecxx::OverrideReplacement>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_replace(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_replace (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-bool Treefile::has_packages_override_replace() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$has_packages_override_replace(*this);
+bool
+Treefile::has_packages_override_replace () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$has_packages_override_replace (*this);
 }
 
-bool Treefile::add_packages_override_replace(::rpmostreecxx::OverrideReplacement replacement) noexcept {
-  ::rust::ManuallyDrop<::rpmostreecxx::OverrideReplacement> replacement$(::std::move(replacement));
-  return rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_replace(*this, &replacement$.value);
+bool
+Treefile::add_packages_override_replace (::rpmostreecxx::OverrideReplacement replacement) noexcept
+{
+  ::rust::ManuallyDrop<::rpmostreecxx::OverrideReplacement> replacement$ (
+      ::std::move (replacement));
+  return rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_replace (*this,
+                                                                             &replacement$.value);
 }
 
-bool Treefile::remove_package_override_replace(::rust::Str package) noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_replace(*this, package);
+bool
+Treefile::remove_package_override_replace (::rust::Str package) noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_replace (*this, package);
 }
 
-::rust::Vec<::rust::String> Treefile::get_packages_override_replace_local() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_packages_override_replace_local () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_replace_local(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_replace_local (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-void Treefile::add_packages_override_replace_local(::rust::Vec<::rust::String> packages) {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$(::std::move(packages));
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_replace_local(*this, &packages$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+Treefile::add_packages_override_replace_local (::rust::Vec<::rust::String> packages)
+{
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$ (::std::move (packages));
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_replace_local (*this,
+                                                                                  &packages$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-bool Treefile::remove_package_override_replace_local(::rust::Str package) noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_replace_local(*this, package);
+bool
+Treefile::remove_package_override_replace_local (::rust::Str package) noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_replace_local (*this,
+                                                                                     package);
 }
 
-::rust::Vec<::rust::String> Treefile::get_packages_override_remove() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_packages_override_remove () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_remove(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_packages_override_remove (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-void Treefile::add_packages_override_remove(::rust::Vec<::rust::String> packages) {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$(::std::move(packages));
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_remove(*this, &packages$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+Treefile::add_packages_override_remove (::rust::Vec<::rust::String> packages)
+{
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> packages$ (::std::move (packages));
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$Treefile$add_packages_override_remove (*this, &packages$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-bool Treefile::remove_package_override_remove(::rust::Str package) noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_remove(*this, package);
+bool
+Treefile::remove_package_override_remove (::rust::Str package) noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$remove_package_override_remove (*this, package);
 }
 
-bool Treefile::has_packages_override_remove_name(::rust::Str name) const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$has_packages_override_remove_name(*this, name);
+bool
+Treefile::has_packages_override_remove_name (::rust::Str name) const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$has_packages_override_remove_name (*this, name);
 }
 
-bool Treefile::remove_all_overrides() noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$remove_all_overrides(*this);
+bool
+Treefile::remove_all_overrides () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$remove_all_overrides (*this);
 }
 
-bool Treefile::remove_all_packages() noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$remove_all_packages(*this);
+bool
+Treefile::remove_all_packages () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$remove_all_packages (*this);
 }
 
-::rust::Vec<::rust::String> Treefile::get_exclude_packages() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_exclude_packages () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_exclude_packages(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_exclude_packages (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::String Treefile::get_platform_module() const noexcept {
+::rust::String
+Treefile::get_platform_module () const noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_platform_module(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_platform_module (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::Vec<::rust::String> Treefile::get_install_langs() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_install_langs () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_install_langs(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_install_langs (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::String Treefile::format_install_langs_macro() const noexcept {
+::rust::String
+Treefile::format_install_langs_macro () const noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$format_install_langs_macro(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$format_install_langs_macro (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::Vec<::rust::String> Treefile::get_lockfile_repos() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_lockfile_repos () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_lockfile_repos(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_lockfile_repos (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::Str Treefile::get_ref() const noexcept {
-  return ::rust::impl<::rust::Str>::new_unchecked(rpmostreecxx$cxxbridge1$194$Treefile$get_ref(*this));
+::rust::Str
+Treefile::get_ref () const noexcept
+{
+  return ::rust::impl<::rust::Str>::new_unchecked (
+      rpmostreecxx$cxxbridge1$194$Treefile$get_ref (*this));
 }
 
-bool Treefile::get_cliwrap() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_cliwrap(*this);
+bool
+Treefile::get_cliwrap () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_cliwrap (*this);
 }
 
-::rust::Vec<::rust::String> Treefile::get_cliwrap_binaries() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_cliwrap_binaries () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_cliwrap_binaries(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_cliwrap_binaries (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-void Treefile::set_cliwrap(bool enabled) noexcept {
-  rpmostreecxx$cxxbridge1$194$Treefile$set_cliwrap(*this, enabled);
+void
+Treefile::set_cliwrap (bool enabled) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Treefile$set_cliwrap (*this, enabled);
 }
 
-::rust::Vec<::rust::String> Treefile::get_container_cmd() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_container_cmd () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_container_cmd(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_container_cmd (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-bool Treefile::get_readonly_executables() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_readonly_executables(*this);
+bool
+Treefile::get_readonly_executables () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_readonly_executables (*this);
 }
 
-bool Treefile::get_documentation() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_documentation(*this);
+bool
+Treefile::get_documentation () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_documentation (*this);
 }
 
-bool Treefile::get_recommends() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_recommends(*this);
+bool
+Treefile::get_recommends () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_recommends (*this);
 }
 
-bool Treefile::get_selinux() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_selinux(*this);
+bool
+Treefile::get_selinux () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_selinux (*this);
 }
 
-bool Treefile::get_sysusers_is_forced() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_sysusers_is_forced(*this);
+bool
+Treefile::get_sysusers_is_forced () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_sysusers_is_forced (*this);
 }
 
-::std::uint32_t Treefile::get_selinux_label_version() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_selinux_label_version(*this);
+::std::uint32_t
+Treefile::get_selinux_label_version () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_selinux_label_version (*this);
 }
 
-::rust::String Treefile::get_gpg_key() const noexcept {
+::rust::String
+Treefile::get_gpg_key () const noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_gpg_key(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_gpg_key (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::String Treefile::get_automatic_version_suffix() const noexcept {
+::rust::String
+Treefile::get_automatic_version_suffix () const noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_automatic_version_suffix(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_automatic_version_suffix (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-bool Treefile::get_container() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_container(*this);
+bool
+Treefile::get_container () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_container (*this);
 }
 
-bool Treefile::get_machineid_compat() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_machineid_compat(*this);
+bool
+Treefile::get_machineid_compat () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_machineid_compat (*this);
 }
 
-::rust::Vec<::rust::String> Treefile::get_etc_group_members() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_etc_group_members () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_etc_group_members(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_etc_group_members (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-bool Treefile::get_boot_location_is_modules() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_boot_location_is_modules(*this);
+bool
+Treefile::get_boot_location_is_modules () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_boot_location_is_modules (*this);
 }
 
-bool Treefile::use_kernel_install() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$use_kernel_install(*this);
+bool
+Treefile::use_kernel_install () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$use_kernel_install (*this);
 }
 
-bool Treefile::get_ima() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_ima(*this);
+bool
+Treefile::get_ima () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_ima (*this);
 }
 
-::rust::String Treefile::get_releasever() const noexcept {
+::rust::String
+Treefile::get_releasever () const noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_releasever(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_releasever (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rpmostreecxx::RepoMetadataTarget Treefile::get_repo_metadata_target() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_repo_metadata_target(*this);
+::rpmostreecxx::RepoMetadataTarget
+Treefile::get_repo_metadata_target () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_repo_metadata_target (*this);
 }
 
-::rpmostreecxx::AdvisoriesMetadataTarget Treefile::get_advisories_metadata_target() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_advisories_metadata_target(*this);
+::rpmostreecxx::AdvisoriesMetadataTarget
+Treefile::get_advisories_metadata_target () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_advisories_metadata_target (*this);
 }
 
-bool Treefile::rpmdb_backend_is_target() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$rpmdb_backend_is_target(*this);
+bool
+Treefile::rpmdb_backend_is_target () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$rpmdb_backend_is_target (*this);
 }
 
-bool Treefile::should_normalize_rpmdb() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$should_normalize_rpmdb(*this);
+bool
+Treefile::should_normalize_rpmdb () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$should_normalize_rpmdb (*this);
 }
 
-::rpmostreecxx::OptUsrLocal Treefile::get_opt_usrlocal() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_opt_usrlocal(*this);
+::rpmostreecxx::OptUsrLocal
+Treefile::get_opt_usrlocal () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_opt_usrlocal (*this);
 }
 
-::rust::Vec<::rust::String> Treefile::get_files_remove_regex(::rust::Str package) const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_files_remove_regex (::rust::Str package) const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_files_remove_regex(*this, package, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_files_remove_regex (*this, package, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::String Treefile::get_checksum(::rpmostreecxx::OstreeRepo const &repo) const {
+::rust::String
+Treefile::get_checksum (::rpmostreecxx::OstreeRepo const &repo) const
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$get_checksum(*this, repo, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$Treefile$get_checksum (*this, repo, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::String Treefile::get_ostree_ref() const noexcept {
+::rust::String
+Treefile::get_ostree_ref () const noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_ref(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_ostree_ref (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::Slice<::rpmostreecxx::RepoPackage const> Treefile::get_repo_packages() const noexcept {
-  return ::rust::impl<::rust::Slice<::rpmostreecxx::RepoPackage const>>::slice(rpmostreecxx$cxxbridge1$194$Treefile$get_repo_packages(*this));
+::rust::Slice<::rpmostreecxx::RepoPackage const>
+Treefile::get_repo_packages () const noexcept
+{
+  return ::rust::impl<::rust::Slice<::rpmostreecxx::RepoPackage const>>::slice (
+      rpmostreecxx$cxxbridge1$194$Treefile$get_repo_packages (*this));
 }
 
-void Treefile::clear_repo_packages() noexcept {
-  rpmostreecxx$cxxbridge1$194$Treefile$clear_repo_packages(*this);
+void
+Treefile::clear_repo_packages () noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Treefile$clear_repo_packages (*this);
 }
 
-void Treefile::prettyprint_json_stdout() const noexcept {
-  rpmostreecxx$cxxbridge1$194$Treefile$prettyprint_json_stdout(*this);
+void
+Treefile::prettyprint_json_stdout () const noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Treefile$prettyprint_json_stdout (*this);
 }
 
-void Treefile::print_deprecation_warnings() const noexcept {
-  rpmostreecxx$cxxbridge1$194$Treefile$print_deprecation_warnings(*this);
+void
+Treefile::print_deprecation_warnings () const noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Treefile$print_deprecation_warnings (*this);
 }
 
-void Treefile::print_experimental_notices() const noexcept {
-  rpmostreecxx$cxxbridge1$194$Treefile$print_experimental_notices(*this);
+void
+Treefile::print_experimental_notices () const noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Treefile$print_experimental_notices (*this);
 }
 
-void Treefile::sanitycheck_externals() const {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$sanitycheck_externals(*this);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+Treefile::sanitycheck_externals () const
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$sanitycheck_externals (*this);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::rust::Box<::rpmostreecxx::RpmImporterFlags> Treefile::importer_flags(::rust::Str pkg_name) const noexcept {
-  return ::rust::Box<::rpmostreecxx::RpmImporterFlags>::from_raw(rpmostreecxx$cxxbridge1$194$Treefile$importer_flags(*this, pkg_name));
+::rust::Box<::rpmostreecxx::RpmImporterFlags>
+Treefile::importer_flags (::rust::Str pkg_name) const noexcept
+{
+  return ::rust::Box<::rpmostreecxx::RpmImporterFlags>::from_raw (
+      rpmostreecxx$cxxbridge1$194$Treefile$importer_flags (*this, pkg_name));
 }
 
-::rust::String Treefile::write_repovars(::std::int32_t workdir_dfd_raw) const {
+::rust::String
+Treefile::write_repovars (::std::int32_t workdir_dfd_raw) const
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$write_repovars(*this, workdir_dfd_raw, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$write_repovars (
+      *this, workdir_dfd_raw, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void Treefile::set_releasever(::rust::Str releasever) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$set_releasever(*this, releasever);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+Treefile::set_releasever (::rust::Str releasever)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$Treefile$set_releasever (*this, releasever);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void Treefile::set_recommends(bool val) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$set_recommends(*this, val);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+Treefile::set_recommends (bool val)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$set_recommends (*this, val);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void Treefile::enable_repo(::rust::Str repo) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$enable_repo(*this, repo);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+Treefile::enable_repo (::rust::Str repo)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$enable_repo (*this, repo);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void Treefile::disable_repo(::rust::Str repo) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$disable_repo(*this, repo);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+Treefile::disable_repo (::rust::Str repo)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$disable_repo (*this, repo);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void Treefile::validate_for_container() const {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$validate_for_container(*this);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+Treefile::validate_for_container () const
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$validate_for_container (*this);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::rpmostreecxx::Refspec Treefile::get_base_refspec() const noexcept {
+::rpmostreecxx::Refspec
+Treefile::get_base_refspec () const noexcept
+{
   ::rust::MaybeUninit<::rpmostreecxx::Refspec> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_base_refspec(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_base_refspec (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-void Treefile::rebase(::rust::Str new_refspec, ::rust::Str custom_origin_url, ::rust::Str custom_origin_description) noexcept {
-  rpmostreecxx$cxxbridge1$194$Treefile$rebase(*this, new_refspec, custom_origin_url, custom_origin_description);
+void
+Treefile::rebase (::rust::Str new_refspec, ::rust::Str custom_origin_url,
+                  ::rust::Str custom_origin_description) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Treefile$rebase (*this, new_refspec, custom_origin_url,
+                                               custom_origin_description);
 }
 
-::rust::String Treefile::get_origin_custom_url() const noexcept {
+::rust::String
+Treefile::get_origin_custom_url () const noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_origin_custom_url(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_origin_custom_url (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::String Treefile::get_origin_custom_description() const noexcept {
+::rust::String
+Treefile::get_origin_custom_description () const noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_origin_custom_description(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_origin_custom_description (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::String Treefile::get_override_commit() const noexcept {
+::rust::String
+Treefile::get_override_commit () const noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_override_commit(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_override_commit (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-void Treefile::set_override_commit(::rust::Str checksum) noexcept {
-  rpmostreecxx$cxxbridge1$194$Treefile$set_override_commit(*this, checksum);
+void
+Treefile::set_override_commit (::rust::Str checksum) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$Treefile$set_override_commit (*this, checksum);
 }
 
-::rust::Vec<::rust::String> Treefile::get_initramfs_etc_files() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_initramfs_etc_files () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_etc_files(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_etc_files (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-bool Treefile::has_initramfs_etc_files() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$has_initramfs_etc_files(*this);
+bool
+Treefile::has_initramfs_etc_files () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$has_initramfs_etc_files (*this);
 }
 
-bool Treefile::initramfs_etc_files_track(::rust::Vec<::rust::String> files) noexcept {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> files$(::std::move(files));
-  return rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_track(*this, &files$.value);
+bool
+Treefile::initramfs_etc_files_track (::rust::Vec<::rust::String> files) noexcept
+{
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> files$ (::std::move (files));
+  return rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_track (*this, &files$.value);
 }
 
-bool Treefile::initramfs_etc_files_untrack(::rust::Vec<::rust::String> files) noexcept {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> files$(::std::move(files));
-  return rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_untrack(*this, &files$.value);
+bool
+Treefile::initramfs_etc_files_untrack (::rust::Vec<::rust::String> files) noexcept
+{
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> files$ (::std::move (files));
+  return rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_untrack (*this, &files$.value);
 }
 
-bool Treefile::initramfs_etc_files_untrack_all() noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_untrack_all(*this);
+bool
+Treefile::initramfs_etc_files_untrack_all () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$initramfs_etc_files_untrack_all (*this);
 }
 
-bool Treefile::get_initramfs_regenerate() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_regenerate(*this);
+bool
+Treefile::get_initramfs_regenerate () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_regenerate (*this);
 }
 
-::rust::Vec<::rust::String> Treefile::get_initramfs_args() const noexcept {
+::rust::Vec<::rust::String>
+Treefile::get_initramfs_args () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_args(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_initramfs_args (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-void Treefile::set_initramfs_regenerate(bool enabled, ::rust::Vec<::rust::String> args) noexcept {
-  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$(::std::move(args));
-  rpmostreecxx$cxxbridge1$194$Treefile$set_initramfs_regenerate(*this, enabled, &args$.value);
+void
+Treefile::set_initramfs_regenerate (bool enabled, ::rust::Vec<::rust::String> args) noexcept
+{
+  ::rust::ManuallyDrop<::rust::Vec<::rust::String>> args$ (::std::move (args));
+  rpmostreecxx$cxxbridge1$194$Treefile$set_initramfs_regenerate (*this, enabled, &args$.value);
 }
 
-::rust::String Treefile::get_unconfigured_state() const noexcept {
+::rust::String
+Treefile::get_unconfigured_state () const noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$Treefile$get_unconfigured_state(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Treefile$get_unconfigured_state (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-bool Treefile::may_require_local_assembly() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$may_require_local_assembly(*this);
+bool
+Treefile::may_require_local_assembly () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$may_require_local_assembly (*this);
 }
 
-bool Treefile::has_any_packages() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$has_any_packages(*this);
+bool
+Treefile::has_any_packages () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$has_any_packages (*this);
 }
 
-bool Treefile::merge_treefile(::rust::Str treefile) {
+bool
+Treefile::merge_treefile (::rust::Str treefile)
+{
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Treefile$merge_treefile(*this, treefile, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$Treefile$merge_treefile (*this, treefile, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-bool Treefile::get_no_initramfs() const noexcept {
-  return rpmostreecxx$cxxbridge1$194$Treefile$get_no_initramfs(*this);
+bool
+Treefile::get_no_initramfs () const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Treefile$get_no_initramfs (*this);
 }
 
-::std::size_t RepoPackage::layout::size() noexcept {
-  return rpmostreecxx$cxxbridge1$194$RepoPackage$operator$sizeof();
+::std::size_t
+RepoPackage::layout::size () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$RepoPackage$operator$sizeof ();
 }
 
-::std::size_t RepoPackage::layout::align() noexcept {
-  return rpmostreecxx$cxxbridge1$194$RepoPackage$operator$alignof();
+::std::size_t
+RepoPackage::layout::align () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$RepoPackage$operator$alignof ();
 }
 
-::rust::Str RepoPackage::get_repo() const noexcept {
-  return ::rust::impl<::rust::Str>::new_unchecked(rpmostreecxx$cxxbridge1$194$RepoPackage$get_repo(*this));
+::rust::Str
+RepoPackage::get_repo () const noexcept
+{
+  return ::rust::impl<::rust::Str>::new_unchecked (
+      rpmostreecxx$cxxbridge1$194$RepoPackage$get_repo (*this));
 }
 
-::rust::Vec<::rust::String> RepoPackage::get_packages() const noexcept {
+::rust::Vec<::rust::String>
+RepoPackage::get_packages () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$RepoPackage$get_packages(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$RepoPackage$get_packages (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::String varsubstitute(::rust::Str s, ::rust::Vec<::rpmostreecxx::StringMapping> const &vars) {
-  ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$varsubstitute(s, vars, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
-}
-
-::rust::Vec<::rust::String> get_features() noexcept {
+// Return the list of repo configuration directories to search
+// (e.g. ["/etc/yum.repos.d", "/usr/share/dnf5/repos.d"]).
+::rust::Vec<::rust::String>
+get_repos_dirs () noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$get_features(&return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$get_repos_dirs (&return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::String get_rpm_basearch() noexcept {
+::rust::String
+varsubstitute (::rust::Str s, ::rust::Vec<::rpmostreecxx::StringMapping> const &vars)
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$get_rpm_basearch(&return$.value);
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$varsubstitute (s, vars, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::std::int32_t sealed_memfd(::rust::Str description, ::rust::Slice<::std::uint8_t const> content) {
+::rust::Vec<::rust::String>
+get_features () noexcept
+{
+  ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
+  rpmostreecxx$cxxbridge1$194$get_features (&return$.value);
+  return ::std::move (return$.value);
+}
+
+::rust::String
+get_rpm_basearch () noexcept
+{
+  ::rust::MaybeUninit<::rust::String> return$;
+  rpmostreecxx$cxxbridge1$194$get_rpm_basearch (&return$.value);
+  return ::std::move (return$.value);
+}
+
+::std::int32_t
+sealed_memfd (::rust::Str description, ::rust::Slice<::std::uint8_t const> content)
+{
   ::rust::MaybeUninit<::std::int32_t> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$sealed_memfd(description, content, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$sealed_memfd (description, content, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-bool running_in_systemd() noexcept {
-  return rpmostreecxx$cxxbridge1$194$running_in_systemd();
+bool
+running_in_systemd () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$running_in_systemd ();
 }
 
-::rpmostreecxx::GVariant *calculate_advisories_diff(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str checksum_from, ::rust::Str checksum_to) {
+::rpmostreecxx::GVariant *
+calculate_advisories_diff (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str checksum_from,
+                           ::rust::Str checksum_to)
+{
   ::rust::MaybeUninit<::rpmostreecxx::GVariant *> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$calculate_advisories_diff(repo, checksum_from, checksum_to, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$calculate_advisories_diff (
+      repo, checksum_from, checksum_to, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::String translate_path_for_ostree(::rust::Str path) noexcept {
+::rust::String
+translate_path_for_ostree (::rust::Str path) noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$translate_path_for_ostree(path, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$translate_path_for_ostree (path, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rpmostreecxx::LiveApplyState get_live_apply_state(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment) {
+::rpmostreecxx::LiveApplyState
+get_live_apply_state (::rpmostreecxx::OstreeSysroot const &sysroot,
+                      ::rpmostreecxx::OstreeDeployment const &deployment)
+{
   ::rust::MaybeUninit<::rpmostreecxx::LiveApplyState> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$get_live_apply_state(sysroot, deployment, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$get_live_apply_state (sysroot, deployment, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-bool has_live_apply_state(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment) {
+bool
+has_live_apply_state (::rpmostreecxx::OstreeSysroot const &sysroot,
+                      ::rpmostreecxx::OstreeDeployment const &deployment)
+{
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$has_live_apply_state(sysroot, deployment, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$has_live_apply_state (sysroot, deployment, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void applylive_sync_ref(::rpmostreecxx::OstreeSysroot const &sysroot) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$applylive_sync_ref(sysroot);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+applylive_sync_ref (::rpmostreecxx::OstreeSysroot const &sysroot)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$applylive_sync_ref (sysroot);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void transaction_apply_live(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::GVariant const &target) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$transaction_apply_live(sysroot, target);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+transaction_apply_live (::rpmostreecxx::OstreeSysroot const &sysroot,
+                        ::rpmostreecxx::GVariant const &target)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$transaction_apply_live (sysroot, target);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void normalize_etc_shadow(::std::int32_t rootfs_dfd) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$normalize_etc_shadow(rootfs_dfd);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+normalize_etc_shadow (::std::int32_t rootfs_dfd)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$normalize_etc_shadow (rootfs_dfd);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-bool prepare_rpm_layering(::std::int32_t rootfs, ::std::int32_t merge_passwd_dir) {
+bool
+prepare_rpm_layering (::std::int32_t rootfs, ::std::int32_t merge_passwd_dir)
+{
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$prepare_rpm_layering(rootfs, merge_passwd_dir, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$prepare_rpm_layering (rootfs, merge_passwd_dir, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void complete_rpm_layering(::std::int32_t rootfs) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$complete_rpm_layering(rootfs);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+complete_rpm_layering (::std::int32_t rootfs)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$complete_rpm_layering (rootfs);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void deduplicate_tmpfiles_entries(::std::int32_t rootfs) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deduplicate_tmpfiles_entries(rootfs);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+deduplicate_tmpfiles_entries (::std::int32_t rootfs)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$deduplicate_tmpfiles_entries (rootfs);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void passwd_cleanup(::std::int32_t rootfs) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$passwd_cleanup(rootfs);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+passwd_cleanup (::std::int32_t rootfs)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$passwd_cleanup (rootfs);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void migrate_group_except_root(::std::int32_t rootfs, ::rust::Vec<::rust::String> const &preserved_groups) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$migrate_group_except_root(rootfs, preserved_groups);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+migrate_group_except_root (::std::int32_t rootfs,
+                           ::rust::Vec<::rust::String> const &preserved_groups)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$migrate_group_except_root (rootfs, preserved_groups);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void migrate_passwd_except_root(::std::int32_t rootfs) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$migrate_passwd_except_root(rootfs);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+migrate_passwd_except_root (::std::int32_t rootfs)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$migrate_passwd_except_root (rootfs);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void passwd_compose_prep(::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$passwd_compose_prep(rootfs, treefile);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+passwd_compose_prep (::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$passwd_compose_prep (rootfs, treefile);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void passwd_compose_prep_repo(::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile, ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str previous_checksum, bool unified_core) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$passwd_compose_prep_repo(rootfs, treefile, repo, previous_checksum, unified_core);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+passwd_compose_prep_repo (::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile,
+                          ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str previous_checksum,
+                          bool unified_core)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$passwd_compose_prep_repo (
+      rootfs, treefile, repo, previous_checksum, unified_core);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-bool dir_contains_uid(::std::int32_t dirfd, ::std::uint32_t id) {
+bool
+dir_contains_uid (::std::int32_t dirfd, ::std::uint32_t id)
+{
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$dir_contains_uid(dirfd, id, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$dir_contains_uid (dirfd, id, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-bool dir_contains_gid(::std::int32_t dirfd, ::std::uint32_t id) {
+bool
+dir_contains_gid (::std::int32_t dirfd, ::std::uint32_t id)
+{
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$dir_contains_gid(dirfd, id, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$dir_contains_gid (dirfd, id, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void check_passwd_group_entries(::rpmostreecxx::OstreeRepo const &ffi_repo, ::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile, ::rust::Str previous_rev) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$check_passwd_group_entries(ffi_repo, rootfs_dfd, treefile, previous_rev);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+check_passwd_group_entries (::rpmostreecxx::OstreeRepo const &ffi_repo, ::std::int32_t rootfs_dfd,
+                            ::rpmostreecxx::Treefile &treefile, ::rust::Str previous_rev)
+{
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$check_passwd_group_entries (
+      ffi_repo, rootfs_dfd, treefile, previous_rev);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::rust::Box<::rpmostreecxx::PasswdDB> passwddb_open(::std::int32_t rootfs) {
+::rust::Box<::rpmostreecxx::PasswdDB>
+passwddb_open (::std::int32_t rootfs)
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::PasswdDB>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$passwddb_open(rootfs, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$passwddb_open (rootfs, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::std::size_t PasswdDB::layout::size() noexcept {
-  return rpmostreecxx$cxxbridge1$194$PasswdDB$operator$sizeof();
+::std::size_t
+PasswdDB::layout::size () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$PasswdDB$operator$sizeof ();
 }
 
-::std::size_t PasswdDB::layout::align() noexcept {
-  return rpmostreecxx$cxxbridge1$194$PasswdDB$operator$alignof();
+::std::size_t
+PasswdDB::layout::align () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$PasswdDB$operator$alignof ();
 }
 
-::rust::String PasswdDB::lookup_user(::std::uint32_t uid) const {
+::rust::String
+PasswdDB::lookup_user (::std::uint32_t uid) const
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$PasswdDB$lookup_user(*this, uid, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$PasswdDB$lookup_user (*this, uid, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::String PasswdDB::lookup_group(::std::uint32_t gid) const {
+::rust::String
+PasswdDB::lookup_group (::std::uint32_t gid) const
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$PasswdDB$lookup_group(*this, gid, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$PasswdDB$lookup_group (*this, gid, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::Box<::rpmostreecxx::PasswdEntries> new_passwd_entries() noexcept {
-  return ::rust::Box<::rpmostreecxx::PasswdEntries>::from_raw(rpmostreecxx$cxxbridge1$194$new_passwd_entries());
+::rust::Box<::rpmostreecxx::PasswdEntries>
+new_passwd_entries () noexcept
+{
+  return ::rust::Box<::rpmostreecxx::PasswdEntries>::from_raw (
+      rpmostreecxx$cxxbridge1$194$new_passwd_entries ());
 }
 
-::std::size_t PasswdEntries::layout::size() noexcept {
-  return rpmostreecxx$cxxbridge1$194$PasswdEntries$operator$sizeof();
+::std::size_t
+PasswdEntries::layout::size () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$PasswdEntries$operator$sizeof ();
 }
 
-::std::size_t PasswdEntries::layout::align() noexcept {
-  return rpmostreecxx$cxxbridge1$194$PasswdEntries$operator$alignof();
+::std::size_t
+PasswdEntries::layout::align () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$PasswdEntries$operator$alignof ();
 }
 
-void PasswdEntries::add_group_content(::std::int32_t rootfs, ::rust::Str path) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$PasswdEntries$add_group_content(*this, rootfs, path);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+PasswdEntries::add_group_content (::std::int32_t rootfs, ::rust::Str path)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$PasswdEntries$add_group_content (*this, rootfs, path);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void PasswdEntries::add_passwd_content(::std::int32_t rootfs, ::rust::Str path) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$PasswdEntries$add_passwd_content(*this, rootfs, path);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+PasswdEntries::add_passwd_content (::std::int32_t rootfs, ::rust::Str path)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$PasswdEntries$add_passwd_content (*this, rootfs, path);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-bool PasswdEntries::contains_group(::rust::Str user) const noexcept {
-  return rpmostreecxx$cxxbridge1$194$PasswdEntries$contains_group(*this, user);
+bool
+PasswdEntries::contains_group (::rust::Str user) const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$PasswdEntries$contains_group (*this, user);
 }
 
-bool PasswdEntries::contains_user(::rust::Str user) const noexcept {
-  return rpmostreecxx$cxxbridge1$194$PasswdEntries$contains_user(*this, user);
+bool
+PasswdEntries::contains_user (::rust::Str user) const noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$PasswdEntries$contains_user (*this, user);
 }
 
-::std::uint32_t PasswdEntries::lookup_user_id(::rust::Str user) const {
+::std::uint32_t
+PasswdEntries::lookup_user_id (::rust::Str user) const
+{
   ::rust::MaybeUninit<::std::uint32_t> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$PasswdEntries$lookup_user_id(*this, user, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$PasswdEntries$lookup_user_id (*this, user, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::std::uint32_t PasswdEntries::lookup_group_id(::rust::Str group) const {
+::std::uint32_t
+PasswdEntries::lookup_group_id (::rust::Str group) const
+{
   ::rust::MaybeUninit<::std::uint32_t> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$PasswdEntries$lookup_group_id(*this, group, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$PasswdEntries$lookup_group_id (*this, group, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::std::size_t Extensions::layout::size() noexcept {
-  return rpmostreecxx$cxxbridge1$194$Extensions$operator$sizeof();
+::std::size_t
+Extensions::layout::size () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Extensions$operator$sizeof ();
 }
 
-::std::size_t Extensions::layout::align() noexcept {
-  return rpmostreecxx$cxxbridge1$194$Extensions$operator$alignof();
+::std::size_t
+Extensions::layout::align () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$Extensions$operator$alignof ();
 }
 
-::rust::Box<::rpmostreecxx::Extensions> extensions_load(::rust::Str path, ::rust::Str basearch, ::rust::Vec<::rpmostreecxx::StringMapping> const &base_pkgs) {
+::rust::Box<::rpmostreecxx::Extensions>
+extensions_load (::rust::Str path, ::rust::Str basearch,
+                 ::rust::Vec<::rpmostreecxx::StringMapping> const &base_pkgs)
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Extensions>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$extensions_load(path, basearch, base_pkgs, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$extensions_load (path, basearch, base_pkgs, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::Vec<::rust::String> Extensions::get_repos() const noexcept {
+::rust::Vec<::rust::String>
+Extensions::get_repos () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Extensions$get_repos(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Extensions$get_repos (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::Vec<::rust::String> Extensions::get_os_extension_packages() const noexcept {
+::rust::Vec<::rust::String>
+Extensions::get_os_extension_packages () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Extensions$get_os_extension_packages(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Extensions$get_os_extension_packages (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-::rust::Vec<::rust::String> Extensions::get_development_packages() const noexcept {
+::rust::Vec<::rust::String>
+Extensions::get_development_packages () const noexcept
+{
   ::rust::MaybeUninit<::rust::Vec<::rust::String>> return$;
-  rpmostreecxx$cxxbridge1$194$Extensions$get_development_packages(*this, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$Extensions$get_development_packages (*this, &return$.value);
+  return ::std::move (return$.value);
 }
 
-bool Extensions::state_checksum_changed(::rust::Str chksum, ::rust::Str output_dir) const {
+bool
+Extensions::state_checksum_changed (::rust::Str chksum, ::rust::Str output_dir) const
+{
   ::rust::MaybeUninit<bool> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Extensions$state_checksum_changed(*this, chksum, output_dir, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Extensions$state_checksum_changed (
+      *this, chksum, output_dir, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void Extensions::update_state_checksum(::rust::Str chksum, ::rust::Str output_dir) const {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Extensions$update_state_checksum(*this, chksum, output_dir);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+Extensions::update_state_checksum (::rust::Str chksum, ::rust::Str output_dir) const
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$Extensions$update_state_checksum (*this, chksum, output_dir);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-void Extensions::serialize_to_dir(::rust::Str output_dir) const {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Extensions$serialize_to_dir(*this, output_dir);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+Extensions::serialize_to_dir (::rust::Str output_dir) const
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$Extensions$serialize_to_dir (*this, output_dir);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::rust::Box<::rpmostreecxx::Treefile> Extensions::generate_treefile(::rpmostreecxx::Treefile const &src) const {
+::rust::Box<::rpmostreecxx::Treefile>
+Extensions::generate_treefile (::rpmostreecxx::Treefile const &src) const
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Treefile>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$Extensions$generate_treefile(*this, src, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$Extensions$generate_treefile (*this, src, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::std::size_t LockfileConfig::layout::size() noexcept {
-  return rpmostreecxx$cxxbridge1$194$LockfileConfig$operator$sizeof();
+::std::size_t
+LockfileConfig::layout::size () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$LockfileConfig$operator$sizeof ();
 }
 
-::std::size_t LockfileConfig::layout::align() noexcept {
-  return rpmostreecxx$cxxbridge1$194$LockfileConfig$operator$alignof();
+::std::size_t
+LockfileConfig::layout::align () noexcept
+{
+  return rpmostreecxx$cxxbridge1$194$LockfileConfig$operator$alignof ();
 }
 
-::rust::Box<::rpmostreecxx::LockfileConfig> lockfile_read(::rust::Vec<::rust::String> const &filenames) {
+::rust::Box<::rpmostreecxx::LockfileConfig>
+lockfile_read (::rust::Vec<::rust::String> const &filenames)
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::LockfileConfig>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$lockfile_read(filenames, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$lockfile_read (filenames, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void lockfile_write(::rust::Str filename, ::rpmostreecxx::CxxGObjectArray &packages, ::rpmostreecxx::CxxGObjectArray &rpmmd_repos) {
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$lockfile_write(filename, packages, rpmmd_repos);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
+void
+lockfile_write (::rust::Str filename, ::rpmostreecxx::CxxGObjectArray &packages,
+                ::rpmostreecxx::CxxGObjectArray &rpmmd_repos)
+{
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$lockfile_write (filename, packages, rpmmd_repos);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
 }
 
-::rust::Vec<::rpmostreecxx::LockedPackage> LockfileConfig::get_locked_packages() const {
+::rust::Vec<::rpmostreecxx::LockedPackage>
+LockfileConfig::get_locked_packages () const
+{
   ::rust::MaybeUninit<::rust::Vec<::rpmostreecxx::LockedPackage>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$LockfileConfig$get_locked_packages(*this, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$
+      = rpmostreecxx$cxxbridge1$194$LockfileConfig$get_locked_packages (*this, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rust::Box<::rpmostreecxx::Treefile> origin_to_treefile(::rpmostreecxx::GKeyFile const &kf) {
+::rust::Box<::rpmostreecxx::Treefile>
+origin_to_treefile (::rpmostreecxx::GKeyFile const &kf)
+{
   ::rust::MaybeUninit<::rust::Box<::rpmostreecxx::Treefile>> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$origin_to_treefile(kf, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$origin_to_treefile (kf, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-::rpmostreecxx::GKeyFile *treefile_to_origin(::rpmostreecxx::Treefile const &tf) {
+::rpmostreecxx::GKeyFile *
+treefile_to_origin (::rpmostreecxx::Treefile const &tf)
+{
   ::rust::MaybeUninit<::rpmostreecxx::GKeyFile *> return$;
-  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_to_origin(tf, &return$.value);
-  if (error$.ptr) {
-    throw ::rust::impl<::rust::Error>::error(error$);
-  }
-  return ::std::move(return$.value);
+  ::rust::repr::PtrLen error$ = rpmostreecxx$cxxbridge1$194$treefile_to_origin (tf, &return$.value);
+  if (error$.ptr)
+    {
+      throw ::rust::impl<::rust::Error>::error (error$);
+    }
+  return ::std::move (return$.value);
 }
 
-void origin_validate_roundtrip(::rpmostreecxx::GKeyFile const &kf) noexcept {
-  rpmostreecxx$cxxbridge1$194$origin_validate_roundtrip(kf);
+void
+origin_validate_roundtrip (::rpmostreecxx::GKeyFile const &kf) noexcept
+{
+  rpmostreecxx$cxxbridge1$194$origin_validate_roundtrip (kf);
 }
 
-::rust::String cache_branch_to_nevra(::rust::Str nevra) noexcept {
+::rust::String
+cache_branch_to_nevra (::rust::Str nevra) noexcept
+{
   ::rust::MaybeUninit<::rust::String> return$;
-  rpmostreecxx$cxxbridge1$194$cache_branch_to_nevra(nevra, &return$.value);
-  return ::std::move(return$.value);
+  rpmostreecxx$cxxbridge1$194$cache_branch_to_nevra (nevra, &return$.value);
+  return ::std::move (return$.value);
 }
 } // namespace rpmostreecxx
 
-extern "C" {
-::rpmostreecxx::Bubblewrap *cxxbridge1$box$rpmostreecxx$Bubblewrap$alloc() noexcept;
-void cxxbridge1$box$rpmostreecxx$Bubblewrap$dealloc(::rpmostreecxx::Bubblewrap *) noexcept;
-void cxxbridge1$box$rpmostreecxx$Bubblewrap$drop(::rust::Box<::rpmostreecxx::Bubblewrap> *ptr) noexcept;
+extern "C"
+{
+  ::rpmostreecxx::Bubblewrap *cxxbridge1$box$rpmostreecxx$Bubblewrap$alloc () noexcept;
+  void cxxbridge1$box$rpmostreecxx$Bubblewrap$dealloc (::rpmostreecxx::Bubblewrap *) noexcept;
+  void cxxbridge1$box$rpmostreecxx$Bubblewrap$drop (
+      ::rust::Box<::rpmostreecxx::Bubblewrap> *ptr) noexcept;
 
-::rpmostreecxx::ContainerImageState *cxxbridge1$box$rpmostreecxx$ContainerImageState$alloc() noexcept;
-void cxxbridge1$box$rpmostreecxx$ContainerImageState$dealloc(::rpmostreecxx::ContainerImageState *) noexcept;
-void cxxbridge1$box$rpmostreecxx$ContainerImageState$drop(::rust::Box<::rpmostreecxx::ContainerImageState> *ptr) noexcept;
+  ::rpmostreecxx::ContainerImageState *
+  cxxbridge1$box$rpmostreecxx$ContainerImageState$alloc () noexcept;
+  void cxxbridge1$box$rpmostreecxx$ContainerImageState$dealloc (
+      ::rpmostreecxx::ContainerImageState *) noexcept;
+  void cxxbridge1$box$rpmostreecxx$ContainerImageState$drop (
+      ::rust::Box<::rpmostreecxx::ContainerImageState> *ptr) noexcept;
 
-::rpmostreecxx::TempEtcGuard *cxxbridge1$box$rpmostreecxx$TempEtcGuard$alloc() noexcept;
-void cxxbridge1$box$rpmostreecxx$TempEtcGuard$dealloc(::rpmostreecxx::TempEtcGuard *) noexcept;
-void cxxbridge1$box$rpmostreecxx$TempEtcGuard$drop(::rust::Box<::rpmostreecxx::TempEtcGuard> *ptr) noexcept;
+  ::rpmostreecxx::TempEtcGuard *cxxbridge1$box$rpmostreecxx$TempEtcGuard$alloc () noexcept;
+  void cxxbridge1$box$rpmostreecxx$TempEtcGuard$dealloc (::rpmostreecxx::TempEtcGuard *) noexcept;
+  void cxxbridge1$box$rpmostreecxx$TempEtcGuard$drop (
+      ::rust::Box<::rpmostreecxx::TempEtcGuard> *ptr) noexcept;
 
-::rpmostreecxx::FilesystemScriptPrep *cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$alloc() noexcept;
-void cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$dealloc(::rpmostreecxx::FilesystemScriptPrep *) noexcept;
-void cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$drop(::rust::Box<::rpmostreecxx::FilesystemScriptPrep> *ptr) noexcept;
+  ::rpmostreecxx::FilesystemScriptPrep *
+  cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$alloc () noexcept;
+  void cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$dealloc (
+      ::rpmostreecxx::FilesystemScriptPrep *) noexcept;
+  void cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$drop (
+      ::rust::Box<::rpmostreecxx::FilesystemScriptPrep> *ptr) noexcept;
 
-::rpmostreecxx::RpmImporterFlags *cxxbridge1$box$rpmostreecxx$RpmImporterFlags$alloc() noexcept;
-void cxxbridge1$box$rpmostreecxx$RpmImporterFlags$dealloc(::rpmostreecxx::RpmImporterFlags *) noexcept;
-void cxxbridge1$box$rpmostreecxx$RpmImporterFlags$drop(::rust::Box<::rpmostreecxx::RpmImporterFlags> *ptr) noexcept;
+  ::rpmostreecxx::RpmImporterFlags *cxxbridge1$box$rpmostreecxx$RpmImporterFlags$alloc () noexcept;
+  void cxxbridge1$box$rpmostreecxx$RpmImporterFlags$dealloc (
+      ::rpmostreecxx::RpmImporterFlags *) noexcept;
+  void cxxbridge1$box$rpmostreecxx$RpmImporterFlags$drop (
+      ::rust::Box<::rpmostreecxx::RpmImporterFlags> *ptr) noexcept;
 
-::rpmostreecxx::RpmImporter *cxxbridge1$box$rpmostreecxx$RpmImporter$alloc() noexcept;
-void cxxbridge1$box$rpmostreecxx$RpmImporter$dealloc(::rpmostreecxx::RpmImporter *) noexcept;
-void cxxbridge1$box$rpmostreecxx$RpmImporter$drop(::rust::Box<::rpmostreecxx::RpmImporter> *ptr) noexcept;
+  ::rpmostreecxx::RpmImporter *cxxbridge1$box$rpmostreecxx$RpmImporter$alloc () noexcept;
+  void cxxbridge1$box$rpmostreecxx$RpmImporter$dealloc (::rpmostreecxx::RpmImporter *) noexcept;
+  void cxxbridge1$box$rpmostreecxx$RpmImporter$drop (
+      ::rust::Box<::rpmostreecxx::RpmImporter> *ptr) noexcept;
 
-::rpmostreecxx::HistoryCtx *cxxbridge1$box$rpmostreecxx$HistoryCtx$alloc() noexcept;
-void cxxbridge1$box$rpmostreecxx$HistoryCtx$dealloc(::rpmostreecxx::HistoryCtx *) noexcept;
-void cxxbridge1$box$rpmostreecxx$HistoryCtx$drop(::rust::Box<::rpmostreecxx::HistoryCtx> *ptr) noexcept;
+  ::rpmostreecxx::HistoryCtx *cxxbridge1$box$rpmostreecxx$HistoryCtx$alloc () noexcept;
+  void cxxbridge1$box$rpmostreecxx$HistoryCtx$dealloc (::rpmostreecxx::HistoryCtx *) noexcept;
+  void cxxbridge1$box$rpmostreecxx$HistoryCtx$drop (
+      ::rust::Box<::rpmostreecxx::HistoryCtx> *ptr) noexcept;
 
-::rpmostreecxx::TokioHandle *cxxbridge1$box$rpmostreecxx$TokioHandle$alloc() noexcept;
-void cxxbridge1$box$rpmostreecxx$TokioHandle$dealloc(::rpmostreecxx::TokioHandle *) noexcept;
-void cxxbridge1$box$rpmostreecxx$TokioHandle$drop(::rust::Box<::rpmostreecxx::TokioHandle> *ptr) noexcept;
+  ::rpmostreecxx::TokioHandle *cxxbridge1$box$rpmostreecxx$TokioHandle$alloc () noexcept;
+  void cxxbridge1$box$rpmostreecxx$TokioHandle$dealloc (::rpmostreecxx::TokioHandle *) noexcept;
+  void cxxbridge1$box$rpmostreecxx$TokioHandle$drop (
+      ::rust::Box<::rpmostreecxx::TokioHandle> *ptr) noexcept;
 
-::rpmostreecxx::TokioEnterGuard *cxxbridge1$box$rpmostreecxx$TokioEnterGuard$alloc() noexcept;
-void cxxbridge1$box$rpmostreecxx$TokioEnterGuard$dealloc(::rpmostreecxx::TokioEnterGuard *) noexcept;
-void cxxbridge1$box$rpmostreecxx$TokioEnterGuard$drop(::rust::Box<::rpmostreecxx::TokioEnterGuard> *ptr) noexcept;
+  ::rpmostreecxx::TokioEnterGuard *cxxbridge1$box$rpmostreecxx$TokioEnterGuard$alloc () noexcept;
+  void
+  cxxbridge1$box$rpmostreecxx$TokioEnterGuard$dealloc (::rpmostreecxx::TokioEnterGuard *) noexcept;
+  void cxxbridge1$box$rpmostreecxx$TokioEnterGuard$drop (
+      ::rust::Box<::rpmostreecxx::TokioEnterGuard> *ptr) noexcept;
 
-::rpmostreecxx::Treefile *cxxbridge1$box$rpmostreecxx$Treefile$alloc() noexcept;
-void cxxbridge1$box$rpmostreecxx$Treefile$dealloc(::rpmostreecxx::Treefile *) noexcept;
-void cxxbridge1$box$rpmostreecxx$Treefile$drop(::rust::Box<::rpmostreecxx::Treefile> *ptr) noexcept;
+  ::rpmostreecxx::Treefile *cxxbridge1$box$rpmostreecxx$Treefile$alloc () noexcept;
+  void cxxbridge1$box$rpmostreecxx$Treefile$dealloc (::rpmostreecxx::Treefile *) noexcept;
+  void
+  cxxbridge1$box$rpmostreecxx$Treefile$drop (::rust::Box<::rpmostreecxx::Treefile> *ptr) noexcept;
 
-void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$new(::rust::Vec<::rpmostreecxx::OverrideReplacement> const *ptr) noexcept;
-void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$drop(::rust::Vec<::rpmostreecxx::OverrideReplacement> *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$len(::rust::Vec<::rpmostreecxx::OverrideReplacement> const *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$capacity(::rust::Vec<::rpmostreecxx::OverrideReplacement> const *ptr) noexcept;
-::rpmostreecxx::OverrideReplacement const *cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$data(::rust::Vec<::rpmostreecxx::OverrideReplacement> const *ptr) noexcept;
-void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$reserve_total(::rust::Vec<::rpmostreecxx::OverrideReplacement> *ptr, ::std::size_t new_cap) noexcept;
-void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$set_len(::rust::Vec<::rpmostreecxx::OverrideReplacement> *ptr, ::std::size_t len) noexcept;
-void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$truncate(::rust::Vec<::rpmostreecxx::OverrideReplacement> *ptr, ::std::size_t len) noexcept;
+  void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$new (
+      ::rust::Vec<::rpmostreecxx::OverrideReplacement> const *ptr) noexcept;
+  void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$drop (
+      ::rust::Vec<::rpmostreecxx::OverrideReplacement> *ptr) noexcept;
+  ::std::size_t cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$len (
+      ::rust::Vec<::rpmostreecxx::OverrideReplacement> const *ptr) noexcept;
+  ::std::size_t cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$capacity (
+      ::rust::Vec<::rpmostreecxx::OverrideReplacement> const *ptr) noexcept;
+  ::rpmostreecxx::OverrideReplacement const *
+  cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$data (
+      ::rust::Vec<::rpmostreecxx::OverrideReplacement> const *ptr) noexcept;
+  void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$reserve_total (
+      ::rust::Vec<::rpmostreecxx::OverrideReplacement> *ptr, ::std::size_t new_cap) noexcept;
+  void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$set_len (
+      ::rust::Vec<::rpmostreecxx::OverrideReplacement> *ptr, ::std::size_t len) noexcept;
+  void cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$truncate (
+      ::rust::Vec<::rpmostreecxx::OverrideReplacement> *ptr, ::std::size_t len) noexcept;
 
-void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$new(::rust::Vec<::rpmostreecxx::StringMapping> const *ptr) noexcept;
-void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$drop(::rust::Vec<::rpmostreecxx::StringMapping> *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$rpmostreecxx$StringMapping$len(::rust::Vec<::rpmostreecxx::StringMapping> const *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$rpmostreecxx$StringMapping$capacity(::rust::Vec<::rpmostreecxx::StringMapping> const *ptr) noexcept;
-::rpmostreecxx::StringMapping const *cxxbridge1$rust_vec$rpmostreecxx$StringMapping$data(::rust::Vec<::rpmostreecxx::StringMapping> const *ptr) noexcept;
-void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$reserve_total(::rust::Vec<::rpmostreecxx::StringMapping> *ptr, ::std::size_t new_cap) noexcept;
-void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$set_len(::rust::Vec<::rpmostreecxx::StringMapping> *ptr, ::std::size_t len) noexcept;
-void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$truncate(::rust::Vec<::rpmostreecxx::StringMapping> *ptr, ::std::size_t len) noexcept;
+  void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$new (
+      ::rust::Vec<::rpmostreecxx::StringMapping> const *ptr) noexcept;
+  void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$drop (
+      ::rust::Vec<::rpmostreecxx::StringMapping> *ptr) noexcept;
+  ::std::size_t cxxbridge1$rust_vec$rpmostreecxx$StringMapping$len (
+      ::rust::Vec<::rpmostreecxx::StringMapping> const *ptr) noexcept;
+  ::std::size_t cxxbridge1$rust_vec$rpmostreecxx$StringMapping$capacity (
+      ::rust::Vec<::rpmostreecxx::StringMapping> const *ptr) noexcept;
+  ::rpmostreecxx::StringMapping const *cxxbridge1$rust_vec$rpmostreecxx$StringMapping$data (
+      ::rust::Vec<::rpmostreecxx::StringMapping> const *ptr) noexcept;
+  void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$reserve_total (
+      ::rust::Vec<::rpmostreecxx::StringMapping> *ptr, ::std::size_t new_cap) noexcept;
+  void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$set_len (
+      ::rust::Vec<::rpmostreecxx::StringMapping> *ptr, ::std::size_t len) noexcept;
+  void cxxbridge1$rust_vec$rpmostreecxx$StringMapping$truncate (
+      ::rust::Vec<::rpmostreecxx::StringMapping> *ptr, ::std::size_t len) noexcept;
 
-::rpmostreecxx::PasswdDB *cxxbridge1$box$rpmostreecxx$PasswdDB$alloc() noexcept;
-void cxxbridge1$box$rpmostreecxx$PasswdDB$dealloc(::rpmostreecxx::PasswdDB *) noexcept;
-void cxxbridge1$box$rpmostreecxx$PasswdDB$drop(::rust::Box<::rpmostreecxx::PasswdDB> *ptr) noexcept;
+  ::rpmostreecxx::PasswdDB *cxxbridge1$box$rpmostreecxx$PasswdDB$alloc () noexcept;
+  void cxxbridge1$box$rpmostreecxx$PasswdDB$dealloc (::rpmostreecxx::PasswdDB *) noexcept;
+  void
+  cxxbridge1$box$rpmostreecxx$PasswdDB$drop (::rust::Box<::rpmostreecxx::PasswdDB> *ptr) noexcept;
 
-::rpmostreecxx::PasswdEntries *cxxbridge1$box$rpmostreecxx$PasswdEntries$alloc() noexcept;
-void cxxbridge1$box$rpmostreecxx$PasswdEntries$dealloc(::rpmostreecxx::PasswdEntries *) noexcept;
-void cxxbridge1$box$rpmostreecxx$PasswdEntries$drop(::rust::Box<::rpmostreecxx::PasswdEntries> *ptr) noexcept;
+  ::rpmostreecxx::PasswdEntries *cxxbridge1$box$rpmostreecxx$PasswdEntries$alloc () noexcept;
+  void cxxbridge1$box$rpmostreecxx$PasswdEntries$dealloc (::rpmostreecxx::PasswdEntries *) noexcept;
+  void cxxbridge1$box$rpmostreecxx$PasswdEntries$drop (
+      ::rust::Box<::rpmostreecxx::PasswdEntries> *ptr) noexcept;
 
-::rpmostreecxx::Extensions *cxxbridge1$box$rpmostreecxx$Extensions$alloc() noexcept;
-void cxxbridge1$box$rpmostreecxx$Extensions$dealloc(::rpmostreecxx::Extensions *) noexcept;
-void cxxbridge1$box$rpmostreecxx$Extensions$drop(::rust::Box<::rpmostreecxx::Extensions> *ptr) noexcept;
+  ::rpmostreecxx::Extensions *cxxbridge1$box$rpmostreecxx$Extensions$alloc () noexcept;
+  void cxxbridge1$box$rpmostreecxx$Extensions$dealloc (::rpmostreecxx::Extensions *) noexcept;
+  void cxxbridge1$box$rpmostreecxx$Extensions$drop (
+      ::rust::Box<::rpmostreecxx::Extensions> *ptr) noexcept;
 
-::rpmostreecxx::LockfileConfig *cxxbridge1$box$rpmostreecxx$LockfileConfig$alloc() noexcept;
-void cxxbridge1$box$rpmostreecxx$LockfileConfig$dealloc(::rpmostreecxx::LockfileConfig *) noexcept;
-void cxxbridge1$box$rpmostreecxx$LockfileConfig$drop(::rust::Box<::rpmostreecxx::LockfileConfig> *ptr) noexcept;
+  ::rpmostreecxx::LockfileConfig *cxxbridge1$box$rpmostreecxx$LockfileConfig$alloc () noexcept;
+  void
+  cxxbridge1$box$rpmostreecxx$LockfileConfig$dealloc (::rpmostreecxx::LockfileConfig *) noexcept;
+  void cxxbridge1$box$rpmostreecxx$LockfileConfig$drop (
+      ::rust::Box<::rpmostreecxx::LockfileConfig> *ptr) noexcept;
 
-void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$new(::rust::Vec<::rpmostreecxx::LockedPackage> const *ptr) noexcept;
-void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$drop(::rust::Vec<::rpmostreecxx::LockedPackage> *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$len(::rust::Vec<::rpmostreecxx::LockedPackage> const *ptr) noexcept;
-::std::size_t cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$capacity(::rust::Vec<::rpmostreecxx::LockedPackage> const *ptr) noexcept;
-::rpmostreecxx::LockedPackage const *cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$data(::rust::Vec<::rpmostreecxx::LockedPackage> const *ptr) noexcept;
-void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$reserve_total(::rust::Vec<::rpmostreecxx::LockedPackage> *ptr, ::std::size_t new_cap) noexcept;
-void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$set_len(::rust::Vec<::rpmostreecxx::LockedPackage> *ptr, ::std::size_t len) noexcept;
-void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$truncate(::rust::Vec<::rpmostreecxx::LockedPackage> *ptr, ::std::size_t len) noexcept;
+  void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$new (
+      ::rust::Vec<::rpmostreecxx::LockedPackage> const *ptr) noexcept;
+  void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$drop (
+      ::rust::Vec<::rpmostreecxx::LockedPackage> *ptr) noexcept;
+  ::std::size_t cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$len (
+      ::rust::Vec<::rpmostreecxx::LockedPackage> const *ptr) noexcept;
+  ::std::size_t cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$capacity (
+      ::rust::Vec<::rpmostreecxx::LockedPackage> const *ptr) noexcept;
+  ::rpmostreecxx::LockedPackage const *cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$data (
+      ::rust::Vec<::rpmostreecxx::LockedPackage> const *ptr) noexcept;
+  void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$reserve_total (
+      ::rust::Vec<::rpmostreecxx::LockedPackage> *ptr, ::std::size_t new_cap) noexcept;
+  void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$set_len (
+      ::rust::Vec<::rpmostreecxx::LockedPackage> *ptr, ::std::size_t len) noexcept;
+  void cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$truncate (
+      ::rust::Vec<::rpmostreecxx::LockedPackage> *ptr, ::std::size_t len) noexcept;
 
-static_assert(::rust::detail::is_complete<::std::remove_extent<::rpmostreecxx::ClientConnection>::type>::value, "definition of `::rpmostreecxx::ClientConnection` is required");
-static_assert(sizeof(::std::unique_ptr<::rpmostreecxx::ClientConnection>) == sizeof(void *), "");
-static_assert(alignof(::std::unique_ptr<::rpmostreecxx::ClientConnection>) == alignof(void *), "");
-void cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$null(::std::unique_ptr<::rpmostreecxx::ClientConnection> *ptr) noexcept {
-  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::ClientConnection>();
-}
-void cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$raw(::std::unique_ptr<::rpmostreecxx::ClientConnection> *ptr, ::std::unique_ptr<::rpmostreecxx::ClientConnection>::pointer raw) noexcept {
-  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::ClientConnection>(raw);
-}
-::std::unique_ptr<::rpmostreecxx::ClientConnection>::element_type const *cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$get(::std::unique_ptr<::rpmostreecxx::ClientConnection> const &ptr) noexcept {
-  return ptr.get();
-}
-::std::unique_ptr<::rpmostreecxx::ClientConnection>::pointer cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$release(::std::unique_ptr<::rpmostreecxx::ClientConnection> &ptr) noexcept {
-  return ptr.release();
-}
-void cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$drop(::std::unique_ptr<::rpmostreecxx::ClientConnection> *ptr) noexcept {
-  ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::ClientConnection>::value>{}(ptr);
-}
+  static_assert (::rust::detail::is_complete<
+                     ::std::remove_extent<::rpmostreecxx::ClientConnection>::type>::value,
+                 "definition of `::rpmostreecxx::ClientConnection` is required");
+  static_assert (sizeof (::std::unique_ptr<::rpmostreecxx::ClientConnection>) == sizeof (void *),
+                 "");
+  static_assert (alignof (::std::unique_ptr<::rpmostreecxx::ClientConnection>) == alignof (void *),
+                 "");
+  void
+  cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$null (
+      ::std::unique_ptr<::rpmostreecxx::ClientConnection> *ptr) noexcept
+  {
+    ::new (ptr)::std::unique_ptr<::rpmostreecxx::ClientConnection> ();
+  }
+  void
+  cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$raw (
+      ::std::unique_ptr<::rpmostreecxx::ClientConnection> *ptr,
+      ::std::unique_ptr<::rpmostreecxx::ClientConnection>::pointer raw) noexcept
+  {
+    ::new (ptr)::std::unique_ptr<::rpmostreecxx::ClientConnection> (raw);
+  }
+  ::std::unique_ptr<::rpmostreecxx::ClientConnection>::element_type const *
+  cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$get (
+      ::std::unique_ptr<::rpmostreecxx::ClientConnection> const &ptr) noexcept
+  {
+    return ptr.get ();
+  }
+  ::std::unique_ptr<::rpmostreecxx::ClientConnection>::pointer
+  cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$release (
+      ::std::unique_ptr<::rpmostreecxx::ClientConnection> &ptr) noexcept
+  {
+    return ptr.release ();
+  }
+  void
+  cxxbridge1$unique_ptr$rpmostreecxx$ClientConnection$drop (
+      ::std::unique_ptr<::rpmostreecxx::ClientConnection> *ptr) noexcept
+  {
+    ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::ClientConnection>::value>{}(ptr);
+  }
 
-static_assert(::rust::detail::is_complete<::std::remove_extent<::rpmostreecxx::RPMDiff>::type>::value, "definition of `::rpmostreecxx::RPMDiff` is required");
-static_assert(sizeof(::std::unique_ptr<::rpmostreecxx::RPMDiff>) == sizeof(void *), "");
-static_assert(alignof(::std::unique_ptr<::rpmostreecxx::RPMDiff>) == alignof(void *), "");
-void cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$null(::std::unique_ptr<::rpmostreecxx::RPMDiff> *ptr) noexcept {
-  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::RPMDiff>();
-}
-void cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$raw(::std::unique_ptr<::rpmostreecxx::RPMDiff> *ptr, ::std::unique_ptr<::rpmostreecxx::RPMDiff>::pointer raw) noexcept {
-  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::RPMDiff>(raw);
-}
-::std::unique_ptr<::rpmostreecxx::RPMDiff>::element_type const *cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$get(::std::unique_ptr<::rpmostreecxx::RPMDiff> const &ptr) noexcept {
-  return ptr.get();
-}
-::std::unique_ptr<::rpmostreecxx::RPMDiff>::pointer cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$release(::std::unique_ptr<::rpmostreecxx::RPMDiff> &ptr) noexcept {
-  return ptr.release();
-}
-void cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$drop(::std::unique_ptr<::rpmostreecxx::RPMDiff> *ptr) noexcept {
-  ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::RPMDiff>::value>{}(ptr);
-}
+  static_assert (
+      ::rust::detail::is_complete<::std::remove_extent<::rpmostreecxx::RPMDiff>::type>::value,
+      "definition of `::rpmostreecxx::RPMDiff` is required");
+  static_assert (sizeof (::std::unique_ptr<::rpmostreecxx::RPMDiff>) == sizeof (void *), "");
+  static_assert (alignof (::std::unique_ptr<::rpmostreecxx::RPMDiff>) == alignof (void *), "");
+  void
+  cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$null (
+      ::std::unique_ptr<::rpmostreecxx::RPMDiff> *ptr) noexcept
+  {
+    ::new (ptr)::std::unique_ptr<::rpmostreecxx::RPMDiff> ();
+  }
+  void
+  cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$raw (
+      ::std::unique_ptr<::rpmostreecxx::RPMDiff> *ptr,
+      ::std::unique_ptr<::rpmostreecxx::RPMDiff>::pointer raw) noexcept
+  {
+    ::new (ptr)::std::unique_ptr<::rpmostreecxx::RPMDiff> (raw);
+  }
+  ::std::unique_ptr<::rpmostreecxx::RPMDiff>::element_type const *
+  cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$get (
+      ::std::unique_ptr<::rpmostreecxx::RPMDiff> const &ptr) noexcept
+  {
+    return ptr.get ();
+  }
+  ::std::unique_ptr<::rpmostreecxx::RPMDiff>::pointer
+  cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$release (
+      ::std::unique_ptr<::rpmostreecxx::RPMDiff> &ptr) noexcept
+  {
+    return ptr.release ();
+  }
+  void
+  cxxbridge1$unique_ptr$rpmostreecxx$RPMDiff$drop (
+      ::std::unique_ptr<::rpmostreecxx::RPMDiff> *ptr) noexcept
+  {
+    ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::RPMDiff>::value>{}(ptr);
+  }
 
-static_assert(::rust::detail::is_complete<::std::remove_extent<::rpmostreecxx::Progress>::type>::value, "definition of `::rpmostreecxx::Progress` is required");
-static_assert(sizeof(::std::unique_ptr<::rpmostreecxx::Progress>) == sizeof(void *), "");
-static_assert(alignof(::std::unique_ptr<::rpmostreecxx::Progress>) == alignof(void *), "");
-void cxxbridge1$unique_ptr$rpmostreecxx$Progress$null(::std::unique_ptr<::rpmostreecxx::Progress> *ptr) noexcept {
-  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::Progress>();
-}
-void cxxbridge1$unique_ptr$rpmostreecxx$Progress$raw(::std::unique_ptr<::rpmostreecxx::Progress> *ptr, ::std::unique_ptr<::rpmostreecxx::Progress>::pointer raw) noexcept {
-  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::Progress>(raw);
-}
-::std::unique_ptr<::rpmostreecxx::Progress>::element_type const *cxxbridge1$unique_ptr$rpmostreecxx$Progress$get(::std::unique_ptr<::rpmostreecxx::Progress> const &ptr) noexcept {
-  return ptr.get();
-}
-::std::unique_ptr<::rpmostreecxx::Progress>::pointer cxxbridge1$unique_ptr$rpmostreecxx$Progress$release(::std::unique_ptr<::rpmostreecxx::Progress> &ptr) noexcept {
-  return ptr.release();
-}
-void cxxbridge1$unique_ptr$rpmostreecxx$Progress$drop(::std::unique_ptr<::rpmostreecxx::Progress> *ptr) noexcept {
-  ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::Progress>::value>{}(ptr);
-}
+  static_assert (
+      ::rust::detail::is_complete<::std::remove_extent<::rpmostreecxx::Progress>::type>::value,
+      "definition of `::rpmostreecxx::Progress` is required");
+  static_assert (sizeof (::std::unique_ptr<::rpmostreecxx::Progress>) == sizeof (void *), "");
+  static_assert (alignof (::std::unique_ptr<::rpmostreecxx::Progress>) == alignof (void *), "");
+  void
+  cxxbridge1$unique_ptr$rpmostreecxx$Progress$null (
+      ::std::unique_ptr<::rpmostreecxx::Progress> *ptr) noexcept
+  {
+    ::new (ptr)::std::unique_ptr<::rpmostreecxx::Progress> ();
+  }
+  void
+  cxxbridge1$unique_ptr$rpmostreecxx$Progress$raw (
+      ::std::unique_ptr<::rpmostreecxx::Progress> *ptr,
+      ::std::unique_ptr<::rpmostreecxx::Progress>::pointer raw) noexcept
+  {
+    ::new (ptr)::std::unique_ptr<::rpmostreecxx::Progress> (raw);
+  }
+  ::std::unique_ptr<::rpmostreecxx::Progress>::element_type const *
+  cxxbridge1$unique_ptr$rpmostreecxx$Progress$get (
+      ::std::unique_ptr<::rpmostreecxx::Progress> const &ptr) noexcept
+  {
+    return ptr.get ();
+  }
+  ::std::unique_ptr<::rpmostreecxx::Progress>::pointer
+  cxxbridge1$unique_ptr$rpmostreecxx$Progress$release (
+      ::std::unique_ptr<::rpmostreecxx::Progress> &ptr) noexcept
+  {
+    return ptr.release ();
+  }
+  void
+  cxxbridge1$unique_ptr$rpmostreecxx$Progress$drop (
+      ::std::unique_ptr<::rpmostreecxx::Progress> *ptr) noexcept
+  {
+    ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::Progress>::value>{}(ptr);
+  }
 
-static_assert(::rust::detail::is_complete<::std::remove_extent<::rpmostreecxx::RpmTs>::type>::value, "definition of `::rpmostreecxx::RpmTs` is required");
-static_assert(sizeof(::std::unique_ptr<::rpmostreecxx::RpmTs>) == sizeof(void *), "");
-static_assert(alignof(::std::unique_ptr<::rpmostreecxx::RpmTs>) == alignof(void *), "");
-void cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$null(::std::unique_ptr<::rpmostreecxx::RpmTs> *ptr) noexcept {
-  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::RpmTs>();
-}
-void cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$raw(::std::unique_ptr<::rpmostreecxx::RpmTs> *ptr, ::std::unique_ptr<::rpmostreecxx::RpmTs>::pointer raw) noexcept {
-  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::RpmTs>(raw);
-}
-::std::unique_ptr<::rpmostreecxx::RpmTs>::element_type const *cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$get(::std::unique_ptr<::rpmostreecxx::RpmTs> const &ptr) noexcept {
-  return ptr.get();
-}
-::std::unique_ptr<::rpmostreecxx::RpmTs>::pointer cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$release(::std::unique_ptr<::rpmostreecxx::RpmTs> &ptr) noexcept {
-  return ptr.release();
-}
-void cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$drop(::std::unique_ptr<::rpmostreecxx::RpmTs> *ptr) noexcept {
-  ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::RpmTs>::value>{}(ptr);
-}
+  static_assert (
+      ::rust::detail::is_complete<::std::remove_extent<::rpmostreecxx::RpmTs>::type>::value,
+      "definition of `::rpmostreecxx::RpmTs` is required");
+  static_assert (sizeof (::std::unique_ptr<::rpmostreecxx::RpmTs>) == sizeof (void *), "");
+  static_assert (alignof (::std::unique_ptr<::rpmostreecxx::RpmTs>) == alignof (void *), "");
+  void
+  cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$null (
+      ::std::unique_ptr<::rpmostreecxx::RpmTs> *ptr) noexcept
+  {
+    ::new (ptr)::std::unique_ptr<::rpmostreecxx::RpmTs> ();
+  }
+  void
+  cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$raw (
+      ::std::unique_ptr<::rpmostreecxx::RpmTs> *ptr,
+      ::std::unique_ptr<::rpmostreecxx::RpmTs>::pointer raw) noexcept
+  {
+    ::new (ptr)::std::unique_ptr<::rpmostreecxx::RpmTs> (raw);
+  }
+  ::std::unique_ptr<::rpmostreecxx::RpmTs>::element_type const *
+  cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$get (
+      ::std::unique_ptr<::rpmostreecxx::RpmTs> const &ptr) noexcept
+  {
+    return ptr.get ();
+  }
+  ::std::unique_ptr<::rpmostreecxx::RpmTs>::pointer
+  cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$release (
+      ::std::unique_ptr<::rpmostreecxx::RpmTs> &ptr) noexcept
+  {
+    return ptr.release ();
+  }
+  void
+  cxxbridge1$unique_ptr$rpmostreecxx$RpmTs$drop (
+      ::std::unique_ptr<::rpmostreecxx::RpmTs> *ptr) noexcept
+  {
+    ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::RpmTs>::value>{}(ptr);
+  }
 
-static_assert(::rust::detail::is_complete<::std::remove_extent<::rpmostreecxx::PackageMeta>::type>::value, "definition of `::rpmostreecxx::PackageMeta` is required");
-static_assert(sizeof(::std::unique_ptr<::rpmostreecxx::PackageMeta>) == sizeof(void *), "");
-static_assert(alignof(::std::unique_ptr<::rpmostreecxx::PackageMeta>) == alignof(void *), "");
-void cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$null(::std::unique_ptr<::rpmostreecxx::PackageMeta> *ptr) noexcept {
-  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::PackageMeta>();
-}
-void cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$raw(::std::unique_ptr<::rpmostreecxx::PackageMeta> *ptr, ::std::unique_ptr<::rpmostreecxx::PackageMeta>::pointer raw) noexcept {
-  ::new (ptr) ::std::unique_ptr<::rpmostreecxx::PackageMeta>(raw);
-}
-::std::unique_ptr<::rpmostreecxx::PackageMeta>::element_type const *cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$get(::std::unique_ptr<::rpmostreecxx::PackageMeta> const &ptr) noexcept {
-  return ptr.get();
-}
-::std::unique_ptr<::rpmostreecxx::PackageMeta>::pointer cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$release(::std::unique_ptr<::rpmostreecxx::PackageMeta> &ptr) noexcept {
-  return ptr.release();
-}
-void cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$drop(::std::unique_ptr<::rpmostreecxx::PackageMeta> *ptr) noexcept {
-  ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::PackageMeta>::value>{}(ptr);
-}
+  static_assert (
+      ::rust::detail::is_complete<::std::remove_extent<::rpmostreecxx::PackageMeta>::type>::value,
+      "definition of `::rpmostreecxx::PackageMeta` is required");
+  static_assert (sizeof (::std::unique_ptr<::rpmostreecxx::PackageMeta>) == sizeof (void *), "");
+  static_assert (alignof (::std::unique_ptr<::rpmostreecxx::PackageMeta>) == alignof (void *), "");
+  void
+  cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$null (
+      ::std::unique_ptr<::rpmostreecxx::PackageMeta> *ptr) noexcept
+  {
+    ::new (ptr)::std::unique_ptr<::rpmostreecxx::PackageMeta> ();
+  }
+  void
+  cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$raw (
+      ::std::unique_ptr<::rpmostreecxx::PackageMeta> *ptr,
+      ::std::unique_ptr<::rpmostreecxx::PackageMeta>::pointer raw) noexcept
+  {
+    ::new (ptr)::std::unique_ptr<::rpmostreecxx::PackageMeta> (raw);
+  }
+  ::std::unique_ptr<::rpmostreecxx::PackageMeta>::element_type const *
+  cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$get (
+      ::std::unique_ptr<::rpmostreecxx::PackageMeta> const &ptr) noexcept
+  {
+    return ptr.get ();
+  }
+  ::std::unique_ptr<::rpmostreecxx::PackageMeta>::pointer
+  cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$release (
+      ::std::unique_ptr<::rpmostreecxx::PackageMeta> &ptr) noexcept
+  {
+    return ptr.release ();
+  }
+  void
+  cxxbridge1$unique_ptr$rpmostreecxx$PackageMeta$drop (
+      ::std::unique_ptr<::rpmostreecxx::PackageMeta> *ptr) noexcept
+  {
+    ::rust::deleter_if<::rust::detail::is_complete<::rpmostreecxx::PackageMeta>::value>{}(ptr);
+  }
 } // extern "C"
 
-namespace rust {
-inline namespace cxxbridge1 {
+namespace rust
+{
+inline namespace cxxbridge1
+{
 template <>
-::rpmostreecxx::Bubblewrap *Box<::rpmostreecxx::Bubblewrap>::allocation::alloc() noexcept {
-  return cxxbridge1$box$rpmostreecxx$Bubblewrap$alloc();
+::rpmostreecxx::Bubblewrap *
+Box<::rpmostreecxx::Bubblewrap>::allocation::alloc () noexcept
+{
+  return cxxbridge1$box$rpmostreecxx$Bubblewrap$alloc ();
 }
 template <>
-void Box<::rpmostreecxx::Bubblewrap>::allocation::dealloc(::rpmostreecxx::Bubblewrap *ptr) noexcept {
-  cxxbridge1$box$rpmostreecxx$Bubblewrap$dealloc(ptr);
+void
+Box<::rpmostreecxx::Bubblewrap>::allocation::dealloc (::rpmostreecxx::Bubblewrap *ptr) noexcept
+{
+  cxxbridge1$box$rpmostreecxx$Bubblewrap$dealloc (ptr);
 }
 template <>
-void Box<::rpmostreecxx::Bubblewrap>::drop() noexcept {
-  cxxbridge1$box$rpmostreecxx$Bubblewrap$drop(this);
+void
+Box<::rpmostreecxx::Bubblewrap>::drop () noexcept
+{
+  cxxbridge1$box$rpmostreecxx$Bubblewrap$drop (this);
 }
 template <>
-::rpmostreecxx::ContainerImageState *Box<::rpmostreecxx::ContainerImageState>::allocation::alloc() noexcept {
-  return cxxbridge1$box$rpmostreecxx$ContainerImageState$alloc();
+::rpmostreecxx::ContainerImageState *
+Box<::rpmostreecxx::ContainerImageState>::allocation::alloc () noexcept
+{
+  return cxxbridge1$box$rpmostreecxx$ContainerImageState$alloc ();
 }
 template <>
-void Box<::rpmostreecxx::ContainerImageState>::allocation::dealloc(::rpmostreecxx::ContainerImageState *ptr) noexcept {
-  cxxbridge1$box$rpmostreecxx$ContainerImageState$dealloc(ptr);
+void
+Box<::rpmostreecxx::ContainerImageState>::allocation::dealloc (
+    ::rpmostreecxx::ContainerImageState *ptr) noexcept
+{
+  cxxbridge1$box$rpmostreecxx$ContainerImageState$dealloc (ptr);
 }
 template <>
-void Box<::rpmostreecxx::ContainerImageState>::drop() noexcept {
-  cxxbridge1$box$rpmostreecxx$ContainerImageState$drop(this);
+void
+Box<::rpmostreecxx::ContainerImageState>::drop () noexcept
+{
+  cxxbridge1$box$rpmostreecxx$ContainerImageState$drop (this);
 }
 template <>
-::rpmostreecxx::TempEtcGuard *Box<::rpmostreecxx::TempEtcGuard>::allocation::alloc() noexcept {
-  return cxxbridge1$box$rpmostreecxx$TempEtcGuard$alloc();
+::rpmostreecxx::TempEtcGuard *
+Box<::rpmostreecxx::TempEtcGuard>::allocation::alloc () noexcept
+{
+  return cxxbridge1$box$rpmostreecxx$TempEtcGuard$alloc ();
 }
 template <>
-void Box<::rpmostreecxx::TempEtcGuard>::allocation::dealloc(::rpmostreecxx::TempEtcGuard *ptr) noexcept {
-  cxxbridge1$box$rpmostreecxx$TempEtcGuard$dealloc(ptr);
+void
+Box<::rpmostreecxx::TempEtcGuard>::allocation::dealloc (::rpmostreecxx::TempEtcGuard *ptr) noexcept
+{
+  cxxbridge1$box$rpmostreecxx$TempEtcGuard$dealloc (ptr);
 }
 template <>
-void Box<::rpmostreecxx::TempEtcGuard>::drop() noexcept {
-  cxxbridge1$box$rpmostreecxx$TempEtcGuard$drop(this);
+void
+Box<::rpmostreecxx::TempEtcGuard>::drop () noexcept
+{
+  cxxbridge1$box$rpmostreecxx$TempEtcGuard$drop (this);
 }
 template <>
-::rpmostreecxx::FilesystemScriptPrep *Box<::rpmostreecxx::FilesystemScriptPrep>::allocation::alloc() noexcept {
-  return cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$alloc();
+::rpmostreecxx::FilesystemScriptPrep *
+Box<::rpmostreecxx::FilesystemScriptPrep>::allocation::alloc () noexcept
+{
+  return cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$alloc ();
 }
 template <>
-void Box<::rpmostreecxx::FilesystemScriptPrep>::allocation::dealloc(::rpmostreecxx::FilesystemScriptPrep *ptr) noexcept {
-  cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$dealloc(ptr);
+void
+Box<::rpmostreecxx::FilesystemScriptPrep>::allocation::dealloc (
+    ::rpmostreecxx::FilesystemScriptPrep *ptr) noexcept
+{
+  cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$dealloc (ptr);
 }
 template <>
-void Box<::rpmostreecxx::FilesystemScriptPrep>::drop() noexcept {
-  cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$drop(this);
+void
+Box<::rpmostreecxx::FilesystemScriptPrep>::drop () noexcept
+{
+  cxxbridge1$box$rpmostreecxx$FilesystemScriptPrep$drop (this);
 }
 template <>
-::rpmostreecxx::RpmImporterFlags *Box<::rpmostreecxx::RpmImporterFlags>::allocation::alloc() noexcept {
-  return cxxbridge1$box$rpmostreecxx$RpmImporterFlags$alloc();
+::rpmostreecxx::RpmImporterFlags *
+Box<::rpmostreecxx::RpmImporterFlags>::allocation::alloc () noexcept
+{
+  return cxxbridge1$box$rpmostreecxx$RpmImporterFlags$alloc ();
 }
 template <>
-void Box<::rpmostreecxx::RpmImporterFlags>::allocation::dealloc(::rpmostreecxx::RpmImporterFlags *ptr) noexcept {
-  cxxbridge1$box$rpmostreecxx$RpmImporterFlags$dealloc(ptr);
+void
+Box<::rpmostreecxx::RpmImporterFlags>::allocation::dealloc (
+    ::rpmostreecxx::RpmImporterFlags *ptr) noexcept
+{
+  cxxbridge1$box$rpmostreecxx$RpmImporterFlags$dealloc (ptr);
 }
 template <>
-void Box<::rpmostreecxx::RpmImporterFlags>::drop() noexcept {
-  cxxbridge1$box$rpmostreecxx$RpmImporterFlags$drop(this);
+void
+Box<::rpmostreecxx::RpmImporterFlags>::drop () noexcept
+{
+  cxxbridge1$box$rpmostreecxx$RpmImporterFlags$drop (this);
 }
 template <>
-::rpmostreecxx::RpmImporter *Box<::rpmostreecxx::RpmImporter>::allocation::alloc() noexcept {
-  return cxxbridge1$box$rpmostreecxx$RpmImporter$alloc();
+::rpmostreecxx::RpmImporter *
+Box<::rpmostreecxx::RpmImporter>::allocation::alloc () noexcept
+{
+  return cxxbridge1$box$rpmostreecxx$RpmImporter$alloc ();
 }
 template <>
-void Box<::rpmostreecxx::RpmImporter>::allocation::dealloc(::rpmostreecxx::RpmImporter *ptr) noexcept {
-  cxxbridge1$box$rpmostreecxx$RpmImporter$dealloc(ptr);
+void
+Box<::rpmostreecxx::RpmImporter>::allocation::dealloc (::rpmostreecxx::RpmImporter *ptr) noexcept
+{
+  cxxbridge1$box$rpmostreecxx$RpmImporter$dealloc (ptr);
 }
 template <>
-void Box<::rpmostreecxx::RpmImporter>::drop() noexcept {
-  cxxbridge1$box$rpmostreecxx$RpmImporter$drop(this);
+void
+Box<::rpmostreecxx::RpmImporter>::drop () noexcept
+{
+  cxxbridge1$box$rpmostreecxx$RpmImporter$drop (this);
 }
 template <>
-::rpmostreecxx::HistoryCtx *Box<::rpmostreecxx::HistoryCtx>::allocation::alloc() noexcept {
-  return cxxbridge1$box$rpmostreecxx$HistoryCtx$alloc();
+::rpmostreecxx::HistoryCtx *
+Box<::rpmostreecxx::HistoryCtx>::allocation::alloc () noexcept
+{
+  return cxxbridge1$box$rpmostreecxx$HistoryCtx$alloc ();
 }
 template <>
-void Box<::rpmostreecxx::HistoryCtx>::allocation::dealloc(::rpmostreecxx::HistoryCtx *ptr) noexcept {
-  cxxbridge1$box$rpmostreecxx$HistoryCtx$dealloc(ptr);
+void
+Box<::rpmostreecxx::HistoryCtx>::allocation::dealloc (::rpmostreecxx::HistoryCtx *ptr) noexcept
+{
+  cxxbridge1$box$rpmostreecxx$HistoryCtx$dealloc (ptr);
 }
 template <>
-void Box<::rpmostreecxx::HistoryCtx>::drop() noexcept {
-  cxxbridge1$box$rpmostreecxx$HistoryCtx$drop(this);
+void
+Box<::rpmostreecxx::HistoryCtx>::drop () noexcept
+{
+  cxxbridge1$box$rpmostreecxx$HistoryCtx$drop (this);
 }
 template <>
-::rpmostreecxx::TokioHandle *Box<::rpmostreecxx::TokioHandle>::allocation::alloc() noexcept {
-  return cxxbridge1$box$rpmostreecxx$TokioHandle$alloc();
+::rpmostreecxx::TokioHandle *
+Box<::rpmostreecxx::TokioHandle>::allocation::alloc () noexcept
+{
+  return cxxbridge1$box$rpmostreecxx$TokioHandle$alloc ();
 }
 template <>
-void Box<::rpmostreecxx::TokioHandle>::allocation::dealloc(::rpmostreecxx::TokioHandle *ptr) noexcept {
-  cxxbridge1$box$rpmostreecxx$TokioHandle$dealloc(ptr);
+void
+Box<::rpmostreecxx::TokioHandle>::allocation::dealloc (::rpmostreecxx::TokioHandle *ptr) noexcept
+{
+  cxxbridge1$box$rpmostreecxx$TokioHandle$dealloc (ptr);
 }
 template <>
-void Box<::rpmostreecxx::TokioHandle>::drop() noexcept {
-  cxxbridge1$box$rpmostreecxx$TokioHandle$drop(this);
+void
+Box<::rpmostreecxx::TokioHandle>::drop () noexcept
+{
+  cxxbridge1$box$rpmostreecxx$TokioHandle$drop (this);
 }
 template <>
-::rpmostreecxx::TokioEnterGuard *Box<::rpmostreecxx::TokioEnterGuard>::allocation::alloc() noexcept {
-  return cxxbridge1$box$rpmostreecxx$TokioEnterGuard$alloc();
+::rpmostreecxx::TokioEnterGuard *
+Box<::rpmostreecxx::TokioEnterGuard>::allocation::alloc () noexcept
+{
+  return cxxbridge1$box$rpmostreecxx$TokioEnterGuard$alloc ();
 }
 template <>
-void Box<::rpmostreecxx::TokioEnterGuard>::allocation::dealloc(::rpmostreecxx::TokioEnterGuard *ptr) noexcept {
-  cxxbridge1$box$rpmostreecxx$TokioEnterGuard$dealloc(ptr);
+void
+Box<::rpmostreecxx::TokioEnterGuard>::allocation::dealloc (
+    ::rpmostreecxx::TokioEnterGuard *ptr) noexcept
+{
+  cxxbridge1$box$rpmostreecxx$TokioEnterGuard$dealloc (ptr);
 }
 template <>
-void Box<::rpmostreecxx::TokioEnterGuard>::drop() noexcept {
-  cxxbridge1$box$rpmostreecxx$TokioEnterGuard$drop(this);
+void
+Box<::rpmostreecxx::TokioEnterGuard>::drop () noexcept
+{
+  cxxbridge1$box$rpmostreecxx$TokioEnterGuard$drop (this);
 }
 template <>
-::rpmostreecxx::Treefile *Box<::rpmostreecxx::Treefile>::allocation::alloc() noexcept {
-  return cxxbridge1$box$rpmostreecxx$Treefile$alloc();
+::rpmostreecxx::Treefile *
+Box<::rpmostreecxx::Treefile>::allocation::alloc () noexcept
+{
+  return cxxbridge1$box$rpmostreecxx$Treefile$alloc ();
 }
 template <>
-void Box<::rpmostreecxx::Treefile>::allocation::dealloc(::rpmostreecxx::Treefile *ptr) noexcept {
-  cxxbridge1$box$rpmostreecxx$Treefile$dealloc(ptr);
+void
+Box<::rpmostreecxx::Treefile>::allocation::dealloc (::rpmostreecxx::Treefile *ptr) noexcept
+{
+  cxxbridge1$box$rpmostreecxx$Treefile$dealloc (ptr);
 }
 template <>
-void Box<::rpmostreecxx::Treefile>::drop() noexcept {
-  cxxbridge1$box$rpmostreecxx$Treefile$drop(this);
+void
+Box<::rpmostreecxx::Treefile>::drop () noexcept
+{
+  cxxbridge1$box$rpmostreecxx$Treefile$drop (this);
 }
-template <>
-Vec<::rpmostreecxx::OverrideReplacement>::Vec() noexcept {
-  cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$new(this);
+template <> Vec<::rpmostreecxx::OverrideReplacement>::Vec () noexcept
+{
+  cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$new (this);
 }
 template <>
-void Vec<::rpmostreecxx::OverrideReplacement>::drop() noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$drop(this);
+void
+Vec<::rpmostreecxx::OverrideReplacement>::drop () noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$drop (this);
 }
 template <>
-::std::size_t Vec<::rpmostreecxx::OverrideReplacement>::size() const noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$len(this);
+::std::size_t
+Vec<::rpmostreecxx::OverrideReplacement>::size () const noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$len (this);
 }
 template <>
-::std::size_t Vec<::rpmostreecxx::OverrideReplacement>::capacity() const noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$capacity(this);
+::std::size_t
+Vec<::rpmostreecxx::OverrideReplacement>::capacity () const noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$capacity (this);
 }
 template <>
-::rpmostreecxx::OverrideReplacement const *Vec<::rpmostreecxx::OverrideReplacement>::data() const noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$data(this);
+::rpmostreecxx::OverrideReplacement const *
+Vec<::rpmostreecxx::OverrideReplacement>::data () const noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$data (this);
 }
 template <>
-void Vec<::rpmostreecxx::OverrideReplacement>::reserve_total(::std::size_t new_cap) noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$reserve_total(this, new_cap);
+void
+Vec<::rpmostreecxx::OverrideReplacement>::reserve_total (::std::size_t new_cap) noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$reserve_total (this, new_cap);
 }
 template <>
-void Vec<::rpmostreecxx::OverrideReplacement>::set_len(::std::size_t len) noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$set_len(this, len);
+void
+Vec<::rpmostreecxx::OverrideReplacement>::set_len (::std::size_t len) noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$set_len (this, len);
 }
 template <>
-void Vec<::rpmostreecxx::OverrideReplacement>::truncate(::std::size_t len) {
-  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$truncate(this, len);
+void
+Vec<::rpmostreecxx::OverrideReplacement>::truncate (::std::size_t len)
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$OverrideReplacement$truncate (this, len);
 }
-template <>
-Vec<::rpmostreecxx::StringMapping>::Vec() noexcept {
-  cxxbridge1$rust_vec$rpmostreecxx$StringMapping$new(this);
+template <> Vec<::rpmostreecxx::StringMapping>::Vec () noexcept
+{
+  cxxbridge1$rust_vec$rpmostreecxx$StringMapping$new (this);
 }
 template <>
-void Vec<::rpmostreecxx::StringMapping>::drop() noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$drop(this);
+void
+Vec<::rpmostreecxx::StringMapping>::drop () noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$drop (this);
 }
 template <>
-::std::size_t Vec<::rpmostreecxx::StringMapping>::size() const noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$len(this);
+::std::size_t
+Vec<::rpmostreecxx::StringMapping>::size () const noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$len (this);
 }
 template <>
-::std::size_t Vec<::rpmostreecxx::StringMapping>::capacity() const noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$capacity(this);
+::std::size_t
+Vec<::rpmostreecxx::StringMapping>::capacity () const noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$capacity (this);
 }
 template <>
-::rpmostreecxx::StringMapping const *Vec<::rpmostreecxx::StringMapping>::data() const noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$data(this);
+::rpmostreecxx::StringMapping const *
+Vec<::rpmostreecxx::StringMapping>::data () const noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$data (this);
 }
 template <>
-void Vec<::rpmostreecxx::StringMapping>::reserve_total(::std::size_t new_cap) noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$reserve_total(this, new_cap);
+void
+Vec<::rpmostreecxx::StringMapping>::reserve_total (::std::size_t new_cap) noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$reserve_total (this, new_cap);
 }
 template <>
-void Vec<::rpmostreecxx::StringMapping>::set_len(::std::size_t len) noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$set_len(this, len);
+void
+Vec<::rpmostreecxx::StringMapping>::set_len (::std::size_t len) noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$set_len (this, len);
 }
 template <>
-void Vec<::rpmostreecxx::StringMapping>::truncate(::std::size_t len) {
-  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$truncate(this, len);
+void
+Vec<::rpmostreecxx::StringMapping>::truncate (::std::size_t len)
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$StringMapping$truncate (this, len);
 }
 template <>
-::rpmostreecxx::PasswdDB *Box<::rpmostreecxx::PasswdDB>::allocation::alloc() noexcept {
-  return cxxbridge1$box$rpmostreecxx$PasswdDB$alloc();
+::rpmostreecxx::PasswdDB *
+Box<::rpmostreecxx::PasswdDB>::allocation::alloc () noexcept
+{
+  return cxxbridge1$box$rpmostreecxx$PasswdDB$alloc ();
 }
 template <>
-void Box<::rpmostreecxx::PasswdDB>::allocation::dealloc(::rpmostreecxx::PasswdDB *ptr) noexcept {
-  cxxbridge1$box$rpmostreecxx$PasswdDB$dealloc(ptr);
+void
+Box<::rpmostreecxx::PasswdDB>::allocation::dealloc (::rpmostreecxx::PasswdDB *ptr) noexcept
+{
+  cxxbridge1$box$rpmostreecxx$PasswdDB$dealloc (ptr);
 }
 template <>
-void Box<::rpmostreecxx::PasswdDB>::drop() noexcept {
-  cxxbridge1$box$rpmostreecxx$PasswdDB$drop(this);
+void
+Box<::rpmostreecxx::PasswdDB>::drop () noexcept
+{
+  cxxbridge1$box$rpmostreecxx$PasswdDB$drop (this);
 }
 template <>
-::rpmostreecxx::PasswdEntries *Box<::rpmostreecxx::PasswdEntries>::allocation::alloc() noexcept {
-  return cxxbridge1$box$rpmostreecxx$PasswdEntries$alloc();
+::rpmostreecxx::PasswdEntries *
+Box<::rpmostreecxx::PasswdEntries>::allocation::alloc () noexcept
+{
+  return cxxbridge1$box$rpmostreecxx$PasswdEntries$alloc ();
 }
 template <>
-void Box<::rpmostreecxx::PasswdEntries>::allocation::dealloc(::rpmostreecxx::PasswdEntries *ptr) noexcept {
-  cxxbridge1$box$rpmostreecxx$PasswdEntries$dealloc(ptr);
+void
+Box<::rpmostreecxx::PasswdEntries>::allocation::dealloc (
+    ::rpmostreecxx::PasswdEntries *ptr) noexcept
+{
+  cxxbridge1$box$rpmostreecxx$PasswdEntries$dealloc (ptr);
 }
 template <>
-void Box<::rpmostreecxx::PasswdEntries>::drop() noexcept {
-  cxxbridge1$box$rpmostreecxx$PasswdEntries$drop(this);
+void
+Box<::rpmostreecxx::PasswdEntries>::drop () noexcept
+{
+  cxxbridge1$box$rpmostreecxx$PasswdEntries$drop (this);
 }
 template <>
-::rpmostreecxx::Extensions *Box<::rpmostreecxx::Extensions>::allocation::alloc() noexcept {
-  return cxxbridge1$box$rpmostreecxx$Extensions$alloc();
+::rpmostreecxx::Extensions *
+Box<::rpmostreecxx::Extensions>::allocation::alloc () noexcept
+{
+  return cxxbridge1$box$rpmostreecxx$Extensions$alloc ();
 }
 template <>
-void Box<::rpmostreecxx::Extensions>::allocation::dealloc(::rpmostreecxx::Extensions *ptr) noexcept {
-  cxxbridge1$box$rpmostreecxx$Extensions$dealloc(ptr);
+void
+Box<::rpmostreecxx::Extensions>::allocation::dealloc (::rpmostreecxx::Extensions *ptr) noexcept
+{
+  cxxbridge1$box$rpmostreecxx$Extensions$dealloc (ptr);
 }
 template <>
-void Box<::rpmostreecxx::Extensions>::drop() noexcept {
-  cxxbridge1$box$rpmostreecxx$Extensions$drop(this);
+void
+Box<::rpmostreecxx::Extensions>::drop () noexcept
+{
+  cxxbridge1$box$rpmostreecxx$Extensions$drop (this);
 }
 template <>
-::rpmostreecxx::LockfileConfig *Box<::rpmostreecxx::LockfileConfig>::allocation::alloc() noexcept {
-  return cxxbridge1$box$rpmostreecxx$LockfileConfig$alloc();
+::rpmostreecxx::LockfileConfig *
+Box<::rpmostreecxx::LockfileConfig>::allocation::alloc () noexcept
+{
+  return cxxbridge1$box$rpmostreecxx$LockfileConfig$alloc ();
 }
 template <>
-void Box<::rpmostreecxx::LockfileConfig>::allocation::dealloc(::rpmostreecxx::LockfileConfig *ptr) noexcept {
-  cxxbridge1$box$rpmostreecxx$LockfileConfig$dealloc(ptr);
+void
+Box<::rpmostreecxx::LockfileConfig>::allocation::dealloc (
+    ::rpmostreecxx::LockfileConfig *ptr) noexcept
+{
+  cxxbridge1$box$rpmostreecxx$LockfileConfig$dealloc (ptr);
 }
 template <>
-void Box<::rpmostreecxx::LockfileConfig>::drop() noexcept {
-  cxxbridge1$box$rpmostreecxx$LockfileConfig$drop(this);
+void
+Box<::rpmostreecxx::LockfileConfig>::drop () noexcept
+{
+  cxxbridge1$box$rpmostreecxx$LockfileConfig$drop (this);
 }
-template <>
-Vec<::rpmostreecxx::LockedPackage>::Vec() noexcept {
-  cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$new(this);
+template <> Vec<::rpmostreecxx::LockedPackage>::Vec () noexcept
+{
+  cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$new (this);
 }
 template <>
-void Vec<::rpmostreecxx::LockedPackage>::drop() noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$drop(this);
+void
+Vec<::rpmostreecxx::LockedPackage>::drop () noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$drop (this);
 }
 template <>
-::std::size_t Vec<::rpmostreecxx::LockedPackage>::size() const noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$len(this);
+::std::size_t
+Vec<::rpmostreecxx::LockedPackage>::size () const noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$len (this);
 }
 template <>
-::std::size_t Vec<::rpmostreecxx::LockedPackage>::capacity() const noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$capacity(this);
+::std::size_t
+Vec<::rpmostreecxx::LockedPackage>::capacity () const noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$capacity (this);
 }
 template <>
-::rpmostreecxx::LockedPackage const *Vec<::rpmostreecxx::LockedPackage>::data() const noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$data(this);
+::rpmostreecxx::LockedPackage const *
+Vec<::rpmostreecxx::LockedPackage>::data () const noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$data (this);
 }
 template <>
-void Vec<::rpmostreecxx::LockedPackage>::reserve_total(::std::size_t new_cap) noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$reserve_total(this, new_cap);
+void
+Vec<::rpmostreecxx::LockedPackage>::reserve_total (::std::size_t new_cap) noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$reserve_total (this, new_cap);
 }
 template <>
-void Vec<::rpmostreecxx::LockedPackage>::set_len(::std::size_t len) noexcept {
-  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$set_len(this, len);
+void
+Vec<::rpmostreecxx::LockedPackage>::set_len (::std::size_t len) noexcept
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$set_len (this, len);
 }
 template <>
-void Vec<::rpmostreecxx::LockedPackage>::truncate(::std::size_t len) {
-  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$truncate(this, len);
+void
+Vec<::rpmostreecxx::LockedPackage>::truncate (::std::size_t len)
+{
+  return cxxbridge1$rust_vec$rpmostreecxx$LockedPackage$truncate (this, len);
 }
 } // namespace cxxbridge1
 } // namespace rust

--- a/rpmostree-cxxrs.h
+++ b/rpmostree-cxxrs.h
@@ -1,16 +1,15 @@
 #pragma once
-#include "src/libpriv/rpmostree-cxxrs-prelude.h"
+#include "rpmostree-clientlib.h"
 #include "rpmostree-container.hpp"
 #include "rpmostree-cxxrsutil.hpp"
-#include "rpmostree-util.h"
-#include "rpmostreemain.h"
-#include "rpmostree-clientlib.h"
 #include "rpmostree-diff.hpp"
 #include "rpmostree-libbuiltin.h"
-#include "rpmostree-util.h"
 #include "rpmostree-output.h"
-#include "rpmostree-rpm-util.h"
 #include "rpmostree-package-variants.h"
+#include "rpmostree-rpm-util.h"
+#include "rpmostree-util.h"
+#include "rpmostreemain.h"
+#include "src/libpriv/rpmostree-cxxrs-prelude.h"
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -36,94 +35,98 @@
 #pragma clang diagnostic ignored "-Wdollar-in-identifier-extension"
 #endif // __clang__
 
-namespace rust {
-inline namespace cxxbridge1 {
+namespace rust
+{
+inline namespace cxxbridge1
+{
 // #include "rust/cxx.h"
 
 #ifndef CXXBRIDGE1_PANIC
 #define CXXBRIDGE1_PANIC
-template <typename Exception>
-void panic [[noreturn]] (const char *msg);
+template <typename Exception> void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE1_PANIC
 
 struct unsafe_bitcopy_t;
 
-namespace {
-template <typename T>
-class impl;
+namespace
+{
+template <typename T> class impl;
 } // namespace
 
-template <typename T>
-::std::size_t size_of();
-template <typename T>
-::std::size_t align_of();
+template <typename T>::std::size_t size_of ();
+template <typename T>::std::size_t align_of ();
 
 #ifndef CXXBRIDGE1_RUST_STRING
 #define CXXBRIDGE1_RUST_STRING
-class String final {
+class String final
+{
 public:
-  String() noexcept;
-  String(const String &) noexcept;
-  String(String &&) noexcept;
-  ~String() noexcept;
+  String () noexcept;
+  String (const String &) noexcept;
+  String (String &&) noexcept;
+  ~String () noexcept;
 
-  String(const std::string &);
-  String(const char *);
-  String(const char *, std::size_t);
-  String(const char16_t *);
-  String(const char16_t *, std::size_t);
+  String (const std::string &);
+  String (const char *);
+  String (const char *, std::size_t);
+  String (const char16_t *);
+  String (const char16_t *, std::size_t);
 #ifdef __cpp_char8_t
-  String(const char8_t *s);
-  String(const char8_t *s, std::size_t len);
+  String (const char8_t *s);
+  String (const char8_t *s, std::size_t len);
 #endif
 
-  static String lossy(const std::string &) noexcept;
-  static String lossy(const char *) noexcept;
-  static String lossy(const char *, std::size_t) noexcept;
-  static String lossy(const char16_t *) noexcept;
-  static String lossy(const char16_t *, std::size_t) noexcept;
+  static String lossy (const std::string &) noexcept;
+  static String lossy (const char *) noexcept;
+  static String lossy (const char *, std::size_t) noexcept;
+  static String lossy (const char16_t *) noexcept;
+  static String lossy (const char16_t *, std::size_t) noexcept;
 
-  String &operator=(const String &) & noexcept;
-  String &operator=(String &&) & noexcept;
+  String &operator= (const String &) & noexcept;
+  String &operator= (String &&) & noexcept;
 
-  explicit operator std::string() const;
+  explicit operator std::string () const;
 
-  const char *data() const noexcept;
-  std::size_t size() const noexcept;
-  std::size_t length() const noexcept;
-  bool empty() const noexcept;
+  const char *data () const noexcept;
+  std::size_t size () const noexcept;
+  std::size_t length () const noexcept;
+  bool empty () const noexcept;
 
-  const char *c_str() noexcept;
+  const char *c_str () noexcept;
 
-  std::size_t capacity() const noexcept;
-  void reserve(size_t new_cap) noexcept;
+  std::size_t capacity () const noexcept;
+  void reserve (size_t new_cap) noexcept;
 
   using iterator = char *;
-  iterator begin() noexcept;
-  iterator end() noexcept;
+  iterator begin () noexcept;
+  iterator end () noexcept;
 
   using const_iterator = const char *;
-  const_iterator begin() const noexcept;
-  const_iterator end() const noexcept;
-  const_iterator cbegin() const noexcept;
-  const_iterator cend() const noexcept;
+  const_iterator begin () const noexcept;
+  const_iterator end () const noexcept;
+  const_iterator cbegin () const noexcept;
+  const_iterator cend () const noexcept;
 
-  bool operator==(const String &) const noexcept;
-  bool operator!=(const String &) const noexcept;
-  bool operator<(const String &) const noexcept;
-  bool operator<=(const String &) const noexcept;
-  bool operator>(const String &) const noexcept;
-  bool operator>=(const String &) const noexcept;
+  bool operator== (const String &) const noexcept;
+  bool operator!= (const String &) const noexcept;
+  bool operator< (const String &) const noexcept;
+  bool operator<= (const String &) const noexcept;
+  bool operator> (const String &) const noexcept;
+  bool operator>= (const String &) const noexcept;
 
-  void swap(String &) noexcept;
+  void swap (String &) noexcept;
 
-  String(unsafe_bitcopy_t, const String &) noexcept;
+  String (unsafe_bitcopy_t, const String &) noexcept;
 
 private:
   struct lossy_t;
-  String(lossy_t, const char *, std::size_t) noexcept;
-  String(lossy_t, const char16_t *, std::size_t) noexcept;
-  friend void swap(String &lhs, String &rhs) noexcept { lhs.swap(rhs); }
+  String (lossy_t, const char *, std::size_t) noexcept;
+  String (lossy_t, const char16_t *, std::size_t) noexcept;
+  friend void
+  swap (String &lhs, String &rhs) noexcept
+  {
+    lhs.swap (rhs);
+  }
 
   std::array<std::uintptr_t, 3> repr;
 };
@@ -131,48 +134,49 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_STR
 #define CXXBRIDGE1_RUST_STR
-class Str final {
+class Str final
+{
 public:
-  Str() noexcept;
-  Str(const String &) noexcept;
-  Str(const std::string &);
-  Str(const char *);
-  Str(const char *, std::size_t);
+  Str () noexcept;
+  Str (const String &) noexcept;
+  Str (const std::string &);
+  Str (const char *);
+  Str (const char *, std::size_t);
 
-  Str &operator=(const Str &) & noexcept = default;
+  Str &operator= (const Str &) & noexcept = default;
 
-  explicit operator std::string() const;
+  explicit operator std::string () const;
 #if __cplusplus >= 201703L
-  explicit operator std::string_view() const;
+  explicit operator std::string_view () const;
 #endif
 
-  const char *data() const noexcept;
-  std::size_t size() const noexcept;
-  std::size_t length() const noexcept;
-  bool empty() const noexcept;
+  const char *data () const noexcept;
+  std::size_t size () const noexcept;
+  std::size_t length () const noexcept;
+  bool empty () const noexcept;
 
-  Str(const Str &) noexcept = default;
-  ~Str() noexcept = default;
+  Str (const Str &) noexcept = default;
+  ~Str () noexcept = default;
 
   using iterator = const char *;
   using const_iterator = const char *;
-  const_iterator begin() const noexcept;
-  const_iterator end() const noexcept;
-  const_iterator cbegin() const noexcept;
-  const_iterator cend() const noexcept;
+  const_iterator begin () const noexcept;
+  const_iterator end () const noexcept;
+  const_iterator cbegin () const noexcept;
+  const_iterator cend () const noexcept;
 
-  bool operator==(const Str &) const noexcept;
-  bool operator!=(const Str &) const noexcept;
-  bool operator<(const Str &) const noexcept;
-  bool operator<=(const Str &) const noexcept;
-  bool operator>(const Str &) const noexcept;
-  bool operator>=(const Str &) const noexcept;
+  bool operator== (const Str &) const noexcept;
+  bool operator!= (const Str &) const noexcept;
+  bool operator< (const Str &) const noexcept;
+  bool operator<= (const Str &) const noexcept;
+  bool operator> (const Str &) const noexcept;
+  bool operator>= (const Str &) const noexcept;
 
-  void swap(Str &) noexcept;
+  void swap (Str &) noexcept;
 
 private:
   class uninit;
-  Str(uninit) noexcept;
+  Str (uninit) noexcept;
   friend impl<Str>;
 
   std::array<std::uintptr_t, 2> repr;
@@ -181,72 +185,72 @@ private:
 
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
-namespace detail {
-template <bool>
-struct copy_assignable_if {};
+namespace detail
+{
+template <bool> struct copy_assignable_if
+{
+};
 
-template <>
-struct copy_assignable_if<false> {
-  copy_assignable_if() noexcept = default;
-  copy_assignable_if(const copy_assignable_if &) noexcept = default;
-  copy_assignable_if &operator=(const copy_assignable_if &) & noexcept = delete;
-  copy_assignable_if &operator=(copy_assignable_if &&) & noexcept = default;
+template <> struct copy_assignable_if<false>
+{
+  copy_assignable_if () noexcept = default;
+  copy_assignable_if (const copy_assignable_if &) noexcept = default;
+  copy_assignable_if &operator= (const copy_assignable_if &) & noexcept = delete;
+  copy_assignable_if &operator= (copy_assignable_if &&) & noexcept = default;
 };
 } // namespace detail
 
 template <typename T>
-class Slice final
-    : private detail::copy_assignable_if<std::is_const<T>::value> {
+class Slice final : private detail::copy_assignable_if<std::is_const<T>::value>
+{
 public:
   using value_type = T;
 
-  Slice() noexcept;
-  Slice(T *, std::size_t count) noexcept;
+  Slice () noexcept;
+  Slice (T *, std::size_t count) noexcept;
 
-  template <typename C>
-  explicit Slice(C &c) : Slice(c.data(), c.size()) {}
+  template <typename C> explicit Slice (C &c) : Slice (c.data (), c.size ()) {}
 
-  Slice &operator=(const Slice<T> &) & noexcept = default;
-  Slice &operator=(Slice<T> &&) & noexcept = default;
+  Slice &operator= (const Slice<T> &) & noexcept = default;
+  Slice &operator= (Slice<T> &&) & noexcept = default;
 
-  T *data() const noexcept;
-  std::size_t size() const noexcept;
-  std::size_t length() const noexcept;
-  bool empty() const noexcept;
+  T *data () const noexcept;
+  std::size_t size () const noexcept;
+  std::size_t length () const noexcept;
+  bool empty () const noexcept;
 
-  T &operator[](std::size_t n) const noexcept;
-  T &at(std::size_t n) const;
-  T &front() const noexcept;
-  T &back() const noexcept;
+  T &operator[] (std::size_t n) const noexcept;
+  T &at (std::size_t n) const;
+  T &front () const noexcept;
+  T &back () const noexcept;
 
-  Slice(const Slice<T> &) noexcept = default;
-  ~Slice() noexcept = default;
+  Slice (const Slice<T> &) noexcept = default;
+  ~Slice () noexcept = default;
 
   class iterator;
-  iterator begin() const noexcept;
-  iterator end() const noexcept;
+  iterator begin () const noexcept;
+  iterator end () const noexcept;
 
-  void swap(Slice &) noexcept;
+  void swap (Slice &) noexcept;
 
 private:
   class uninit;
-  Slice(uninit) noexcept;
+  Slice (uninit) noexcept;
   friend impl<Slice>;
-  friend void sliceInit(void *, const void *, std::size_t) noexcept;
-  friend void *slicePtr(const void *) noexcept;
-  friend std::size_t sliceLen(const void *) noexcept;
+  friend void sliceInit (void *, const void *, std::size_t) noexcept;
+  friend void *slicePtr (const void *) noexcept;
+  friend std::size_t sliceLen (const void *) noexcept;
 
   std::array<std::uintptr_t, 2> repr;
 };
 
 #ifdef __cpp_deduction_guides
 template <typename C>
-explicit Slice(C &c)
-    -> Slice<std::remove_reference_t<decltype(*std::declval<C>().data())>>;
+explicit Slice (C &c) -> Slice<std::remove_reference_t<decltype (*std::declval<C> ().data ())>>;
 #endif // __cpp_deduction_guides
 
-template <typename T>
-class Slice<T>::iterator final {
+template <typename T> class Slice<T>::iterator final
+{
 public:
 #if __cplusplus >= 202002L
   using iterator_category = std::contiguous_iterator_tag;
@@ -258,30 +262,32 @@ public:
   using pointer = typename std::add_pointer<T>::type;
   using reference = typename std::add_lvalue_reference<T>::type;
 
-  reference operator*() const noexcept;
+  reference operator* () const noexcept;
   pointer operator->() const noexcept;
-  reference operator[](difference_type) const noexcept;
+  reference operator[] (difference_type) const noexcept;
 
-  iterator &operator++() noexcept;
-  iterator operator++(int) noexcept;
-  iterator &operator--() noexcept;
-  iterator operator--(int) noexcept;
+  iterator &operator++ () noexcept;
+  iterator operator++ (int) noexcept;
+  iterator &operator-- () noexcept;
+  iterator operator-- (int) noexcept;
 
-  iterator &operator+=(difference_type) noexcept;
-  iterator &operator-=(difference_type) noexcept;
-  iterator operator+(difference_type) const noexcept;
-  friend inline iterator operator+(difference_type lhs, iterator rhs) noexcept {
+  iterator &operator+= (difference_type) noexcept;
+  iterator &operator-= (difference_type) noexcept;
+  iterator operator+ (difference_type) const noexcept;
+  friend inline iterator
+  operator+ (difference_type lhs, iterator rhs) noexcept
+  {
     return rhs + lhs;
   }
-  iterator operator-(difference_type) const noexcept;
-  difference_type operator-(const iterator &) const noexcept;
+  iterator operator- (difference_type) const noexcept;
+  difference_type operator- (const iterator &) const noexcept;
 
-  bool operator==(const iterator &) const noexcept;
-  bool operator!=(const iterator &) const noexcept;
-  bool operator<(const iterator &) const noexcept;
-  bool operator<=(const iterator &) const noexcept;
-  bool operator>(const iterator &) const noexcept;
-  bool operator>=(const iterator &) const noexcept;
+  bool operator== (const iterator &) const noexcept;
+  bool operator!= (const iterator &) const noexcept;
+  bool operator< (const iterator &) const noexcept;
+  bool operator<= (const iterator &) const noexcept;
+  bool operator> (const iterator &) const noexcept;
+  bool operator>= (const iterator &) const noexcept;
 
 private:
   friend class Slice;
@@ -290,683 +296,810 @@ private:
 };
 
 #if __cplusplus >= 202002L
-static_assert(std::ranges::contiguous_range<rust::Slice<const uint8_t>>);
-static_assert(std::contiguous_iterator<rust::Slice<const uint8_t>::iterator>);
+static_assert (std::ranges::contiguous_range<rust::Slice<const uint8_t>>);
+static_assert (std::contiguous_iterator<rust::Slice<const uint8_t>::iterator>);
 #endif
 
-template <typename T>
-Slice<T>::Slice() noexcept {
-  sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
+template <typename T> Slice<T>::Slice () noexcept
+{
+  sliceInit (this, reinterpret_cast<void *> (align_of<T> ()), 0);
+}
+
+template <typename T> Slice<T>::Slice (T *s, std::size_t count) noexcept
+{
+  assert (s != nullptr || count == 0);
+  sliceInit (this,
+             s == nullptr && count == 0 ? reinterpret_cast<void *> (align_of<T> ())
+                                        : const_cast<typename std::remove_const<T>::type *> (s),
+             count);
 }
 
 template <typename T>
-Slice<T>::Slice(T *s, std::size_t count) noexcept {
-  assert(s != nullptr || count == 0);
-  sliceInit(this,
-            s == nullptr && count == 0
-                ? reinterpret_cast<void *>(align_of<T>())
-                : const_cast<typename std::remove_const<T>::type *>(s),
-            count);
+T *
+Slice<T>::data () const noexcept
+{
+  return reinterpret_cast<T *> (slicePtr (this));
 }
 
 template <typename T>
-T *Slice<T>::data() const noexcept {
-  return reinterpret_cast<T *>(slicePtr(this));
+std::size_t
+Slice<T>::size () const noexcept
+{
+  return sliceLen (this);
 }
 
 template <typename T>
-std::size_t Slice<T>::size() const noexcept {
-  return sliceLen(this);
+std::size_t
+Slice<T>::length () const noexcept
+{
+  return this->size ();
 }
 
 template <typename T>
-std::size_t Slice<T>::length() const noexcept {
-  return this->size();
+bool
+Slice<T>::empty () const noexcept
+{
+  return this->size () == 0;
 }
 
 template <typename T>
-bool Slice<T>::empty() const noexcept {
-  return this->size() == 0;
+T &
+Slice<T>::operator[] (std::size_t n) const noexcept
+{
+  assert (n < this->size ());
+  auto ptr = static_cast<char *> (slicePtr (this)) + size_of<T> () * n;
+  return *reinterpret_cast<T *> (ptr);
 }
 
 template <typename T>
-T &Slice<T>::operator[](std::size_t n) const noexcept {
-  assert(n < this->size());
-  auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
-  return *reinterpret_cast<T *>(ptr);
-}
-
-template <typename T>
-T &Slice<T>::at(std::size_t n) const {
-  if (n >= this->size()) {
-    panic<std::out_of_range>("rust::Slice index out of range");
-  }
+T &
+Slice<T>::at (std::size_t n) const
+{
+  if (n >= this->size ())
+    {
+      panic<std::out_of_range> ("rust::Slice index out of range");
+    }
   return (*this)[n];
 }
 
 template <typename T>
-T &Slice<T>::front() const noexcept {
-  assert(!this->empty());
+T &
+Slice<T>::front () const noexcept
+{
+  assert (!this->empty ());
   return (*this)[0];
 }
 
 template <typename T>
-T &Slice<T>::back() const noexcept {
-  assert(!this->empty());
-  return (*this)[this->size() - 1];
+T &
+Slice<T>::back () const noexcept
+{
+  assert (!this->empty ());
+  return (*this)[this->size () - 1];
 }
 
 template <typename T>
 typename Slice<T>::iterator::reference
-Slice<T>::iterator::operator*() const noexcept {
-  return *static_cast<T *>(this->pos);
+Slice<T>::iterator::operator* () const noexcept
+{
+  return *static_cast<T *> (this->pos);
 }
 
 template <typename T>
 typename Slice<T>::iterator::pointer
-Slice<T>::iterator::operator->() const noexcept {
-  return static_cast<T *>(this->pos);
+Slice<T>::iterator::operator->() const noexcept
+{
+  return static_cast<T *> (this->pos);
 }
 
 template <typename T>
-typename Slice<T>::iterator::reference Slice<T>::iterator::operator[](
-    typename Slice<T>::iterator::difference_type n) const noexcept {
-  auto ptr = static_cast<char *>(this->pos) + this->stride * n;
-  return *reinterpret_cast<T *>(ptr);
+typename Slice<T>::iterator::reference
+Slice<T>::iterator::operator[] (typename Slice<T>::iterator::difference_type n) const noexcept
+{
+  auto ptr = static_cast<char *> (this->pos) + this->stride * n;
+  return *reinterpret_cast<T *> (ptr);
 }
 
 template <typename T>
-typename Slice<T>::iterator &Slice<T>::iterator::operator++() noexcept {
-  this->pos = static_cast<char *>(this->pos) + this->stride;
+typename Slice<T>::iterator &
+Slice<T>::iterator::operator++ () noexcept
+{
+  this->pos = static_cast<char *> (this->pos) + this->stride;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::iterator::operator++(int) noexcept {
-  auto ret = iterator(*this);
-  this->pos = static_cast<char *>(this->pos) + this->stride;
+typename Slice<T>::iterator
+Slice<T>::iterator::operator++ (int) noexcept
+{
+  auto ret = iterator (*this);
+  this->pos = static_cast<char *> (this->pos) + this->stride;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator &Slice<T>::iterator::operator--() noexcept {
-  this->pos = static_cast<char *>(this->pos) - this->stride;
+typename Slice<T>::iterator &
+Slice<T>::iterator::operator-- () noexcept
+{
+  this->pos = static_cast<char *> (this->pos) - this->stride;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::iterator::operator--(int) noexcept {
-  auto ret = iterator(*this);
-  this->pos = static_cast<char *>(this->pos) - this->stride;
+typename Slice<T>::iterator
+Slice<T>::iterator::operator-- (int) noexcept
+{
+  auto ret = iterator (*this);
+  this->pos = static_cast<char *> (this->pos) - this->stride;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator &Slice<T>::iterator::operator+=(
-    typename Slice<T>::iterator::difference_type n) noexcept {
-  this->pos = static_cast<char *>(this->pos) + this->stride * n;
+typename Slice<T>::iterator &
+Slice<T>::iterator::operator+= (typename Slice<T>::iterator::difference_type n) noexcept
+{
+  this->pos = static_cast<char *> (this->pos) + this->stride * n;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator &Slice<T>::iterator::operator-=(
-    typename Slice<T>::iterator::difference_type n) noexcept {
-  this->pos = static_cast<char *>(this->pos) - this->stride * n;
+typename Slice<T>::iterator &
+Slice<T>::iterator::operator-= (typename Slice<T>::iterator::difference_type n) noexcept
+{
+  this->pos = static_cast<char *> (this->pos) - this->stride * n;
   return *this;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::iterator::operator+(
-    typename Slice<T>::iterator::difference_type n) const noexcept {
-  auto ret = iterator(*this);
-  ret.pos = static_cast<char *>(this->pos) + this->stride * n;
+typename Slice<T>::iterator
+Slice<T>::iterator::operator+ (typename Slice<T>::iterator::difference_type n) const noexcept
+{
+  auto ret = iterator (*this);
+  ret.pos = static_cast<char *> (this->pos) + this->stride * n;
   return ret;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::iterator::operator-(
-    typename Slice<T>::iterator::difference_type n) const noexcept {
-  auto ret = iterator(*this);
-  ret.pos = static_cast<char *>(this->pos) - this->stride * n;
+typename Slice<T>::iterator
+Slice<T>::iterator::operator- (typename Slice<T>::iterator::difference_type n) const noexcept
+{
+  auto ret = iterator (*this);
+  ret.pos = static_cast<char *> (this->pos) - this->stride * n;
   return ret;
 }
 
 template <typename T>
 typename Slice<T>::iterator::difference_type
-Slice<T>::iterator::operator-(const iterator &other) const noexcept {
-  auto diff = std::distance(static_cast<char *>(other.pos),
-                            static_cast<char *>(this->pos));
-  return diff / static_cast<typename Slice<T>::iterator::difference_type>(
-                    this->stride);
+Slice<T>::iterator::operator- (const iterator &other) const noexcept
+{
+  auto diff = std::distance (static_cast<char *> (other.pos), static_cast<char *> (this->pos));
+  return diff / static_cast<typename Slice<T>::iterator::difference_type> (this->stride);
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator==(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator== (const iterator &other) const noexcept
+{
   return this->pos == other.pos;
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator!=(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator!= (const iterator &other) const noexcept
+{
   return this->pos != other.pos;
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator<(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator< (const iterator &other) const noexcept
+{
   return this->pos < other.pos;
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator<=(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator<= (const iterator &other) const noexcept
+{
   return this->pos <= other.pos;
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator>(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator> (const iterator &other) const noexcept
+{
   return this->pos > other.pos;
 }
 
 template <typename T>
-bool Slice<T>::iterator::operator>=(const iterator &other) const noexcept {
+bool
+Slice<T>::iterator::operator>= (const iterator &other) const noexcept
+{
   return this->pos >= other.pos;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::begin() const noexcept {
+typename Slice<T>::iterator
+Slice<T>::begin () const noexcept
+{
   iterator it;
-  it.pos = slicePtr(this);
-  it.stride = size_of<T>();
+  it.pos = slicePtr (this);
+  it.stride = size_of<T> ();
   return it;
 }
 
 template <typename T>
-typename Slice<T>::iterator Slice<T>::end() const noexcept {
-  iterator it = this->begin();
-  it.pos = static_cast<char *>(it.pos) + it.stride * this->size();
+typename Slice<T>::iterator
+Slice<T>::end () const noexcept
+{
+  iterator it = this->begin ();
+  it.pos = static_cast<char *> (it.pos) + it.stride * this->size ();
   return it;
 }
 
 template <typename T>
-void Slice<T>::swap(Slice &rhs) noexcept {
-  std::swap(*this, rhs);
+void
+Slice<T>::swap (Slice &rhs) noexcept
+{
+  std::swap (*this, rhs);
 }
 #endif // CXXBRIDGE1_RUST_SLICE
 
 #ifndef CXXBRIDGE1_RUST_BOX
 #define CXXBRIDGE1_RUST_BOX
-template <typename T>
-class Box final {
+template <typename T> class Box final
+{
 public:
   using element_type = T;
-  using const_pointer =
-      typename std::add_pointer<typename std::add_const<T>::type>::type;
+  using const_pointer = typename std::add_pointer<typename std::add_const<T>::type>::type;
   using pointer = typename std::add_pointer<T>::type;
 
-  Box() = delete;
-  Box(Box &&) noexcept;
-  ~Box() noexcept;
+  Box () = delete;
+  Box (Box &&) noexcept;
+  ~Box () noexcept;
 
-  explicit Box(const T &);
-  explicit Box(T &&);
+  explicit Box (const T &);
+  explicit Box (T &&);
 
-  Box &operator=(Box &&) & noexcept;
+  Box &operator= (Box &&) & noexcept;
 
   const T *operator->() const noexcept;
-  const T &operator*() const noexcept;
+  const T &operator* () const noexcept;
   T *operator->() noexcept;
-  T &operator*() noexcept;
+  T &operator* () noexcept;
 
-  template <typename... Fields>
-  static Box in_place(Fields &&...);
+  template <typename... Fields> static Box in_place (Fields &&...);
 
-  void swap(Box &) noexcept;
+  void swap (Box &) noexcept;
 
-  static Box from_raw(T *) noexcept;
+  static Box from_raw (T *) noexcept;
 
-  T *into_raw() noexcept;
+  T *into_raw () noexcept;
 
   /* Deprecated */ using value_type = element_type;
 
 private:
   class uninit;
   class allocation;
-  Box(uninit) noexcept;
-  void drop() noexcept;
+  Box (uninit) noexcept;
+  void drop () noexcept;
 
-  friend void swap(Box &lhs, Box &rhs) noexcept { lhs.swap(rhs); }
+  friend void
+  swap (Box &lhs, Box &rhs) noexcept
+  {
+    lhs.swap (rhs);
+  }
 
   T *ptr;
 };
 
-template <typename T>
-class Box<T>::uninit {};
+template <typename T> class Box<T>::uninit
+{
+};
 
-template <typename T>
-class Box<T>::allocation {
-  static T *alloc() noexcept;
-  static void dealloc(T *) noexcept;
+template <typename T> class Box<T>::allocation
+{
+  static T *alloc () noexcept;
+  static void dealloc (T *) noexcept;
 
 public:
-  allocation() noexcept : ptr(alloc()) {}
-  ~allocation() noexcept {
-    if (this->ptr) {
-      dealloc(this->ptr);
-    }
+  allocation () noexcept : ptr (alloc ()) {}
+  ~allocation () noexcept
+  {
+    if (this->ptr)
+      {
+        dealloc (this->ptr);
+      }
   }
   T *ptr;
 };
 
-template <typename T>
-Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
-  other.ptr = nullptr;
-}
+template <typename T> Box<T>::Box (Box &&other) noexcept : ptr (other.ptr) { other.ptr = nullptr; }
 
-template <typename T>
-Box<T>::Box(const T &val) {
+template <typename T> Box<T>::Box (const T &val)
+{
   allocation alloc;
-  ::new (alloc.ptr) T(val);
+  ::new (alloc.ptr) T (val);
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::Box(T &&val) {
+template <typename T> Box<T>::Box (T &&val)
+{
   allocation alloc;
-  ::new (alloc.ptr) T(std::move(val));
+  ::new (alloc.ptr) T (std::move (val));
   this->ptr = alloc.ptr;
   alloc.ptr = nullptr;
 }
 
-template <typename T>
-Box<T>::~Box() noexcept {
-  if (this->ptr) {
-    this->drop();
-  }
+template <typename T> Box<T>::~Box () noexcept
+{
+  if (this->ptr)
+    {
+      this->drop ();
+    }
 }
 
 template <typename T>
-Box<T> &Box<T>::operator=(Box &&other) & noexcept {
-  if (this->ptr) {
-    this->drop();
-  }
+Box<T> &
+Box<T>::operator= (Box &&other) & noexcept
+{
+  if (this->ptr)
+    {
+      this->drop ();
+    }
   this->ptr = other.ptr;
   other.ptr = nullptr;
   return *this;
 }
 
 template <typename T>
-const T *Box<T>::operator->() const noexcept {
+const T *
+Box<T>::operator->() const noexcept
+{
   return this->ptr;
 }
 
 template <typename T>
-const T &Box<T>::operator*() const noexcept {
+const T &
+Box<T>::operator* () const noexcept
+{
   return *this->ptr;
 }
 
 template <typename T>
-T *Box<T>::operator->() noexcept {
+T *
+Box<T>::operator->() noexcept
+{
   return this->ptr;
 }
 
 template <typename T>
-T &Box<T>::operator*() noexcept {
+T &
+Box<T>::operator* () noexcept
+{
   return *this->ptr;
 }
 
 template <typename T>
 template <typename... Fields>
-Box<T> Box<T>::in_place(Fields &&...fields) {
+Box<T>
+Box<T>::in_place (Fields &&...fields)
+{
   allocation alloc;
   auto ptr = alloc.ptr;
-  ::new (ptr) T{std::forward<Fields>(fields)...};
+  ::new (ptr) T{ std::forward<Fields> (fields)... };
   alloc.ptr = nullptr;
-  return from_raw(ptr);
+  return from_raw (ptr);
 }
 
 template <typename T>
-void Box<T>::swap(Box &rhs) noexcept {
+void
+Box<T>::swap (Box &rhs) noexcept
+{
   using std::swap;
-  swap(this->ptr, rhs.ptr);
+  swap (this->ptr, rhs.ptr);
 }
 
 template <typename T>
-Box<T> Box<T>::from_raw(T *raw) noexcept {
+Box<T>
+Box<T>::from_raw (T *raw) noexcept
+{
   Box box = uninit{};
   box.ptr = raw;
   return box;
 }
 
 template <typename T>
-T *Box<T>::into_raw() noexcept {
+T *
+Box<T>::into_raw () noexcept
+{
   T *raw = this->ptr;
   this->ptr = nullptr;
   return raw;
 }
 
-template <typename T>
-Box<T>::Box(uninit) noexcept {}
+template <typename T> Box<T>::Box (uninit) noexcept {}
 #endif // CXXBRIDGE1_RUST_BOX
 
 #ifndef CXXBRIDGE1_RUST_BITCOPY_T
 #define CXXBRIDGE1_RUST_BITCOPY_T
-struct unsafe_bitcopy_t final {
-  explicit unsafe_bitcopy_t() = default;
+struct unsafe_bitcopy_t final
+{
+  explicit unsafe_bitcopy_t () = default;
 };
 #endif // CXXBRIDGE1_RUST_BITCOPY_T
 
 #ifndef CXXBRIDGE1_RUST_VEC
 #define CXXBRIDGE1_RUST_VEC
-template <typename T>
-class Vec final {
+template <typename T> class Vec final
+{
 public:
   using value_type = T;
 
-  Vec() noexcept;
-  Vec(std::initializer_list<T>);
-  Vec(const Vec &);
-  Vec(Vec &&) noexcept;
-  ~Vec() noexcept;
+  Vec () noexcept;
+  Vec (std::initializer_list<T>);
+  Vec (const Vec &);
+  Vec (Vec &&) noexcept;
+  ~Vec () noexcept;
 
-  Vec &operator=(Vec &&) & noexcept;
-  Vec &operator=(const Vec &) &;
+  Vec &operator= (Vec &&) & noexcept;
+  Vec &operator= (const Vec &) &;
 
-  std::size_t size() const noexcept;
-  bool empty() const noexcept;
-  const T *data() const noexcept;
-  T *data() noexcept;
-  std::size_t capacity() const noexcept;
+  std::size_t size () const noexcept;
+  bool empty () const noexcept;
+  const T *data () const noexcept;
+  T *data () noexcept;
+  std::size_t capacity () const noexcept;
 
-  const T &operator[](std::size_t n) const noexcept;
-  const T &at(std::size_t n) const;
-  const T &front() const noexcept;
-  const T &back() const noexcept;
+  const T &operator[] (std::size_t n) const noexcept;
+  const T &at (std::size_t n) const;
+  const T &front () const noexcept;
+  const T &back () const noexcept;
 
-  T &operator[](std::size_t n) noexcept;
-  T &at(std::size_t n);
-  T &front() noexcept;
-  T &back() noexcept;
+  T &operator[] (std::size_t n) noexcept;
+  T &at (std::size_t n);
+  T &front () noexcept;
+  T &back () noexcept;
 
-  void reserve(std::size_t new_cap);
-  void push_back(const T &value);
-  void push_back(T &&value);
-  template <typename... Args>
-  void emplace_back(Args &&...args);
-  void truncate(std::size_t len);
-  void clear();
+  void reserve (std::size_t new_cap);
+  void push_back (const T &value);
+  void push_back (T &&value);
+  template <typename... Args> void emplace_back (Args &&...args);
+  void truncate (std::size_t len);
+  void clear ();
 
   using iterator = typename Slice<T>::iterator;
-  iterator begin() noexcept;
-  iterator end() noexcept;
+  iterator begin () noexcept;
+  iterator end () noexcept;
 
   using const_iterator = typename Slice<const T>::iterator;
-  const_iterator begin() const noexcept;
-  const_iterator end() const noexcept;
-  const_iterator cbegin() const noexcept;
-  const_iterator cend() const noexcept;
+  const_iterator begin () const noexcept;
+  const_iterator end () const noexcept;
+  const_iterator cbegin () const noexcept;
+  const_iterator cend () const noexcept;
 
-  void swap(Vec &) noexcept;
+  void swap (Vec &) noexcept;
 
-  Vec(unsafe_bitcopy_t, const Vec &) noexcept;
+  Vec (unsafe_bitcopy_t, const Vec &) noexcept;
 
 private:
-  void reserve_total(std::size_t new_cap) noexcept;
-  void set_len(std::size_t len) noexcept;
-  void drop() noexcept;
+  void reserve_total (std::size_t new_cap) noexcept;
+  void set_len (std::size_t len) noexcept;
+  void drop () noexcept;
 
-  friend void swap(Vec &lhs, Vec &rhs) noexcept { lhs.swap(rhs); }
+  friend void
+  swap (Vec &lhs, Vec &rhs) noexcept
+  {
+    lhs.swap (rhs);
+  }
 
   std::array<std::uintptr_t, 3> repr;
 };
 
-template <typename T>
-Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
-  this->reserve_total(init.size());
-  std::move(init.begin(), init.end(), std::back_inserter(*this));
+template <typename T> Vec<T>::Vec (std::initializer_list<T> init) : Vec{}
+{
+  this->reserve_total (init.size ());
+  std::move (init.begin (), init.end (), std::back_inserter (*this));
 }
 
-template <typename T>
-Vec<T>::Vec(const Vec &other) : Vec() {
-  this->reserve_total(other.size());
-  std::copy(other.begin(), other.end(), std::back_inserter(*this));
+template <typename T> Vec<T>::Vec (const Vec &other) : Vec ()
+{
+  this->reserve_total (other.size ());
+  std::copy (other.begin (), other.end (), std::back_inserter (*this));
 }
 
-template <typename T>
-Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
-  new (&other) Vec();
+template <typename T> Vec<T>::Vec (Vec &&other) noexcept : repr (other.repr)
+{
+  new (&other) Vec ();
 }
 
-template <typename T>
-Vec<T>::~Vec() noexcept {
-  this->drop();
-}
+template <typename T> Vec<T>::~Vec () noexcept { this->drop (); }
 
 template <typename T>
-Vec<T> &Vec<T>::operator=(Vec &&other) & noexcept {
-  this->drop();
+Vec<T> &
+Vec<T>::operator= (Vec &&other) & noexcept
+{
+  this->drop ();
   this->repr = other.repr;
-  new (&other) Vec();
+  new (&other) Vec ();
   return *this;
 }
 
 template <typename T>
-Vec<T> &Vec<T>::operator=(const Vec &other) & {
-  if (this != &other) {
-    this->drop();
-    new (this) Vec(other);
-  }
+Vec<T> &
+Vec<T>::operator= (const Vec &other) &
+{
+  if (this != &other)
+    {
+      this->drop ();
+      new (this) Vec (other);
+    }
   return *this;
 }
 
 template <typename T>
-bool Vec<T>::empty() const noexcept {
-  return this->size() == 0;
+bool
+Vec<T>::empty () const noexcept
+{
+  return this->size () == 0;
 }
 
 template <typename T>
-T *Vec<T>::data() noexcept {
-  return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
+T *
+Vec<T>::data () noexcept
+{
+  return const_cast<T *> (const_cast<const Vec<T> *> (this)->data ());
 }
 
 template <typename T>
-const T &Vec<T>::operator[](std::size_t n) const noexcept {
-  assert(n < this->size());
-  auto data = reinterpret_cast<const char *>(this->data());
-  return *reinterpret_cast<const T *>(data + n * size_of<T>());
+const T &
+Vec<T>::operator[] (std::size_t n) const noexcept
+{
+  assert (n < this->size ());
+  auto data = reinterpret_cast<const char *> (this->data ());
+  return *reinterpret_cast<const T *> (data + n * size_of<T> ());
 }
 
 template <typename T>
-const T &Vec<T>::at(std::size_t n) const {
-  if (n >= this->size()) {
-    panic<std::out_of_range>("rust::Vec index out of range");
-  }
+const T &
+Vec<T>::at (std::size_t n) const
+{
+  if (n >= this->size ())
+    {
+      panic<std::out_of_range> ("rust::Vec index out of range");
+    }
   return (*this)[n];
 }
 
 template <typename T>
-const T &Vec<T>::front() const noexcept {
-  assert(!this->empty());
+const T &
+Vec<T>::front () const noexcept
+{
+  assert (!this->empty ());
   return (*this)[0];
 }
 
 template <typename T>
-const T &Vec<T>::back() const noexcept {
-  assert(!this->empty());
-  return (*this)[this->size() - 1];
+const T &
+Vec<T>::back () const noexcept
+{
+  assert (!this->empty ());
+  return (*this)[this->size () - 1];
 }
 
 template <typename T>
-T &Vec<T>::operator[](std::size_t n) noexcept {
-  assert(n < this->size());
-  auto data = reinterpret_cast<char *>(this->data());
-  return *reinterpret_cast<T *>(data + n * size_of<T>());
+T &
+Vec<T>::operator[] (std::size_t n) noexcept
+{
+  assert (n < this->size ());
+  auto data = reinterpret_cast<char *> (this->data ());
+  return *reinterpret_cast<T *> (data + n * size_of<T> ());
 }
 
 template <typename T>
-T &Vec<T>::at(std::size_t n) {
-  if (n >= this->size()) {
-    panic<std::out_of_range>("rust::Vec index out of range");
-  }
+T &
+Vec<T>::at (std::size_t n)
+{
+  if (n >= this->size ())
+    {
+      panic<std::out_of_range> ("rust::Vec index out of range");
+    }
   return (*this)[n];
 }
 
 template <typename T>
-T &Vec<T>::front() noexcept {
-  assert(!this->empty());
+T &
+Vec<T>::front () noexcept
+{
+  assert (!this->empty ());
   return (*this)[0];
 }
 
 template <typename T>
-T &Vec<T>::back() noexcept {
-  assert(!this->empty());
-  return (*this)[this->size() - 1];
+T &
+Vec<T>::back () noexcept
+{
+  assert (!this->empty ());
+  return (*this)[this->size () - 1];
 }
 
 template <typename T>
-void Vec<T>::reserve(std::size_t new_cap) {
-  this->reserve_total(new_cap);
+void
+Vec<T>::reserve (std::size_t new_cap)
+{
+  this->reserve_total (new_cap);
 }
 
 template <typename T>
-void Vec<T>::push_back(const T &value) {
-  this->emplace_back(value);
+void
+Vec<T>::push_back (const T &value)
+{
+  this->emplace_back (value);
 }
 
 template <typename T>
-void Vec<T>::push_back(T &&value) {
-  this->emplace_back(std::move(value));
+void
+Vec<T>::push_back (T &&value)
+{
+  this->emplace_back (std::move (value));
 }
 
 template <typename T>
 template <typename... Args>
-void Vec<T>::emplace_back(Args &&...args) {
-  auto size = this->size();
-  this->reserve_total(size + 1);
-  ::new (reinterpret_cast<T *>(reinterpret_cast<char *>(this->data()) +
-                               size * size_of<T>()))
-      T(std::forward<Args>(args)...);
-  this->set_len(size + 1);
+void
+Vec<T>::emplace_back (Args &&...args)
+{
+  auto size = this->size ();
+  this->reserve_total (size + 1);
+  ::new (reinterpret_cast<T *> (reinterpret_cast<char *> (this->data ()) + size * size_of<T> ()))
+      T (std::forward<Args> (args)...);
+  this->set_len (size + 1);
 }
 
 template <typename T>
-void Vec<T>::clear() {
-  this->truncate(0);
+void
+Vec<T>::clear ()
+{
+  this->truncate (0);
 }
 
 template <typename T>
-typename Vec<T>::iterator Vec<T>::begin() noexcept {
-  return Slice<T>(this->data(), this->size()).begin();
+typename Vec<T>::iterator
+Vec<T>::begin () noexcept
+{
+  return Slice<T> (this->data (), this->size ()).begin ();
 }
 
 template <typename T>
-typename Vec<T>::iterator Vec<T>::end() noexcept {
-  return Slice<T>(this->data(), this->size()).end();
+typename Vec<T>::iterator
+Vec<T>::end () noexcept
+{
+  return Slice<T> (this->data (), this->size ()).end ();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator Vec<T>::begin() const noexcept {
-  return this->cbegin();
+typename Vec<T>::const_iterator
+Vec<T>::begin () const noexcept
+{
+  return this->cbegin ();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator Vec<T>::end() const noexcept {
-  return this->cend();
+typename Vec<T>::const_iterator
+Vec<T>::end () const noexcept
+{
+  return this->cend ();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator Vec<T>::cbegin() const noexcept {
-  return Slice<const T>(this->data(), this->size()).begin();
+typename Vec<T>::const_iterator
+Vec<T>::cbegin () const noexcept
+{
+  return Slice<const T> (this->data (), this->size ()).begin ();
 }
 
 template <typename T>
-typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
-  return Slice<const T>(this->data(), this->size()).end();
+typename Vec<T>::const_iterator
+Vec<T>::cend () const noexcept
+{
+  return Slice<const T> (this->data (), this->size ()).end ();
 }
 
 template <typename T>
-void Vec<T>::swap(Vec &rhs) noexcept {
+void
+Vec<T>::swap (Vec &rhs) noexcept
+{
   using std::swap;
-  swap(this->repr, rhs.repr);
+  swap (this->repr, rhs.repr);
 }
 
-template <typename T>
-Vec<T>::Vec(unsafe_bitcopy_t, const Vec &bits) noexcept : repr(bits.repr) {}
+template <typename T> Vec<T>::Vec (unsafe_bitcopy_t, const Vec &bits) noexcept : repr (bits.repr) {}
 #endif // CXXBRIDGE1_RUST_VEC
 
 #ifndef CXXBRIDGE1_RUST_OPAQUE
 #define CXXBRIDGE1_RUST_OPAQUE
-class Opaque {
+class Opaque
+{
 public:
-  Opaque() = delete;
-  Opaque(const Opaque &) = delete;
-  ~Opaque() = delete;
+  Opaque () = delete;
+  Opaque (const Opaque &) = delete;
+  ~Opaque () = delete;
 };
 #endif // CXXBRIDGE1_RUST_OPAQUE
 
 #ifndef CXXBRIDGE1_IS_COMPLETE
 #define CXXBRIDGE1_IS_COMPLETE
-namespace detail {
-namespace {
-template <typename T, typename = std::size_t>
-struct is_complete : std::false_type {};
-template <typename T>
-struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
+namespace detail
+{
+namespace
+{
+template <typename T, typename = std::size_t> struct is_complete : std::false_type
+{
+};
+template <typename T> struct is_complete<T, decltype (sizeof (T))> : std::true_type
+{
+};
 } // namespace
 } // namespace detail
 #endif // CXXBRIDGE1_IS_COMPLETE
 
 #ifndef CXXBRIDGE1_LAYOUT
 #define CXXBRIDGE1_LAYOUT
-class layout {
+class layout
+{
+  template <typename T> friend std::size_t size_of ();
+  template <typename T> friend std::size_t align_of ();
   template <typename T>
-  friend std::size_t size_of();
-  template <typename T>
-  friend std::size_t align_of();
-  template <typename T>
-  static typename std::enable_if<std::is_base_of<Opaque, T>::value,
-                                 std::size_t>::type
-  do_size_of() {
-    return T::layout::size();
+  static typename std::enable_if<std::is_base_of<Opaque, T>::value, std::size_t>::type
+  do_size_of ()
+  {
+    return T::layout::size ();
   }
   template <typename T>
-  static typename std::enable_if<!std::is_base_of<Opaque, T>::value,
-                                 std::size_t>::type
-  do_size_of() {
-    return sizeof(T);
+  static typename std::enable_if<!std::is_base_of<Opaque, T>::value, std::size_t>::type
+  do_size_of ()
+  {
+    return sizeof (T);
   }
   template <typename T>
-  static
-      typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
-      size_of() {
-    return do_size_of<T>();
+  static typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
+  size_of ()
+  {
+    return do_size_of<T> ();
   }
   template <typename T>
-  static typename std::enable_if<std::is_base_of<Opaque, T>::value,
-                                 std::size_t>::type
-  do_align_of() {
-    return T::layout::align();
+  static typename std::enable_if<std::is_base_of<Opaque, T>::value, std::size_t>::type
+  do_align_of ()
+  {
+    return T::layout::align ();
   }
   template <typename T>
-  static typename std::enable_if<!std::is_base_of<Opaque, T>::value,
-                                 std::size_t>::type
-  do_align_of() {
-    return alignof(T);
+  static typename std::enable_if<!std::is_base_of<Opaque, T>::value, std::size_t>::type
+  do_align_of ()
+  {
+    return alignof (T);
   }
   template <typename T>
-  static
-      typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
-      align_of() {
-    return do_align_of<T>();
+  static typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
+  align_of ()
+  {
+    return do_align_of<T> ();
   }
 };
 
 template <typename T>
-std::size_t size_of() {
-  return layout::size_of<T>();
+std::size_t
+size_of ()
+{
+  return layout::size_of<T> ();
 }
 
 template <typename T>
-std::size_t align_of() {
-  return layout::align_of<T>();
+std::size_t
+align_of ()
+{
+  return layout::align_of<T> ();
 }
 #endif // CXXBRIDGE1_LAYOUT
 } // namespace cxxbridge1
@@ -978,51 +1111,53 @@ std::size_t align_of() {
 #define CXX_DEFAULT_VALUE(value)
 #endif
 
-namespace rpmostreecxx {
-  struct StringMapping;
-  enum class SystemHostType : ::std::uint8_t;
-  enum class BubblewrapMutability : ::std::uint8_t;
-  struct Bubblewrap;
-  struct ContainerImageState;
-  struct ExportedManifestDiff;
-  struct PrunedContainerInfo;
-  enum class RefspecType : ::std::uint8_t;
-  struct TempEtcGuard;
-  struct FilesystemScriptPrep;
-  struct DeploymentLayeredMeta;
-  struct OverrideReplacementSource;
-  enum class ParsedRevisionKind : ::std::uint8_t;
-  struct ParsedRevision;
-  struct RpmImporterFlags;
-  struct RpmImporter;
-  struct HistoryEntry;
-  struct HistoryCtx;
-  struct TokioHandle;
-  struct TokioEnterGuard;
-  enum class RepoMetadataTarget : ::std::uint8_t;
-  enum class AdvisoriesMetadataTarget : ::std::uint8_t;
-  struct Refspec;
-  enum class OverrideReplacementType : ::std::uint8_t;
-  struct OverrideReplacement;
-  enum class OptUsrLocal : ::std::uint8_t;
-  struct Treefile;
-  struct RepoPackage;
-  struct LiveApplyState;
-  struct PasswdDB;
-  struct PasswdEntries;
-  struct Extensions;
-  struct LockedPackage;
-  struct LockfileConfig;
-  using CxxGObjectArray = ::rpmostreecxx::CxxGObjectArray;
-  using ClientConnection = ::rpmostreecxx::ClientConnection;
-  using RPMDiff = ::rpmostreecxx::RPMDiff;
-  using RpmOstreeDiffPrintFormat = ::rpmostreecxx::RpmOstreeDiffPrintFormat;
-  using Progress = ::rpmostreecxx::Progress;
-  using RpmTs = ::rpmostreecxx::RpmTs;
-  using PackageMeta = ::rpmostreecxx::PackageMeta;
+namespace rpmostreecxx
+{
+struct StringMapping;
+enum class SystemHostType : ::std::uint8_t;
+enum class BubblewrapMutability : ::std::uint8_t;
+struct Bubblewrap;
+struct ContainerImageState;
+struct ExportedManifestDiff;
+struct PrunedContainerInfo;
+enum class RefspecType : ::std::uint8_t;
+struct TempEtcGuard;
+struct FilesystemScriptPrep;
+struct DeploymentLayeredMeta;
+struct OverrideReplacementSource;
+enum class ParsedRevisionKind : ::std::uint8_t;
+struct ParsedRevision;
+struct RpmImporterFlags;
+struct RpmImporter;
+struct HistoryEntry;
+struct HistoryCtx;
+struct TokioHandle;
+struct TokioEnterGuard;
+enum class RepoMetadataTarget : ::std::uint8_t;
+enum class AdvisoriesMetadataTarget : ::std::uint8_t;
+struct Refspec;
+enum class OverrideReplacementType : ::std::uint8_t;
+struct OverrideReplacement;
+enum class OptUsrLocal : ::std::uint8_t;
+struct Treefile;
+struct RepoPackage;
+struct LiveApplyState;
+struct PasswdDB;
+struct PasswdEntries;
+struct Extensions;
+struct LockedPackage;
+struct LockfileConfig;
+using CxxGObjectArray = ::rpmostreecxx::CxxGObjectArray;
+using ClientConnection = ::rpmostreecxx::ClientConnection;
+using RPMDiff = ::rpmostreecxx::RPMDiff;
+using RpmOstreeDiffPrintFormat = ::rpmostreecxx::RpmOstreeDiffPrintFormat;
+using Progress = ::rpmostreecxx::Progress;
+using RpmTs = ::rpmostreecxx::RpmTs;
+using PackageMeta = ::rpmostreecxx::PackageMeta;
 }
 
-namespace rpmostreecxx {
+namespace rpmostreecxx
+{
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$StringMapping
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$StringMapping
 // Currently cxx-rs doesn't support mappings; like probably most projects,
@@ -1030,7 +1165,8 @@ namespace rpmostreecxx {
 // our data sizes aren't large, we serialize this as a vector of strings pairs.
 // In the future it's also likely that cxx-rs will support a C++ string_view
 // so we could avoid duplicating in that direction.
-struct StringMapping final {
+struct StringMapping final
+{
   ::rust::String k;
   ::rust::String v;
 
@@ -1041,7 +1177,8 @@ struct StringMapping final {
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$SystemHostType
 #define CXXBRIDGE1_ENUM_rpmostreecxx$SystemHostType
 // Classify the running system.
-enum class SystemHostType : ::std::uint8_t {
+enum class SystemHostType : ::std::uint8_t
+{
   OstreeContainer = 0,
   OstreeHost = 1,
   Unknown = 2,
@@ -1050,7 +1187,8 @@ enum class SystemHostType : ::std::uint8_t {
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$BubblewrapMutability
 #define CXXBRIDGE1_ENUM_rpmostreecxx$BubblewrapMutability
-enum class BubblewrapMutability : ::std::uint8_t {
+enum class BubblewrapMutability : ::std::uint8_t
+{
   Immutable = 0,
   RoFiles = 1,
   MutateFreely = 2,
@@ -1059,49 +1197,52 @@ enum class BubblewrapMutability : ::std::uint8_t {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Bubblewrap
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Bubblewrap
-struct Bubblewrap final : public ::rust::Opaque {
-  ::std::int32_t get_rootfs_fd() const noexcept;
-  void append_bwrap_arg(::rust::Str arg) noexcept;
-  void append_child_arg(::rust::Str arg) noexcept;
-  void setenv(::rust::Str k, ::rust::Str v) noexcept;
-  void take_fd(::std::int32_t source_fd, ::std::int32_t target_fd) noexcept;
-  void set_inherit_stdin() noexcept;
-  void take_stdin_fd(::std::int32_t source_fd) noexcept;
-  void take_stdout_fd(::std::int32_t source_fd) noexcept;
-  void take_stderr_fd(::std::int32_t source_fd) noexcept;
-  void take_stdout_and_stderr_fd(::std::int32_t source_fd) noexcept;
-  void bind_read(::rust::Str src, ::rust::Str dest) noexcept;
-  void bind_readwrite(::rust::Str src, ::rust::Str dest) noexcept;
-  void setup_compat_var();
-  void run(::rpmostreecxx::GCancellable const &cancellable);
-  ~Bubblewrap() = delete;
+struct Bubblewrap final : public ::rust::Opaque
+{
+  ::std::int32_t get_rootfs_fd () const noexcept;
+  void append_bwrap_arg (::rust::Str arg) noexcept;
+  void append_child_arg (::rust::Str arg) noexcept;
+  void setenv (::rust::Str k, ::rust::Str v) noexcept;
+  void take_fd (::std::int32_t source_fd, ::std::int32_t target_fd) noexcept;
+  void set_inherit_stdin () noexcept;
+  void take_stdin_fd (::std::int32_t source_fd) noexcept;
+  void take_stdout_fd (::std::int32_t source_fd) noexcept;
+  void take_stderr_fd (::std::int32_t source_fd) noexcept;
+  void take_stdout_and_stderr_fd (::std::int32_t source_fd) noexcept;
+  void bind_read (::rust::Str src, ::rust::Str dest) noexcept;
+  void bind_readwrite (::rust::Str src, ::rust::Str dest) noexcept;
+  void setup_compat_var ();
+  void run (::rpmostreecxx::GCancellable const &cancellable);
+  ~Bubblewrap () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$Bubblewrap
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$ExportedManifestDiff
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$ExportedManifestDiff
-struct ExportedManifestDiff final {
+struct ExportedManifestDiff final
+{
   // Check if the struct is initialized
-  bool initialized CXX_DEFAULT_VALUE(false);
+  bool initialized CXX_DEFAULT_VALUE (false);
   // The total number of packages in the next upgrade
-  ::std::uint64_t total CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t total CXX_DEFAULT_VALUE (0);
   // The size of the total number of packages in the next upgrade
-  ::std::uint64_t total_size CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t total_size CXX_DEFAULT_VALUE (0);
   // The total number of removed packages in the next upgrade
-  ::std::uint64_t n_removed CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t n_removed CXX_DEFAULT_VALUE (0);
   // The size of total number of removed packages in the next upgrade
-  ::std::uint64_t removed_size CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t removed_size CXX_DEFAULT_VALUE (0);
   // The total number of added packages in the next upgrade
-  ::std::uint64_t n_added CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t n_added CXX_DEFAULT_VALUE (0);
   // The size of total number of added packages in the next upgrade
-  ::std::uint64_t added_size CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t added_size CXX_DEFAULT_VALUE (0);
   // The version of the next upgrade
   ::rust::String version;
 
@@ -1111,10 +1252,11 @@ struct ExportedManifestDiff final {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$ContainerImageState
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$ContainerImageState
-// `ContainerImageState` is currently identical to ostree-rs-ext's `LayeredImageState` struct, because
-// cxx.rs currently requires types used as extern Rust types to be defined by the same crate
+// `ContainerImageState` is currently identical to ostree-rs-ext's `LayeredImageState` struct,
+// because cxx.rs currently requires types used as extern Rust types to be defined by the same crate
 // that contains the bridge using them, so we redefine an `ContainerImport` struct here.
-struct ContainerImageState final {
+struct ContainerImageState final
+{
   ::rust::String base_commit;
   ::rust::String merge_commit;
   ::rust::String image_digest;
@@ -1128,19 +1270,21 @@ struct ContainerImageState final {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$PrunedContainerInfo
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$PrunedContainerInfo
-struct PrunedContainerInfo final {
-  ::std::uint32_t images CXX_DEFAULT_VALUE(0);
-  ::std::uint32_t layers CXX_DEFAULT_VALUE(0);
+struct PrunedContainerInfo final
+{
+  ::std::uint32_t images CXX_DEFAULT_VALUE (0);
+  ::std::uint32_t layers CXX_DEFAULT_VALUE (0);
 
-  bool operator==(PrunedContainerInfo const &) const noexcept;
-  bool operator!=(PrunedContainerInfo const &) const noexcept;
+  bool operator== (PrunedContainerInfo const &) const noexcept;
+  bool operator!= (PrunedContainerInfo const &) const noexcept;
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$PrunedContainerInfo
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$RefspecType
 #define CXXBRIDGE1_ENUM_rpmostreecxx$RefspecType
-enum class RefspecType : ::std::uint8_t {
+enum class RefspecType : ::std::uint8_t
+{
   Ostree = 0,
   Checksum = 1,
   Container = 2,
@@ -1149,40 +1293,45 @@ enum class RefspecType : ::std::uint8_t {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$TempEtcGuard
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$TempEtcGuard
-struct TempEtcGuard final : public ::rust::Opaque {
-  void undo() const;
-  ~TempEtcGuard() = delete;
+struct TempEtcGuard final : public ::rust::Opaque
+{
+  void undo () const;
+  ~TempEtcGuard () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$TempEtcGuard
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$FilesystemScriptPrep
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$FilesystemScriptPrep
-struct FilesystemScriptPrep final : public ::rust::Opaque {
-  void undo();
-  ~FilesystemScriptPrep() = delete;
+struct FilesystemScriptPrep final : public ::rust::Opaque
+{
+  void undo ();
+  ~FilesystemScriptPrep () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$FilesystemScriptPrep
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$DeploymentLayeredMeta
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$DeploymentLayeredMeta
-struct DeploymentLayeredMeta final {
-  bool is_layered CXX_DEFAULT_VALUE(false);
+struct DeploymentLayeredMeta final
+{
+  bool is_layered CXX_DEFAULT_VALUE (false);
   ::rust::String base_commit;
-  ::std::uint32_t clientlayer_version CXX_DEFAULT_VALUE(0);
+  ::std::uint32_t clientlayer_version CXX_DEFAULT_VALUE (0);
 
   using IsRelocatable = ::std::true_type;
 };
@@ -1190,7 +1339,8 @@ struct DeploymentLayeredMeta final {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacementSource
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacementSource
-struct OverrideReplacementSource final {
+struct OverrideReplacementSource final
+{
   ::rpmostreecxx::OverrideReplacementType kind;
   ::rust::String name;
 
@@ -1200,7 +1350,8 @@ struct OverrideReplacementSource final {
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$ParsedRevisionKind
 #define CXXBRIDGE1_ENUM_rpmostreecxx$ParsedRevisionKind
-enum class ParsedRevisionKind : ::std::uint8_t {
+enum class ParsedRevisionKind : ::std::uint8_t
+{
   Version = 0,
   Checksum = 1,
 };
@@ -1208,7 +1359,8 @@ enum class ParsedRevisionKind : ::std::uint8_t {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$ParsedRevision
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$ParsedRevision
-struct ParsedRevision final {
+struct ParsedRevision final
+{
   ::rpmostreecxx::ParsedRevisionKind kind;
   ::rust::String value;
 
@@ -1218,44 +1370,50 @@ struct ParsedRevision final {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporterFlags
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporterFlags
-struct RpmImporterFlags final : public ::rust::Opaque {
-  bool is_ima_enabled() const noexcept;
-  ~RpmImporterFlags() = delete;
+struct RpmImporterFlags final : public ::rust::Opaque
+{
+  bool is_ima_enabled () const noexcept;
+  ~RpmImporterFlags () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporterFlags
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporter
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporter
-struct RpmImporter final : public ::rust::Opaque {
-  ::rust::String handle_translate_pathname(::rust::Str path) noexcept;
-  ::rust::String ostree_branch() const noexcept;
-  ::rust::String pkg_name() const noexcept;
-  bool doc_files_are_filtered() const noexcept;
-  void doc_files_insert(::rust::Str path) noexcept;
-  bool doc_files_contains(::rust::Str path) const noexcept;
-  void rpmfi_overrides_insert(::rust::Str path, ::std::uint64_t index) noexcept;
-  bool rpmfi_overrides_contains(::rust::Str path) const noexcept;
-  ::std::uint64_t rpmfi_overrides_get(::rust::Str path) const noexcept;
-  bool is_ima_enabled() const noexcept;
-  void tweak_imported_file_info(::rpmostreecxx::GFileInfo const &file_info) const noexcept;
-  bool is_file_filtered(::rust::Str path, ::rpmostreecxx::GFileInfo const &file_info) const;
-  void translate_to_tmpfiles_entry(::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username, ::rust::Str groupname);
-  bool has_tmpfiles_entries() const noexcept;
-  ::rust::String serialize_tmpfiles_content() const noexcept;
-  ~RpmImporter() = delete;
+struct RpmImporter final : public ::rust::Opaque
+{
+  ::rust::String handle_translate_pathname (::rust::Str path) noexcept;
+  ::rust::String ostree_branch () const noexcept;
+  ::rust::String pkg_name () const noexcept;
+  bool doc_files_are_filtered () const noexcept;
+  void doc_files_insert (::rust::Str path) noexcept;
+  bool doc_files_contains (::rust::Str path) const noexcept;
+  void rpmfi_overrides_insert (::rust::Str path, ::std::uint64_t index) noexcept;
+  bool rpmfi_overrides_contains (::rust::Str path) const noexcept;
+  ::std::uint64_t rpmfi_overrides_get (::rust::Str path) const noexcept;
+  bool is_ima_enabled () const noexcept;
+  void tweak_imported_file_info (::rpmostreecxx::GFileInfo const &file_info) const noexcept;
+  bool is_file_filtered (::rust::Str path, ::rpmostreecxx::GFileInfo const &file_info) const;
+  void translate_to_tmpfiles_entry (::rust::Str abs_path,
+                                    ::rpmostreecxx::GFileInfo const &file_info,
+                                    ::rust::Str username, ::rust::Str groupname);
+  bool has_tmpfiles_entries () const noexcept;
+  ::rust::String serialize_tmpfiles_content () const noexcept;
+  ~RpmImporter () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$RpmImporter
@@ -1264,73 +1422,81 @@ private:
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryEntry
 // A history entry in the journal. It may represent multiple consecutive boots
 // into the same deployment. This struct is exposed directly via FFI to C.
-struct HistoryEntry final {
+struct HistoryEntry final
+{
   // The deployment root timestamp.
-  ::std::uint64_t deploy_timestamp CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t deploy_timestamp CXX_DEFAULT_VALUE (0);
   // The command-line that was used to create the deployment, if any.
   ::rust::String deploy_cmdline;
   // The number of consecutive times the deployment was booted.
-  ::std::uint64_t boot_count CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t boot_count CXX_DEFAULT_VALUE (0);
   // The first time the deployment was booted if multiple consecutive times.
-  ::std::uint64_t first_boot_timestamp CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t first_boot_timestamp CXX_DEFAULT_VALUE (0);
   // The last time the deployment was booted if multiple consecutive times.
-  ::std::uint64_t last_boot_timestamp CXX_DEFAULT_VALUE(0);
+  ::std::uint64_t last_boot_timestamp CXX_DEFAULT_VALUE (0);
   // `true` if there are no more entries.
-  bool eof CXX_DEFAULT_VALUE(false);
+  bool eof CXX_DEFAULT_VALUE (false);
 
-  bool operator==(HistoryEntry const &) const noexcept;
-  bool operator!=(HistoryEntry const &) const noexcept;
+  bool operator== (HistoryEntry const &) const noexcept;
+  bool operator!= (HistoryEntry const &) const noexcept;
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryEntry
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryCtx
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryCtx
-struct HistoryCtx final : public ::rust::Opaque {
-  ::rpmostreecxx::HistoryEntry next_entry();
-  ~HistoryCtx() = delete;
+struct HistoryCtx final : public ::rust::Opaque
+{
+  ::rpmostreecxx::HistoryEntry next_entry ();
+  ~HistoryCtx () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$HistoryCtx
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$TokioHandle
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$TokioHandle
-struct TokioHandle final : public ::rust::Opaque {
-  ::rust::Box<::rpmostreecxx::TokioEnterGuard> enter() const noexcept;
-  ~TokioHandle() = delete;
+struct TokioHandle final : public ::rust::Opaque
+{
+  ::rust::Box<::rpmostreecxx::TokioEnterGuard> enter () const noexcept;
+  ~TokioHandle () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$TokioHandle
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$TokioEnterGuard
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$TokioEnterGuard
-struct TokioEnterGuard final : public ::rust::Opaque {
-  ~TokioEnterGuard() = delete;
+struct TokioEnterGuard final : public ::rust::Opaque
+{
+  ~TokioEnterGuard () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$TokioEnterGuard
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$RepoMetadataTarget
 #define CXXBRIDGE1_ENUM_rpmostreecxx$RepoMetadataTarget
-enum class RepoMetadataTarget : ::std::uint8_t {
+enum class RepoMetadataTarget : ::std::uint8_t
+{
   Inline = 0,
   Detached = 1,
   Disabled = 2,
@@ -1339,7 +1505,8 @@ enum class RepoMetadataTarget : ::std::uint8_t {
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$AdvisoriesMetadataTarget
 #define CXXBRIDGE1_ENUM_rpmostreecxx$AdvisoriesMetadataTarget
-enum class AdvisoriesMetadataTarget : ::std::uint8_t {
+enum class AdvisoriesMetadataTarget : ::std::uint8_t
+{
   Inline = 0,
   Detached = 1,
   Disabled = 2,
@@ -1348,39 +1515,43 @@ enum class AdvisoriesMetadataTarget : ::std::uint8_t {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Refspec
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Refspec
-struct Refspec final {
+struct Refspec final
+{
   ::rpmostreecxx::RefspecType kind;
   ::rust::String refspec;
 
-  bool operator==(Refspec const &) const noexcept;
-  bool operator!=(Refspec const &) const noexcept;
+  bool operator== (Refspec const &) const noexcept;
+  bool operator!= (Refspec const &) const noexcept;
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$Refspec
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$OverrideReplacementType
 #define CXXBRIDGE1_ENUM_rpmostreecxx$OverrideReplacementType
-enum class OverrideReplacementType : ::std::uint8_t {
+enum class OverrideReplacementType : ::std::uint8_t
+{
   Repo = 0,
 };
 #endif // CXXBRIDGE1_ENUM_rpmostreecxx$OverrideReplacementType
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacement
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacement
-struct OverrideReplacement final {
+struct OverrideReplacement final
+{
   ::rust::String from;
   ::rpmostreecxx::OverrideReplacementType from_kind;
   ::rust::Vec<::rust::String> packages;
 
-  bool operator==(OverrideReplacement const &) const noexcept;
-  bool operator!=(OverrideReplacement const &) const noexcept;
+  bool operator== (OverrideReplacement const &) const noexcept;
+  bool operator!= (OverrideReplacement const &) const noexcept;
   using IsRelocatable = ::std::true_type;
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$OverrideReplacement
 
 #ifndef CXXBRIDGE1_ENUM_rpmostreecxx$OptUsrLocal
 #define CXXBRIDGE1_ENUM_rpmostreecxx$OptUsrLocal
-enum class OptUsrLocal : ::std::uint8_t {
+enum class OptUsrLocal : ::std::uint8_t
+{
   Var = 0,
   Root = 1,
   StateOverlay = 2,
@@ -1389,125 +1560,131 @@ enum class OptUsrLocal : ::std::uint8_t {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Treefile
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Treefile
-struct Treefile final : public ::rust::Opaque {
-  ::rust::Str get_workdir() const noexcept;
-  ::std::int32_t get_passwd_fd() noexcept;
-  ::std::int32_t get_group_fd() noexcept;
-  ::rust::String get_json_string() const noexcept;
-  ::rust::Vec<::rust::String> get_ostree_layers() const noexcept;
-  ::rust::Vec<::rust::String> get_ostree_override_layers() const noexcept;
-  ::rust::Vec<::rust::String> get_all_ostree_layers() const noexcept;
-  ::rust::Vec<::rust::String> get_repos() const noexcept;
-  ::rust::Vec<::rust::String> get_packages() const noexcept;
-  ::rust::String require_automatic_version_prefix() const;
-  bool add_packages(::rust::Vec<::rust::String> packages, bool allow_existing);
-  bool has_packages() const noexcept;
-  ::rust::Vec<::rust::String> get_local_packages() const noexcept;
-  bool add_local_packages(::rust::Vec<::rust::String> packages, bool allow_existing);
-  ::rust::Vec<::rust::String> get_local_fileoverride_packages() const noexcept;
-  bool add_local_fileoverride_packages(::rust::Vec<::rust::String> packages, bool allow_existing);
-  bool remove_packages(::rust::Vec<::rust::String> packages, bool allow_noent);
-  ::rust::Vec<::rpmostreecxx::OverrideReplacement> get_packages_override_replace() const noexcept;
-  bool has_packages_override_replace() const noexcept;
-  bool add_packages_override_replace(::rpmostreecxx::OverrideReplacement replacement) noexcept;
-  bool remove_package_override_replace(::rust::Str package) noexcept;
-  ::rust::Vec<::rust::String> get_packages_override_replace_local() const noexcept;
-  void add_packages_override_replace_local(::rust::Vec<::rust::String> packages);
-  bool remove_package_override_replace_local(::rust::Str package) noexcept;
-  ::rust::Vec<::rust::String> get_packages_override_remove() const noexcept;
-  void add_packages_override_remove(::rust::Vec<::rust::String> packages);
-  bool remove_package_override_remove(::rust::Str package) noexcept;
-  bool has_packages_override_remove_name(::rust::Str name) const noexcept;
-  bool remove_all_overrides() noexcept;
-  bool remove_all_packages() noexcept;
-  ::rust::Vec<::rust::String> get_exclude_packages() const noexcept;
-  ::rust::String get_platform_module() const noexcept;
-  ::rust::Vec<::rust::String> get_install_langs() const noexcept;
-  ::rust::String format_install_langs_macro() const noexcept;
-  ::rust::Vec<::rust::String> get_lockfile_repos() const noexcept;
-  ::rust::Str get_ref() const noexcept;
-  bool get_cliwrap() const noexcept;
-  ::rust::Vec<::rust::String> get_cliwrap_binaries() const noexcept;
-  void set_cliwrap(bool enabled) noexcept;
-  ::rust::Vec<::rust::String> get_container_cmd() const noexcept;
-  bool get_readonly_executables() const noexcept;
-  bool get_documentation() const noexcept;
-  bool get_recommends() const noexcept;
-  bool get_selinux() const noexcept;
-  bool get_sysusers_is_forced() const noexcept;
-  ::std::uint32_t get_selinux_label_version() const noexcept;
-  ::rust::String get_gpg_key() const noexcept;
-  ::rust::String get_automatic_version_suffix() const noexcept;
-  bool get_container() const noexcept;
-  bool get_machineid_compat() const noexcept;
-  ::rust::Vec<::rust::String> get_etc_group_members() const noexcept;
-  bool get_boot_location_is_modules() const noexcept;
-  bool use_kernel_install() const noexcept;
-  bool get_ima() const noexcept;
-  ::rust::String get_releasever() const noexcept;
-  ::rpmostreecxx::RepoMetadataTarget get_repo_metadata_target() const noexcept;
-  ::rpmostreecxx::AdvisoriesMetadataTarget get_advisories_metadata_target() const noexcept;
-  bool rpmdb_backend_is_target() const noexcept;
-  bool should_normalize_rpmdb() const noexcept;
-  ::rpmostreecxx::OptUsrLocal get_opt_usrlocal() const noexcept;
-  ::rust::Vec<::rust::String> get_files_remove_regex(::rust::Str package) const noexcept;
-  ::rust::String get_checksum(::rpmostreecxx::OstreeRepo const &repo) const;
-  ::rust::String get_ostree_ref() const noexcept;
-  ::rust::Slice<::rpmostreecxx::RepoPackage const> get_repo_packages() const noexcept;
-  void clear_repo_packages() noexcept;
-  void prettyprint_json_stdout() const noexcept;
-  void print_deprecation_warnings() const noexcept;
-  void print_experimental_notices() const noexcept;
-  void sanitycheck_externals() const;
-  ::rust::Box<::rpmostreecxx::RpmImporterFlags> importer_flags(::rust::Str pkg_name) const noexcept;
-  ::rust::String write_repovars(::std::int32_t workdir_dfd_raw) const;
-  void set_releasever(::rust::Str releasever);
-  void set_recommends(bool val);
-  void enable_repo(::rust::Str repo);
-  void disable_repo(::rust::Str repo);
-  void validate_for_container() const;
-  ::rpmostreecxx::Refspec get_base_refspec() const noexcept;
-  void rebase(::rust::Str new_refspec, ::rust::Str custom_origin_url, ::rust::Str custom_origin_description) noexcept;
-  ::rust::String get_origin_custom_url() const noexcept;
-  ::rust::String get_origin_custom_description() const noexcept;
-  ::rust::String get_override_commit() const noexcept;
-  void set_override_commit(::rust::Str checksum) noexcept;
-  ::rust::Vec<::rust::String> get_initramfs_etc_files() const noexcept;
-  bool has_initramfs_etc_files() const noexcept;
-  bool initramfs_etc_files_track(::rust::Vec<::rust::String> files) noexcept;
-  bool initramfs_etc_files_untrack(::rust::Vec<::rust::String> files) noexcept;
-  bool initramfs_etc_files_untrack_all() noexcept;
-  bool get_initramfs_regenerate() const noexcept;
-  ::rust::Vec<::rust::String> get_initramfs_args() const noexcept;
-  void set_initramfs_regenerate(bool enabled, ::rust::Vec<::rust::String> args) noexcept;
-  ::rust::String get_unconfigured_state() const noexcept;
-  bool may_require_local_assembly() const noexcept;
-  bool has_any_packages() const noexcept;
-  bool merge_treefile(::rust::Str treefile);
-  bool get_no_initramfs() const noexcept;
-  ~Treefile() = delete;
+struct Treefile final : public ::rust::Opaque
+{
+  ::rust::Str get_workdir () const noexcept;
+  ::std::int32_t get_passwd_fd () noexcept;
+  ::std::int32_t get_group_fd () noexcept;
+  ::rust::String get_json_string () const noexcept;
+  ::rust::Vec<::rust::String> get_ostree_layers () const noexcept;
+  ::rust::Vec<::rust::String> get_ostree_override_layers () const noexcept;
+  ::rust::Vec<::rust::String> get_all_ostree_layers () const noexcept;
+  ::rust::Vec<::rust::String> get_repos () const noexcept;
+  ::rust::Vec<::rust::String> get_packages () const noexcept;
+  ::rust::String require_automatic_version_prefix () const;
+  bool add_packages (::rust::Vec<::rust::String> packages, bool allow_existing);
+  bool has_packages () const noexcept;
+  ::rust::Vec<::rust::String> get_local_packages () const noexcept;
+  bool add_local_packages (::rust::Vec<::rust::String> packages, bool allow_existing);
+  ::rust::Vec<::rust::String> get_local_fileoverride_packages () const noexcept;
+  bool add_local_fileoverride_packages (::rust::Vec<::rust::String> packages, bool allow_existing);
+  bool remove_packages (::rust::Vec<::rust::String> packages, bool allow_noent);
+  ::rust::Vec<::rpmostreecxx::OverrideReplacement> get_packages_override_replace () const noexcept;
+  bool has_packages_override_replace () const noexcept;
+  bool add_packages_override_replace (::rpmostreecxx::OverrideReplacement replacement) noexcept;
+  bool remove_package_override_replace (::rust::Str package) noexcept;
+  ::rust::Vec<::rust::String> get_packages_override_replace_local () const noexcept;
+  void add_packages_override_replace_local (::rust::Vec<::rust::String> packages);
+  bool remove_package_override_replace_local (::rust::Str package) noexcept;
+  ::rust::Vec<::rust::String> get_packages_override_remove () const noexcept;
+  void add_packages_override_remove (::rust::Vec<::rust::String> packages);
+  bool remove_package_override_remove (::rust::Str package) noexcept;
+  bool has_packages_override_remove_name (::rust::Str name) const noexcept;
+  bool remove_all_overrides () noexcept;
+  bool remove_all_packages () noexcept;
+  ::rust::Vec<::rust::String> get_exclude_packages () const noexcept;
+  ::rust::String get_platform_module () const noexcept;
+  ::rust::Vec<::rust::String> get_install_langs () const noexcept;
+  ::rust::String format_install_langs_macro () const noexcept;
+  ::rust::Vec<::rust::String> get_lockfile_repos () const noexcept;
+  ::rust::Str get_ref () const noexcept;
+  bool get_cliwrap () const noexcept;
+  ::rust::Vec<::rust::String> get_cliwrap_binaries () const noexcept;
+  void set_cliwrap (bool enabled) noexcept;
+  ::rust::Vec<::rust::String> get_container_cmd () const noexcept;
+  bool get_readonly_executables () const noexcept;
+  bool get_documentation () const noexcept;
+  bool get_recommends () const noexcept;
+  bool get_selinux () const noexcept;
+  bool get_sysusers_is_forced () const noexcept;
+  ::std::uint32_t get_selinux_label_version () const noexcept;
+  ::rust::String get_gpg_key () const noexcept;
+  ::rust::String get_automatic_version_suffix () const noexcept;
+  bool get_container () const noexcept;
+  bool get_machineid_compat () const noexcept;
+  ::rust::Vec<::rust::String> get_etc_group_members () const noexcept;
+  bool get_boot_location_is_modules () const noexcept;
+  bool use_kernel_install () const noexcept;
+  bool get_ima () const noexcept;
+  ::rust::String get_releasever () const noexcept;
+  ::rpmostreecxx::RepoMetadataTarget get_repo_metadata_target () const noexcept;
+  ::rpmostreecxx::AdvisoriesMetadataTarget get_advisories_metadata_target () const noexcept;
+  bool rpmdb_backend_is_target () const noexcept;
+  bool should_normalize_rpmdb () const noexcept;
+  ::rpmostreecxx::OptUsrLocal get_opt_usrlocal () const noexcept;
+  ::rust::Vec<::rust::String> get_files_remove_regex (::rust::Str package) const noexcept;
+  ::rust::String get_checksum (::rpmostreecxx::OstreeRepo const &repo) const;
+  ::rust::String get_ostree_ref () const noexcept;
+  ::rust::Slice<::rpmostreecxx::RepoPackage const> get_repo_packages () const noexcept;
+  void clear_repo_packages () noexcept;
+  void prettyprint_json_stdout () const noexcept;
+  void print_deprecation_warnings () const noexcept;
+  void print_experimental_notices () const noexcept;
+  void sanitycheck_externals () const;
+  ::rust::Box<::rpmostreecxx::RpmImporterFlags>
+  importer_flags (::rust::Str pkg_name) const noexcept;
+  ::rust::String write_repovars (::std::int32_t workdir_dfd_raw) const;
+  void set_releasever (::rust::Str releasever);
+  void set_recommends (bool val);
+  void enable_repo (::rust::Str repo);
+  void disable_repo (::rust::Str repo);
+  void validate_for_container () const;
+  ::rpmostreecxx::Refspec get_base_refspec () const noexcept;
+  void rebase (::rust::Str new_refspec, ::rust::Str custom_origin_url,
+               ::rust::Str custom_origin_description) noexcept;
+  ::rust::String get_origin_custom_url () const noexcept;
+  ::rust::String get_origin_custom_description () const noexcept;
+  ::rust::String get_override_commit () const noexcept;
+  void set_override_commit (::rust::Str checksum) noexcept;
+  ::rust::Vec<::rust::String> get_initramfs_etc_files () const noexcept;
+  bool has_initramfs_etc_files () const noexcept;
+  bool initramfs_etc_files_track (::rust::Vec<::rust::String> files) noexcept;
+  bool initramfs_etc_files_untrack (::rust::Vec<::rust::String> files) noexcept;
+  bool initramfs_etc_files_untrack_all () noexcept;
+  bool get_initramfs_regenerate () const noexcept;
+  ::rust::Vec<::rust::String> get_initramfs_args () const noexcept;
+  void set_initramfs_regenerate (bool enabled, ::rust::Vec<::rust::String> args) noexcept;
+  ::rust::String get_unconfigured_state () const noexcept;
+  bool may_require_local_assembly () const noexcept;
+  bool has_any_packages () const noexcept;
+  bool merge_treefile (::rust::Str treefile);
+  bool get_no_initramfs () const noexcept;
+  ~Treefile () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$Treefile
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$RepoPackage
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$RepoPackage
-struct RepoPackage final : public ::rust::Opaque {
-  ::rust::Str get_repo() const noexcept;
-  ::rust::Vec<::rust::String> get_packages() const noexcept;
-  ~RepoPackage() = delete;
+struct RepoPackage final : public ::rust::Opaque
+{
+  ::rust::Str get_repo () const noexcept;
+  ::rust::Vec<::rust::String> get_packages () const noexcept;
+  ~RepoPackage () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$RepoPackage
@@ -1517,7 +1694,8 @@ private:
 // A copy of LiveFsState that is bridged to C++; the main
 // change here is we can't use Option<> yet, so empty values
 // are represented by the empty string.
-struct LiveApplyState final {
+struct LiveApplyState final
+{
   ::rust::String inprogress;
   ::rust::String commit;
 
@@ -1527,64 +1705,72 @@ struct LiveApplyState final {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdDB
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdDB
-struct PasswdDB final : public ::rust::Opaque {
-  ::rust::String lookup_user(::std::uint32_t uid) const;
-  ::rust::String lookup_group(::std::uint32_t gid) const;
-  ~PasswdDB() = delete;
+struct PasswdDB final : public ::rust::Opaque
+{
+  ::rust::String lookup_user (::std::uint32_t uid) const;
+  ::rust::String lookup_group (::std::uint32_t gid) const;
+  ~PasswdDB () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdDB
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdEntries
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdEntries
-struct PasswdEntries final : public ::rust::Opaque {
-  void add_group_content(::std::int32_t rootfs, ::rust::Str path);
-  void add_passwd_content(::std::int32_t rootfs, ::rust::Str path);
-  bool contains_group(::rust::Str user) const noexcept;
-  bool contains_user(::rust::Str user) const noexcept;
-  ::std::uint32_t lookup_user_id(::rust::Str user) const;
-  ::std::uint32_t lookup_group_id(::rust::Str group) const;
-  ~PasswdEntries() = delete;
+struct PasswdEntries final : public ::rust::Opaque
+{
+  void add_group_content (::std::int32_t rootfs, ::rust::Str path);
+  void add_passwd_content (::std::int32_t rootfs, ::rust::Str path);
+  bool contains_group (::rust::Str user) const noexcept;
+  bool contains_user (::rust::Str user) const noexcept;
+  ::std::uint32_t lookup_user_id (::rust::Str user) const;
+  ::std::uint32_t lookup_group_id (::rust::Str group) const;
+  ~PasswdEntries () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$PasswdEntries
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$Extensions
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$Extensions
-struct Extensions final : public ::rust::Opaque {
-  ::rust::Vec<::rust::String> get_repos() const noexcept;
-  ::rust::Vec<::rust::String> get_os_extension_packages() const noexcept;
-  ::rust::Vec<::rust::String> get_development_packages() const noexcept;
-  bool state_checksum_changed(::rust::Str chksum, ::rust::Str output_dir) const;
-  void update_state_checksum(::rust::Str chksum, ::rust::Str output_dir) const;
-  void serialize_to_dir(::rust::Str output_dir) const;
-  ::rust::Box<::rpmostreecxx::Treefile> generate_treefile(::rpmostreecxx::Treefile const &src) const;
-  ~Extensions() = delete;
+struct Extensions final : public ::rust::Opaque
+{
+  ::rust::Vec<::rust::String> get_repos () const noexcept;
+  ::rust::Vec<::rust::String> get_os_extension_packages () const noexcept;
+  ::rust::Vec<::rust::String> get_development_packages () const noexcept;
+  bool state_checksum_changed (::rust::Str chksum, ::rust::Str output_dir) const;
+  void update_state_checksum (::rust::Str chksum, ::rust::Str output_dir) const;
+  void serialize_to_dir (::rust::Str output_dir) const;
+  ::rust::Box<::rpmostreecxx::Treefile>
+  generate_treefile (::rpmostreecxx::Treefile const &src) const;
+  ~Extensions () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$Extensions
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$LockedPackage
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$LockedPackage
-struct LockedPackage final {
+struct LockedPackage final
+{
   ::rust::String name;
   ::rust::String evr;
   ::rust::String arch;
@@ -1596,292 +1782,367 @@ struct LockedPackage final {
 
 #ifndef CXXBRIDGE1_STRUCT_rpmostreecxx$LockfileConfig
 #define CXXBRIDGE1_STRUCT_rpmostreecxx$LockfileConfig
-struct LockfileConfig final : public ::rust::Opaque {
-  ::rust::Vec<::rpmostreecxx::LockedPackage> get_locked_packages() const;
-  ~LockfileConfig() = delete;
+struct LockfileConfig final : public ::rust::Opaque
+{
+  ::rust::Vec<::rpmostreecxx::LockedPackage> get_locked_packages () const;
+  ~LockfileConfig () = delete;
 
 private:
   friend ::rust::layout;
-  struct layout {
-    static ::std::size_t size() noexcept;
-    static ::std::size_t align() noexcept;
+  struct layout
+  {
+    static ::std::size_t size () noexcept;
+    static ::std::size_t align () noexcept;
   };
 };
 #endif // CXXBRIDGE1_STRUCT_rpmostreecxx$LockfileConfig
 
-static_assert(::std::is_enum<RpmOstreeDiffPrintFormat>::value, "expected enum");
-static_assert(sizeof(RpmOstreeDiffPrintFormat) == sizeof(::std::uint8_t), "incorrect size");
-static_assert(static_cast<::std::uint8_t>(RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_SUMMARY) == 0, "disagrees with the value in #[cxx::bridge]");
-static_assert(static_cast<::std::uint8_t>(RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_ALIGNED) == 1, "disagrees with the value in #[cxx::bridge]");
-static_assert(static_cast<::std::uint8_t>(RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE) == 2, "disagrees with the value in #[cxx::bridge]");
+static_assert (::std::is_enum<RpmOstreeDiffPrintFormat>::value, "expected enum");
+static_assert (sizeof (RpmOstreeDiffPrintFormat) == sizeof (::std::uint8_t), "incorrect size");
+static_assert (
+    static_cast<::std::uint8_t> (RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_SUMMARY)
+        == 0,
+    "disagrees with the value in #[cxx::bridge]");
+static_assert (
+    static_cast<::std::uint8_t> (RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_ALIGNED)
+        == 1,
+    "disagrees with the value in #[cxx::bridge]");
+static_assert (static_cast<::std::uint8_t> (
+                   RpmOstreeDiffPrintFormat::RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE)
+                   == 2,
+               "disagrees with the value in #[cxx::bridge]");
 
-bool is_bare_split_xattrs();
+bool is_bare_split_xattrs ();
 
-bool is_http_arg(::rust::Str arg) noexcept;
+bool is_http_arg (::rust::Str arg) noexcept;
 
-bool is_ostree_container();
+bool is_ostree_container ();
 
-::rpmostreecxx::SystemHostType get_system_host_type();
+::rpmostreecxx::SystemHostType get_system_host_type ();
 
-void require_system_host_type(::rpmostreecxx::SystemHostType t);
+void require_system_host_type (::rpmostreecxx::SystemHostType t);
 
-bool is_rpm_arg(::rust::Str arg) noexcept;
+bool is_rpm_arg (::rust::Str arg) noexcept;
 
-void client_start_daemon();
+void client_start_daemon ();
 
-::rust::Vec<::std::int32_t> client_handle_fd_argument(::rust::Str arg, ::rust::Str arch, bool is_replace);
+::rust::Vec<::std::int32_t> client_handle_fd_argument (::rust::Str arg, ::rust::Str arch,
+                                                       bool is_replace);
 
-::rust::String client_render_download_progress(::rpmostreecxx::GVariant const &progress) noexcept;
+::rust::String client_render_download_progress (::rpmostreecxx::GVariant const &progress) noexcept;
 
-bool running_in_container() noexcept;
+bool running_in_container () noexcept;
 
-bool confirm();
+bool confirm ();
 
-void confirm_or_abort();
+void confirm_or_abort ();
 
-void bubblewrap_selftest();
+void bubblewrap_selftest ();
 
-::rust::Vec<::std::uint8_t> bubblewrap_run_sync(::std::int32_t rootfs_dfd, ::rust::Vec<::rust::String> const &args, bool capture_stdout, ::rpmostreecxx::BubblewrapMutability mutability);
+::rust::Vec<::std::uint8_t> bubblewrap_run_sync (::std::int32_t rootfs_dfd,
+                                                 ::rust::Vec<::rust::String> const &args,
+                                                 bool capture_stdout,
+                                                 ::rpmostreecxx::BubblewrapMutability mutability);
 
-::rust::Box<::rpmostreecxx::Bubblewrap> bubblewrap_new(::std::int32_t rootfs_fd);
+::rust::Box<::rpmostreecxx::Bubblewrap> bubblewrap_new (::std::int32_t rootfs_fd);
 
-::rust::Box<::rpmostreecxx::Bubblewrap> bubblewrap_new_with_mutability(::std::int32_t rootfs_fd, ::rpmostreecxx::BubblewrapMutability mutability);
+::rust::Box<::rpmostreecxx::Bubblewrap>
+bubblewrap_new_with_mutability (::std::int32_t rootfs_fd,
+                                ::rpmostreecxx::BubblewrapMutability mutability);
 
-::rpmostreecxx::BubblewrapMutability mutability_for_unified_core(bool unified_core) noexcept;
+::rpmostreecxx::BubblewrapMutability mutability_for_unified_core (bool unified_core) noexcept;
 
-void usroverlay_entrypoint(::rust::Vec<::rust::String> const &args);
+void usroverlay_entrypoint (::rust::Vec<::rust::String> const &args);
 
-void applylive_entrypoint(::rust::Vec<::rust::String> const &args);
+void applylive_entrypoint (::rust::Vec<::rust::String> const &args);
 
-void applylive_finish(::rpmostreecxx::OstreeSysroot const &sysroot);
+void applylive_finish (::rpmostreecxx::OstreeSysroot const &sysroot);
 
-void composeutil_legacy_prep_dev_and_run(::std::int32_t rootfs_dfd);
+void composeutil_legacy_prep_dev_and_run (::std::int32_t rootfs_dfd);
 
-void print_ostree_txn_stats(::rpmostreecxx::OstreeRepoTransactionStats &stats) noexcept;
+void print_ostree_txn_stats (::rpmostreecxx::OstreeRepoTransactionStats &stats) noexcept;
 
-void write_commit_id(::rust::Str target_path, ::rust::Str revision);
+void write_commit_id (::rust::Str target_path, ::rust::Str revision);
 
-void cliwrap_write_wrappers(::std::int32_t rootfs);
+void cliwrap_write_wrappers (::std::int32_t rootfs);
 
-void cliwrap_write_some_wrappers(::std::int32_t rootfs, ::rust::Vec<::rust::String> const &args);
+void cliwrap_write_some_wrappers (::std::int32_t rootfs, ::rust::Vec<::rust::String> const &args);
 
-::rust::String cliwrap_destdir() noexcept;
+::rust::String cliwrap_destdir () noexcept;
 
-void container_encapsulate(::rust::Vec<::rust::String> args);
+void container_encapsulate (::rust::Vec<::rust::String> args);
 
-void deploy_from_self_entrypoint(::rust::Vec<::rust::String> args);
+void deploy_from_self_entrypoint (::rust::Vec<::rust::String> args);
 
-::rust::Box<::rpmostreecxx::ContainerImageState> pull_container(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref, ::rust::Str digest_override);
+::rust::Box<::rpmostreecxx::ContainerImageState>
+pull_container (::rpmostreecxx::OstreeRepo const &repo,
+                ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref,
+                ::rust::Str digest_override);
 
-::rpmostreecxx::PrunedContainerInfo container_prune(::rpmostreecxx::OstreeSysroot const &sysroot);
+::rpmostreecxx::PrunedContainerInfo container_prune (::rpmostreecxx::OstreeSysroot const &sysroot);
 
-::rust::Box<::rpmostreecxx::ContainerImageState> query_container_image_commit(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str c);
+::rust::Box<::rpmostreecxx::ContainerImageState>
+query_container_image_commit (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str c);
 
-void purge_refspec(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec);
+void purge_refspec (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec);
 
-bool check_container_update(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref);
+bool check_container_update (::rpmostreecxx::OstreeRepo const &repo,
+                             ::rpmostreecxx::GCancellable const &cancellable, ::rust::Str imgref);
 
-::rust::Box<::rpmostreecxx::TempEtcGuard> prepare_tempetc_guard(::std::int32_t rootfs);
+::rust::Box<::rpmostreecxx::TempEtcGuard> prepare_tempetc_guard (::std::int32_t rootfs);
 
-::rust::Box<::rpmostreecxx::FilesystemScriptPrep> prepare_filesystem_script_prep(::std::int32_t rootfs);
+::rust::Box<::rpmostreecxx::FilesystemScriptPrep>
+prepare_filesystem_script_prep (::std::int32_t rootfs);
 
-void run_depmod(::std::int32_t rootfs_dfd, ::rust::Str kver, bool unified_core);
+void run_depmod (::std::int32_t rootfs_dfd, ::rust::Str kver, bool unified_core);
 
-void run_sysusers(::std::int32_t rootfs_dfd, bool force);
+void run_sysusers (::std::int32_t rootfs_dfd, bool force);
 
-void log_treefile(::rpmostreecxx::Treefile const &tf) noexcept;
+void log_treefile (::rpmostreecxx::Treefile const &tf) noexcept;
 
-bool is_container_image_reference(::rust::Str refspec) noexcept;
+bool is_container_image_reference (::rust::Str refspec) noexcept;
 
-bool is_container_image_digest_reference(::rust::Str refspec) noexcept;
+bool is_container_image_digest_reference (::rust::Str refspec) noexcept;
 
-::rpmostreecxx::RefspecType refspec_classify(::rust::Str refspec) noexcept;
+::rpmostreecxx::RefspecType refspec_classify (::rust::Str refspec) noexcept;
 
-void verify_kernel_hmac(::std::int32_t rootfs, ::rust::Str moddir);
+void verify_kernel_hmac (::std::int32_t rootfs, ::rust::Str moddir);
 
-::rust::Vec<::rust::String> stage_container_rpms(::rust::Vec<::rust::String> rpms);
+::rust::Vec<::rust::String> stage_container_rpms (::rust::Vec<::rust::String> rpms);
 
-::rust::Vec<::rust::String> stage_container_rpm_raw_fds(::rust::Vec<::std::int32_t> fds);
+::rust::Vec<::rust::String> stage_container_rpm_raw_fds (::rust::Vec<::std::int32_t> fds);
 
-bool commit_has_matching_sepolicy(::rpmostreecxx::GVariant const &commit, ::rpmostreecxx::OstreeSePolicy const &policy);
+bool commit_has_matching_sepolicy (::rpmostreecxx::GVariant const &commit,
+                                   ::rpmostreecxx::OstreeSePolicy const &policy);
 
-::rpmostreecxx::GVariant *get_header_variant(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str cachebranch);
+::rpmostreecxx::GVariant *get_header_variant (::rpmostreecxx::OstreeRepo const &repo,
+                                              ::rust::Str cachebranch);
 
-void compose_build_chunked_oci_entrypoint(::rust::Vec<::rust::String> args);
+void compose_build_chunked_oci_entrypoint (::rust::Vec<::rust::String> args);
 
-void compose_image(::rust::Vec<::rust::String> args);
+void compose_image (::rust::Vec<::rust::String> args);
 
-void compose_rootfs_entrypoint(::rust::Vec<::rust::String> args);
+void compose_rootfs_entrypoint (::rust::Vec<::rust::String> args);
 
-void configure_build_repo_from_target(::rpmostreecxx::OstreeRepo const &build_repo, ::rpmostreecxx::OstreeRepo const &target_repo);
+void configure_build_repo_from_target (::rpmostreecxx::OstreeRepo const &build_repo,
+                                       ::rpmostreecxx::OstreeRepo const &target_repo);
 
-void compose_prepare_rootfs(::std::int32_t src_rootfs_dfd, ::std::int32_t dest_rootfs_dfd, ::rpmostreecxx::Treefile &treefile);
+void compose_prepare_rootfs (::std::int32_t src_rootfs_dfd, ::std::int32_t dest_rootfs_dfd,
+                             ::rpmostreecxx::Treefile &treefile);
 
-void composepost_nsswitch_altfiles(::std::int32_t rootfs_dfd);
+void composepost_nsswitch_altfiles (::std::int32_t rootfs_dfd);
 
-void compose_postprocess(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile, ::rust::Str next_version, bool unified_core);
+void compose_postprocess (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile,
+                          ::rust::Str next_version, bool unified_core);
 
-void compose_postprocess_final_pre(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile);
+void compose_postprocess_final_pre (::std::int32_t rootfs_dfd,
+                                    ::rpmostreecxx::Treefile const &treefile);
 
-void compose_postprocess_final(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile);
+void compose_postprocess_final (::std::int32_t rootfs_dfd,
+                                ::rpmostreecxx::Treefile const &treefile);
 
-void convert_var_to_tmpfiles_d(::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable const &cancellable);
+void convert_var_to_tmpfiles_d (::std::int32_t rootfs_dfd,
+                                ::rpmostreecxx::GCancellable const &cancellable);
 
-void rootfs_prepare_links(::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile, bool skip_usrlocal);
+void rootfs_prepare_links (::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile const &treefile,
+                           bool skip_usrlocal);
 
-void workaround_selinux_cross_labeling(::std::int32_t rootfs_dfd, ::rpmostreecxx::GCancellable &cancellable);
+void workaround_selinux_cross_labeling (::std::int32_t rootfs_dfd,
+                                        ::rpmostreecxx::GCancellable &cancellable);
 
-void postprocess_cleanup_rpmdb(::std::int32_t rootfs_dfd);
+void postprocess_cleanup_rpmdb (::std::int32_t rootfs_dfd);
 
-void rewrite_rpmdb_for_target(::std::int32_t rootfs_dfd, bool normalize);
+void rewrite_rpmdb_for_target (::std::int32_t rootfs_dfd, bool normalize);
 
-::std::uint64_t directory_size(::std::int32_t dfd, ::rpmostreecxx::GCancellable const &cancellable);
+::std::uint64_t directory_size (::std::int32_t dfd,
+                                ::rpmostreecxx::GCancellable const &cancellable);
 
-::rpmostreecxx::OstreeDeployment *deployment_for_id(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id);
+::rpmostreecxx::OstreeDeployment *deployment_for_id (::rpmostreecxx::OstreeSysroot &sysroot,
+                                                     ::rust::Str deploy_id);
 
-::rust::String deployment_checksum_for_id(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str deploy_id);
+::rust::String deployment_checksum_for_id (::rpmostreecxx::OstreeSysroot &sysroot,
+                                           ::rust::Str deploy_id);
 
-::rpmostreecxx::OstreeDeployment *deployment_get_base(::rpmostreecxx::OstreeSysroot &sysroot, ::rust::Str opt_deploy_id, ::rust::Str opt_os_name);
+::rpmostreecxx::OstreeDeployment *deployment_get_base (::rpmostreecxx::OstreeSysroot &sysroot,
+                                                       ::rust::Str opt_deploy_id,
+                                                       ::rust::Str opt_os_name);
 
-bool deployment_add_manifest_diff(::rpmostreecxx::GVariantDict const &dict, ::rpmostreecxx::ExportedManifestDiff const &diff) noexcept;
+bool deployment_add_manifest_diff (::rpmostreecxx::GVariantDict const &dict,
+                                   ::rpmostreecxx::ExportedManifestDiff const &diff) noexcept;
 
-void daemon_sanitycheck_environment(::rpmostreecxx::OstreeSysroot const &sysroot);
+void daemon_sanitycheck_environment (::rpmostreecxx::OstreeSysroot const &sysroot);
 
-::rust::String deployment_generate_id(::rpmostreecxx::OstreeDeployment const &deployment) noexcept;
+::rust::String deployment_generate_id (::rpmostreecxx::OstreeDeployment const &deployment) noexcept;
 
-void deployment_populate_variant(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::GVariantDict const &dict);
+void deployment_populate_variant (::rpmostreecxx::OstreeSysroot const &sysroot,
+                                  ::rpmostreecxx::OstreeDeployment const &deployment,
+                                  ::rpmostreecxx::GVariantDict const &dict);
 
-void generate_baselayer_refs(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::GCancellable const &cancellable);
+void generate_baselayer_refs (::rpmostreecxx::OstreeSysroot const &sysroot,
+                              ::rpmostreecxx::OstreeRepo const &repo,
+                              ::rpmostreecxx::GCancellable const &cancellable);
 
-void variant_add_remote_status(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec, ::rust::Str base_checksum, ::rpmostreecxx::GVariantDict const &dict);
+void variant_add_remote_status (::rpmostreecxx::OstreeRepo const &repo, ::rust::Str refspec,
+                                ::rust::Str base_checksum,
+                                ::rpmostreecxx::GVariantDict const &dict);
 
-::rpmostreecxx::DeploymentLayeredMeta deployment_layeredmeta_from_commit(::rpmostreecxx::OstreeDeployment const &deployment, ::rpmostreecxx::GVariant const &commit);
+::rpmostreecxx::DeploymentLayeredMeta
+deployment_layeredmeta_from_commit (::rpmostreecxx::OstreeDeployment const &deployment,
+                                    ::rpmostreecxx::GVariant const &commit);
 
-::rpmostreecxx::DeploymentLayeredMeta deployment_layeredmeta_load(::rpmostreecxx::OstreeRepo const &repo, ::rpmostreecxx::OstreeDeployment const &deployment);
+::rpmostreecxx::DeploymentLayeredMeta
+deployment_layeredmeta_load (::rpmostreecxx::OstreeRepo const &repo,
+                             ::rpmostreecxx::OstreeDeployment const &deployment);
 
-::rpmostreecxx::OverrideReplacementSource parse_override_source(::rust::Str source);
+::rpmostreecxx::OverrideReplacementSource parse_override_source (::rust::Str source);
 
-::rpmostreecxx::ParsedRevision parse_revision(::rust::Str source);
+::rpmostreecxx::ParsedRevision parse_revision (::rust::Str source);
 
-::rust::String generate_object_path(::rust::Str base, ::rust::Str next_segment);
+::rust::String generate_object_path (::rust::Str base, ::rust::Str next_segment);
 
-void failpoint(::rust::Str p);
+void failpoint (::rust::Str p);
 
-::rust::Box<::rpmostreecxx::RpmImporterFlags> rpm_importer_flags_new_empty() noexcept;
+::rust::Box<::rpmostreecxx::RpmImporterFlags> rpm_importer_flags_new_empty () noexcept;
 
-::rust::Box<::rpmostreecxx::RpmImporter> rpm_importer_new(::rust::Str pkg_name, ::rust::Str ostree_branch, ::rpmostreecxx::RpmImporterFlags const &flags);
+::rust::Box<::rpmostreecxx::RpmImporter>
+rpm_importer_new (::rust::Str pkg_name, ::rust::Str ostree_branch,
+                  ::rpmostreecxx::RpmImporterFlags const &flags);
 
-::rust::String tmpfiles_translate(::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info, ::rust::Str username, ::rust::Str groupname);
+::rust::String tmpfiles_translate (::rust::Str abs_path, ::rpmostreecxx::GFileInfo const &file_info,
+                                   ::rust::Str username, ::rust::Str groupname);
 
-void append_dracut_random_cpio(::std::int32_t fd);
+void append_dracut_random_cpio (::std::int32_t fd);
 
-::std::int32_t initramfs_overlay_generate(::rust::Vec<::rust::String> const &files, ::rpmostreecxx::GCancellable &cancellable);
+::std::int32_t initramfs_overlay_generate (::rust::Vec<::rust::String> const &files,
+                                           ::rpmostreecxx::GCancellable &cancellable);
 
-void journal_print_staging_failure() noexcept;
+void journal_print_staging_failure () noexcept;
 
-void console_progress_begin_task(::rust::Str msg) noexcept;
+void console_progress_begin_task (::rust::Str msg) noexcept;
 
-void console_progress_begin_n_items(::rust::Str msg, ::std::uint64_t n) noexcept;
+void console_progress_begin_n_items (::rust::Str msg, ::std::uint64_t n) noexcept;
 
-void console_progress_begin_percent(::rust::Str msg) noexcept;
+void console_progress_begin_percent (::rust::Str msg) noexcept;
 
-void console_progress_set_message(::rust::Str msg) noexcept;
+void console_progress_set_message (::rust::Str msg) noexcept;
 
-void console_progress_set_sub_message(::rust::Str msg) noexcept;
+void console_progress_set_sub_message (::rust::Str msg) noexcept;
 
-void console_progress_update(::std::uint64_t n) noexcept;
+void console_progress_update (::std::uint64_t n) noexcept;
 
-void console_progress_end(::rust::Str suffix) noexcept;
+void console_progress_end (::rust::Str suffix) noexcept;
 
-::rust::Box<::rpmostreecxx::HistoryCtx> history_ctx_new();
+::rust::Box<::rpmostreecxx::HistoryCtx> history_ctx_new ();
 
-void history_prune();
+void history_prune ();
 
-::rust::Box<::rpmostreecxx::TokioHandle> tokio_handle_get() noexcept;
+::rust::Box<::rpmostreecxx::TokioHandle> tokio_handle_get () noexcept;
 
-bool script_is_ignored(::rust::Str pkg, ::rust::Str script, bool use_kernel_install) noexcept;
+bool script_is_ignored (::rust::Str pkg, ::rust::Str script, bool use_kernel_install) noexcept;
 
-void testutils_entrypoint(::rust::Vec<::rust::String> argv);
+void testutils_entrypoint (::rust::Vec<::rust::String> argv);
 
-::rust::String maybe_shell_quote(::rust::Str input) noexcept;
+::rust::String maybe_shell_quote (::rust::Str input) noexcept;
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new(::rust::Str filename, ::rust::Str basearch);
+::rust::Box<::rpmostreecxx::Treefile> treefile_new (::rust::Str filename, ::rust::Str basearch);
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new_empty();
+::rust::Box<::rpmostreecxx::Treefile> treefile_new_empty ();
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new_from_string(::rust::Str buf, bool client);
+::rust::Box<::rpmostreecxx::Treefile> treefile_new_from_string (::rust::Str buf, bool client);
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new_compose(::rust::Str filename, ::rust::Str basearch);
+::rust::Box<::rpmostreecxx::Treefile> treefile_new_compose (::rust::Str filename,
+                                                            ::rust::Str basearch);
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new_client(::rust::Str filename, ::rust::Str basearch);
+::rust::Box<::rpmostreecxx::Treefile> treefile_new_client (::rust::Str filename,
+                                                           ::rust::Str basearch);
 
-::rust::Box<::rpmostreecxx::Treefile> treefile_new_client_from_etc(::rust::Str basearch);
+::rust::Box<::rpmostreecxx::Treefile> treefile_new_client_from_etc (::rust::Str basearch);
 
-::std::uint32_t treefile_delete_client_etc();
+::std::uint32_t treefile_delete_client_etc ();
 
-::rust::String varsubstitute(::rust::Str s, ::rust::Vec<::rpmostreecxx::StringMapping> const &vars);
+// Return the list of repo configuration directories to search
+// (e.g. ["/etc/yum.repos.d", "/usr/share/dnf5/repos.d"]).
+::rust::Vec<::rust::String> get_repos_dirs () noexcept;
 
-::rust::Vec<::rust::String> get_features() noexcept;
+::rust::String varsubstitute (::rust::Str s,
+                              ::rust::Vec<::rpmostreecxx::StringMapping> const &vars);
 
-::rust::String get_rpm_basearch() noexcept;
+::rust::Vec<::rust::String> get_features () noexcept;
 
-::std::int32_t sealed_memfd(::rust::Str description, ::rust::Slice<::std::uint8_t const> content);
+::rust::String get_rpm_basearch () noexcept;
 
-bool running_in_systemd() noexcept;
+::std::int32_t sealed_memfd (::rust::Str description, ::rust::Slice<::std::uint8_t const> content);
 
-::rpmostreecxx::GVariant *calculate_advisories_diff(::rpmostreecxx::OstreeRepo const &repo, ::rust::Str checksum_from, ::rust::Str checksum_to);
+bool running_in_systemd () noexcept;
 
-::rust::String translate_path_for_ostree(::rust::Str path) noexcept;
+::rpmostreecxx::GVariant *calculate_advisories_diff (::rpmostreecxx::OstreeRepo const &repo,
+                                                     ::rust::Str checksum_from,
+                                                     ::rust::Str checksum_to);
 
-::rpmostreecxx::LiveApplyState get_live_apply_state(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment);
+::rust::String translate_path_for_ostree (::rust::Str path) noexcept;
 
-bool has_live_apply_state(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::OstreeDeployment const &deployment);
+::rpmostreecxx::LiveApplyState
+get_live_apply_state (::rpmostreecxx::OstreeSysroot const &sysroot,
+                      ::rpmostreecxx::OstreeDeployment const &deployment);
 
-void applylive_sync_ref(::rpmostreecxx::OstreeSysroot const &sysroot);
+bool has_live_apply_state (::rpmostreecxx::OstreeSysroot const &sysroot,
+                           ::rpmostreecxx::OstreeDeployment const &deployment);
 
-void transaction_apply_live(::rpmostreecxx::OstreeSysroot const &sysroot, ::rpmostreecxx::GVariant const &target);
+void applylive_sync_ref (::rpmostreecxx::OstreeSysroot const &sysroot);
 
-void normalize_etc_shadow(::std::int32_t rootfs_dfd);
+void transaction_apply_live (::rpmostreecxx::OstreeSysroot const &sysroot,
+                             ::rpmostreecxx::GVariant const &target);
 
-bool prepare_rpm_layering(::std::int32_t rootfs, ::std::int32_t merge_passwd_dir);
+void normalize_etc_shadow (::std::int32_t rootfs_dfd);
 
-void complete_rpm_layering(::std::int32_t rootfs);
+bool prepare_rpm_layering (::std::int32_t rootfs, ::std::int32_t merge_passwd_dir);
 
-void deduplicate_tmpfiles_entries(::std::int32_t rootfs);
+void complete_rpm_layering (::std::int32_t rootfs);
 
-void passwd_cleanup(::std::int32_t rootfs);
+void deduplicate_tmpfiles_entries (::std::int32_t rootfs);
 
-void migrate_group_except_root(::std::int32_t rootfs, ::rust::Vec<::rust::String> const &preserved_groups);
+void passwd_cleanup (::std::int32_t rootfs);
 
-void migrate_passwd_except_root(::std::int32_t rootfs);
+void migrate_group_except_root (::std::int32_t rootfs,
+                                ::rust::Vec<::rust::String> const &preserved_groups);
 
-void passwd_compose_prep(::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile);
+void migrate_passwd_except_root (::std::int32_t rootfs);
 
-void passwd_compose_prep_repo(::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile, ::rpmostreecxx::OstreeRepo const &repo, ::rust::Str previous_checksum, bool unified_core);
+void passwd_compose_prep (::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile);
 
-bool dir_contains_uid(::std::int32_t dirfd, ::std::uint32_t id);
+void passwd_compose_prep_repo (::std::int32_t rootfs, ::rpmostreecxx::Treefile &treefile,
+                               ::rpmostreecxx::OstreeRepo const &repo,
+                               ::rust::Str previous_checksum, bool unified_core);
 
-bool dir_contains_gid(::std::int32_t dirfd, ::std::uint32_t id);
+bool dir_contains_uid (::std::int32_t dirfd, ::std::uint32_t id);
 
-void check_passwd_group_entries(::rpmostreecxx::OstreeRepo const &ffi_repo, ::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile, ::rust::Str previous_rev);
+bool dir_contains_gid (::std::int32_t dirfd, ::std::uint32_t id);
 
-::rust::Box<::rpmostreecxx::PasswdDB> passwddb_open(::std::int32_t rootfs);
+void check_passwd_group_entries (::rpmostreecxx::OstreeRepo const &ffi_repo,
+                                 ::std::int32_t rootfs_dfd, ::rpmostreecxx::Treefile &treefile,
+                                 ::rust::Str previous_rev);
 
-::rust::Box<::rpmostreecxx::PasswdEntries> new_passwd_entries() noexcept;
+::rust::Box<::rpmostreecxx::PasswdDB> passwddb_open (::std::int32_t rootfs);
 
-::rust::Box<::rpmostreecxx::Extensions> extensions_load(::rust::Str path, ::rust::Str basearch, ::rust::Vec<::rpmostreecxx::StringMapping> const &base_pkgs);
+::rust::Box<::rpmostreecxx::PasswdEntries> new_passwd_entries () noexcept;
 
-::rust::Box<::rpmostreecxx::LockfileConfig> lockfile_read(::rust::Vec<::rust::String> const &filenames);
+::rust::Box<::rpmostreecxx::Extensions>
+extensions_load (::rust::Str path, ::rust::Str basearch,
+                 ::rust::Vec<::rpmostreecxx::StringMapping> const &base_pkgs);
 
-void lockfile_write(::rust::Str filename, ::rpmostreecxx::CxxGObjectArray &packages, ::rpmostreecxx::CxxGObjectArray &rpmmd_repos);
+::rust::Box<::rpmostreecxx::LockfileConfig>
+lockfile_read (::rust::Vec<::rust::String> const &filenames);
 
-::rust::Box<::rpmostreecxx::Treefile> origin_to_treefile(::rpmostreecxx::GKeyFile const &kf);
+void lockfile_write (::rust::Str filename, ::rpmostreecxx::CxxGObjectArray &packages,
+                     ::rpmostreecxx::CxxGObjectArray &rpmmd_repos);
 
-::rpmostreecxx::GKeyFile *treefile_to_origin(::rpmostreecxx::Treefile const &tf);
+::rust::Box<::rpmostreecxx::Treefile> origin_to_treefile (::rpmostreecxx::GKeyFile const &kf);
 
-void origin_validate_roundtrip(::rpmostreecxx::GKeyFile const &kf) noexcept;
+::rpmostreecxx::GKeyFile *treefile_to_origin (::rpmostreecxx::Treefile const &tf);
 
-::rust::String cache_branch_to_nevra(::rust::Str nevra) noexcept;
+void origin_validate_roundtrip (::rpmostreecxx::GKeyFile const &kf) noexcept;
+
+::rust::String cache_branch_to_nevra (::rust::Str nevra) noexcept;
 } // namespace rpmostreecxx
 
 #ifdef __clang__

--- a/rust/src/compose.rs
+++ b/rust/src/compose.rs
@@ -33,7 +33,7 @@ use crate::cmdutils::CommandRunExt;
 use crate::containers_storage::Mount;
 use crate::cxxrsutil::{CxxResult, FFIGObjectWrapper};
 use crate::isolation::self_command;
-use crate::{RPMOSTREE_RPMDB_LOCATION, RPMOSTREE_SYSIMAGE_RPMDB};
+use crate::{REPOS_DIRS, RPMOSTREE_RPMDB_LOCATION, RPMOSTREE_SYSIMAGE_RPMDB};
 
 const OSTREE_COMPOSEFS_DIGEST_V0_KEY: &str = "ostree.composefs.digest.v0";
 
@@ -640,23 +640,24 @@ fn mutate_source_root(exec_root: &Dir, source_root: &Utf8Path) -> Result<()> {
         println!("Symlinked {RPMOSTREE_RPMDB_LOCATION} in source root");
     }
 
-    if !source_root_dir.try_exists("etc")? {
-        return Ok(());
-    }
-    if let Some(repos) = source_root_dir
-        .open_dir_optional("etc/yum.repos.d")
-        .context("Opening yum.repos.d")?
-    {
-        for ent in repos.entries_utf8()? {
-            let ent = ent?;
-            if !ent.file_type()?.is_file() {
-                continue;
+    // Scan all repo directory locations for .repo files that may need
+    // GPG key path rewriting.
+    for repos_dir in REPOS_DIRS {
+        if let Some(repos) = source_root_dir
+            .open_dir_optional(repos_dir)
+            .with_context(|| format!("Opening {repos_dir}"))?
+        {
+            for ent in repos.entries_utf8()? {
+                let ent = ent?;
+                if !ent.file_type()?.is_file() {
+                    continue;
+                }
+                let name: Utf8PathBuf = ent.file_name()?.into();
+                let Some("repo") = name.extension() else {
+                    continue;
+                };
+                mutate_one_dnf_repo(exec_root, source_root, &repos, &name)?;
             }
-            let name: Utf8PathBuf = ent.file_name()?.into();
-            let Some("repo") = name.extension() else {
-                continue;
-            };
-            mutate_one_dnf_repo(exec_root, source_root, &repos, &name)?;
         }
     }
 
@@ -1683,6 +1684,29 @@ mod tests {
         gpgkey=file:///absolute/path/not-in-source-root
     "#};
         similar_asserts::assert_eq!(expected, found_repos);
+
+        // Also test with repos in the new /usr/share/dnf5/repos.d location
+        rootfs.create_dir_all("repos/usr/share/dnf5/repos.d")?;
+        rootfs.create_dir_all("repos/usr/share/pki/rpm-gpg")?;
+        rootfs.write("repos/usr/share/pki/rpm-gpg/repo5.key", "repo5 gpg key")?;
+        let dnf5_repo_content = indoc::indoc! { r#"
+        [repo5]
+        baseurl=blah
+        gpgkey=file:///usr/share/pki/rpm-gpg/repo5.key
+    "#};
+        rootfs.write(
+            "repos/usr/share/dnf5/repos.d/test-dnf5.repo",
+            dnf5_repo_content,
+        )?;
+        mutate_source_root(rootfs, "repos".into()).unwrap();
+        let found_dnf5_repos =
+            rootfs.read_to_string("repos/usr/share/dnf5/repos.d/test-dnf5.repo")?;
+        let expected_dnf5 = indoc::indoc! { r#"
+        [repo5]
+        baseurl=blah
+        gpgkey=file:///repos/usr/share/pki/rpm-gpg/repo5.key
+    "#};
+        similar_asserts::assert_eq!(expected_dnf5, found_dnf5_repos);
 
         Ok(())
     }

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -50,6 +50,23 @@ pub(crate) const RPMOSTREE_RPMDB_LOCATION: &str = "usr/share/rpm";
 pub(crate) const RPMOSTREE_SYSIMAGE_RPMDB: &str = "usr/lib/sysimage/rpm";
 pub(crate) const TRADITIONAL_RPMDB_LOCATION: &str = "var/lib/rpm";
 
+/// Repository configuration directories. The /etc path is for user-added
+/// configuration; the /usr path is for distribution-provided configuration
+/// (introduced with DNF5 in Fedora 45).
+pub(crate) const YUM_REPOS_D: &str = "etc/yum.repos.d";
+pub(crate) const DNF5_REPOS_D: &str = "usr/share/dnf5/repos.d";
+pub(crate) const REPOS_DIRS: &[&str] = &[YUM_REPOS_D, DNF5_REPOS_D];
+
+/// Absolute-path versions of the above, for use in contexts that need them.
+pub(crate) const ABS_YUM_REPOS_D: &str = "/etc/yum.repos.d";
+pub(crate) const ABS_DNF5_REPOS_D: &str = "/usr/share/dnf5/repos.d";
+
+/// Return the list of absolute repo configuration directories to search,
+/// exposed to C++ via cxx bridge.
+pub(crate) fn get_repos_dirs() -> Vec<String> {
+    vec![ABS_YUM_REPOS_D.to_string(), ABS_DNF5_REPOS_D.to_string()]
+}
+
 const SD_LOCAL_FS_TARGET_REQUIRES: &str = "usr/lib/systemd/system/local-fs.target.requires";
 
 #[context("Moving {}", name)]

--- a/rust/src/countme/repo.rs
+++ b/rust/src/countme/repo.rs
@@ -3,14 +3,12 @@
 use anyhow::{Context, Result};
 use fn_error_context::context;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use ini::Ini;
 
 use crate::utils;
-
-/// Location for DNF repositories configuration
-pub const YUM_REPOS_D: &str = "/etc/yum.repos.d";
+use crate::{ABS_DNF5_REPOS_D, ABS_YUM_REPOS_D};
 
 /// Repository configuration
 /// Not exhaustive and only includes the options needed for Count Me support.
@@ -28,12 +26,17 @@ fn is_true(string: &str) -> bool {
     string == "1" || string == "yes" || string == "true" || string == "on"
 }
 
-/// Read all repository configuration files from the default location
-pub fn all() -> Result<Vec<Repo>> {
-    let configs = fs::read_dir(YUM_REPOS_D)
-        .with_context(|| format!("Could not list files in: {}", YUM_REPOS_D))?;
-    let mut repos = Vec::new();
-    for c in configs {
+/// Read repo config files from a single directory, appending to `repos`.
+/// Silently skips the directory if it does not exist.
+fn collect_repos_from_dir(dir: &Path, repos: &mut Vec<Repo>) -> Result<()> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(e).with_context(|| format!("Could not list files in: {}", dir.display()))
+        }
+    };
+    for c in entries {
         let path = c?.path();
         match parse_repo_file(&path) {
             Err(e) => {
@@ -45,6 +48,15 @@ pub fn all() -> Result<Vec<Repo>> {
             }
             Ok(mut r) => repos.append(&mut r),
         }
+    }
+    Ok(())
+}
+
+/// Read all repository configuration files from both repo config directories
+pub fn all() -> Result<Vec<Repo>> {
+    let mut repos = Vec::new();
+    for dir in &[ABS_YUM_REPOS_D, ABS_DNF5_REPOS_D] {
+        collect_repos_from_dir(Path::new(dir), &mut repos)?;
     }
     Ok(repos)
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -701,6 +701,13 @@ pub mod ffi {
         fn get_packages(&self) -> Vec<String>;
     }
 
+    // composepost.rs
+    extern "Rust" {
+        /// Return the list of repo configuration directories to search
+        /// (e.g. ["/etc/yum.repos.d", "/usr/share/dnf5/repos.d"]).
+        fn get_repos_dirs() -> Vec<String>;
+    }
+
     // utils.rs
     extern "Rust" {
         fn varsubstitute(s: &str, vars: &Vec<StringMapping>) -> Result<String>;

--- a/src/daemon/rpmostree-sysroot-upgrader.h
+++ b/src/daemon/rpmostree-sysroot-upgrader.h
@@ -65,7 +65,7 @@ typedef enum
 
 /* _NONE means we're doing pure ostree, no client-side computation.
  * _LOCAL is just e.g. rpm-ostree initramfs
- * _RPMMD_REPOS is where we're downloading data from /etc/yum.repos.d
+ * _RPMMD_REPOS is where we're downloading data from yum.repos.d / dnf5 repos.d
  */
 typedef enum
 {

--- a/src/libpriv/rpmostree-core.cxx
+++ b/src/libpriv/rpmostree-core.cxx
@@ -186,6 +186,25 @@ state_action_changed_cb (DnfState *state, DnfStateAction action, const gchar *ac
     }
 }
 
+/* Build a NULL-terminated array of repo configuration directories,
+ * using the canonical list from Rust. If @root is non-NULL, each
+ * path is prefixed with it (for deployment/source root contexts).
+ */
+static GStrv
+build_repos_dirs (const char *root)
+{
+  auto dirs = rpmostreecxx::get_repos_dirs ();
+  auto ret = g_new0 (gchar *, dirs.size () + 1);
+  for (size_t i = 0; i < dirs.size (); i++)
+    {
+      if (root)
+        ret[i] = g_build_filename (root, dirs[i].c_str (), NULL);
+      else
+        ret[i] = g_strdup (dirs[i].c_str ());
+    }
+  return ret;
+}
+
 /* Low level API to create a context.  Avoid this in preference
  * to creating a client or compose context unless necessary.
  */
@@ -206,7 +225,13 @@ rpmostree_context_new_base (OstreeRepo *repo)
   self->dnfctx = dnf_context_new ();
   dnf_context_set_http_proxy (self->dnfctx, g_getenv ("http_proxy"));
 
-  dnf_context_set_repo_dir (self->dnfctx, "/etc/yum.repos.d");
+  /* Set repo configuration directories using the canonical list from Rust.
+   * The repo loader gracefully skips non-existent directories.
+   */
+  {
+    g_auto (GStrv) repos_dirs = build_repos_dirs (NULL);
+    dnf_context_set_repos_dir (self->dnfctx, (const gchar *const *)repos_dirs);
+  }
   dnf_context_set_cache_dir (self->dnfctx, RPMOSTREE_CORE_CACHEDIR RPMOSTREE_DIR_CACHE_REPOMD);
   dnf_context_set_solv_dir (self->dnfctx, RPMOSTREE_CORE_CACHEDIR RPMOSTREE_DIR_CACHE_SOLV);
   dnf_context_set_lock_dir (self->dnfctx, "/run/rpm-ostree/" RPMOSTREE_DIR_LOCK);
@@ -357,16 +382,26 @@ rpmostree_context_set_repos_dir (RpmOstreeContext *self, const char *reposdir)
   g_debug ("set override for repos dir");
 }
 
+// Same as above but using the multi-directory variant to allow setting
+// multiple repos dirs (e.g. both /etc/yum.repos.d and /usr/share/dnf5/repos.d).
+void
+rpmostree_context_set_repos_dirs (RpmOstreeContext *self, const char *const *reposdirs)
+{
+  dnf_context_set_repos_dir (self->dnfctx, reposdirs);
+  self->repos_dir_configured = TRUE;
+  g_debug ("set override for repos dirs (multi)");
+}
+
 /* Pick up repos dir and passwd from @cfg_deployment. */
 void
 rpmostree_context_configure_from_deployment (RpmOstreeContext *self, OstreeSysroot *sysroot,
                                              OstreeDeployment *cfg_deployment)
 {
   g_autofree char *cfg_deployment_root = rpmostree_get_deployment_root (sysroot, cfg_deployment);
-  g_autofree char *reposdir = g_build_filename (cfg_deployment_root, "etc/yum.repos.d", NULL);
 
-  /* point libhif to the yum.repos.d and os-release of the merge deployment */
-  rpmostree_context_set_repos_dir (self, reposdir);
+  /* Point libdnf to repo config dirs under the merge deployment. */
+  g_auto (GStrv) repos_dirs = build_repos_dirs (cfg_deployment_root);
+  rpmostree_context_set_repos_dirs (self, (const gchar *const *)repos_dirs);
 
   /* point the core to the passwd & group of the merge deployment */
   g_assert (!self->passwd_dir);
@@ -694,9 +729,9 @@ rpmostree_context_setup (RpmOstreeContext *self, const char *install_root, const
       // overrode the repos dir.
       if (!self->repos_dir_configured)
         {
-          g_autofree char *source_repos = g_build_filename (source_root, "etc/yum.repos.d", NULL);
-          dnf_context_set_repo_dir (self->dnfctx, source_repos);
-          g_debug ("Set repos dir from source root");
+          g_auto (GStrv) repos_dirs = build_repos_dirs (source_root);
+          dnf_context_set_repos_dir (self->dnfctx, (const gchar *const *)repos_dirs);
+          g_debug ("Set repos dirs from source root");
         }
     }
 
@@ -2370,8 +2405,10 @@ rpmostree_find_and_download_packages (const char *const *packages, const char *s
   if (!rpmostree_context_setup (ctx, NULL, source_root, cancellable, error))
     return glnx_prefix_error (error, "Setting up dnf context");
 
-  g_autofree char *reposdir = g_build_filename (repo_root ?: source_root, "etc/yum.repos.d", NULL);
-  dnf_context_set_repo_dir (ctx->dnfctx, reposdir);
+  {
+    g_auto (GStrv) repos_dirs = build_repos_dirs (repo_root ?: source_root);
+    dnf_context_set_repos_dir (ctx->dnfctx, (const gchar *const *)repos_dirs);
+  }
 
   auto flags = (DnfContextSetupSackFlags)(DNF_CONTEXT_SETUP_SACK_FLAG_SKIP_RPMDB
                                           | DNF_CONTEXT_SETUP_SACK_FLAG_SKIP_FILELISTS);

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -114,6 +114,7 @@ void rpmostree_context_disable_selinux (RpmOstreeContext *self);
 const char *rpmostree_context_get_ref (RpmOstreeContext *self);
 
 void rpmostree_context_set_repos_dir (RpmOstreeContext *self, const char *reposdir);
+void rpmostree_context_set_repos_dirs (RpmOstreeContext *self, const char *const *reposdirs);
 
 void rpmostree_context_set_repos (RpmOstreeContext *self, OstreeRepo *base_repo,
                                   OstreeRepo *pkgcache_repo);

--- a/tests/common/libtestrepos.sh
+++ b/tests/common/libtestrepos.sh
@@ -20,7 +20,13 @@
 setup_rpmmd_repos() {
     dest=$1
     shift
-    repos=${RPMOSTREE_COMPOSE_TEST_USE_REPOS:-/etc/yum.repos.d}
+    if [ -n "${RPMOSTREE_COMPOSE_TEST_USE_REPOS:-}" ]; then
+        repos=${RPMOSTREE_COMPOSE_TEST_USE_REPOS}
+    elif [ -d /usr/share/dnf5/repos.d ]; then
+        repos=/usr/share/dnf5/repos.d
+    else
+        repos=/etc/yum.repos.d
+    fi
     for x in ${repos}/fedora{,-updates}.repo; do
         bn=$(basename ${x})
         cp $x ${dest}/${bn}

--- a/tests/compose-image.sh
+++ b/tests/compose-image.sh
@@ -59,7 +59,10 @@ ${systemd_sysusers}
 repos:
   - fedora  # Intentially using frozen GA repo
 EOF
-cp /etc/yum.repos.d/*.repo .
+# Copy repo files from whichever location exists
+for d in /usr/share/dnf5/repos.d /etc/yum.repos.d; do
+  test -d "$d" && cp "$d"/*.repo . 2>/dev/null || true
+done
 if rpm-ostree compose image --cachedir=../cache-container --label=foo=bar --label=baz=blah --initialize-mode=never minimal.yaml minimal.ociarchive 2>/dev/null; then
   fatal "built an image in --initialize-mode=never"
 fi
@@ -90,7 +93,10 @@ packages:
 repos:
   - fedora  # Intentially using frozen GA repo
 EOF
-cp /etc/yum.repos.d/*.repo .
+# Copy repo files from whichever location exists
+for d in /usr/share/dnf5/repos.d /etc/yum.repos.d; do
+  test -d "$d" && cp "$d"/*.repo . 2>/dev/null || true
+done
 # Unfortunately, --initialize-mode=if-not-exists is broken with .ociarchive...
 rpm-ostree compose image --cachedir=../cache --touch-if-changed=changed.stamp --initialize-mode=always minimal.yaml minimal.ociarchive
 # TODO actually test this container image


### PR DESCRIPTION
## Summary

Fedora 45 [Changes/RelocateRpmRepoConfigsToUsr](https://fedoraproject.org/wiki/Changes/RelocateRpmRepoConfigsToUsr) moved:
- Repo configs: `/etc/yum.repos.d` -> `/usr/share/dnf5/repos.d`
- GPG keys: `/etc/pki/rpm-gpg` -> `/usr/share/pki/rpm-gpg`

This broke package overlay operations (`rpm-ostree install`) on Fedora 45 / Rawhide with `error: No enabled repositories`.

## Approach

Switch from the single-directory `dnf_context_set_repo_dir()` API to the multi-directory `dnf_context_set_repos_dir()` API, passing both old and new locations. The libdnf repo loader already gracefully skips non-existent directories, so this works on both old (Fedora <=44, RHEL) and new (Fedora 45+) layouts without any version detection.

This follows the same approach used by [PackageKit](https://github.com/PackageKit/PackageKit/blob/d851630f787b436777b8280dfea8874b26259032/backends/dnf/pk-backend-dnf-common.c#L55-L75) as suggested by @Conan-Kudo in the issue.

## Changes

- **`rpmostree-core.cxx`**: Update `rpmostree_context_new_base()`, `rpmostree_context_configure_from_deployment()`, `rpmostree_context_setup()`, and `rpmostree_find_and_download_packages()` to pass both `/etc/yum.repos.d` and `/usr/share/dnf5/repos.d`. Add `rpmostree_context_set_repos_dirs()` for multi-dir overrides.
- **`libdnf` (submodule)**: Update `dnf_keyring_add_public_keys()` to scan both `/etc/pki/rpm-gpg` and `/usr/share/pki/rpm-gpg`, fixing signature verification failures on F45. This patch should also be proposed upstream to `rpm-software-management/libdnf`.
- **`rust/countme`**: Scan both repo directories for Count Me support.
- **`rust/compose`**: Handle both repo layouts in `mutate_source_root()`.
- Tests and documentation updated.

## Note on libdnf submodule

The GPG keyring fix (`dnf-keyring.cpp`) is carried as a local patch on the submodule since the upstream libdnf4 (`dnf-4-master`) does not have this fix. A corresponding upstream PR should be filed. The `ConfigMain.cpp` default reposdir change is **not** needed because rpm-ostree explicitly overrides the repo dir at every call site and disables reading `/etc/dnf/dnf.conf`.

Closes #5623

> Assisted-by: AI
> I am knowledgeable in this problem domain and reviewed it carefully.

CC @cgwalters @AdamWill @Conan-Kudo