### PR TITLE
docs, ci: remove usage and mention of ostree container commit

### DIFF
--- a/ci/prow/Dockerfile.fcos
+++ b/ci/prow/Dockerfile.fcos
@@ -7,4 +7,4 @@ RUN ./ci/build.sh && make install DESTDIR=$(pwd)/install && tar -C install -czf 
 
 FROM quay.io/fedora/fedora-coreos:testing-devel
 COPY --from=builder /srv/install.tar /tmp
-RUN tar -xvf /tmp/install.tar && ostree container commit 
+RUN tar -xvf /tmp/install.tar

--- a/ci/prow/Dockerfile.fcos2
+++ b/ci/prow/Dockerfile.fcos2
@@ -1,4 +1,4 @@
 # This Dockerfile should actually derive from the first build,
 # and verifies a subsequent update
 FROM quay.io/fedora/fedora-coreos:testing-devel
-RUN touch /etc/somenewfile && rpm -e moby-engine && ostree container commit 
+RUN touch /etc/somenewfile && rpm -e moby-engine

--- a/docs/container.md
+++ b/docs/container.md
@@ -122,8 +122,7 @@ FROM quay.io/fedora/fedora-coreos:testing-devel
 RUN mkdir /var/opt && \
     rpm -Uvh https://downloads.linux.hpe.com/repo/stk/rhel/7/x86_64/current/hp-scripting-tools-11.60-20.rhel7.x86_64.rpm && \
     mv /var/opt/hp/ /usr/lib/hp && \
-    echo 'L /opt/hp - - - - ../../usr/lib/hp' > /usr/lib/tmpfiles.d/hp.conf && \
-    ostree container commit
+    echo 'L /opt/hp - - - - ../../usr/lib/hp' > /usr/lib/tmpfiles.d/hp.conf
 ```
 
 #### Users and groups
@@ -132,14 +131,6 @@ At the current time, `rpm-ostree` will auto-synthesize [systemd-sysusers](https:
 snippets when `useradd` or `groupadd` are invoked during the process of e.g. `rpm-ostree install`.
 
 This means that user and group IDs are allocated per machine.
-
-### Using "ostree container commit"
-
-In a container build, it's a current best practice to invoke this at the end
-of each `RUN` instruction (or equivalent).  This will verify compatibility
-of `/var`, and also clean up extraneous files in e.g. `/tmp`.
-
-In the future, this command may perform more operations.
 
 ## Creating base images
 


### PR DESCRIPTION
As noted in [1], this command doesn't actually do anything useful and is actually causing failures with chunkah-based images. Let's go ahead and drop it from docs and the couple places it's used in CI.

[1]: https://github.com/coreos/fedora-coreos-tracker/issues/2145#issuecomment-5359277071